### PR TITLE
feat(mjs): Add support for .mjs files in node_modules

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -196,6 +196,11 @@ const buildWebpackConfigs = builds.map(
               )
             },
             {
+              test: /\.mjs$/,
+              include: /node_modules/,
+              type: 'javascript/auto'
+            },
+            {
               test: /\.less$/,
               oneOf: [
                 ...paths.compilePackages.map(packageName => ({

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -222,6 +222,11 @@ const buildWebpackConfigs = builds.map(
                   )
             },
             {
+              test: /\.mjs$/,
+              include: /node_modules/,
+              type: 'javascript/auto'
+            },
+            {
               test: /\.less$/,
               oneOf: [
                 ...paths.compilePackages.map(packageName => ({
@@ -304,6 +309,11 @@ const buildWebpackConfigs = builds.map(
               use: makeCssLoaders({ server: true, js: true })
             },
             {
+              test: /\.mjs$/,
+              include: /node_modules/,
+              type: 'javascript/auto'
+            },
+            {
               test: /\.less$/,
               oneOf: [
                 ...paths.compilePackages.map(packageName => ({
@@ -316,7 +326,6 @@ const buildWebpackConfigs = builds.map(
                 }
               ]
             },
-
             {
               test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
               use: makeImageLoaders({ server: true })


### PR DESCRIPTION
Some node modules are being published with the mjs extension (module js) and webpack is currently
unable to handle them. This change adds support for mjs modules/files
