### PR TITLE
feat(eslint): Add dangerouslySetESLintConfig

### DIFF
--- a/config/builds.js
+++ b/config/builds.js
@@ -54,6 +54,8 @@ const builds = buildConfigs
       buildConfig.dangerouslySetWebpackConfig || defaultDecorator;
     const jestDecorator =
       buildConfig.dangerouslySetJestConfig || defaultDecorator;
+    const eslintDecorator =
+      buildConfig.dangerouslySetEslintConfig || defaultDecorator;
 
     const paths = {
       src: path.join(cwd, 'src'),
@@ -76,6 +78,7 @@ const builds = buildConfigs
       locales,
       webpackDecorator,
       jestDecorator,
+      eslintDecorator,
       hosts,
       port
     };

--- a/config/builds.js
+++ b/config/builds.js
@@ -55,7 +55,7 @@ const builds = buildConfigs
     const jestDecorator =
       buildConfig.dangerouslySetJestConfig || defaultDecorator;
     const eslintDecorator =
-      buildConfig.dangerouslySetEslintConfig || defaultDecorator;
+      buildConfig.dangerouslySetESLintConfig || defaultDecorator;
 
     const paths = {
       src: path.join(cwd, 'src'),

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -1,12 +1,19 @@
 const chalk = require('chalk');
 const baseConfig = require('eslint-config-sku');
 const EslintCLI = require('eslint').CLIEngine;
+const builds = require('../config/builds');
 
 const prettierCheck = require('../lib/runPrettier').check;
 const prettierConfig = require('../config/prettier/prettierConfig');
 
+// Decorate eslint config is not supported for monorepo
+const eslintConfig =
+  builds.length === 1
+    ? builds[0].eslintDecorator(baseConfig)
+    : baseConfig;
+
 const cli = new EslintCLI({
-  baseConfig,
+  baseConfig: eslintConfig,
   useEslintrc: false
 });
 

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -8,9 +8,7 @@ const prettierConfig = require('../config/prettier/prettierConfig');
 
 // Decorate eslint config is not supported for monorepo
 const eslintConfig =
-  builds.length === 1
-    ? builds[0].eslintDecorator(baseConfig)
-    : baseConfig;
+  builds.length === 1 ? builds[0].eslintDecorator(baseConfig) : baseConfig;
 
 const cli = new EslintCLI({
   baseConfig: eslintConfig,

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -1,5 +1,5 @@
 const chalk = require('chalk');
-const baseConfig = require('eslint-config-sku');
+const baseESlintConfig = require('eslint-config-sku');
 const EslintCLI = require('eslint').CLIEngine;
 const builds = require('../config/builds');
 
@@ -8,7 +8,9 @@ const prettierConfig = require('../config/prettier/prettierConfig');
 
 // Decorate eslint config is not supported for monorepo
 const eslintConfig =
-  builds.length === 1 ? builds[0].eslintDecorator(baseConfig) : baseConfig;
+  builds.length === 1
+    ? builds[0].eslintDecorator(baseESlintConfig)
+    : baseESlintConfig;
 
 const cli = new EslintCLI({
   baseConfig: eslintConfig,


### PR DESCRIPTION
Allow consumers to override eslint config similarly to what we currently allow for jest and webpack. This is required in our use case as we wish to add a couple variables to the globals.

**sku.config.js**
```js
const dangerouslySetESLintConfig = config => {
  const eslintOverrides = {
    globals: {
      shallow: true,
      render: true
    }
  };

  return Object.assign(config, eslintOverrides);
};

module.exports = {
  ...,
  dangerouslySetESLintConfig
}
```
