### PR TITLE
fix(lint): Use cross-spawn when running prettier

### DIFF
--- a/lib/runPrettier.js
+++ b/lib/runPrettier.js
@@ -1,4 +1,4 @@
-const { spawn } = require('child_process');
+const spawn = require('cross-spawn');
 const path = require('path');
 
 const cwd = process.cwd();


### PR DESCRIPTION
Calling child_process module directly can result in unpredictable behaviour with Windows machines.
Some consumers have received issues where spawned command would see a 'UNKNOWN' as the first argument when running `lint`.

Use already available [cross-spawn[(https://www.npmjs.com/package/cross-spawn) module to ensure predictable results cross-operating system.