### PR TITLE
fix(deps): Update dependency jest to 23.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "autoprefixer": "^7.1.5",
     "babel-core": "^6.26.0",
-    "babel-jest": "^21.2.0",
+    "babel-jest": "^23.4.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-plugin-flow-react-proptypes": "^10.0.0",
@@ -75,7 +75,7 @@
     "fs-extra": "^5.0.0",
     "identity-obj-proxy": "^3.0.0",
     "inquirer": "^4.0.0",
-    "jest": "^21.2.1",
+    "jest": "^23.4.1",
     "kopy": "^8.3.0",
     "less": "^2.7.2",
     "less-loader": "^4.0.5",


### PR DESCRIPTION
# Highlights

- Inline Snapshots
- `--coverage` works with watch mode
- Drop Node 4 support
- Multiple breaking changes including changes to the result of snapshots

# Commit message for review
BREAKING CHANGE: Upgrade to Jest version may affect consumer test code.
Especially snapshot test output. Run `npm run test` and update snapshots with `u`.
See [release notes](https://github.com/facebook/jest/blob/master/CHANGELOG.md) for more details.