### PR TITLE
fix(svg): Disable SVGO removeViewBox plugin

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -93,6 +93,9 @@ const svgLoaders = [
           addAttributesToSVGElement: {
             attribute: 'focusable="false"'
           }
+        },
+        {
+          removeViewBox: false
         }
       ]
     }

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -95,6 +95,9 @@ const svgLoaders = [
           addAttributesToSVGElement: {
             attribute: 'focusable="false"'
           }
+        },
+        {
+          removeViewBox: false
         }
       ]
     }


### PR DESCRIPTION
The latest version of SVGO now enables the `removeViewBox` plugin by default, but we've found that it causes issues with certain images when embedding the SVG markup directly in the document.

If you're interested, you can see the plugin source here: https://github.com/svg/svgo/blob/master/plugins/removeViewBox.js