### PR TITLE
fix(less): Ensure only a single set of style loaders is used

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -178,20 +178,23 @@ const buildWebpackConfigs = builds.map(
             },
             {
               test: /\.less$/,
-              exclude: /node_modules/,
-              use: ExtractTextPlugin.extract({
-                fallback: 'style-loader',
-                use: makeCssLoaders()
-              })
+              oneOf: [
+                ...paths.compilePackages.map(packageName => ({
+                  include: packageName,
+                  use: ExtractTextPlugin.extract({
+                    fallback: 'style-loader',
+                    use: makeCssLoaders({ packageName })
+                  })
+                })),
+                {
+                  exclude: /node_modules/,
+                  use: ExtractTextPlugin.extract({
+                    fallback: 'style-loader',
+                    use: makeCssLoaders()
+                  })
+                }
+              ]
             },
-            ...paths.compilePackages.map(packageName => ({
-              test: /\.less$/,
-              include: packageName,
-              use: ExtractTextPlugin.extract({
-                fallback: 'style-loader',
-                use: makeCssLoaders({ packageName })
-              })
-            })),
             {
               test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
               use: makeImageLoaders()
@@ -241,14 +244,18 @@ const buildWebpackConfigs = builds.map(
             },
             {
               test: /\.less$/,
-              exclude: /node_modules/,
-              use: makeCssLoaders({ server: true })
+              oneOf: [
+                ...paths.compilePackages.map(packageName => ({
+                  include: packageName,
+                  use: makeCssLoaders({ server: true, packageName })
+                })),
+                {
+                  exclude: /node_modules/,
+                  use: makeCssLoaders({ server: true })
+                }
+              ]
             },
-            ...paths.compilePackages.map(packageName => ({
-              test: /\.less$/,
-              include: packageName,
-              use: makeCssLoaders({ server: true, packageName })
-            })),
+
             {
               test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
               use: makeImageLoaders({ server: true })

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -195,24 +195,27 @@ const buildWebpackConfigs = builds.map(
             },
             {
               test: /\.less$/,
-              exclude: /node_modules/,
-              use: isStartScript
-                ? makeCssLoaders()
-                : ExtractTextPlugin.extract({
-                    fallback: 'style-loader',
-                    use: makeCssLoaders()
-                  })
+              oneOf: [
+                ...paths.compilePackages.map(packageName => ({
+                  include: packageName,
+                  use: isStartScript
+                    ? makeCssLoaders({ packageName })
+                    : ExtractTextPlugin.extract({
+                        fallback: 'style-loader',
+                        use: makeCssLoaders({ packageName })
+                      })
+                })),
+                {
+                  exclude: /node_modules/,
+                  use: isStartScript
+                    ? makeCssLoaders()
+                    : ExtractTextPlugin.extract({
+                        fallback: 'style-loader',
+                        use: makeCssLoaders()
+                      })
+                }
+              ]
             },
-            ...paths.compilePackages.map(packageName => ({
-              test: /\.less$/,
-              include: packageName,
-              use: isStartScript
-                ? makeCssLoaders({ packageName })
-                : ExtractTextPlugin.extract({
-                    fallback: 'style-loader',
-                    use: makeCssLoaders({ packageName })
-                  })
-            })),
             {
               test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
               use: makeImageLoaders()
@@ -277,14 +280,18 @@ const buildWebpackConfigs = builds.map(
             },
             {
               test: /\.less$/,
-              exclude: /node_modules/,
-              use: makeCssLoaders({ server: true })
+              oneOf: [
+                ...paths.compilePackages.map(packageName => ({
+                  include: packageName,
+                  use: makeCssLoaders({ server: true, packageName })
+                })),
+                {
+                  exclude: /node_modules/,
+                  use: makeCssLoaders({ server: true })
+                }
+              ]
             },
-            ...paths.compilePackages.map(packageName => ({
-              test: /\.less$/,
-              include: packageName,
-              use: makeCssLoaders({ server: true, packageName })
-            })),
+
             {
               test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
               use: makeImageLoaders({ server: true })


### PR DESCRIPTION
Currently sku creates a webpack configuration which loads loaders to handle .less files via multiple configurations.
The configurations all use exclusive include or exclude values that should mean no two set of loaders are loaded at one time.

Unfortunately, due to complexity in testing with symlink directories (created by `npm link` or `yarn link`) combined with the Babel's Resolve plugin it is possible for multiple sets of loaders to run, causing a build error.

[oneOf](https://webpack.js.org/configuration/module/#rule-oneof) will ensure a single set of style loaders is used at one time.