### PR TITLE
fix(test): Don't mock packages when using relative imports

### DIFF
--- a/config/jest/jestConfig.js
+++ b/config/jest/jestConfig.js
@@ -12,9 +12,9 @@ module.exports = {
     // to the string 'Text'. This way, snapshot tests won't break when
     // these packages get updated, which happens regularly. There's
     // still room for debate about whether this is a good idea or not...
-    'seek-style-guide/react': require.resolve('identity-obj-proxy'),
-    'seek-asia-style-guide/react': require.resolve('identity-obj-proxy'),
-    'braid-design-system': require.resolve('identity-obj-proxy')
+    '^seek-style-guide/react': require.resolve('identity-obj-proxy'),
+    '^seek-asia-style-guide/react': require.resolve('identity-obj-proxy'),
+    '^braid-design-system': require.resolve('identity-obj-proxy')
   },
   transform: {
     '^.+\\.css\\.js$': require.resolve('./cssJsTransform.js'),


### PR DESCRIPTION
## Why?

Right now, if you run `sku test` within the repo of a mocked package, all of its code is incorrectly mocked out, causing its tests to fail.

This fix ensures that packages are only mocked when the package name is at the *start* of the string.