### PR TITLE
feat(flow): Flow proptypes and flow type stripping

### DIFF
--- a/config/babel/babelConfig.js
+++ b/config/babel/babelConfig.js
@@ -18,6 +18,8 @@ module.exports = ({ target }) => {
   const plugins = [
     require.resolve('babel-plugin-transform-class-properties'),
     require.resolve('babel-plugin-transform-object-rest-spread'),
+    require.resolve('babel-plugin-flow-react-proptypes'),
+    require.resolve('babel-plugin-transform-flow-strip-types'),
     [
       require.resolve('babel-plugin-module-resolver'),
       {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-plugin-flow-react-proptypes": "^10.0.0",
     "babel-plugin-module-resolver": "^3.0.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-plugin-transform-imports": "^1.4.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.0",


### PR DESCRIPTION
## Purpose

As we'll be adding flow type proptypes to the style guide, the loaders for sku
will need to be able to strip those types but also transform them to proptypes.

## Approach

Have added them to the babelConfig which I believe gets used by the webpack config. They will be needed both server side and client side.