### PR TITLE
chore: Remove redundant output cleanup in tests

### DIFF
--- a/test/test-cases/braid-design-system/braid-design-system.test.js
+++ b/test/test-cases/braid-design-system/braid-design-system.test.js
@@ -2,7 +2,6 @@ const path = require('path');
 const { promisify } = require('es6-promisify');
 const rimrafAsync = promisify(require('rimraf'));
 const fs = require('fs').promises;
-const { F_OK } = require('fs').constants;
 const dirContentsToObject = require('../../utils/dirContentsToObject');
 const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
 const appDir = path.resolve(__dirname, 'app');
@@ -10,8 +9,6 @@ const distDir = path.resolve(appDir, 'dist');
 
 describe('braid-design-system', () => {
   beforeAll(async () => {
-    await rimrafAsync(distDir);
-
     // "Install" React and braid-design-system into this test app so that webpack-node-externals
     // treats them correctly.
     await linkLocalDependencies();

--- a/test/test-cases/custom-src-paths/custom-src-paths.test.js
+++ b/test/test-cases/custom-src-paths/custom-src-paths.test.js
@@ -1,5 +1,3 @@
-const { promisify } = require('es6-promisify');
-const rimrafAsync = promisify(require('rimraf'));
 const dirContentsToObject = require('../../utils/dirContentsToObject');
 const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
 const waitForUrls = require('../../utils/waitForUrls');
@@ -29,7 +27,6 @@ describe('custom-src-paths', () => {
 
   describe('build', () => {
     beforeAll(async () => {
-      await rimrafAsync(`${__dirname}/dist/`);
       await runSkuScriptInDir('build', __dirname);
     });
 

--- a/test/test-cases/hello-world/hello-world.test.js
+++ b/test/test-cases/hello-world/hello-world.test.js
@@ -1,5 +1,3 @@
-const { promisify } = require('es6-promisify');
-const rimrafAsync = promisify(require('rimraf'));
 const dirContentsToObject = require('../../utils/dirContentsToObject');
 const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
 const waitForUrls = require('../../utils/waitForUrls');
@@ -29,7 +27,6 @@ describe('hello-world', () => {
 
   describe('build', () => {
     beforeAll(async () => {
-      await rimrafAsync(`${__dirname}/dist/`);
       await runSkuScriptInDir('build', __dirname);
     });
 

--- a/test/test-cases/react-css-modules/react-css-modules.test.js
+++ b/test/test-cases/react-css-modules/react-css-modules.test.js
@@ -1,6 +1,4 @@
 const path = require('path');
-const { promisify } = require('es6-promisify');
-const rimrafAsync = promisify(require('rimraf'));
 const dirContentsToObject = require('../../utils/dirContentsToObject');
 const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
 const appDir = path.resolve(__dirname, 'app');
@@ -8,7 +6,6 @@ const distDir = path.resolve(appDir, 'dist');
 
 describe('react-css-modules', () => {
   beforeAll(async () => {
-    await rimrafAsync(distDir);
     await runSkuScriptInDir('build', appDir);
   });
 

--- a/test/test-cases/seek-asia-style-guide/seek-asia-style-guide.test.js
+++ b/test/test-cases/seek-asia-style-guide/seek-asia-style-guide.test.js
@@ -10,8 +10,6 @@ const distDir = path.resolve(appDir, 'dist');
 
 describe('seek-asia-style-guide', () => {
   beforeAll(async () => {
-    await rimrafAsync(distDir);
-
     // "Install" React and seek-asia-style-guide into this test app so that webpack-node-externals
     // treats them correctly.
     await linkLocalDependencies();

--- a/test/test-cases/seek-style-guide/seek-style-guide.test.js
+++ b/test/test-cases/seek-style-guide/seek-style-guide.test.js
@@ -10,8 +10,6 @@ const distDir = path.resolve(appDir, 'dist');
 
 describe('seek-style-guide', () => {
   beforeAll(async () => {
-    await rimrafAsync(distDir);
-
     // "Install" React and seek-style-guide into this test app so that webpack-node-externals
     // treats them correctly.
     await linkLocalDependencies();

--- a/test/test-cases/ssr-hello-world/ssr-hello-world.test.js
+++ b/test/test-cases/ssr-hello-world/ssr-hello-world.test.js
@@ -1,5 +1,3 @@
-const { promisify } = require('es6-promisify');
-const rimrafAsync = promisify(require('rimraf'));
 const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
 const gracefulSpawn = require('../../../lib/gracefulSpawn');
 const waitForUrls = require('../../utils/waitForUrls');
@@ -15,7 +13,6 @@ describe('ssr-hello-world', () => {
     let server;
 
     beforeAll(async () => {
-      await rimrafAsync(`${__dirname}/dist/`);
       server = await runSkuScriptInDir('start-ssr', __dirname);
       await waitForUrls(backendUrl, clientJsUrl);
     });
@@ -40,7 +37,6 @@ describe('ssr-hello-world', () => {
     let server;
 
     beforeAll(async () => {
-      await rimrafAsync(`${__dirname}/dist/`);
       await runSkuScriptInDir('build-ssr', __dirname);
       server = gracefulSpawn('node', ['server'], {
         cwd: `${__dirname}/dist`,

--- a/test/test-cases/zero-config/zero-config.test.js
+++ b/test/test-cases/zero-config/zero-config.test.js
@@ -1,5 +1,3 @@
-const { promisify } = require('es6-promisify');
-const rimrafAsync = promisify(require('rimraf'));
 const dirContentsToObject = require('../../utils/dirContentsToObject');
 const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
 const waitForUrls = require('../../utils/waitForUrls');
@@ -28,7 +26,6 @@ describe('zero-config', () => {
 
   describe('build', () => {
     beforeAll(async () => {
-      await rimrafAsync(`${__dirname}/dist/`);
       await runSkuScriptInDir('build', __dirname);
     });
 


### PR DESCRIPTION
This is just a simple clean up PR to remove the unnecessary output cleanup through our tests before every build. This clean up is no longer required since [build now does this for us](https://github.com/seek-oss/sku/pull/178)