### PR TITLE
fix(docs): Corrected location of public folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ echo 'document.getElementById("app").innerHTML = "Hello world!"' >> src/client
 To include static assets that aren't handled by Webpack (e.g. `favicon.ico`), you can create a `public` directory:
 
 ```bash
-$ mkdir src/public
+$ mkdir public
 ```
 
 ## Development Workflow


### PR DESCRIPTION
Public folder provided in docs was incorrect as `src/public` when in fact sku was looking in `./public`. This PR fixes this.