### PR TITLE
style(prettier): Rename reserved word ‘package’ to ‘packageName’

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: node_js
-cache:
-  directories:
-    - node_modules
 notifications:
   email: false
 before_script:

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -16,18 +16,20 @@ const jsLoaders = [
   }
 ];
 
-const packageToClassPrefix = name =>
-  `__${name
+const packageNameToClassPrefix = packageName =>
+  `__${packageName
     .match(/([^\/]*)$/)[0]
     .toUpperCase()
     .replace(/[\/\-]/g, '_')}__`;
 
 const makeCssLoaders = (options = {}) => {
-  const { server = false, package = '', js = false } = options;
+  const { server = false, packageName = '', js = false } = options;
 
   const debugIdent = isProductionBuild
     ? ''
-    : `${package ? packageToClassPrefix(package) : ''}[name]__[local]___`;
+    : `${
+        packageName ? packageNameToClassPrefix(packageName) : ''
+      }[name]__[local]___`;
 
   const cssInJsLoaders = [
     { loader: require.resolve('css-in-js-loader') },
@@ -179,12 +181,12 @@ const buildWebpackConfigs = builds.map(
                 use: makeCssLoaders()
               })
             },
-            ...paths.compilePackages.map(package => ({
+            ...paths.compilePackages.map(packageName => ({
               test: /\.less$/,
-              include: package,
+              include: packageName,
               use: ExtractTextPlugin.extract({
                 fallback: 'style-loader',
-                use: makeCssLoaders({ package })
+                use: makeCssLoaders({ packageName })
               })
             })),
             {
@@ -239,10 +241,10 @@ const buildWebpackConfigs = builds.map(
               exclude: /node_modules/,
               use: makeCssLoaders({ server: true })
             },
-            ...paths.compilePackages.map(package => ({
+            ...paths.compilePackages.map(packageName => ({
               test: /\.less$/,
-              include: package,
-              use: makeCssLoaders({ server: true, package })
+              include: packageName,
+              use: makeCssLoaders({ server: true, packageName })
             })),
             {
               test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -17,18 +17,20 @@ const jsLoaders = [
   }
 ];
 
-const packageToClassPrefix = name =>
-  `__${name
+const packageNameToClassPrefix = packageName =>
+  `__${packageName
     .match(/([^\/]*)$/)[0]
     .toUpperCase()
     .replace(/[\/\-]/g, '_')}__`;
 
 const makeCssLoaders = (options = {}) => {
-  const { server = false, package = '', js = false } = options;
+  const { server = false, packageName = '', js = false } = options;
 
   const debugIdent = isProductionBuild
     ? ''
-    : `${package ? packageToClassPrefix(package) : ''}[name]__[local]___`;
+    : `${
+        packageName ? packageNameToClassPrefix(packageName) : ''
+      }[name]__[local]___`;
 
   const cssInJsLoaders = [
     { loader: require.resolve('css-in-js-loader') },
@@ -198,14 +200,14 @@ const buildWebpackConfigs = builds.map(
                     use: makeCssLoaders()
                   })
             },
-            ...paths.compilePackages.map(package => ({
+            ...paths.compilePackages.map(packageName => ({
               test: /\.less$/,
-              include: package,
+              include: packageName,
               use: isStartScript
-                ? makeCssLoaders({ package })
+                ? makeCssLoaders({ packageName })
                 : ExtractTextPlugin.extract({
                     fallback: 'style-loader',
-                    use: makeCssLoaders({ package })
+                    use: makeCssLoaders({ packageName })
                   })
             })),
             {
@@ -275,10 +277,10 @@ const buildWebpackConfigs = builds.map(
               exclude: /node_modules/,
               use: makeCssLoaders({ server: true })
             },
-            ...paths.compilePackages.map(package => ({
+            ...paths.compilePackages.map(packageName => ({
               test: /\.less$/,
-              include: package,
-              use: makeCssLoaders({ server: true, package })
+              include: packageName,
+              use: makeCssLoaders({ server: true, packageName })
             })),
             {
               test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],


### PR DESCRIPTION
Went to introduce an svgo-related bug fix, and tripped over a Prettier issue where it only threw an error for the reserved word 'package' once I'd actually made a change to the file.

While I was at it, to ensure we're always building against the latest version of Prettier (among others), I disabled package-lock.json and Travis CI node modules caching.