### PR TITLE
feat(polyfills): Support polyfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,18 @@ module.exports = {
 
 Any `node_modules` passed into this option will be compiled through webpack as if they are part of your app.
 
+### Polyfills
+
+Sometime you might need to polyfill a new object or method in browsers that don’t support that object or method, and you might also want polyfill is loaded and executed as part of entry point without your files needing to know about it.
+```js
+module.exports = {
+  polyfills: ['core-js/modules/es6.symbol', 'regenerator-runtime/runtime']
+}
+```
+
+Note: From a performance point of view, you should only send polyfills to browsers that need them.
+
+
 ### Locales
 
 Often we render multiple versions of our application for different locations, eg. Australia & New Zealand. To render an HTML file for each location you can use the locales option in `sku.config.js`. Locales are preferable to [monorepos](#monorepo-support) when you need to render multiple versions of your HTML file but only need one version of each of the assets (JS, CSS, images, etc). Note: You can use `locales` inside a monorepo project.

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Note: Polyfills are only loaded in a browser context. This feature can't be used
 module.exports = {
   ...,
   polyfills: [
+    'promise-polyfill',
     'core-js/modules/es6.symbol',
     'regenerator-runtime/runtime'
   ]

--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ Note: Running `sku start` will always use the `development` environment.
 
 Since sku injects its own code into your bundle in development mode, it's important for polyfills that modify the global environment to be loaded before all other code. To address this, the `polyfills` option allows you to provide an array of modules to import before any other code is executed.
 
+Note: Polyfills are only loaded in a browser context. This feature can't be used to modify the global environment in Node.
+
 ```js
 module.exports = {
   ...,

--- a/README.md
+++ b/README.md
@@ -261,6 +261,20 @@ module.exports = {
 
 Note: Running `sku start` will always use the `development` environment.
 
+### Polyfills
+
+Since sku injects its own code into your bundle in development mode, it's important for polyfills that modify the global environment to be loaded before all other code. To address this, the `polyfills` option allows you to provide an array of modules to import before any other code is executed.
+
+```js
+module.exports = {
+  ...,
+  polyfills: [
+    'core-js/modules/es6.symbol',
+    'regenerator-runtime/runtime'
+  ]
+}
+```
+
 ### Compile Packages
 
 Sometimes you might want to extract and share code between sku projects, but this code is likely to rely on the same tooling and language features that this toolkit provides. A great example of this is [seek-style-guide](https://github.com/seek-oss/seek-style-guide). Out of the box sku supports loading the seek-style-guide but if you need to treat other packages in this way you can use `compilePackages`.
@@ -272,18 +286,6 @@ module.exports = {
 ```
 
 Any `node_modules` passed into this option will be compiled through webpack as if they are part of your app.
-
-### Polyfills
-
-Sometime you might need to polyfill a new object or method in browsers that don’t support that object or method, and you might also want polyfill is loaded and executed as part of entry point without your files needing to know about it.
-```js
-module.exports = {
-  polyfills: ['core-js/modules/es6.symbol', 'regenerator-runtime/runtime']
-}
-```
-
-Note: From a performance point of view, you should only send polyfills to browsers that need them.
-
 
 ### Locales
 

--- a/config/builds.js
+++ b/config/builds.js
@@ -50,6 +50,8 @@ const builds = buildConfigs
 
     const port = buildConfig.port || 8080;
 
+    const polyfills = buildConfig.polyfills || [];
+
     const webpackDecorator =
       buildConfig.dangerouslySetWebpackConfig || defaultDecorator;
     const jestDecorator =
@@ -81,7 +83,8 @@ const builds = buildConfigs
       jestDecorator,
       eslintDecorator,
       hosts,
-      port
+      port,
+      polyfills
     };
   });
 

--- a/config/builds.ssr.js
+++ b/config/builds.ssr.js
@@ -59,6 +59,8 @@ const builds = buildConfigs
           : 8181
     };
 
+    const polyfills = buildConfig.polyfills || [];
+
     const webpackDecorator =
       buildConfig.dangerouslySetWebpackConfig || defaultDecorator;
     const jestDecorator =
@@ -87,7 +89,8 @@ const builds = buildConfigs
       webpackDecorator,
       jestDecorator,
       hosts,
-      port
+      port,
+      polyfills
     };
   });
 

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -134,7 +134,7 @@ const buildWebpackConfigs = builds.map(
 
     const internalJs = [paths.src, ...paths.compilePackages];
     const resolvedPolyfills = polyfills.map(polyfill => {
-      return require.resolve(polyfill);
+      return require.resolve(polyfill, { paths: [process.cwd()] });
     });
     const entry = [...resolvedPolyfills, paths.clientEntry];
     const devServerEntries = [

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -106,7 +106,7 @@ const svgLoaders = [
 ];
 
 const buildWebpackConfigs = builds.map(
-  ({ name, paths, env, locales, webpackDecorator, port }) => {
+  ({ name, paths, env, locales, webpackDecorator, port, polyfills }) => {
     const envVars = lodash
       .chain(env)
       .mapValues((value, key) => {
@@ -133,8 +133,10 @@ const buildWebpackConfigs = builds.map(
       .value();
 
     const internalJs = [paths.src, ...paths.compilePackages];
-
-    const entry = [paths.clientEntry];
+    const resolvedPolyfills = polyfills.map(polyfill => {
+      return require.resolve(polyfill);
+    });
+    const entry = [...resolvedPolyfills, paths.clientEntry];
     const devServerEntries = [
       `${require.resolve(
         'webpack-dev-server/client'

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -140,7 +140,7 @@ const buildWebpackConfigs = builds.map(
     const isStartScript = args.script === 'start-ssr';
 
     const resolvedPolyfills = polyfills.map(polyfill => {
-      return require.resolve(polyfill);
+      return require.resolve(polyfill, { paths: [process.cwd()] });
     });
 
     const clientEntry = [...resolvedPolyfills, paths.clientEntry];

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -109,7 +109,7 @@ const svgLoaders = [
 ];
 
 const buildWebpackConfigs = builds.map(
-  ({ name, paths, env, locales, webpackDecorator, port }) => {
+  ({ name, paths, env, locales, webpackDecorator, port, polyfills }) => {
     const envVars = lodash
       .chain(env)
       .mapValues((value, key) => {
@@ -139,7 +139,11 @@ const buildWebpackConfigs = builds.map(
 
     const isStartScript = args.script === 'start-ssr';
 
-    const clientEntry = [paths.clientEntry];
+    const resolvedPolyfills = polyfills.map(polyfill => {
+      return require.resolve(polyfill);
+    });
+
+    const clientEntry = [...resolvedPolyfills, paths.clientEntry];
     const clientDevServerEntries = [
       'react-hot-loader/patch',
       `${require.resolve('webpack-dev-server/client')}?http://localhost:${


### PR DESCRIPTION
Support polyfills.

Sometime you might need to polyfill a new object or method in browsers that don’t support that object or method, and you might also want polyfill is loaded and executed as part of entry point without your files needing to know about it. 

**sku.config.js**

```js
module.exports = {
  ...,
  polyfills: ['core-js/modules/es6.symbol', 'regenerator-runtime/runtime']
};
```

Note: From a performance point of view, you might only send polyfills to browsers that need them. 
