### PR TITLE
fix(config): add ability to serve generated static files for ssr dev

### DIFF
--- a/config/server/server.js
+++ b/config/server/server.js
@@ -8,7 +8,12 @@ const port = process.env.PORT || 8080;
 
 const app = express();
 
-app.use(express.static(path.join(__dirname, './')));
+const env = process.env.NODE_ENV || 'development';
+
+if (env === 'development') {
+  app.use(express.static(path.join(__dirname, './')));
+}
+
 if (middleware) {
   app.use(middleware);
 }

--- a/config/server/server.js
+++ b/config/server/server.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const express = require('express');
 const {
   renderCallback,
@@ -7,6 +8,7 @@ const port = process.env.PORT || 8080;
 
 const app = express();
 
+app.use(express.static(path.join(__dirname, './')));
 if (middleware) {
   app.use(middleware);
 }


### PR DESCRIPTION
## Commit Message For Review

Adds serving for static files in the root directory for server side rendering. 

REASON FOR CHANGE:

Without this, when using SSR in dev requests for `main.js`, `styles.css` and their friends will simply return the output of the render callback.  In most apps this will be the rendered HTML intended for a 404.