### PR TITLE
fix(test): No longer default to watch mode outside of CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ The `sku test` command will invoke Jest, running any tests in files named `*.tes
 
 Since sku uses Jest as a testing framework, you can read the [Jest documentation](https://facebook.github.io/jest/) for more information on writing compatible tests.
 
+Note: `sku` will forward all command line args to `jest`.
+
+Example running tests in watch mode:
+```bash
+$ sku test --watch
+```
+
 ### Linting and Formatting (via [ESLint](http://eslint.org/) and [Prettier](https://github.com/prettier/prettier))
 
 Running `sku lint` will execute the ESLint rules over the code in your `src` directory. You can see the ESLint rules defined for sku projects in [eslint-config-seek](https://github.com/seek-oss/eslint-config-seek).

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -9,10 +9,6 @@ const jestConfig =
     ? builds[0].jestDecorator(baseJestConfig)
     : baseJestConfig;
 
-if (!process.env.CI && argv.indexOf('--coverage') < 0) {
-  argv.push('--watch');
-}
-
 argv.push('--config', JSON.stringify(jestConfig));
 
 jest.run(argv);

--- a/test/utils/runSkuScriptInDir.js
+++ b/test/utils/runSkuScriptInDir.js
@@ -14,7 +14,7 @@ module.exports = async (script, cwd) => {
     return await exec(`${skuBin} ${script}`, {
       stdio: 'inherit',
       cwd,
-      env: { ...process.env, CI: 'true' }
+      env: process.env
     });
   } catch (error) {
     // Print the stdout of a failed command so we can see it in the jest output.


### PR DESCRIPTION
Previously, `sku test` would default the `jest` watch mode unless the `CI` environment variable was set. We are removing this behaviour to allow users to choose what mode they prefer, without setting the `CI` environment variable.

Any teams who prefer this as their default behaviour for `npm test` can update like this:

```json
"scripts": {
  "test": "sku test --watch"
}
```