### PR TITLE
fix(start): Fix dev server callback

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -15,13 +15,14 @@ const devServer = new WebpackDevServer(compiler, {
   allowedHosts: hosts
 });
 
-devServer.listen(port, (err, result) => {
+devServer.listen(port, '127.0.0.1', (err, result) => {
   if (err) {
     return console.log(err);
   }
 
   const url = `http://${hosts[0]}:${port}`;
 
+  console.log();
   console.log(`Starting the development server on ${url}...`);
   console.log();
 


### PR DESCRIPTION
## Commit Message For Review

We were missing the hostname argument, which meant that the dev server callback wasn't running. This change has been tested with custom hostnames and it works, even though it's set to 127.0.0.1, which they use in their example.