### PR TITLE
feat(babel): Add module directory resolution to babel

### DIFF
--- a/config/babel/babel.config.js
+++ b/config/babel/babel.config.js
@@ -2,7 +2,13 @@ module.exports = ({ webpack }) => {
   const es2015Options = webpack ? { modules: false } : {};
   const plugins = [
     require.resolve('babel-plugin-transform-class-properties'),
-    require.resolve('babel-plugin-transform-object-rest-spread')
+    require.resolve('babel-plugin-transform-object-rest-spread'),
+    [
+      require.resolve('babel-plugin-module-resolver'),
+      {
+        root: [process.cwd()]
+      }
+    ]
   ];
 
   if (webpack) {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "babel-core": "^6.22.1",
     "babel-jest": "^18.0.0",
     "babel-loader": "^6.2.10",
+    "babel-plugin-module-resolver": "^2.7.1",
     "babel-plugin-transform-class-properties": "^6.22.0",
     "babel-plugin-transform-imports": "^1.1.0",
     "babel-plugin-transform-object-rest-spread": "^6.22.0",


### PR DESCRIPTION
Custom module directory points to the root of the folder. Allowing imports like `import AwesomeComponent from 'src/components/AwesomeComponent'` from anywhere in the app. 