### PR TITLE
feat(webpack): Add bundle analyser to build

### DIFF
--- a/config/webpack/plugins/bundleAnalyzer.js
+++ b/config/webpack/plugins/bundleAnalyzer.js
@@ -1,0 +1,8 @@
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
+
+module.exports = ({ name }) =>
+  new BundleAnalyzerPlugin({
+    analyzerMode: 'static',
+    openAnalyzer: false,
+    reportFilename: `report/${name}.html`
+  });

--- a/config/webpack/plugins/bundleAnalyzer.js
+++ b/config/webpack/plugins/bundleAnalyzer.js
@@ -4,5 +4,5 @@ module.exports = ({ name }) =>
   new BundleAnalyzerPlugin({
     analyzerMode: 'static',
     openAnalyzer: false,
-    reportFilename: `report/${name}.html`
+    reportFilename: `../report/${name}.html`
   });

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -9,6 +9,7 @@ const path = require('path');
 const supportedBrowsers = require('../browsers/supportedBrowsers');
 const isProductionBuild = process.env.NODE_ENV === 'production';
 const webpackMode = isProductionBuild ? 'production' : 'development';
+const bundleAnalyzerPlugin = require('./plugins/bundleAnalyzer');
 
 const makeJsLoaders = ({ target }) => [
   {
@@ -222,6 +223,7 @@ const buildWebpackConfigs = builds.map(
         },
         plugins: [
           new webpack.DefinePlugin(envVars),
+          bundleAnalyzerPlugin({ name: 'client' }),
           new MiniCssExtractPlugin({
             filename: 'style.css'
           })
@@ -281,6 +283,7 @@ const buildWebpackConfigs = builds.map(
         },
         plugins: [
           new webpack.DefinePlugin(envVars),
+          bundleAnalyzerPlugin({ name: 'render' }),
           ...locales.slice(0, isProductionBuild ? locales.length : 1).map(
             locale =>
               new StaticSiteGeneratorPlugin({

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -11,6 +11,7 @@ const webpackMode = isProductionBuild ? 'production' : 'development';
 const nodeExternals = require('webpack-node-externals');
 const findUp = require('find-up');
 const StartServerPlugin = require('start-server-webpack-plugin');
+const bundleAnalyzerPlugin = require('./plugins/bundleAnalyzer');
 
 const makeJsLoaders = ({ target }) => [
   {
@@ -258,6 +259,7 @@ const buildWebpackConfigs = builds.map(
                 new webpack.NoEmitOnErrorsPlugin()
               ]
             : [
+                bundleAnalyzerPlugin({ name: 'client' }),
                 new MiniCssExtractPlugin({
                   filename: 'style.css'
                 })
@@ -343,7 +345,7 @@ const buildWebpackConfigs = builds.map(
                 new webpack.HotModuleReplacementPlugin(),
                 new webpack.NoEmitOnErrorsPlugin()
               ]
-            : []
+            : [bundleAnalyzerPlugin({ name: 'server' })]
         )
       }
     ].map(webpackDecorator);

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "url-loader": "^1.0.1",
     "validate-npm-package-name": "^3.0.0",
     "webpack": "^4.16.4",
+    "webpack-bundle-analyzer": "^3.0.2",
     "webpack-dev-server": "^3.1.5",
     "webpack-node-externals": "^1.7.2"
   },

--- a/template/_.gitignore
+++ b/template/_.gitignore
@@ -1,4 +1,4 @@
 node_modules
 npm-debug.log
-dist
-report
+/dist
+/report

--- a/template/_.gitignore
+++ b/template/_.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 dist
+report


### PR DESCRIPTION
Provides an analysis report to help consumers identify and refine their dependencies in order to optimise their bundle at build time.

After running a `sku build` the report can be found at `dist/report/<bundle_name>.html`, where the bundle name will be either `client`, `render` or `server`.