### PR TITLE
fix(build): Remove contents of dist only when building

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -32,7 +32,7 @@ const runWebpack = config => {
 };
 
 const cleanDistFolders = () =>
-  Promise.all(builds.map(({ paths }) => rimraf(paths.dist)));
+  Promise.all(builds.map(({ paths }) => rimraf(`${paths.dist}/*`)));
 
 const compileAll = () => Promise.all(webpackConfigs.map(runWebpack));
 


### PR DESCRIPTION
A recent change to sku deleted the `dist` folder on build.
This `dist` folder can sometimes be a mounted volume and can not be deleted.
This change ensure only the contents of the dist folder and not the folder itself is deleted.