### PR TITLE
fix: Fix build error when seek-style-guide isn’t a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+report/
 *.log
 dist/
 yarn.lock

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/config/builds.js
+++ b/config/builds.js
@@ -63,14 +63,24 @@ const builds = buildConfigs
       src: (buildConfig.srcPaths || ['src']).map(srcPath =>
         path.join(cwd, srcPath)
       ),
-      compilePackages: [
-        path.dirname(
-          require.resolve('seek-style-guide/package.json', { paths: [cwd] })
-        ),
-        ...compilePackages.map(package =>
-          path.join(cwd, 'node_modules', package)
-        )
-      ],
+      compilePackages: ['seek-style-guide', ...compilePackages].map(
+        packageName => {
+          try {
+            // First, try to leverage Node's require algorithm to find
+            // the package relative to the current directory.
+            return path.dirname(
+              require.resolve(`${packageName}/package.json`, { paths: [cwd] })
+            );
+          } catch (err) {
+            // If a `package.json` file can't be resolved, maintain
+            // legacy behaviour by providing a naive directory path.
+            // This ensures the build still passes when a supported
+            // package is missing, e.g. your project might not be
+            // using 'seek-style-guide'.
+            return path.join(cwd, 'node_modules', packageName);
+          }
+        }
+      ),
       clientEntry: path.join(cwd, entry.client || 'src/client.js'),
       renderEntry: path.join(cwd, entry.render || 'src/render.js'),
       public: path.join(cwd, buildConfig.public || 'public'),


### PR DESCRIPTION
## Why?

Builds without `seek-style-guide` were broken in https://github.com/seek-oss/sku/pull/166 because we call `require.resolve('seek-style-guide/package.json')`, which throws an error if it can't be found.

To fix this, we now wrap the require call in a try/catch block, falling back to the legacy behaviour if a package can't be found to maintain backwards compatibility.

## Development Notes

- Added a `.prettierrc` so Prettier editor extensions can pick it up.
- Added `report/` to `.gitignore`, so we don't commit reports generated during test runs.