### PR TITLE
chore(config): Disable comment perserving in uglifyjs

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -215,7 +215,7 @@ const buildWebpackConfigs = builds.map(
           !isProductionBuild
             ? []
             : [
-                new webpack.optimize.UglifyJsPlugin(),
+                new webpack.optimize.UglifyJsPlugin({ comments: false }),
                 new webpack.DefinePlugin({
                   'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
                 }),

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -242,7 +242,7 @@ const buildWebpackConfigs = builds.map(
                 new webpack.NoEmitOnErrorsPlugin()
               ]
             : [
-                new webpack.optimize.UglifyJsPlugin(),
+                new webpack.optimize.UglifyJsPlugin({ comments: false }),
                 new webpack.DefinePlugin({
                   'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
                 }),


### PR DESCRIPTION

Remove many preserving comments containing /*!, /**!, @preserve or @license that we don't need and reduce bundle size

```js
 * react.production.min.js
 *
 * Copyright (c) 2013-present, Facebook, Inc.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 */
```
Look at this mess in main.js ☝️ 