### PR TITLE
chore(babel): upgrade from es2015 preset to env preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This tool is heavily inspired by other work, most notably:
 
 Use `import`, `const`, `=>`, rest/spread operators, destructuring, classes with class properties, [JSX](https://facebook.github.io/react/docs/jsx-in-depth.html) and all their friends in your code.  It'll all just work, thanks to the following Babel plugins:
 
-* [babel-preset-es2015](https://babeljs.io/docs/plugins/preset-es2015/)
+* [babel-preset-env](https://babeljs.io/docs/plugins/preset-env/)
 * [babel-preset-react](https://babeljs.io/docs/plugins/preset-react/)
 * [babel-preset-react-optimize](https://github.com/thejameskyle/babel-react-optimize)
 * [babel-plugin-transform-object-rest-spread](https://babeljs.io/docs/plugins/transform-object-rest-spread/)

--- a/config/babel/babel.config.js
+++ b/config/babel/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = ({ webpack }) => {
-  const es2015Options = webpack ? { modules: false } : {};
+  const envPresetOptions = webpack ? { modules: false } : {};
   const plugins = [
     require.resolve('babel-plugin-transform-class-properties'),
     require.resolve('babel-plugin-transform-object-rest-spread'),
@@ -26,7 +26,7 @@ module.exports = ({ webpack }) => {
   return {
     babelrc: false,
     presets: [
-      [require.resolve('babel-preset-es2015'), es2015Options],
+      [require.resolve('babel-preset-env'), envPresetOptions],
       require.resolve('babel-preset-react')
     ],
     plugins,

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -165,7 +165,7 @@ const buildWebpackConfigs = builds.map(
                   loader: require.resolve('babel-loader'),
                   options: {
                     babelrc: false,
-                    presets: [require.resolve('babel-preset-es2015')]
+                    presets: [require.resolve('babel-preset-env')]
                   }
                 }
               ]

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "babel-plugin-transform-class-properties": "^6.22.0",
     "babel-plugin-transform-imports": "^1.1.0",
     "babel-plugin-transform-object-rest-spread": "^6.22.0",
-    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.22.0",
     "babel-preset-react-optimize": "^1.0.1",
     "bluebird": "^3.5.0",


### PR DESCRIPTION
## Commit Message For Review

Replaces `babel-preset-es2015` with `babel-preset-env`

REASON FOR CHANGE:

Installing `babel-preset-es2015` currently spams an emoji-laden deprecation message, which is good for all consumers to remove.  Furthermore, at least one consumer has a use case for async/await.