### PR TITLE
feat(build): Support custom file output

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,20 @@ $ sku start --config sku.custom.config.js
 
 _**NOTE:** The `--config` parameter is only used for dev (`sku start`) and build steps (`sku build`). Linting (`sku lint`), formatting (`sku format`) and running of unit tests (`sku test`) will still use the default config file and does **not** support it._
 
+### Filename
+
+Build artefacts are created according to the naming convention set by `outputFilename` and `outputCssFilename`.
+
+Option | Default value
+-------|-------
+outputFilename | `[name].js`
+outputCssFilename | `style.css`
+publicPath | `/`
+
+See [Webpack output.filename](https://webpack.js.org/configuration/output/#output-filename) for available filename conventions.
+
+See [Webpack publicPath](https://webpack.js.org/guides/public-path/) for details on publicPath.
+
 ### Environment Variables
 
 By default, `process.env.NODE_ENV` is handled correctly for you and provided globally, even to your client code. This is based on the sku script that's currently being executed, so `NODE_ENV` is `'development'` when running `sku start`, but `'production'` when running `sku build`.

--- a/config/builds.js
+++ b/config/builds.js
@@ -48,6 +48,14 @@ const builds = buildConfigs
     const compilePackages = buildConfig.compilePackages || [];
     const hosts = buildConfig.hosts || ['localhost'];
 
+    const outputFilename = buildConfig.outputFilename || '[name].js';
+    const outputCssFilename = buildConfig.outputCssFilename || 'style.css';
+    const publicPath = buildConfig.publicPath || '';
+    const historyApiFallback =
+      buildConfig.historyApiFallback !== undefined
+        ? buildConfig.historyApiFallback
+        : true;
+
     const port = buildConfig.port || 8080;
 
     const webpackDecorator =
@@ -77,6 +85,10 @@ const builds = buildConfigs
       paths,
       locales,
       webpackDecorator,
+      outputFilename,
+      outputCssFilename,
+      historyApiFallback,
+      publicPath,
       jestDecorator,
       eslintDecorator,
       hosts,

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -4,12 +4,12 @@ const webpackConfig = require('../config/webpack/webpack.config');
 const builds = require('../config/builds');
 const opn = require('opn');
 
-const { hosts, port } = builds[0];
+const { hosts, port, historyApiFallback } = builds[0];
 
 const compiler = webpack(webpackConfig);
 const devServer = new WebpackDevServer(compiler, {
   contentBase: builds.map(({ paths }) => paths.public),
-  historyApiFallback: true,
+  historyApiFallback,
   overlay: true,
   stats: 'errors-only',
   allowedHosts: hosts


### PR DESCRIPTION
# Custom file naming
`sku build` currently hard-codes asset names according to the naming convention '[name].js' and 'style.css'.

This change allows the consumer to provide a name that includes '[chunkHash]' or other values to support more fine-grain cache controls.

The new behaviour is optional, and if not set the default behaviour remains the same. Later changes may work to change the default behaviour after a migratory period.

### Example
**File level versioning**
``` javascript
const skuConfig = {
  outputFilename: '[name]-[chunkhash].js',
  outputCssFilename: '[name]-[chunkhash].css',
  publicPath: isProductionBuild ? 'https://seekcdn.com/fooSite/barApp/' : '/'
};
```

**Folder level versioning**
``` javascript

const UI_VERSION = process.env.BUILD_NUMBER
const skuConfig = {
  outputFilename: '[name].js',
  outputCssFilename: '[name].css',
  publicPath: isProductionBuild ? `https://seekcdn.com/fooSite/barApp/${UI_VERSION}/` : '/'
};
```

# Filenames with multiple webpack builds
Currently `sku` consumers hardcode a script name, such as `main.js` into the render script, this cannot be done with dynamic asset naming.

This change combines the currently separated 'client' an 'render' configurations into a single configuration. This allows the 'render' function to have access to the assets produced, allowing the direct use of the file names.

**Note:** This change affects out ability to support `process.env.{key}` variables such as SKU_ENV. A backwards compatible fix has not been found yet.

### Example
``` javascript
export default ({ assets }) => {
  return `<!DOCTYPE html>
    <html>
      <body>
        <div id="app">${appHtml}</div>
        <script type="text/javascript" src="/${assets.client}"></script>
      </body>
    </html>`;
}
```

# API Changes

This change involves proposing the following additional parameters available for sku.config

Documented in README.md:
- outputFilename
- outputCssFilename
- publicPath

Undocumented / not currently recommended behaviour:
- historyApiFallback