### PR TITLE
ci(publish): Cause build to fail on deploy error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: node_js
+
 notifications:
   email: false
+
 before_script:
   - npm prune
-after_success:
-  - npm run semantic-release
-branches:
-  except:
-    - /^v\d+\.\d+\.\d+$/
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    - npm run semantic-release
+  on:
+    branch: master

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "precommit": "lint-staged",
     "commit": "git-cz",
     "commitmsg": "commitlint --edit --extends seek",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release"
   },
   "lint-staged": {
     "{bin,config,scripts}/**/*.js": [
@@ -98,6 +98,6 @@
     "lint-staged": "^6.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "semantic-release": "^8.0.3"
+    "semantic-release": "^15.0.1"
   }
 }


### PR DESCRIPTION
`after_success` command will not fail the build when errors occur during deployment.
This was beneficial as older versions of semantic-release caused errors to be thrown when no-release was required.
The current version of semantic-release no-longer returns an error.

This change will ensure errors, such as a misconfigured access token will show as a build error.

This change also sets the build to only deploy for `master` branch. Semantic-release will already only deploy on `master` branch by default, however it might be good to make this restriction explicit. [branch configuration semantic-release](https://github.com/semantic-release/semantic-release/blob/caribou/docs/usage/configuration.md#branch)