### PR TITLE
fix(lint): Improve error message when prettier fails

### DIFF
--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -26,6 +26,7 @@ prettierCheck(prettierConfig)
     console.log(chalk.cyan('Prettier format rules passed'));
   })
   .catch(exitCode => {
+    console.error('Error: The file(s) listed above failed the prettier check');
     console.error('Error: Prettier check exited with exit code', exitCode);
     process.exit(1);
   });


### PR DESCRIPTION
## Commit Message For Review

REASON FOR CHANGE:

When the prettier lint step failed, it would print the names of the failing files and then say
"Prettier check exited with exit code 1". Now there's a message that tells you that the listed files
are the files that failed the test.