### PR TITLE
fix(test): Add prettierPath to Jest config

### DIFF
--- a/config/jest/jestConfig.js
+++ b/config/jest/jestConfig.js
@@ -1,4 +1,5 @@
 module.exports = {
+  prettierPath: require.resolve('prettier'),
   testPathIgnorePatterns: ['<rootDir>[/\\\\](dist|node_modules)[/\\\\]'],
   moduleNameMapper: {
     '(seek-style-guide/react|.(css|less)$)': require.resolve(


### PR DESCRIPTION
Jest [recently released](https://github.com/facebook/jest/blob/master/CHANGELOG.md#2330) the ability to use Inline Snapshots.
https://jestjs.io/docs/en/snapshot-testing#inline-snapshots

To use inline snapshots Jest uses Prettier to write then format the snapshot directly to the test file.

Jest will attempt to resolve the path to prettier via the string 'prettier'. This wont work as prettier is typically installed in the consumer package's node_modules.

Provide Jest with the exact path to Prettier via a require.resolve lookup.
https://jestjs.io/docs/en/configuration#prettierpath-string

Prettier is a direct dependency of sku and can be relied upon to exist for the `require.resolve`