### PR TITLE
ci(travis): Remove Travis CI Node version config, use nvmrc instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ cache:
     - node_modules
 notifications:
   email: false
-node_js:
-  - '7'
-  - '6'
 before_script:
   - npm prune
 after_success:


### PR DESCRIPTION
Semantic-release requires Node 8, but the nvmrc file was being ignored.