### PR TITLE
Feature/dangerously override jest config

### DIFF
--- a/config/builds.js
+++ b/config/builds.js
@@ -50,6 +50,7 @@ const builds = buildConfigs
     const port = buildConfig.port || 8080;
     const webpackDecorator =
       buildConfig.dangerouslySetWebpackConfig || defaultDecorator;
+    const jestOverrideConfig = buildConfig.dangerouslySetJestConfig || {};
 
     let renderEntry = path.join(cwd, 'src/render.js');
     let serverEntry = null;
@@ -81,6 +82,7 @@ const builds = buildConfigs
       paths,
       locales,
       webpackDecorator,
+      jestOverrideConfig,
       hosts,
       port
     };

--- a/config/builds.js
+++ b/config/builds.js
@@ -50,7 +50,8 @@ const builds = buildConfigs
     const port = buildConfig.port || 8080;
     const webpackDecorator =
       buildConfig.dangerouslySetWebpackConfig || defaultDecorator;
-    const jestOverrideConfig = buildConfig.dangerouslySetJestConfig || {};
+    const jestDecorator =
+      buildConfig.dangerouslySetJestConfig || defaultDecorator;
 
     let renderEntry = path.join(cwd, 'src/render.js');
     let serverEntry = null;
@@ -82,7 +83,7 @@ const builds = buildConfigs
       paths,
       locales,
       webpackDecorator,
-      jestOverrideConfig,
+      jestDecorator,
       hosts,
       port
     };

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -1,19 +1,14 @@
 module.exports = {
-  generateJestConfig: overrideConfig => {
-    return {
-      testPathIgnorePatterns: ['<rootDir>[/\\\\](dist|node_modules)[/\\\\]'],
-      moduleNameMapper: {
-        '(seek-style-guide/react|.(css|less)$)': require.resolve(
-          'identity-obj-proxy'
-        ),
-        '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|svg)$': require.resolve(
-          './fileMock'
-        )
-      },
-      transform: {
-        '^.+\\.js$': require.resolve('./babelTransform.js')
-      },
-      ...overrideConfig
-    };
+  testPathIgnorePatterns: ['<rootDir>[/\\\\](dist|node_modules)[/\\\\]'],
+  moduleNameMapper: {
+    '(seek-style-guide/react|.(css|less)$)': require.resolve(
+      'identity-obj-proxy'
+    ),
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|svg)$': require.resolve(
+      './fileMock'
+    )
+  },
+  transform: {
+    '^.+\\.js$': require.resolve('./babelTransform.js')
   }
 };

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -1,14 +1,19 @@
 module.exports = {
-  testPathIgnorePatterns: ['<rootDir>[/\\\\](dist|node_modules)[/\\\\]'],
-  moduleNameMapper: {
-    '(seek-style-guide/react|.(css|less)$)': require.resolve(
-      'identity-obj-proxy'
-    ),
-    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|svg)$': require.resolve(
-      './fileMock'
-    )
-  },
-  transform: {
-    '^.+\\.js$': require.resolve('./babelTransform.js')
+  generateJestConfig: overrideConfig => {
+    return {
+      testPathIgnorePatterns: ['<rootDir>[/\\\\](dist|node_modules)[/\\\\]'],
+      moduleNameMapper: {
+        '(seek-style-guide/react|.(css|less)$)': require.resolve(
+          'identity-obj-proxy'
+        ),
+        '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|svg)$': require.resolve(
+          './fileMock'
+        )
+      },
+      transform: {
+        '^.+\\.js$': require.resolve('./babelTransform.js')
+      },
+      ...overrideConfig
+    };
   }
 };

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,7 +1,14 @@
 const jest = require('jest');
-const jestConfig = require('../config/jest/jest.config');
-
+const generateJestConfig = require('../config/jest/jest.config')
+  .generateJestConfig;
 const argv = process.argv.slice(2);
+const builds = require('../config/builds');
+
+const overrideConfig =
+  Array.isArray(builds) && builds.length && builds[0].jestOverrideConfig
+    ? builds[0].jestOverrideConfig
+    : {};
+const jestConfig = generateJestConfig(overrideConfig);
 
 if (!process.env.CI && argv.indexOf('--coverage') < 0) {
   argv.push('--watch');

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,14 +1,9 @@
 const jest = require('jest');
-const generateJestConfig = require('../config/jest/jest.config')
-  .generateJestConfig;
+const baseJestConfig = require('../config/jest/jest.config');
 const argv = process.argv.slice(2);
 const builds = require('../config/builds');
 
-const overrideConfig =
-  Array.isArray(builds) && builds.length && builds[0].jestOverrideConfig
-    ? builds[0].jestOverrideConfig
-    : {};
-const jestConfig = generateJestConfig(overrideConfig);
+const jestConfig = builds[0].jestDecorator(baseJestConfig);
 
 if (!process.env.CI && argv.indexOf('--coverage') < 0) {
   argv.push('--watch');


### PR DESCRIPTION
## Commit Message For Review

Spreads object supplied as `dangerouslySetJestConfig` in `sku.config.js` onto the existing jest config when running `sku test`.

RFC URL:

https://github.com/seek-oss/sku/issues/60

REASON FOR CHANGE:

Currently sku's jest configuration is hard coded, so there's no recourse for use cases outside that configuration (eg passing a novel module name to `identity-obj-proxy`).  This change allows apps with those use cases to continue using sku, without sku needing to prematurely annoint any such use cases with a formal api.

EXAMPLE USAGE:

```js
module.exports = {
  entry: {
    client: 'src/client.js',
    server: 'src/server/server.js'
  },
  public: 'src/public',
  target: 'dist',
  port: 3300,
  compilePackages: ['awesome-components'],
  dangerouslySetJestConfig: {
    moduleNameMapper: {
      '(seek-style-guide/react|awesome-components|.(css|less)$)': require.resolve(
          'identity-obj-proxy'
      ),
      '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|svg)$': 'MOCK_FILE'
    }
  }
};

```