### PR TITLE
ci(PullApprove): Only require one approval per PR

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -2,7 +2,7 @@ version: 2
 
 groups:
   reviewers:
-    required: 2
+    required: 1
     teams:
       - sku-contributors
     approve_by_comment:


### PR DESCRIPTION
As discussed, the contributor community is a little too small at the moment, so we're temporarily dropping this value.