### PR TITLE
feat(ssr): add initial undocumented SSR support

### DIFF
--- a/config/builds.js
+++ b/config/builds.js
@@ -51,6 +51,15 @@ const builds = buildConfigs
     const webpackDecorator =
       buildConfig.dangerouslySetWebpackConfig || defaultDecorator;
 
+    let renderEntry = path.join(cwd, 'src/render.js');
+    let serverEntry = null;
+    if (entry.render) {
+      renderEntry = path.join(cwd, entry.render);
+    } else if (entry.server) {
+      renderEntry = null;
+      serverEntry = path.join(cwd, entry.server);
+    }
+
     const paths = {
       src: path.join(cwd, 'src'),
       compilePackages: [
@@ -60,8 +69,8 @@ const builds = buildConfigs
         )
       ],
       clientEntry: path.join(cwd, entry.client || 'src/client.js'),
-      renderEntry: entry.render ? path.join(cwd, entry.render) : null,
-      serverEntry: entry.server ? path.join(cwd, entry.server) : null,
+      renderEntry: renderEntry,
+      serverEntry: serverEntry,
       public: path.join(cwd, buildConfig.public || 'public'),
       dist: path.join(cwd, buildConfig.target || 'dist')
     };

--- a/config/builds.js
+++ b/config/builds.js
@@ -60,7 +60,8 @@ const builds = buildConfigs
         )
       ],
       clientEntry: path.join(cwd, entry.client || 'src/client.js'),
-      renderEntry: path.join(cwd, entry.render || 'src/render.js'),
+      renderEntry: entry.render ? path.join(cwd, entry.render) : null,
+      serverEntry: entry.server ? path.join(cwd, entry.server) : null,
       public: path.join(cwd, buildConfig.public || 'public'),
       dist: path.join(cwd, buildConfig.target || 'dist')
     };


### PR DESCRIPTION

## Commit Message For Review
Added basic setup for SSR:
- Reuses setup for static rendering as I was keen to avoid multiplication of configuration files
- Does not provide a server, hot-module reloading or API consumption
- Does not force the user to provide either a static or a server-side entry point and does not default anymore back to render.js for static rendering


RFC URL:
https://github.com/seek-oss/sku/issues/46

REASON FOR CHANGE:
Base support for SSR

EXAMPLE USAGE:
In a file called server.js:
```js
import render from './render';
import express from 'express';

const server = express();

server.get('/', (req, res) => {
  res.send(render());
});

server.listen(8080);
```

In the sku.config.js file:
```module.exports = [
  {
    name: 'home',
    env: extendDefaultEnv({}),
    entry: {
      client: 'src/client.js',
      server: 'src/server.js'
    },
    public: 'public',
    target: 'dist'
   }];```

Start your node server:
```node ./dist/server.js```
