### PR TITLE
chore(pullapprove): Align PullApprove title regex to commitlint config

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -8,7 +8,7 @@ groups:
     approve_by_comment:
       enabled: false
     always_rejected:
-      title_regex: '^(?!(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+\))?\:\s(\S+)).*$'
+      title_regex: '^(?!(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+\))?\:\s[A-Z]).*$'
       explanation: 'Invalid PR title. For more information please see https://github.com/seek-oss/commitlint-config-seek'
     reset_on_push:
       enabled: false


### PR DESCRIPTION
Aligning the regex used by PullApprove for PR title validation to enforce the same rules as `commitlint-config-seek`. The difference is only to enforce the subject is in sentence case.
  