### PR TITLE
fix(images): Make client and server URLs consistent

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -75,7 +75,9 @@ const makeImageLoaders = (options = {}) => {
     {
       loader: require.resolve('url-loader'),
       options: {
-        limit: server ? 999999999 : 10000
+        limit: 10000,
+        fallback: require.resolve('file-loader'),
+        emitFile: !server
       }
     }
   ];

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -38,6 +38,8 @@ const makeCssLoaders = (options = {}) => {
 
   return (cssLoaders = [
     {
+      // On the server, we use 'css-loader/locals' to avoid generating a CSS file.
+      // Only the client build should generate CSS files.
       loader: require.resolve(`css-loader${server ? '/locals' : ''}`),
       options: {
         modules: true,
@@ -77,6 +79,8 @@ const makeImageLoaders = (options = {}) => {
       options: {
         limit: 10000,
         fallback: require.resolve('file-loader'),
+        // We only want to emit client assets during the client build.
+        // The server build should only emit server-side JS and HTML files.
         emitFile: !server
       }
     }

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -78,7 +78,9 @@ const makeImageLoaders = (options = {}) => {
     {
       loader: require.resolve('url-loader'),
       options: {
-        limit: server ? 999999999 : 10000
+        limit: 10000,
+        fallback: require.resolve('file-loader'),
+        emitFile: !server
       }
     }
   ];

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -41,6 +41,8 @@ const makeCssLoaders = (options = {}) => {
   return (cssLoaders = [
     ...(isProductionBuild || server ? [] : ['style-loader']),
     {
+      // On the server, we use 'css-loader/locals' to avoid generating a CSS file.
+      // Only the client build should generate CSS files.
       loader: require.resolve(`css-loader${server ? '/locals' : ''}`),
       options: {
         modules: true,
@@ -80,6 +82,8 @@ const makeImageLoaders = (options = {}) => {
       options: {
         limit: 10000,
         fallback: require.resolve('file-loader'),
+        // We only want to emit client assets during the client build.
+        // The server build should only emit server-side JS and HTML files.
         emitFile: !server
       }
     }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-config-seek": "^3.0.0",
     "express": "^4.16.2",
     "extract-text-webpack-plugin": "^3.0.1",
+    "file-loader": "^1.1.11",
     "find-up": "^2.1.0",
     "fs-extra": "^5.0.0",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
REASON:

The current webpack config provides different limit values for server vs client when it comes to loading images via the `url-loader`. This is causing differing behaviour between the two environments during development on local machine however does not seem to impact files once pushed to production.

A specific example that I can provide is for my teams new vertical where we have a large background image on the homepage.

This image is imported into our HeroBanner component

```
import bannerImage from './hero-cafe-counter-2x.jpg';
...

class HeroBanner extends Component {
  ...
  render() {
    return (
      <div className={classes} style={{backgroundImage: `${bannerImage}`}}> ... </div>
    )
  }
```
Upon recompiling, webpack is inlining this image as a different DataURL in the browser (client.js) compared to the DataURL on the server (render.js' rendered HTML).

The result is the following warning displayed in the console:

![screen shot 2018-08-01 at 10 46 30 am](https://user-images.githubusercontent.com/1221164/43495074-6e3a4974-9579-11e8-9d0e-04ad1348db30.png)

The change that's been made is to set a single byte size limit for the `url-loader` to the smaller `10000 or 10Kb`. This means any image over this size will be linked to rather than inlined as `DataURL`.

We are also taking advantage of the `file-loaders` emitFile option to prevent unnecessary output of image files on the server.

NOTE: During the development of this fix it was discovered that the `file-loader` package which is a required fallback to `url-loader` was not installed as part of this repo's `package.json, so that too has been rectified.