### PR TITLE
feat(babel): Added support for decorators

### DIFF
--- a/config/babel/babelConfig.js
+++ b/config/babel/babelConfig.js
@@ -16,6 +16,7 @@ module.exports = ({ target }) => {
 
   const envPresetOptions = isWebpack ? webpackEnvOptions : nodeEnvOptions;
   const plugins = [
+    require.resolve('babel-plugin-transform-decorators-legacy'),
     require.resolve('babel-plugin-transform-class-properties'),
     require.resolve('babel-plugin-transform-object-rest-spread'),
     [

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-plugin-flow-react-proptypes": "^10.0.0",
     "babel-plugin-module-resolver": "^3.0.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-imports": "^1.4.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.0",


### PR DESCRIPTION
This change adds support for decorators using [transform-decorators-legacy](https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy)

Updating on the state of Decorators:
[According to Babel](https://babeljs.io/docs/plugins/transform-decorators/) decorators we'll have built-in support in Babel 7 Stage-0
This is important as some changes to `babel-plugin-transform-class-properties` may result in breaking of the legacy solution.
[See: Stage 3: Class Properties (from Stage 2)](https://babeljs.io/blog/2017/09/12/planning-for-7.0)