### PR TITLE
chore(commitlint): Adopt and update pullapprove config to match

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -8,8 +8,8 @@ groups:
     approve_by_comment:
       enabled: false
     always_rejected:
-      title_regex: '^((?!: ).)*$'
-      explanation: 'Invalid title. Please read the contribution guide: https://github.com/seek-oss/sku/blob/master/CONTRIBUTING.md'
+      title_regex: '^(?!(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+\))?\:\s(\S+)).*$'
+      explanation: 'Invalid PR title. For more information please see https://github.com/seek-oss/commitlint-config-seek'
     reset_on_push:
       enabled: false
     reset_on_reopened:

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -4,7 +4,7 @@ groups:
   reviewers:
     required: 1
     teams:
-      - sku-contributors
+      - front-end-contributors
     approve_by_comment:
       enabled: false
     always_rejected:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ If you work at SEEK and run into issues along the way, or even if you find some 
 
 ## Setup
 
-First, install [Node.js v6+](https://nodejs.org/).
+First, install [Node.js v8+](https://nodejs.org/).
 
 After cloning the project, install the dependencies:
 
@@ -49,7 +49,7 @@ Once you've made the desired changes and you're ready to commit, stage your loca
 
 Before committing, consider the scope of your changes according to [semantic versioning](http://semver.org), noting whether this is a breaking change, a feature release or a patch.
 
-New versions are published automatically from [Travis CI](https://travis-ci.org) using [semantic-release](https://github.com/semantic-release/semantic-release). In order to automatically increment version numbers correctly, commit messages must follow our [semantic commit message convention](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#-git-commit-guidelines). If your commit includes a breaking change, be sure to prefix your commit body with `BREAKING CHANGE: `. To make this process easier, we have a commit script (powered by [commitizen](https://github.com/commitizen/cz-cli)) to help guide you through the commit process:
+New versions are published automatically from [Travis CI](https://travis-ci.org) using [semantic-release](https://github.com/semantic-release/semantic-release). In order to automatically increment version numbers correctly, commit messages must follow our [semantic commit message convention](https://github.com/seek-oss/commitlint-config-seek). If your commit includes a breaking change, be sure to prefix your commit body with `BREAKING CHANGE: `. To make this process easier, we have a commit script (powered by [commitizen](https://github.com/commitizen/cz-cli)) to help guide you through the commit process:
 
 ```bash
 $ npm run commit

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format-check": "prettier --single-quote --list-different '{bin,config,scripts}/**/*.js'",
     "precommit": "lint-staged",
     "commit": "git-cz",
-    "commitmsg": "validate-commit-msg",
+    "commitmsg": "commitlint --edit --extends seek",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "lint-staged": {
@@ -89,13 +89,14 @@
     "webpack-node-externals": "^1.6.0"
   },
   "devDependencies": {
+    "@commitlint/cli": "^6.0.1",
     "commitizen": "^2.9.6",
-    "cz-conventional-changelog": "^2.0.0",
+    "commitlint-config-seek": "^1.0.0",
+    "cz-conventional-changelog": "^2.1.0",
     "husky": "^0.14.3",
     "lint-staged": "^6.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "semantic-release": "^8.0.3",
-    "validate-commit-msg": "^2.14.0"
+    "semantic-release": "^8.0.3"
   }
 }


### PR DESCRIPTION
Adopting [`commitlint`](https://github.com/marionebl/commitlint) in favour of deprecated [`validate-commit-msg`](https://github.com/conventional-changelog-archived-repos/validate-commit-msg) which also allows us to use our centralised [`commitlint-config-seek`](https://github.com/seek-oss/commitlint-config-seek).

Motivation was updating the PullApprove template to enforce semantic commit titles on PRs rather than block them.