### PR TITLE
docs(readme): Add features list to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ module.exports = {
 
 ### Environment Variables
 
-By default, `process.env.NODE_ENV` is handled correctly for you and provided globally, even to your client code.
+By default, `process.env.NODE_ENV` is handled correctly for you and provided globally, even to your client code. This is based on the sku script that's currently being executed, so `NODE_ENV` is `'development'` when running `sku start`, but `'production'` when running `sku build`.
 
 Any other environment variables can be configured using the `env` option:
 
@@ -223,15 +223,26 @@ module.exports = {
 }
 ```
 
-Environment variables can be configured separately for development and production:
+Since this config is written in JavaScript, not JSON, you can easily pass through any existing environment variables:
 
 ```js
 module.exports = {
   ...
   env: {
-    MY_ENVIRONMENT_VARIABLE: {
-      development: 'hello',
-      production: 'world'
+    BUILD_NUMBER: process.env.BUILD_NUMBER
+  }
+}
+```
+
+Environment variables can also be configured separately for development and production:
+
+```js
+module.exports = {
+  ...
+  env: {
+    API_ENDPOINT: {
+      development: '/mock/api',
+      production: 'https://example.com/real/api'
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -13,39 +13,68 @@ This tool is heavily inspired by other work, most notably:
 
 ## Features
 
-### Modern Javascript (via [Babel](https://babeljs.io/)) ###
+### Modern Javascript (via [Babel](https://babeljs.io/))
 
-Use `import`, `const`, `=>`, spread operators, destructuring and all their friends in your code.  It'll just work.
+Use `import`, `const`, `=>`, rest/spread operators, destructuring, classes with class properties, [JSX](https://facebook.github.io/react/docs/jsx-in-depth.html) and all their friends in your code.  It'll all just work, thanks to the following Babel plugins:
 
 * [babel-preset-es2015](https://babeljs.io/docs/plugins/preset-es2015/)
-* [babel-preset-react](https://babeljs.io/docs/plugins/preset-react/) and [babel-preset-react-optimize](https://github.com/thejameskyle/babel-react-optimize)
+* [babel-preset-react](https://babeljs.io/docs/plugins/preset-react/)
+* [babel-preset-react-optimize](https://github.com/thejameskyle/babel-react-optimize)
 * [babel-plugin-transform-object-rest-spread](https://babeljs.io/docs/plugins/transform-object-rest-spread/)
 * [babel-plugin-transform-class-properties](https://babeljs.io/docs/plugins/transform-class-properties/)
 
-### Locally scoped CSS via [CSS Modules](https://github.com/css-modules/css-modules) and [Less](http://lesscss.org/)###
+### Locally Scoped CSS (via [CSS Modules](https://github.com/css-modules/css-modules) and [Less](http://lesscss.org/))
 
-Import any `*.less` file into your Javascript as a `styles` object, and use its properties as class names.
+Import any `.less` file into your Javascript as a `styles` object and use its properties as class names.
 
-```
-import styles from './example.less';
+For example, given the following Less file:
 
-const ExampleComponent = (props) => {
-  return (
-      <div className={styles.exampleWrapper}>
-        I'm styled with the .exampleWrapper rule in example.less!
-      </div>
-    )
+```less
+.exampleWrapper {
+  font-family: comic sans ms;
+  color: blue;
 }
 ```
 
-### Unit and snapshot testing (via [Jest](https://facebook.github.io/jest/)) ###
+You can then import the classes into your JavaScript code like so:
+
+```js
+import styles from './example.less';
+
+export default () => (
+  <div className={styles.exampleWrapper}>
+    Hello World!
+  </div>
+);
+```
+
+### Unit and Snapshot Testing (via [Jest](https://facebook.github.io/jest/))
 
 The `sku test` command will invoke Jest, running any tests in files named `*.test.js`, `*.spec.js` or in a `__tests__` folder.
 
-### First class support for [SEEK Living Style Guide](https://github.com/seek-oss/seek-style-guide) ###
+Since sku uses Jest as a testing framework, you can read the [Jest documentation](https://facebook.github.io/jest/) for more information on writing compatible tests.
 
-sku is pre-configured for the SEEK Style Guide, so if you want to use it, just install it and go without any extra setup.
+### Linting and Formatting (via [ESLint](http://eslint.org/) and [Prettier](https://github.com/prettier/prettier))
 
+Running `sku lint` will execute the ESLint rules over the code in your `src` directory. You can see the ESLint rules defined for sku projects in [eslint-config-sku](https://github.com/seek-oss/eslint-config-sku).
+
+Adding the following to your package.json file will enable the [Atom ESLint plugin](https://github.com/AtomLinter/linter-eslint) to work correctly with sku.
+
+```js
+"eslintConfig": {
+  "extends": "sku"
+}
+```
+
+Similarly, running `sku format` will reformat the JavaScript code in `src` using Prettier.
+
+### Static Pre-rendering (via [static-site-generator-webpack-plugin](https://github.com/markdalgleish/static-site-generator-webpack-plugin))
+
+Generate static HTML files via a webpack-compiled render function that has access to your application code. For example, when building a React application, you can pre-render to static HTML with React's [renderToString](https://facebook.github.io/react/docs/react-dom-server.html#rendertostring) function.
+
+### [SEEK Style Guide](https://github.com/seek-oss/seek-style-guide) Support
+
+Without any special setup, sku is pre-configured for the SEEK Style Guide. Just start importing components as needed and everything should just work out of the box.
 
 ## Getting Started
 
@@ -216,12 +245,6 @@ To build assets for production:
 $ npm run build
 ```
 
-## Testing
-
-Anywhere inside your project, any file ending in `.test.js` will be included in an `npm test` run.
-
-Since sku uses Jest as a testing framework, you can read the [Jest documentation](https://facebook.github.io/jest/) for more information on writing compatible tests.
-
 ## Configuration
 
 If you need to configure sku, first create a `sku.config.js` file in your project root:
@@ -323,20 +346,6 @@ Alternatively, you can start the relevant project directly:
 
 ```bash
 $ npm start hello
-```
-
-### Linting
-
-Running `sku lint` will execute the ESLint rules over the code in your `src` directory. You can see the ESLint rules defined for sku projects in [eslint-config-sku](https://github.com/seek-oss/eslint-config-sku).
-
-#### Atom support
-
-Adding the following to your package.json file will enable the atom ESLint plugin to work with sku.
-
-```js
-"eslintConfig": {
-  "extends": "sku"
-}
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -11,31 +11,41 @@ This tool is heavily inspired by other work, most notably:
 - [insin/nwb](https://github.com/insin/nwb)
 - [NYTimes/kyt](https://github.com/NYTimes/kyt)
 
-## What does sku give you out of the box?
+## Features
 
-### Modern Javascript support ###
-
-(Babel preconfigured with ES2015 and React presets, Webpack module loading)
+### Modern Javascript (via [Babel](https://babeljs.io/)) ###
 
 Use `import`, `const`, `=>`, spread operators, destructuring and all their friends in your code.  It'll just work.
 
-### CSS Modules ###
+* [babel-preset-es2015](https://babeljs.io/docs/plugins/preset-es2015/)
+* [babel-preset-react](https://babeljs.io/docs/plugins/preset-react/) and [babel-preset-react-optimize](https://github.com/thejameskyle/babel-react-optimize)
+* [babel-plugin-transform-object-rest-spread](https://babeljs.io/docs/plugins/transform-object-rest-spread/)
+* [babel-plugin-transform-class-properties](https://babeljs.io/docs/plugins/transform-class-properties/)
 
-(Webpack style loaders for LESS)
+### Locally scoped CSS via [CSS Modules](https://github.com/css-modules/css-modules) and [Less](http://lesscss.org/)###
 
-Import your LESS styles directly into your components: https://github.com/css-modules/css-modules
+Import any `*.less` file into your Javascript as a `styles` object, and use its properties as class names.
 
-### Jest testing ###
+```
+import styles from './example.less';
 
-https://facebook.github.io/jest/
+const ExampleComponent = (props) => {
+  return (
+      <div className={styles.exampleWrapper}>
+        I'm styled with the .exampleWrapper rule in example.less!
+      </div>
+    )
+}
+```
 
-sku will run any of your `.test.js` files through Jest for your convenience
+### Unit and snapshot testing (via [Jest](https://facebook.github.io/jest/)) ###
 
-### First class support for SEEK Living Style Guide ###
+The `sku test` command will invoke Jest, running any tests in files named `*.test.js`, `*.spec.js` or in a `__tests__` folder.
 
-https://github.com/seek-oss/seek-style-guide
+### First class support for [SEEK Living Style Guide](https://github.com/seek-oss/seek-style-guide) ###
 
-If you choose to include the SEEK Living Style Guide in your project, no further webpack configuration is necessary.  Just start importing components and build your UI!
+sku is pre-configured for the SEEK Style Guide, so if you want to use it, just install it and go without any extra setup.
+
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,32 @@ This tool is heavily inspired by other work, most notably:
 - [insin/nwb](https://github.com/insin/nwb)
 - [NYTimes/kyt](https://github.com/NYTimes/kyt)
 
+## What does sku give you out of the box?
+
+### Modern Javascript support ###
+
+(Babel preconfigured with ES2015 and React presets, Webpack module loading)
+
+Use `import`, `const`, `=>`, spread operators, destructuring and all their friends in your code.  It'll just work.
+
+### CSS Modules ###
+
+(Webpack style loaders for LESS)
+
+Import your LESS styles directly into your components: https://github.com/css-modules/css-modules
+
+### Jest testing ###
+
+https://facebook.github.io/jest/
+
+sku will run any of your `.test.js` files through Jest for your convenience
+
+### First class support for SEEK Living Style Guide ###
+
+https://github.com/seek-oss/seek-style-guide
+
+If you choose to include the SEEK Living Style Guide in your project, no further webpack configuration is necessary.  Just start importing components and build your UI!
+
 ## Getting Started
 
 First, in a new directory, create a git repository with an appropriate `.gitignore` file:


### PR DESCRIPTION
WIP - DO NOT MERGE

I'm proposing we devote a little space at the top of the README to selling the benefits of sku and setting clear expectations for what you can do with it.

As the feature set expands it might make sense to break that out to its own page and provide a link, but for now I think it's useful to put a little "WHY" between "WHAT" and "HOW" in the README.

This needs at the very least some more doco on linting and static prerendering, any input on what to say about those?