### PR TITLE
feat(args): pass through tenant arg as env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,49 +359,46 @@ will create `index-AU.html` & `index-NZ.html`.
 
 Note: When running the app in dev mode only one HTML file will be created, defaulting to the first listed locale.
 
-
 ### Tenants
 
 Applications that serve multiple branded experiences need to know which brand (or tenant) to render.  If invoked with a `--tenant` or `--t` command line, sku will pass through the supplied value as an environment variable named `SKU_TENANT`.
 
 For example, if we invoked
 
-`sku --tenant=jobStreet`
+`sku --tenant=awesomeBrand`
 
 And our application exposes the tenant as a prop to react app like so:
 
 ```
 <div id="app">
-    ${renderToString(
-        <App tenant={process.env.SKU_TENANT} />
-    )}
+  ${renderToString(
+    <App tenant={process.env.SKU_TENANT} />
+  )}
 </div>
 ```
 
 Then we can serve different experiences based on the tenant prop:
 
 ```
-import JobStreetHeader from `./components/JobStreetHeader/JobStreetHeader`;
-import JobsDBHeader from './components/JobsDBHeader/JobsDBHeader';
+import AwesomeHeader from './components/AwesomeHeader';
+import AmazingHeader from './components/AmazingHeader';
 
 const renderHeader = (tenant) => {
-    if (tenant === 'jobStreet') {
-        return (<JobStreetHeader>)
-    } else {
-        return (JobsDBHeader)
-    }
+  if (tenant === 'awesomeBrand') {
+    return (<AwesomeHeader>)
+  } else {
+    return (AmazingHeader)
+  }
 };
 
 const App = (props) => {
-    return (
-        <div>
-            {renderHeader(props.tenant)}
-        </div>
-    );
+  return (
+    <div>
+      {renderHeader(props.tenant)}
+    </div>
+  );
 }
 ```
-
-
 
 ### Development server
 

--- a/README.md
+++ b/README.md
@@ -359,6 +359,50 @@ will create `index-AU.html` & `index-NZ.html`.
 
 Note: When running the app in dev mode only one HTML file will be created, defaulting to the first listed locale.
 
+
+### Tenants
+
+Applications that serve multiple branded experiences need to know which brand (or tenant) to render.  If invoked with a `--tenant` or `--t` command line, sku will pass through the supplied value as an environment variable named `SKU_TENANT`.
+
+For example, if we invoked
+
+`sku --tenant=jobStreet`
+
+And our application exposes the tenant as a prop to react app like so:
+
+```
+<div id="app">
+    ${renderToString(
+        <App tenant={process.env.SKU_TENANT} />
+    )}
+</div>
+```
+
+Then we can serve different experiences based on the tenant prop:
+
+```
+import JobStreetHeader from `./components/JobStreetHeader/JobStreetHeader`;
+import JobsDBHeader from './components/JobsDBHeader/JobsDBHeader';
+
+const renderHeader = (tenant) => {
+    if (tenant === 'jobStreet') {
+        return (<JobStreetHeader>)
+    } else {
+        return (JobsDBHeader)
+    }
+};
+
+const App = (props) => {
+    return (
+        <div>
+            {renderHeader(props.tenant)}
+        </div>
+    );
+}
+```
+
+
+
 ### Development server
 
 Out of the box sku will start your app with [webpack-dev-server](https://github.com/webpack/webpack-dev-server) on http://localhost:8080. However there a few options you can pass `sku.config.js` if needed.

--- a/README.md
+++ b/README.md
@@ -380,26 +380,14 @@ And our application exposes the tenant as a prop to react app like so:
 Then we can serve different experiences based on the tenant prop:
 
 ```
-import AwesomeHeader from './components/AwesomeHeader';
-import AmazingHeader from './components/AmazingHeader';
-
-const renderHeader = (tenant) => {
-  if (tenant === 'awesomeBrand') {
-    return (<AwesomeHeader>)
-  } else {
-    return (AmazingHeader)
-  }
-};
-
 const App = (props) => {
   return (
     <div>
-      {renderHeader(props.tenant)}
+      Welcome to {props.tenant === 'awesomeBrand' ? 'Awesome Brand' : 'Amazing Brand'}!
     </div>
   );
 }
 ```
-
 ### Development server
 
 Out of the box sku will start your app with [webpack-dev-server](https://github.com/webpack/webpack-dev-server) on http://localhost:8080. However there a few options you can pass `sku.config.js` if needed.

--- a/README.md
+++ b/README.md
@@ -359,35 +359,6 @@ will create `index-AU.html` & `index-NZ.html`.
 
 Note: When running the app in dev mode only one HTML file will be created, defaulting to the first listed locale.
 
-### Tenants
-
-Applications that serve multiple branded experiences need to know which brand (or tenant) to render.  If invoked with a `--tenant` or `--t` command line, sku will pass through the supplied value as an environment variable named `SKU_TENANT`.
-
-For example, if we invoked
-
-`sku --tenant=awesomeBrand`
-
-And our application exposes the tenant as a prop to react app like so:
-
-```
-<div id="app">
-  ${renderToString(
-    <App tenant={process.env.SKU_TENANT} />
-  )}
-</div>
-```
-
-Then we can serve different experiences based on the tenant prop:
-
-```
-const App = (props) => {
-  return (
-    <div>
-      Welcome to {props.tenant === 'awesomeBrand' ? 'Awesome Brand' : 'Amazing Brand'}!
-    </div>
-  );
-}
-```
 ### Development server
 
 Out of the box sku will start your app with [webpack-dev-server](https://github.com/webpack/webpack-dev-server) on http://localhost:8080. However there a few options you can pass `sku.config.js` if needed.

--- a/config/args.js
+++ b/config/args.js
@@ -13,8 +13,7 @@ const optionDefinitions = [
   {
     name: 'tenant',
     alias: 't',
-    type: String,
-    defaultValue: 'seek'
+    type: String
   }
 ];
 

--- a/config/args.js
+++ b/config/args.js
@@ -13,7 +13,8 @@ const optionDefinitions = [
   {
     name: 'tenant',
     alias: 't',
-    type: String
+    type: String,
+    defaultValue: ''
   }
 ];
 

--- a/config/args.js
+++ b/config/args.js
@@ -9,6 +9,12 @@ const optionDefinitions = [
     alias: 'e',
     type: String,
     defaultValue: 'production'
+  },
+  {
+    name: 'tenant',
+    alias: 't',
+    type: String,
+    defaultValue: 'seek'
   }
 ];
 
@@ -17,5 +23,6 @@ const options = commandLineArgs(optionDefinitions);
 module.exports = {
   script: scriptName,
   buildName: scriptName === 'start' ? process.argv[2] : null,
-  env: scriptName === 'start' ? 'development' : options.env
+  env: scriptName === 'start' ? 'development' : options.env,
+  tenant: options.tenant
 };

--- a/config/builds.js
+++ b/config/builds.js
@@ -37,9 +37,12 @@ const builds = buildConfigs
   })
   .map(buildConfig => {
     const name = buildConfig.name || '';
-    const env = buildConfig.env || {
-      SKU_TENANT: args.tenant || ''
-    };
+    const env = buildConfig.env
+      ? {
+          SKU_TENANT: args.tenant || '',
+          ...buildConfig.env
+        }
+      : {};
     const entry = buildConfig.entry || {};
     const locales = buildConfig.locales || [''];
     const compilePackages = buildConfig.compilePackages || [];

--- a/config/builds.js
+++ b/config/builds.js
@@ -37,7 +37,9 @@ const builds = buildConfigs
   })
   .map(buildConfig => {
     const name = buildConfig.name || '';
-    const env = buildConfig.env || {};
+    const env = buildConfig.env || {
+      SKU_TENANT: args.tenant
+    };
     const entry = buildConfig.entry || {};
     const locales = buildConfig.locales || [''];
     const compilePackages = buildConfig.compilePackages || [];

--- a/config/builds.js
+++ b/config/builds.js
@@ -38,7 +38,7 @@ const builds = buildConfigs
   .map(buildConfig => {
     const name = buildConfig.name || '';
     const env = buildConfig.env || {
-      SKU_TENANT: args.tenant
+      SKU_TENANT: args.tenant || ''
     };
     const entry = buildConfig.entry || {};
     const locales = buildConfig.locales || [''];

--- a/config/builds.js
+++ b/config/builds.js
@@ -37,12 +37,10 @@ const builds = buildConfigs
   })
   .map(buildConfig => {
     const name = buildConfig.name || '';
-    const env = buildConfig.env
-      ? {
-          SKU_TENANT: args.tenant || '',
-          ...buildConfig.env
-        }
-      : {};
+    const env = {
+      SKU_TENANT: args.tenant || '',
+      ...(buildConfig.env ? { ...buildConfig.env } : {})
+    };
     const entry = buildConfig.entry || {};
     const locales = buildConfig.locales || [''];
     const compilePackages = buildConfig.compilePackages || [];


### PR DESCRIPTION
This is the absolute minimum implementation of a tenant feature, it passes through to be seen by the consuming app and styleguide, but doesn't (yet) have any knowledge of the tenants, map styleguide aliases or anything like that.  It's enough to get us started.