### PR TITLE
fix(lint): add eslint as a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "css-loader": "^0.28.7",
     "deasync-promise": "^1.0.1",
     "dir-compare": "^1.4.0",
+    "eslint": "^4.13.1",
     "eslint-config-sku": "^1.2.0",
     "express": "^4.16.2",
     "extract-text-webpack-plugin": "^3.0.1",


### PR DESCRIPTION
Ensure eslint is available in the event that eslint-config-sku removes eslint as a dependency.

https://github.com/seek-oss/eslint-config-sku/issues/14