### PR TITLE
ci(PullApprove): Require two approvals per PR

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -2,7 +2,7 @@ version: 2
 
 groups:
   reviewers:
-    required: 1
+    required: 2
     teams:
       - front-end-contributors
     approve_by_comment:


### PR DESCRIPTION
The contributor community may now be large enough to support two pull request review approvals before merging.
Ideally the second approver should be from a seperate team to the first.

This helps ensure changes are visible to multiple teams, and works for all consumers.

We lowered this requirement to one in June 2017.
https://github.com/seek-oss/sku/pull/30