### PR TITLE
fix: Remove `inputProps` usage in App template

### DIFF
--- a/template/src/App/App.js
+++ b/template/src/App/App.js
@@ -46,22 +46,18 @@ export default class App extends Component {
                 <TextField
                   label="Name"
                   id="name"
-                  inputProps={{
-                    name: 'name',
-                    value: this.state.name,
-                    onChange: this.handleChange
-                  }}
+                  name="name"
+                  value={this.state.name}
+                  onChange={this.handleChange}
                 />
               </div>
               <div className={styles.showMessage}>
                 <Checkbox
                   label="Show greeting"
                   id="showMessage"
-                  inputProps={{
-                    name: 'showMessage',
-                    checked: this.state.showMessage,
-                    onChange: this.handleChange
-                  }}
+                  name="showMessage"
+                  checked={this.state.showMessage}
+                  onChange={this.handleChange}
                 />
               </div>
             </Section>


### PR DESCRIPTION
On the first `npm start` after `sku init`, I get the following warnings:

![screen shot 2018-07-12 at 4 12 02 pm](https://user-images.githubusercontent.com/1162326/42616137-739d9d5a-85f0-11e8-891c-9a447976f10c.png)

The `App` template is providing `value` and `onChange` props to `TextField` and `CheckBox` via `inputProps`, which has been changed in https://github.com/seek-oss/seek-style-guide/pull/484.