### PR TITLE
feat(config): Add param to support custom config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ If you need to specify a different config file you can do so with the `--config`
 $ sku start --config sku.custom.config.js
 ```
 
-_**NOTE:** The `--config` parameter is only used for dev (`sku start`) and build steps (`sku build`). Linting (`sku lint`) and unit test (`sku test`) will still use the default config file and does **not** support it._
+_**NOTE:** The `--config` parameter is only used for dev (`sku start`) and build steps (`sku build`). Linting (`sku lint`), formatting (`sku format`) and running of unit tests (`sku test`) will still use the default config file and does **not** support it._
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,14 @@ module.exports = {
 }
 ```
 
+If you need to specify a different config path/name you can do so with the `--config` parameter.
+
+```bash
+$ sku start --config sku.custom.config.js
+```
+
+_**NOTE:** The `--config` parameter is only used for dev (`sku start`) and build steps (`sku build`). Linting (`sku lint`) and unit test (`sku test`) will still use the default config file and does **not** support it._
+
 ### Environment Variables
 
 By default, `process.env.NODE_ENV` is handled correctly for you and provided globally, even to your client code. This is based on the sku script that's currently being executed, so `NODE_ENV` is `'development'` when running `sku start`, but `'production'` when running `sku build`.

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ module.exports = {
 }
 ```
 
-If you need to specify a different config path/name you can do so with the `--config` parameter.
+If you need to specify a different config file you can do so with the `--config` parameter.
 
 ```bash
 $ sku start --config sku.custom.config.js

--- a/config/args.js
+++ b/config/args.js
@@ -24,6 +24,12 @@ const optionDefinitions = [
     name: 'build',
     alias: 'b',
     type: String
+  },
+  {
+    name: 'config',
+    alias: 'c',
+    type: String,
+    defaultValue: 'sku.config.js'
   }
 ];
 
@@ -42,5 +48,6 @@ module.exports = {
   script: scriptName,
   buildName: scriptName === 'start' ? buildName() : null,
   env: scriptName === 'start' ? 'development' : options.env,
-  tenant: options.tenant
+  tenant: options.tenant,
+  config: options.config
 };

--- a/config/builds.js
+++ b/config/builds.js
@@ -3,8 +3,8 @@ const path = require('path');
 const fs = require('fs');
 const inquirer = require('inquirer');
 const deasyncPromise = require('deasync-promise');
-const skuConfigPath = path.join(cwd, 'sku.config.js');
 const args = require('./args');
+const skuConfigPath = path.join(cwd, args.config);
 
 const makeArray = x => (Array.isArray(x) ? x : [x]);
 const buildConfigs = fs.existsSync(skuConfigPath)


### PR DESCRIPTION
Add support for custom config file via newly created `--config` parameter.

```js
sku start --config sku.custom.config.js
```

_**NOTE:** The `--config` parameter is only used for dev (`sku start`) and build steps (`sku build`). Linting (`sku lint`), formatting (`sku format`) and running of unit test (`sku test`) will still use the default config file and does **not** support it._