### PR TITLE
fix: Log build errors

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -37,4 +37,7 @@ const copyPublicFiles = () => {
 Promise.each(webpackConfig, runWebpack)
   .then(copyPublicFiles)
   .then(() => console.log('Sku build complete!'))
-  .catch(() => process.exit(1));
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
If webpack throws an error when running `sku build` (for example, because you're using `dangerouslySetWebpackConfig` and have returned an invalid config object), it doesn't get logged to the console.