### PR TITLE
fix(render): Add mjs support to render build

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -263,6 +263,11 @@ const buildWebpackConfigs = builds.map(
               use: makeCssLoaders({ server: true, js: true })
             },
             {
+              test: /\.mjs$/,
+              include: /node_modules/,
+              type: 'javascript/auto'
+            },
+            {
               test: /\.less$/,
               oneOf: [
                 ...paths.compilePackages.map(packageName => ({


### PR DESCRIPTION
Seems we missed adding `.mjs` support to the `render` build in https://github.com/seek-oss/sku/pull/169 😞 

We are discussing more streamlined ways to manage config between the different builds, for now i'd like to fix the builds a priority (currently breaking for those requiring `.mjs` files in their projects)