### PR TITLE
fix(internal): Remove unused arg parsing code

### DIFF
--- a/lib/parseArgs.js
+++ b/lib/parseArgs.js
@@ -49,15 +49,6 @@ module.exports = args => {
 
   let { scriptName, _unknown: argv = [] } = options;
 
-  // Detect if you're trying to execute a script directly...
-  const scriptNameRegex = /scripts[\/\\]([\w-]*)\.js$/i;
-  const scriptInvocation = scriptName.match(scriptNameRegex);
-
-  // ...and if you are, update scriptName accordingly.
-  if (scriptInvocation && scriptInvocation.length) {
-    scriptName = scriptInvocation[1];
-  }
-
   //Backwards compatibility for unnamed build name argument, to be deprecated
   const buildName = () => {
     if (options.build) {


### PR DESCRIPTION
As you can see from [this convo](https://github.com/seek-oss/sku/pull/160/files#r215782079), I was supposed to remove these lines from #160, but I stroked out I guess!