### PR TITLE
fix(webpack): Run builds sequentially

### DIFF
--- a/config/args.js
+++ b/config/args.js
@@ -1,5 +1,7 @@
 const scriptNameRegex = /scripts[\/\\]([\w-]*)\.js$/i;
-const scriptName = process.argv[1].match(scriptNameRegex)[1];
+const scriptName = /threads/.test(process.argv[1])
+  ? 'build' // Hack, if we're in a build thread
+  : process.argv[1].match(scriptNameRegex)[1];
 
 module.exports = {
   script: scriptName,

--- a/config/args.js
+++ b/config/args.js
@@ -1,7 +1,5 @@
 const scriptNameRegex = /scripts[\/\\]([\w-]*)\.js$/i;
-const scriptName = /threads/.test(process.argv[1])
-  ? 'build' // Hack, if we're in a build thread
-  : process.argv[1].match(scriptNameRegex)[1];
+const scriptName = process.argv[1].match(scriptNameRegex)[1];
 
 module.exports = {
   script: scriptName,

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.22.0",
     "babel-preset-react-optimize": "^1.0.1",
+    "bluebird": "^3.5.0",
     "classnames": "^2.2.5",
     "cross-spawn": "^5.0.1",
     "css-loader": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "style-loader": "^0.13.1",
     "svgo-loader": "^1.1.2",
     "url-loader": "^0.5.8",
-    "webpack": "^2.2.1",
+    "webpack": "^v3.0.0-rc.2",
     "webpack-dev-server": "^2.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "style-loader": "^0.13.1",
     "svgo-loader": "^1.1.2",
     "url-loader": "^0.5.8",
-    "webpack": "^v3.0.0-rc.2",
+    "webpack": "^2.2.1",
     "webpack-dev-server": "^2.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "string-replace-loader": "^1.1.0",
     "style-loader": "^0.13.1",
     "svgo-loader": "^1.1.2",
+    "threads": "^0.8.1",
     "url-loader": "^0.5.8",
     "webpack": "^v3.0.0-rc.2",
     "webpack-dev-server": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "string-replace-loader": "^1.1.0",
     "style-loader": "^0.13.1",
     "svgo-loader": "^1.1.2",
-    "threads": "^0.8.1",
     "url-loader": "^0.5.8",
     "webpack": "^v3.0.0-rc.2",
     "webpack-dev-server": "^2.3.0"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2,11 +2,21 @@
 process.env.NODE_ENV = 'production';
 
 const Promise = require('bluebird');
+const webpackPromise = Promise.promisify(require('webpack'));
 const webpackConfig = require('../config/webpack/webpack.config');
 const fs = require('fs-extra');
-const spawn = require('threads').spawn;
-
 const builds = require('../config/builds');
+
+const runWebpack = config => {
+  return webpackPromise(config).then(stats => {
+    console.log(
+      stats.toString({
+        chunks: false, // Makes the build much quieter
+        colors: true
+      })
+    );
+  });
+};
 
 const copyPublicFiles = () => {
   builds.forEach(({ paths }) => {
@@ -19,42 +29,6 @@ const copyPublicFiles = () => {
   });
 };
 
-const spawnWebpackForConfigIndex = configIndex => {
-  const webpackThread = spawn(input => {
-    const path = require('path');
-    const configs = require(path.resolve(
-      input.__dirname,
-      '../config/webpack/webpack.config'
-    ));
-    const config = configs[input.configIndex];
-
-    const Promise = require('bluebird');
-    const webpackPromise = Promise.promisify(require('webpack'));
-
-    return webpackPromise(config).then(stats => {
-      console.log(
-        stats.toString({
-          chunks: false, // Makes the build much quieter
-          colors: true
-        })
-      );
-    });
-  });
-
-  webpackThread
-    .send({
-      configIndex,
-      __dirname,
-      argv: process.argv
-    })
-    .on('done', () => {
-      webpackThread.kill();
-    });
-
-  return webpackThread.promise();
-};
-
-Promise.each(webpackConfig, (_, configIndex) =>
-  spawnWebpackForConfigIndex(configIndex))
+Promise.map(webpackConfig, runWebpack)
   .then(copyPublicFiles)
   .then(() => console.log('Sku build complete!'));

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -29,6 +29,6 @@ const copyPublicFiles = () => {
   });
 };
 
-Promise.map(webpackConfig, runWebpack)
+Promise.each(webpackConfig, runWebpack)
   .then(copyPublicFiles)
   .then(() => console.log('Sku build complete!'));


### PR DESCRIPTION
This fixes issues we've experiences with large monorepos running out of memory during the build process. We achieve this by breaking up the work, only building a single webpack config entry at a time.