### PR TITLE
fix(config): add seek-asia-style-guide to jest config

### DIFF
--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   testPathIgnorePatterns: ['<rootDir>[/\\\\](dist|node_modules)[/\\\\]'],
   moduleNameMapper: {
-    '(seek-style-guide/react|.(css|less)$)': require.resolve(
+    '(seek-style-guide/react|seek-asia-style-guide|.(css|less)$)': require.resolve(
       'identity-obj-proxy'
     ),
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|svg)$': require.resolve(


### PR DESCRIPTION
## Commit Message For Review

Adds `seek-asia-style-guide` alongside `seek-style-guide` in the jest config for `identity-obj-proxy`.  This should be a temporary measure until a configurable approach can be added.

REASON FOR CHANGE:

Sku apps currently run tests on components importing anything from `seek-asia-style-guide`