### PR TITLE
feat(lint): Add support for lint-staged style arguments

### DIFF
--- a/config/eslint/defaultPath.js
+++ b/config/eslint/defaultPath.js
@@ -1,0 +1,1 @@
+module.exports = 'src';

--- a/config/prettier/defaultPath.js
+++ b/config/prettier/defaultPath.js
@@ -1,0 +1,1 @@
+module.exports = 'src/**/*.js';

--- a/lib/runPrettier.js
+++ b/lib/runPrettier.js
@@ -3,8 +3,6 @@ const path = require('path');
 
 const cwd = process.cwd();
 
-const filePattern = 'src/**/*.js';
-
 /*
  * Prettier must be ran from
  * command line to make use of command line output.
@@ -17,12 +15,12 @@ const getPrettierBinLocation = () => {
   );
 };
 
-const runPrettier = ({ write, listDifferent, config }) => {
+const runPrettier = ({ write, listDifferent, config, filePattern }) => {
   const prettierConfig = config || {};
 
   const prettierBinPath = getPrettierBinLocation();
 
-  const prettierArgs = [filePattern];
+  const prettierArgs = [];
 
   if (prettierConfig.singleQuote) {
     prettierArgs.push('--single-quote');
@@ -43,7 +41,11 @@ const runPrettier = ({ write, listDifferent, config }) => {
     stdio: 'inherit'
   };
 
-  const prettierProcess = spawn(prettierBinPath, prettierArgs, processOptions);
+  const prettierProcess = spawn(
+    prettierBinPath,
+    prettierArgs.concat(filePattern),
+    processOptions
+  );
 
   return new Promise((resolve, reject) => {
     prettierProcess.on('exit', exitCode => {
@@ -57,6 +59,6 @@ const runPrettier = ({ write, listDifferent, config }) => {
 };
 
 module.exports = {
-  check: config => runPrettier({ listDifferent: true, config }),
-  write: config => runPrettier({ write: true, config })
+  check: (filePattern, config) => runPrettier({ listDifferent: true, config, filePattern }),
+  write: (filePattern, config) => runPrettier({ write: true, config, filePattern })
 };

--- a/scripts/format.js
+++ b/scripts/format.js
@@ -3,9 +3,14 @@ const chalk = require('chalk');
 const prettierWrite = require('../lib/runPrettier').write;
 const prettierConfig = require('../config/prettier/prettierConfig');
 
+const args = process.argv.slice(2);
+
 console.log(chalk.cyan('Formatting source code with Prettier'));
 
-prettierWrite(prettierConfig)
+const defaultFilePattern = 'src/**/*.js';
+const filePattern = args.length === 0 ? defaultFilePattern : args;
+
+prettierWrite(filePattern, prettierConfig)
   .then(() => {
     console.log(chalk.cyan('Prettier format complete'));
   })

--- a/scripts/format.js
+++ b/scripts/format.js
@@ -3,12 +3,13 @@ const chalk = require('chalk');
 const prettierWrite = require('../lib/runPrettier').write;
 const prettierConfig = require('../config/prettier/prettierConfig');
 
+const defaultPath = require('../config/prettier/defaultPath');
+
 const args = process.argv.slice(2);
 
 console.log(chalk.cyan('Formatting source code with Prettier'));
 
-const defaultFilePattern = 'src/**/*.js';
-const filePattern = args.length === 0 ? defaultFilePattern : args;
+const filePattern = args.length === 0 ? defaultPath : args;
 
 prettierWrite(filePattern, prettierConfig)
   .then(() => {

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -6,6 +6,9 @@ const builds = require('../config/builds');
 const prettierCheck = require('../lib/runPrettier').check;
 const prettierConfig = require('../config/prettier/prettierConfig');
 
+const prettierDefaultPath = require('../config/prettier/defaultPath');
+const eslintDefaultPath = require('../config/eslint/defaultPath');
+
 const args = process.argv.slice(2);
 
 // Decorate eslint config is not supported for monorepo
@@ -19,7 +22,7 @@ const cli = new EslintCLI({
   useEslintrc: false
 });
 
-const pathsToCheck = args.length === 0 ? ['src'] : args;
+const pathsToCheck = args.length === 0 ? [eslintDefaultPath] : args;
 
 const formatter = cli.getFormatter();
 const report = cli.executeOnFiles(pathsToCheck);
@@ -33,8 +36,7 @@ if (report.errorCount > 0) {
 
 console.log(chalk.cyan('Checking Prettier format rules'));
 
-const defaultFilePattern = 'src/**/*.js';
-const filePattern = args.length === 0 ? defaultFilePattern : args;
+const filePattern = args.length === 0 ? prettierDefaultPath : args;
 
 prettierCheck(filePattern, prettierConfig)
   .then(() => {

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -6,6 +6,8 @@ const builds = require('../config/builds');
 const prettierCheck = require('../lib/runPrettier').check;
 const prettierConfig = require('../config/prettier/prettierConfig');
 
+const args = process.argv.slice(2);
+
 // Decorate eslint config is not supported for monorepo
 const eslintConfig =
   builds.length === 1
@@ -17,8 +19,10 @@ const cli = new EslintCLI({
   useEslintrc: false
 });
 
+const pathsToCheck = args.length === 0 ? ['src'] : args;
+
 const formatter = cli.getFormatter();
-const report = cli.executeOnFiles(['src']);
+const report = cli.executeOnFiles(pathsToCheck);
 
 console.log(chalk.cyan('Linting'));
 console.log(formatter(report.results));
@@ -28,7 +32,11 @@ if (report.errorCount > 0) {
 }
 
 console.log(chalk.cyan('Checking Prettier format rules'));
-prettierCheck(prettierConfig)
+
+const defaultFilePattern = 'src/**/*.js';
+const filePattern = args.length === 0 ? defaultFilePattern : args;
+
+prettierCheck(filePattern, prettierConfig)
   .then(() => {
     console.log(chalk.cyan('Prettier format rules passed'));
   })


### PR DESCRIPTION
## Reason
Packages like [lint-staged](https://github.com/okonet/lint-staged) work by passing in each file as a separate argument appended onto the given command.
This works well for eslint, prettier and jest where both allow for [filenames...] in their cli arguments.

As we wrap these calls without passing through arguments we stop the functionality from working.

## Change
All calls still work as before, however if any calls were being passed into `sku format` or `sku lint` commands these will now cause errors. Previously any arguments being sent in would have been ignored.

Currently only the following commands are supported
`sku lint`
`sku format`

`sku test` has some complexity to support and is not required for the current use-case. It would be good to follow up with support for this command in the near future.

Additionally it may be good to consider supporting a precommit hook directly with sku. This change will enable that work.

## EXAMPLE USAGE

package.json
```json
{
  ...
  "scripts": {
    ...
    "precommit": "lint-staged"
  },
  "lint-staged": { "*.js": "lint" }
}
```

If file1.js file2.js and file3.css were changed this would result in a call:
```bash
node lint file1.js file2.js
```
