### PR TITLE
feat(start): Add initialPath param to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,9 @@ module.exports = {
   // A list hosts your app can run off while in the dev environment.
   hosts: ['dev.seek.com.au', 'dev.seek.co.nz'],
   // The port you want the server to run on
-  port: 5000
+  port: 5000,
+  // Optional parameter to set a page to open when the development server starts
+  initialPath: '/my-page'
 }
 ```
 

--- a/config/builds.js
+++ b/config/builds.js
@@ -47,8 +47,8 @@ const builds = buildConfigs
     const locales = buildConfig.locales || [''];
     const compilePackages = buildConfig.compilePackages || [];
     const hosts = buildConfig.hosts || ['localhost'];
-
     const port = buildConfig.port || 8080;
+    const initialPath = buildConfig.initialPath || '/';
 
     const polyfills = buildConfig.polyfills || [];
 
@@ -84,7 +84,8 @@ const builds = buildConfigs
       eslintDecorator,
       hosts,
       port,
-      polyfills
+      polyfills,
+      initialPath
     };
   });
 

--- a/scripts/start-ssr.js
+++ b/scripts/start-ssr.js
@@ -6,7 +6,7 @@ const opn = require('opn');
 const Promise = require('bluebird');
 const webpackPromise = Promise.promisify(require('webpack'));
 const fs = require('fs-extra');
-const { hosts, port } = builds[0];
+const { hosts, port, initialPath } = builds[0];
 const serverEntry = builds[0].paths.serverEntry;
 
 const compiler = webpack(serverEntry ? webpackConfig[0] : webpackConfig);
@@ -62,7 +62,7 @@ const copyPublicFiles = () => {
 runWebpack(webpackConfig[1])
   .then(copyPublicFiles)
   .then(() => {
-    const url = `http://${hosts[0]}:${port.backend}`;
+    const url = `http://${hosts[0]}:${port.backend}${initialPath}`;
     console.log(`Starting the back-end development server on ${url}...`);
     if (process.env.OPEN_TAB !== 'false') {
       opn(url);

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -4,7 +4,7 @@ const webpackConfig = require('../config/webpack/webpack.config');
 const builds = require('../config/builds');
 const opn = require('opn');
 
-const { hosts, port } = builds[0];
+const { hosts, port, initialPath } = builds[0];
 
 const compiler = webpack(webpackConfig);
 const devServer = new WebpackDevServer(compiler, {
@@ -20,7 +20,7 @@ devServer.listen(port, '0.0.0.0', (err, result) => {
     return console.log(err);
   }
 
-  const url = `http://${hosts[0]}:${port}`;
+  const url = `http://${hosts[0]}:${port}${initialPath}`;
 
   console.log();
   console.log(`Starting the development server on ${url}...`);


### PR DESCRIPTION
Allow an initial path to be set so a specific route can be loaded when running `sku start`

EXAMPLE USAGE:

`sku.config.js`

```js
module.exports = {
  entry: {
   ...
  initialPath: '/my-page'
  ...
};
```
