### PR TITLE
feat(Format): Updated and locked prettier version to 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "opn": "^5.1.0",
     "postcss-js": "^1.0.1",
     "postcss-loader": "^2.0.7",
-    "prettier": "^1.7.4",
+    "prettier": "1.8.2",
     "raw-loader": "^0.5.1",
     "static-site-generator-webpack-plugin": "^3.4.1",
     "string-replace-loader": "^1.3.0",


### PR DESCRIPTION
Prettier version changes can often break builds that use it, even patch updates, as even the slightest whitespace change breaks the build.
For this reason I suggest we lock Prettier to a single version, not even allowing patch updates.

This change includes and upgrade to the current latest Prettier version 1.8.2.

New prettier version may result in changes to code format. Inaccurate code formatting may break the build step.
Run `sku format` and commit the resulting changes to fix the build.

## Commit for review
feat(Format): Updated and locked prettier version to 1.8.2