### PR TITLE
fix(init): Allow form to be updated

### DIFF
--- a/template/src/App/App.js
+++ b/template/src/App/App.js
@@ -24,7 +24,7 @@ export default class App extends Component {
 
   handleChange = ({ target }) => {
     this.setState({
-      [target.name]: target.type === 'checkbox' ? target.checked : target.value
+      [target.id]: target.type === 'checkbox' ? target.checked : target.value
     });
   };
 
@@ -46,7 +46,6 @@ export default class App extends Component {
                 <TextField
                   label="Name"
                   id="name"
-                  name="name"
                   value={this.state.name}
                   onChange={this.handleChange}
                 />
@@ -55,7 +54,6 @@ export default class App extends Component {
                 <Checkbox
                   label="Show greeting"
                   id="showMessage"
-                  name="showMessage"
                   checked={this.state.showMessage}
                   onChange={this.handleChange}
                 />

--- a/template/src/App/App.less
+++ b/template/src/App/App.less
@@ -1,5 +1,5 @@
 @import '~seek-style-guide/theme';
 
 .showMessage {
-  margin-bottom: @grid-row-height;
+  margin-bottom: @row-height;
 }


### PR DESCRIPTION
Migrating to the new form field api has broken the ability to interact with the form generated by the `init` script. The problem being `name` was not a property hoisted out of `inputProps` which broke the controlled field contract with the components state.

Also updating the `App` components style to use the new `@row-height` variable.