### PR TITLE
refactor(babel): Simplify Babel config logic

### DIFF
--- a/config/babel/babelConfig.js
+++ b/config/babel/babelConfig.js
@@ -1,6 +1,6 @@
 const supportedBrowsers = require('../browsers/supportedBrowsers');
 
-const webpackEnvOptions = {
+const browserEnvOptions = {
   modules: false,
   targets: supportedBrowsers
 };
@@ -11,10 +11,10 @@ const nodeEnvOptions = {
   }
 };
 
-module.exports = ({ target, convertDynamicImportToRequire }) => {
-  const isWebpack = target === 'webpack';
+module.exports = ({ target }) => {
+  const isBrowser = target === 'browser';
 
-  const envPresetOptions = isWebpack ? webpackEnvOptions : nodeEnvOptions;
+  const envPresetOptions = isBrowser ? browserEnvOptions : nodeEnvOptions;
   const plugins = [
     require.resolve('babel-plugin-syntax-dynamic-import'),
     require.resolve('babel-plugin-transform-class-properties'),
@@ -29,11 +29,9 @@ module.exports = ({ target, convertDynamicImportToRequire }) => {
     ]
   ];
 
-  if (isWebpack) {
+  if (isBrowser) {
     plugins.push(require.resolve('babel-plugin-seek-style-guide'));
-  }
-
-  if (convertDynamicImportToRequire) {
+  } else {
     plugins.push(require.resolve('babel-plugin-dynamic-import-node'));
   }
 

--- a/config/jest/babelTransform.js
+++ b/config/jest/babelTransform.js
@@ -1,6 +1,4 @@
 const babelJest = require('babel-jest');
 const babelConfig = require('../babel/babelConfig');
 
-module.exports = babelJest.createTransformer(
-  babelConfig({ target: 'node', convertDynamicImportToRequire: true })
-);
+module.exports = babelJest.createTransformer(babelConfig({ target: 'node' }));

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -9,13 +9,10 @@ const path = require('path');
 const supportedBrowsers = require('../browsers/supportedBrowsers');
 const isProductionBuild = process.env.NODE_ENV === 'production';
 
-const makeJsLoaders = ({ convertDynamicImportToRequire = false } = {}) => [
+const makeJsLoaders = ({ target }) => [
   {
     loader: require.resolve('babel-loader'),
-    options: require('../babel/babelConfig')({
-      target: 'webpack',
-      convertDynamicImportToRequire
-    })
+    options: require('../babel/babelConfig')({ target })
   }
 ];
 
@@ -36,7 +33,7 @@ const makeCssLoaders = (options = {}) => {
 
   const cssInJsLoaders = [
     { loader: require.resolve('css-in-js-loader') },
-    ...makeJsLoaders()
+    ...makeJsLoaders({ target: 'node' })
   ];
 
   return (cssLoaders = [
@@ -160,7 +157,7 @@ const buildWebpackConfigs = builds.map(
             {
               test: /(?!\.css)\.js$/,
               include: internalJs,
-              use: makeJsLoaders()
+              use: makeJsLoaders({ target: 'browser' })
             },
             {
               test: /(?!\.css)\.js$/,
@@ -243,7 +240,7 @@ const buildWebpackConfigs = builds.map(
             {
               test: /(?!\.css)\.js$/,
               include: internalJs,
-              use: makeJsLoaders({ convertDynamicImportToRequire: true })
+              use: makeJsLoaders({ target: 'node' })
             },
             {
               test: /\.css\.js$/,

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -11,13 +11,10 @@ const nodeExternals = require('webpack-node-externals');
 const findUp = require('find-up');
 const StartServerPlugin = require('start-server-webpack-plugin');
 
-const makeJsLoaders = ({ convertDynamicImportToRequire = false } = {}) => [
+const makeJsLoaders = ({ target }) => [
   {
     loader: require.resolve('babel-loader'),
-    options: require('../babel/babelConfig')({
-      target: 'webpack',
-      convertDynamicImportToRequire
-    })
+    options: require('../babel/babelConfig')({ target })
   }
 ];
 
@@ -38,7 +35,7 @@ const makeCssLoaders = (options = {}) => {
 
   const cssInJsLoaders = [
     { loader: require.resolve('css-in-js-loader') },
-    ...makeJsLoaders()
+    ...makeJsLoaders({ target: 'node' })
   ];
 
   return (cssLoaders = [
@@ -177,7 +174,7 @@ const buildWebpackConfigs = builds.map(
             {
               test: /(?!\.css)\.js$/,
               include: internalJs,
-              use: makeJsLoaders()
+              use: makeJsLoaders({ target: 'browser' })
             },
             {
               test: /(?!\.css)\.js$/,
@@ -281,7 +278,7 @@ const buildWebpackConfigs = builds.map(
             {
               test: /(?!\.css)\.js$/,
               include: internalJs,
-              use: makeJsLoaders({ convertDynamicImportToRequire: true })
+              use: makeJsLoaders({ target: 'node' })
             },
             {
               test: /\.css\.js$/,


### PR DESCRIPTION
This refactor was part of #134, but since it was closed, I figured it'd still be worth keeping this clean-up work.

This gets rid of the `convertDynamicImportToRequire` flag, and simplifies the code to simply make use of `target`, which is now `browser`/`node` rather than `webpack`/`node`, which was logically incorrect since webpack is sometimes used to target node.