### PR TITLE
fix(cli): Fix script detection on Windows

### DIFF
--- a/config/args.js
+++ b/config/args.js
@@ -1,4 +1,4 @@
-const scriptNameRegex = /scripts\/([\w-]*)\.js$/i;
+const scriptNameRegex = /scripts[\/\\]([\w-]*)\.js$/i;
 const scriptName = process.argv[1].match(scriptNameRegex)[1];
 
 module.exports = {


### PR DESCRIPTION
The regular expression used for detecting the current sku script doesn't work on Windows because it uses backslashes as path separators.