### PR TITLE
feat(webpack): Name CSS chunks when split from bundle

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -142,7 +142,8 @@ const buildWebpackConfigs = builds.map(
           new webpack.DefinePlugin(envVars),
           bundleAnalyzerPlugin({ name: 'client' }),
           new MiniCssExtractPlugin({
-            filename: 'style.css'
+            filename: 'style.css',
+            chunkFilename: '[name].css'
           })
         ]
       },


### PR DESCRIPTION
Currently when running `sku build`, if any css files are getting split off, they are unnamed in the form `1.style.css`.

This PR will give name it after the webpackChunkName e.g. `forgot-password.css`

Credit to @mattsjones for finding the fix.