### PR TITLE
feat(ssr): add express and improve build configuration for ssr

### DIFF
--- a/config/server/server.js
+++ b/config/server/server.js
@@ -7,12 +7,7 @@ const port = process.env.PORT || 8080;
 
 const app = express();
 
-if (
-  middleware &&
-  (middleware instanceof Function ||
-    middleware instanceof express ||
-    (middleware instanceof Array && middleware.length > 0))
-) {
+if (middleware) {
   app.use(middleware);
 }
 app.get('*', renderCallback);

--- a/config/server/server.js
+++ b/config/server/server.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const { renderCallback, middlewares } = require('serverEntry').default;
+const port = process.env.PORT || 8080;
+
+const app = express();
+
+if (
+  middlewares &&
+  (middlewares instanceof Function ||
+    middlewares instanceof express ||
+    (middlewares instanceof Array && middlewares.length > 0))
+) {
+  app.use(middlewares);
+}
+app.get('*', renderCallback);
+
+app.listen(port, () => {
+  console.log(`App started on port ${port}`);
+});

--- a/config/server/server.js
+++ b/config/server/server.js
@@ -1,16 +1,19 @@
 const express = require('express');
-const { renderCallback, middlewares } = require('serverEntry').default;
+const {
+  renderCallback,
+  middleware
+} = require('__sku_alias__serverEntry').default;
 const port = process.env.PORT || 8080;
 
 const app = express();
 
 if (
-  middlewares &&
-  (middlewares instanceof Function ||
-    middlewares instanceof express ||
-    (middlewares instanceof Array && middlewares.length > 0))
+  middleware &&
+  (middleware instanceof Function ||
+    middleware instanceof express ||
+    (middleware instanceof Array && middleware.length > 0))
 ) {
-  app.use(middlewares);
+  app.use(middleware);
 }
 app.get('*', renderCallback);
 

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -227,7 +227,7 @@ const buildWebpackConfigs = builds.map(
           alias: isRender
             ? {}
             : {
-                serverEntry: paths.serverEntry
+                __sku_alias__serverEntry: paths.serverEntry
               }
         },
         target: isRender ? 'web' : 'node',

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -5,6 +5,7 @@ const builds = require('../builds');
 const lodash = require('lodash');
 const flatten = require('lodash/flatten');
 const args = require('../args');
+const path = require('path');
 const isProductionBuild = process.env.NODE_ENV === 'production';
 
 const jsLoaders = [
@@ -123,6 +124,7 @@ const buildWebpackConfigs = builds.map(
         return JSON.stringify(valueForEnv);
       })
       .set('SKU_ENV', JSON.stringify(args.env))
+      .set('PORT', JSON.stringify(port))
       .mapKeys((value, key) => `process.env.${key}`)
       .value();
 
@@ -218,7 +220,15 @@ const buildWebpackConfigs = builds.map(
       },
       {
         entry: {
-          render: paths.renderEntry || paths.serverEntry
+          render:
+            paths.renderEntry || path.join(__dirname, '../server/server.js')
+        },
+        resolve: {
+          alias: isRender
+            ? {}
+            : {
+                serverEntry: paths.serverEntry
+              }
         },
         target: isRender ? 'web' : 'node',
         node: isRender

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "deasync-promise": "^1.0.1",
     "dir-compare": "^1.4.0",
     "eslint-config-sku": "^1.0.0",
+    "express": "^4.15.4",
     "extract-text-webpack-plugin": "^3.0.0",
     "fs-extra": "^2.0.0",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
Commit Message for Review
======================

Added Express and improved build configuration for SSR

RFC URL: https://github.com/seek-oss/sku/issues/50

REASON FOR CHANGE: Allows users to render their application server-side with minimal configuration

EXAMPLE USAGE:

server.js
```js
import render from './render.js';

const mw = function (req, res, next) {
  console.log('Time:', Date.now())
  next()
};

export default {
    renderCallback: (req, res) => {
        res.send(render());
    },
    middlewares: [mw]
};
```

sku.config.js
```js
module.exports = {
  entry: {
    client: 'src/client.js',
    server: 'src/server.js'
  },
  public: 'src/public',
  target: 'dist',
  port: 3000
};
```

`renderCallback` is required
`middlewares` is not required. Needs to be a function, an array or an express instance
