### PR TITLE
test(manual): Add manual test script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.snap]
+trim_trailing_whitespace = false

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "test": "npm run format-check && OPEN_TAB=false jest test/test-cases/*/*.test.js",
+    "test-manual": "node test/manual",
     "format": "prettier --single-quote --write '{bin,config,scripts}/**/*.js'",
     "format-check": "prettier --single-quote --list-different '{bin,config,scripts}/**/*.js'",
     "precommit": "lint-staged",
@@ -97,6 +98,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^6.0.1",
+    "async-disk-cache": "^1.3.3",
     "child-process-promise": "^2.2.1",
     "commitizen": "^2.9.6",
     "commitlint-config-seek": "^1.0.0",

--- a/test/manual.js
+++ b/test/manual.js
@@ -1,0 +1,56 @@
+const pkg = require('../package.json');
+const Cache = require('async-disk-cache');
+const inquirer = require('inquirer');
+const { promisify } = require('es6-promisify');
+const readdirAsync = promisify(require('fs').readdir);
+const path = require('path');
+const runSkuScriptInDir = require('./utils/runSkuScriptInDir');
+
+const cache = new Cache(pkg.name);
+const LAST_TEST_CASE = 'lastTestCase';
+const LAST_SCRIPT = 'lastScript';
+
+const runScriptForTestCase = (script, testCase) => {
+  return runSkuScriptInDir(script, path.join(__dirname, 'test-cases', testCase));
+};
+
+(async () => {
+  const { value: lastTestCase } = await cache.get(LAST_TEST_CASE);
+  const { value: lastScript } = await cache.get(LAST_SCRIPT);
+
+  if (lastTestCase && lastScript) {
+    const { useLast } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'useLast',
+        message: `Re-run "${lastTestCase}" with "sku ${lastScript}"?`
+      }
+    ]);
+
+    if (useLast) {
+      return await runScriptForTestCase(lastScript, lastTestCase);
+    }
+  }
+
+  const testCases = await readdirAsync(path.join(__dirname, 'test-cases'));
+
+  const { testCase, script } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'testCase',
+      message: 'Which case would you like to manually test?',
+      choices: testCases
+    },
+    {
+      type: 'list',
+      name: 'script',
+      message: 'Which sku script would you like to run?',
+      choices: ['start', 'start-ssr', 'build', 'build-ssr']
+    }
+  ]);
+
+  await cache.set(LAST_TEST_CASE, testCase);
+  await cache.set(LAST_SCRIPT, script);
+
+  await runScriptForTestCase(script, testCase);
+})();


### PR DESCRIPTION
This allows you to easily start or build any of the test cases. I've even added a nifty little disk-based cache in there which remembers your last choice, making it a bit easier to iterate on a single test case.