### PR TITLE
fix(package): Update eslint-config-seek to version 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ Since sku uses Jest as a testing framework, you can read the [Jest documentation
 
 ### Linting and Formatting (via [ESLint](http://eslint.org/) and [Prettier](https://github.com/prettier/prettier))
 
-Running `sku lint` will execute the ESLint rules over the code in your `src` directory. You can see the ESLint rules defined for sku projects in [eslint-config-sku](https://github.com/seek-oss/eslint-config-sku).
+Running `sku lint` will execute the ESLint rules over the code in your `src` directory. You can see the ESLint rules defined for sku projects in [eslint-config-seek](https://github.com/seek-oss/eslint-config-seek).
 
 Adding the following to your package.json file will enable the [Atom ESLint plugin](https://github.com/AtomLinter/linter-eslint) to work correctly with sku.
 
 ```js
 "eslintConfig": {
-  "extends": "sku"
+  "extends": "seek"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "deasync-promise": "^1.0.1",
     "dir-compare": "^1.4.0",
     "eslint": "^4.13.1",
-    "eslint-config-sku": "^1.2.0",
+    "eslint-config-seek": "^3.0.0",
     "express": "^4.16.2",
     "extract-text-webpack-plugin": "^3.0.1",
     "fs-extra": "^4.0.2",

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -1,5 +1,5 @@
 const chalk = require('chalk');
-const baseESlintConfig = require('eslint-config-sku');
+const baseESlintConfig = require('eslint-config-seek');
 const EslintCLI = require('eslint').CLIEngine;
 const builds = require('../config/builds');
 


### PR DESCRIPTION
As of https://github.com/seek-oss/eslint-config-seek/commit/10e9f733bf63769c5f9e87c038de92256affb340
`eslint-config-sku` has been renamed to `eslint-config-seek`.

To enable the rename a major version release was completed.
This change updates to that major version.