### PR TITLE
fix(prettier): Update Prettier to v1.9.0, narrow version range

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -115,9 +115,9 @@ const buildWebpackConfigs = builds.map(
 
         if (typeof valueForEnv === 'undefined') {
           console.log(
-            `WARNING: Environment variable "${key}" for build "${
-              name
-            }" is missing a value for the "${args.env}" environment`
+            `WARNING: Environment variable "${key}" for build "${name}" is missing a value for the "${
+              args.env
+            }" environment`
           );
           process.exit(1);
         }
@@ -133,9 +133,9 @@ const buildWebpackConfigs = builds.map(
 
     const entry = [paths.clientEntry];
     const devServerEntries = [
-      `${require.resolve('webpack-dev-server/client')}?http://localhost:${
-        port
-      }/`
+      `${require.resolve(
+        'webpack-dev-server/client'
+      )}?http://localhost:${port}/`
     ];
 
     if (args.script === 'start') {

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -117,9 +117,9 @@ const buildWebpackConfigs = builds.map(
 
         if (typeof valueForEnv === 'undefined') {
           console.log(
-            `WARNING: Environment variable "${key}" for build "${
-              name
-            }" is missing a value for the "${args.env}" environment`
+            `WARNING: Environment variable "${key}" for build "${name}" is missing a value for the "${
+              args.env
+            }" environment`
           );
           process.exit(1);
         }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "opn": "^5.1.0",
     "postcss-js": "^1.0.1",
     "postcss-loader": "^2.0.7",
-    "prettier": "^1.7.4",
+    "prettier": "~1.9.0",
     "raw-loader": "^0.5.1",
     "start-server-webpack-plugin": "^2.2.0",
     "static-site-generator-webpack-plugin": "^3.4.1",


### PR DESCRIPTION
Updating Prettier and reformatting code to match the latest rules.

Because we encourage consumers to validate their code against Prettier, it makes sense for us to narrow the version range to only allow automatic patch updates to reduce the amount of build breakage, since minor upgrades often cause the validation to fail.