### PR TITLE
fix: Passing args to lint and format commands

### DIFF
--- a/lib/runPrettier.js
+++ b/lib/runPrettier.js
@@ -1,6 +1,6 @@
 const spawn = require('cross-spawn');
 const path = require('path');
-
+const chalk = require('chalk');
 const cwd = process.cwd();
 
 /*
@@ -22,7 +22,7 @@ const runPrettier = ({ write, listDifferent, config, filePattern }) => {
 
   const prettierBinPath = getPrettierBinLocation();
 
-  const prettierArgs = [];
+  let prettierArgs = [];
 
   if (prettierConfig.singleQuote) {
     prettierArgs.push('--single-quote');
@@ -34,6 +34,8 @@ const runPrettier = ({ write, listDifferent, config, filePattern }) => {
     prettierArgs.push('--list-different');
   }
 
+  prettierArgs = prettierArgs.concat(filePattern);
+
   /*
    * Show Prettier output with stdio: inherit
    * The child process will use the parent process's stdin/stdout/stderr
@@ -42,6 +44,8 @@ const runPrettier = ({ write, listDifferent, config, filePattern }) => {
   const processOptions = {
     stdio: 'inherit'
   };
+
+  console.log(chalk.gray(`prettier ${prettierArgs.join(' ')}`));
 
   const prettierProcess = spawn(
     prettierBinPath,

--- a/scripts/format.js
+++ b/scripts/format.js
@@ -5,7 +5,7 @@ const prettierConfig = require('../config/prettier/prettierConfig');
 
 const defaultPath = require('../config/prettier/defaultPath');
 
-const args = process.argv.slice(2);
+const args = process.argv.slice(3);
 
 console.log(chalk.cyan('Formatting source code with Prettier'));
 

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -9,7 +9,9 @@ const prettierConfig = require('../config/prettier/prettierConfig');
 const prettierDefaultPath = require('../config/prettier/defaultPath');
 const eslintDefaultPath = require('../config/eslint/defaultPath');
 
-const args = process.argv.slice(2);
+const args = process.argv.slice(3);
+
+console.log(chalk.cyan('Linting'));
 
 // Decorate eslint config is not supported for monorepo
 const eslintConfig =
@@ -25,9 +27,9 @@ const cli = new EslintCLI({
 const pathsToCheck = args.length === 0 ? [eslintDefaultPath] : args;
 
 const formatter = cli.getFormatter();
+console.log(chalk.gray(`eslint ${pathsToCheck.join(' ')}`));
 const report = cli.executeOnFiles(pathsToCheck);
 
-console.log(chalk.cyan('Linting'));
 console.log(formatter(report.results));
 
 if (report.errorCount > 0) {


### PR DESCRIPTION
Fixes an error where `lint` and `format` are being passed to `eslint` and `prettier` as file paths e.g.

```
[error] No matching files. Patterns tried: lint !**/node_modules/** !./node_modules/** !**/.{git,svn,hg}/** !./.{git,svn,hg}/**
```