### PR TITLE
feat(build): Wipe dist folders on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "prettier": "1.14.2",
     "raw-loader": "^0.5.1",
     "react-hot-loader": "^3.1.3",
+    "rimraf": "^2.6.2",
     "start-server-webpack-plugin": "^2.2.5",
     "static-site-generator-webpack-plugin": "^3.4.1",
     "string-replace-loader": "^2.1.1",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -31,13 +31,10 @@ const runWebpack = config => {
   });
 };
 
-const cleanDistFolders = async () => {
-  await Promise.all(builds.map(({ paths }) => rimraf(paths.dist)));
-};
+const cleanDistFolders = () =>
+  Promise.all(builds.map(({ paths }) => rimraf(paths.dist)));
 
-const compileAll = async () => {
-  await Promise.all(webpackConfigs.map(runWebpack));
-};
+const compileAll = () => Promise.all(webpackConfigs.map(runWebpack));
 
 const copyPublicFiles = () => {
   builds.forEach(({ paths }) => {


### PR DESCRIPTION
Currently, sku is not clearing the `dist` folder when running `sku build`. This PR implements that.