### PR TITLE
feat(prettier): Support ignore files and control config in project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ package-lock.json
 .idea
 
 # managed by sku
+.prettierrc
 dist/
 report/
 tsconfig.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# managed by sku
+dist/
+report/
+# end managed by sku

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,0 @@
-{
-  "singleQuote": true
-}

--- a/config/isTypeScript.js
+++ b/config/isTypeScript.js
@@ -1,6 +1,9 @@
 const glob = require('glob');
 
-const tsFiles = glob.sync('**/*.{ts,tsx}', { ignore: 'node_modules' });
+const tsFiles = glob.sync('**/*.{ts,tsx}', {
+  cwd: process.cwd(),
+  ignore: 'node_modules'
+});
 const isTypeScript = tsFiles.length > 0;
 
 module.exports = isTypeScript;

--- a/config/prettier/prettierConfig.js
+++ b/config/prettier/prettierConfig.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  tabWidth: 2
 };

--- a/lib/runPrettier.js
+++ b/lib/runPrettier.js
@@ -1,14 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+const { promisify } = require('util');
 const chalk = require('chalk');
 const runBin = require('./runBin');
 
-const runPrettier = ({ write, listDifferent, config, filePattern }) => {
-  const prettierConfig = config || {};
+const exists = promisify(fs.access);
+const prettierIgnorePath = path.join(process.cwd(), '.prettierignore');
 
-  let prettierArgs = [];
+const runPrettier = async ({ write, listDifferent }) => {
+  console.log(
+    chalk.cyan(`${write ? 'Formatting' : 'Checking'} source code with Prettier`)
+  );
 
-  if (prettierConfig.singleQuote) {
-    prettierArgs.push('--single-quote');
-  }
+  const prettierArgs = [];
+
   if (write) {
     prettierArgs.push('--write');
   }
@@ -16,7 +21,16 @@ const runPrettier = ({ write, listDifferent, config, filePattern }) => {
     prettierArgs.push('--list-different');
   }
 
-  prettierArgs = prettierArgs.concat(filePattern);
+  try {
+    const ignoreExists = await exists(prettierIgnorePath);
+    if (ignoreExists) {
+      prettierArgs.push('--ignore-path', prettierIgnorePath);
+    }
+  } catch (err) {
+    // don't error if `.prettierignore` not found
+  }
+
+  prettierArgs.push('**/*.{js,ts,tsx}');
 
   /*
    * Show Prettier output with stdio: inherit
@@ -29,16 +43,29 @@ const runPrettier = ({ write, listDifferent, config, filePattern }) => {
 
   console.log(chalk.gray(`prettier ${prettierArgs.join(' ')}`));
 
-  return runBin({
-    packageName: 'prettier',
-    args: prettierArgs,
-    options: processOptions
-  });
+  try {
+    await runBin({
+      packageName: 'prettier',
+      args: prettierArgs,
+      options: processOptions
+    });
+    console.log(chalk.cyan(`Prettier ${write ? 'format' : 'check'} complete`));
+  } catch (exitCode) {
+    if (listDifferent && exitCode === 1) {
+      console.error(
+        chalk.red('Error: The file(s) listed above failed the prettier check')
+      );
+    } else {
+      console.error(
+        chalk.red('Error: Prettier check exited with exit code', exitCode)
+      );
+    }
+
+    process.exit(1);
+  }
 };
 
 module.exports = {
-  check: (filePattern, config) =>
-    runPrettier({ listDifferent: true, config, filePattern }),
-  write: (filePattern, config) =>
-    runPrettier({ write: true, config, filePattern })
+  check: () => runPrettier({ listDifferent: true }),
+  write: () => runPrettier({ write: true })
 };

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "debug": "^4.0.1",
     "dedent": "^0.7.0",
     "empty-dir": "^1.0.0",
-    "ensure-gitignore": "^1.1.0",
+    "ensure-gitignore": "^1.1.1",
     "es6-promisify": "^6.0.0",
     "eslint": "^5.7.0",
     "eslint-config-seek": "^3.2.0",

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
+const { promisify } = require('util');
 const ensureGitignore = require('ensure-gitignore');
 const uniq = require('lodash/uniq');
+
+const writeFileAsync = promisify(fs.writeFile);
 
 const isTypeScript = require('../config/isTypeScript');
 const builds = require('../config/builds');
@@ -13,10 +16,10 @@ const tslintConfig = require('../config/typescript/tslint.json');
 
 const addSep = p => `${p}${path.sep}`;
 
-const writeFileToCWD = (fileName, content) => {
+const writeFileToCWD = async (fileName, content) => {
   const outPath = path.join(process.cwd(), fileName);
 
-  fs.writeFileSync(outPath, JSON.stringify(content));
+  await writeFileAsync(outPath, JSON.stringify(content));
 };
 
 (async () => {
@@ -41,8 +44,8 @@ const writeFileToCWD = (fileName, content) => {
       exclude: [path.join(process.cwd(), 'node_modules')]
     };
 
-    writeFileToCWD(tsConfigFileName, tsConfig);
-    writeFileToCWD(tslintConfigFileName, tslintConfig);
+    await writeFileToCWD(tsConfigFileName, tsConfig);
+    await writeFileToCWD(tslintConfigFileName, tslintConfig);
 
     gitIgnorePatterns.push(tsConfigFileName, tslintConfigFileName);
   }

--- a/scripts/format.js
+++ b/scripts/format.js
@@ -1,25 +1,3 @@
-const path = require('path');
-const chalk = require('chalk');
-
 const prettierWrite = require('../lib/runPrettier').write;
-const prettierConfig = require('../config/prettier/prettierConfig');
 
-const builds = require('../config/builds');
-
-const args = require('../config/args').argv;
-
-console.log(chalk.cyan('Formatting source code with Prettier'));
-
-const filePattern =
-  args.length === 0
-    ? builds[0].paths.src.map(srcPath => `${srcPath}/**/*.{js,ts,tsx}`)
-    : args;
-
-prettierWrite(filePattern, prettierConfig)
-  .then(() => {
-    console.log(chalk.cyan('Prettier format complete'));
-  })
-  .catch(exitCode => {
-    console.error('Error: Prettier exited with exit code', exitCode);
-    process.exit(1);
-  });
+(async () => await prettierWrite())();

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -4,13 +4,12 @@ const EslintCLI = require('eslint').CLIEngine;
 const builds = require('../config/builds');
 const isTypeScript = require('../config/isTypeScript');
 const prettierCheck = require('../lib/runPrettier').check;
-const prettierConfig = require('../config/prettier/prettierConfig');
 const runTsc = require('../lib/runTsc');
 const runTSLint = require('../lib/runTSLint');
 
 const args = require('../config/args').argv;
 
-const run = async () => {
+(async () => {
   console.log(chalk.cyan('Linting'));
 
   if (isTypeScript) {
@@ -47,24 +46,5 @@ const run = async () => {
     process.exit(1);
   }
 
-  console.log(chalk.cyan('Checking Prettier format rules'));
-
-  const filePattern =
-    args.length === 0
-      ? builds[0].paths.src.map(srcPath => `${srcPath}/**/*.{js,ts,tsx}`)
-      : args;
-
-  prettierCheck(filePattern, prettierConfig)
-    .then(() => {
-      console.log(chalk.cyan('Prettier format rules passed'));
-    })
-    .catch(exitCode => {
-      console.error(
-        'Error: The file(s) listed above failed the prettier check'
-      );
-      console.error('Error: Prettier check exited with exit code', exitCode);
-      process.exit(1);
-    });
-};
-
-run();
+  await prettierCheck();
+})();


### PR DESCRIPTION
Provide editor compliance for prettier and honour a consumers `.prettierignore` file in the root of their project.

This PR also enforces the `tabWidth: 2` and runs both check and format across all `js`, `ts` and `tsx`, not just those within the target directory.