### PR TITLE
fix(format): Use string path in prettier package.json if available

### DIFF
--- a/lib/runPrettier.js
+++ b/lib/runPrettier.js
@@ -10,9 +10,11 @@ const cwd = process.cwd();
  */
 const getPrettierBinLocation = () => {
   const prettierPackageJson = require('prettier/package.json');
-  return require.resolve(
-    path.join('prettier', prettierPackageJson.bin.prettier)
-  );
+  const prettierBinPath =
+    typeof prettierPackageJson.bin === 'string'
+      ? prettierPackageJson.bin
+      : prettierPackageJson.bin.prettier;
+  return require.resolve(path.join('prettier', prettierBinPath));
 };
 
 const runPrettier = ({ write, listDifferent, config, filePattern }) => {
@@ -59,6 +61,8 @@ const runPrettier = ({ write, listDifferent, config, filePattern }) => {
 };
 
 module.exports = {
-  check: (filePattern, config) => runPrettier({ listDifferent: true, config, filePattern }),
-  write: (filePattern, config) => runPrettier({ write: true, config, filePattern })
+  check: (filePattern, config) =>
+    runPrettier({ listDifferent: true, config, filePattern }),
+  write: (filePattern, config) =>
+    runPrettier({ write: true, config, filePattern })
 };

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "test": "npm run format-check && OPEN_TAB=false jest test/test-cases/*/*.test.js --runInBand",
     "test-manual": "node test/manual",
-    "format": "prettier --single-quote --write '{bin,config,scripts}/**/*.js'",
-    "format-check": "prettier --single-quote --list-different '{bin,config,scripts}/**/*.js'",
+    "format": "prettier --single-quote --write '{bin,config,scripts,lib}/**/*.js'",
+    "format-check": "prettier --single-quote --list-different '{bin,config,scripts,lib}/**/*.js'",
     "precommit": "lint-staged",
     "commit": "git-cz",
     "commitmsg": "commitlint --edit --extends seek",


### PR DESCRIPTION
Installing prettier on some docker builds appears to be installing a package.json with the following:
```
{
...
"bin": "./bin-prettier.js"
}
```

This change allows us to accept the bin value as a string if available, otherwise look for the prettier command.