### PR TITLE
test: Add puppeteer tests for start mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "lint-staged": "^7.2.2",
     "node-dir": "^0.1.17",
     "node-fetch": "^2.1.1",
+    "puppeteer": "^1.10.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",

--- a/test/test-cases/custom-src-paths/__snapshots__/custom-src-paths.test.js.snap
+++ b/test/test-cases/custom-src-paths/__snapshots__/custom-src-paths.test.js.snap
@@ -21,7 +21,20 @@ Object {
 `;
 
 exports[`custom-src-paths start should start a development server 1`] = `
-"
+Object {
+  "content": "<!DOCTYPE html><html><head>
+      <meta charset=\\"UTF-8\\">
+      <title>hello-world</title>
+      <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
+    </head>
+    <body>
+      <div id=\\"app\\"><div data-reactroot=\\"\\">Hello World!</div></div>
+      <script type=\\"text/javascript\\" src=\\"/main.js\\"></script>
+    
+  
+</body></html>",
+  "errors": Array [],
+  "sourceHtml": "
   <!DOCTYPE html>
   <html>
     <head>
@@ -34,5 +47,7 @@ exports[`custom-src-paths start should start a development server 1`] = `
       <script type=\\"text/javascript\\" src=\\"/main.js\\"></script>
     </body>
   </html>
-"
+",
+  "warnings": Array [],
+}
 `;

--- a/test/test-cases/custom-src-paths/custom-src-paths.test.js
+++ b/test/test-cases/custom-src-paths/custom-src-paths.test.js
@@ -1,6 +1,7 @@
 const dirContentsToObject = require('../../utils/dirContentsToObject');
 const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
 const waitForUrls = require('../../utils/waitForUrls');
+const getAppSnapshot = require('../../utils/getAppSnapshot');
 const fetch = require('node-fetch');
 const skuConfig = require('./sku.config');
 
@@ -19,9 +20,8 @@ describe('custom-src-paths', () => {
     });
 
     it('should start a development server', async () => {
-      const response = await fetch(devServerUrl);
-      const responseText = await response.text();
-      expect(responseText).toMatchSnapshot();
+      const snapshot = await getAppSnapshot(devServerUrl);
+      expect(snapshot).toMatchSnapshot();
     });
   });
 

--- a/test/test-cases/hello-world/__snapshots__/hello-world.test.js.snap
+++ b/test/test-cases/hello-world/__snapshots__/hello-world.test.js.snap
@@ -22,7 +22,20 @@ Object {
 `;
 
 exports[`hello-world start should start a development server 1`] = `
-"
+Object {
+  "content": "<!DOCTYPE html><html><head>
+      <meta charset=\\"UTF-8\\">
+      <title>hello-world</title>
+      <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
+    <script charset=\\"utf-8\\" src=\\"/0.js\\"></script></head>
+    <body>
+      <div id=\\"app\\" data-message=\\"Hello world!\\">Hello world!</div>
+      <script type=\\"text/javascript\\" src=\\"/main.js\\"></script>
+    
+  
+</body></html>",
+  "errors": Array [],
+  "sourceHtml": "
   <!DOCTYPE html>
   <html>
     <head>
@@ -35,5 +48,7 @@ exports[`hello-world start should start a development server 1`] = `
       <script type=\\"text/javascript\\" src=\\"/main.js\\"></script>
     </body>
   </html>
-"
+",
+  "warnings": Array [],
+}
 `;

--- a/test/test-cases/hello-world/hello-world.test.js
+++ b/test/test-cases/hello-world/hello-world.test.js
@@ -1,6 +1,7 @@
 const dirContentsToObject = require('../../utils/dirContentsToObject');
 const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
 const waitForUrls = require('../../utils/waitForUrls');
+const getAppSnapshot = require('../../utils/getAppSnapshot');
 const fetch = require('node-fetch');
 const skuConfig = require('./sku.config');
 
@@ -19,9 +20,8 @@ describe('hello-world', () => {
     });
 
     it('should start a development server', async () => {
-      const response = await fetch(devServerUrl);
-      const responseText = await response.text();
-      expect(responseText).toMatchSnapshot();
+      const snapshot = await getAppSnapshot(devServerUrl);
+      expect(snapshot).toMatchSnapshot();
     });
   });
 

--- a/test/test-cases/ssr-hello-world/__snapshots__/ssr-hello-world.test.js.snap
+++ b/test/test-cases/ssr-hello-world/__snapshots__/ssr-hello-world.test.js.snap
@@ -26,7 +26,20 @@ Object {
 `;
 
 exports[`ssr-hello-world start should start a development server 1`] = `
-"
+Object {
+  "content": "<!DOCTYPE html><html><head>
+      <meta charset=\\"UTF-8\\">
+      <title>hello-world</title>
+      <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
+    <script charset=\\"utf-8\\" src=\\"http://localhost:8000/0.js\\"></script></head>
+    <body>
+      <div id=\\"app\\" data-message=\\"Hello world!\\">Hello world!</div>
+      <script type=\\"text/javascript\\" src=\\"http://localhost:8000/main.js\\"></script>
+    
+  
+</body></html>",
+  "errors": Array [],
+  "sourceHtml": "
   <!DOCTYPE html>
   <html>
     <head>
@@ -39,5 +52,7 @@ exports[`ssr-hello-world start should start a development server 1`] = `
       <script type=\\"text/javascript\\" src=\\"http://localhost:8000/main.js\\"></script>
     </body>
   </html>
-"
+",
+  "warnings": Array [],
+}
 `;

--- a/test/test-cases/ssr-hello-world/ssr-hello-world.test.js
+++ b/test/test-cases/ssr-hello-world/ssr-hello-world.test.js
@@ -3,6 +3,7 @@ const gracefulSpawn = require('../../../lib/gracefulSpawn');
 const waitForUrls = require('../../utils/waitForUrls');
 const fetch = require('node-fetch');
 const dirContentsToObject = require('../../utils/dirContentsToObject');
+const getAppSnapshot = require('../../utils/getAppSnapshot');
 const skuConfig = require('./sku.config');
 
 const backendUrl = `http://localhost:${skuConfig.port.backend}`;
@@ -22,9 +23,8 @@ describe('ssr-hello-world', () => {
     });
 
     it('should start a development server', async () => {
-      const response = await fetch(backendUrl);
-      const responseText = await response.text();
-      expect(responseText).toMatchSnapshot();
+      const snapshot = await getAppSnapshot(backendUrl);
+      expect(snapshot).toMatchSnapshot();
     });
 
     it('should start a static asset server', async () => {

--- a/test/test-cases/typescript-css-modules/__snapshots__/typescript-css-modules.test.js.snap
+++ b/test/test-cases/typescript-css-modules/__snapshots__/typescript-css-modules.test.js.snap
@@ -99,8 +99,6 @@ Object {
     </body>
   </html>
 ",
-  "warnings": Array [
-    "Warning: render(): Calling ReactDOM.render() to hydrate server-rendered markup will stop working in React v17. Replace the ReactDOM.render() call with ReactDOM.hydrate() if you want React to attach to the server HTML.",
-  ],
+  "warnings": Array [],
 }
 `;

--- a/test/test-cases/typescript-css-modules/__snapshots__/typescript-css-modules.test.js.snap
+++ b/test/test-cases/typescript-css-modules/__snapshots__/typescript-css-modules.test.js.snap
@@ -68,3 +68,39 @@ export const nested: string;
 ",
 }
 `;
+
+exports[`typescript-css-modules start should start a development server 1`] = `
+Object {
+  "content": "<!DOCTYPE html><html><head>
+      <meta charset=\\"UTF-8\\">
+      <title>My Awesome Project</title>
+      <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
+      <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"/style.css\\">
+    </head>
+    <body>
+      <div id=\\"app\\"><div class=\\"lessStyles__root___1brbpTo jsStyles-css__root___Jlnxw97\\" data-reactroot=\\"\\"><div class=\\"lessStyles__nested___3YtmnHj jsStyles-css__nested___lwsthgY\\">Hello World</div></div></div>
+      <script type=\\"text/javascript\\" src=\\"/main.js\\"></script>
+    
+  
+</body></html>",
+  "errors": Array [],
+  "sourceHtml": "
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <meta charset=\\"UTF-8\\">
+      <title>My Awesome Project</title>
+      <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
+      <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"/style.css\\" />
+    </head>
+    <body>
+      <div id=\\"app\\"><div class=\\"lessStyles__root___1brbpTo jsStyles-css__root___Jlnxw97\\" data-reactroot=\\"\\"><div class=\\"lessStyles__nested___3YtmnHj jsStyles-css__nested___lwsthgY\\">Hello World</div></div></div>
+      <script type=\\"text/javascript\\" src=\\"/main.js\\"></script>
+    </body>
+  </html>
+",
+  "warnings": Array [
+    "Warning: render(): Calling ReactDOM.render() to hydrate server-rendered markup will stop working in React v17. Replace the ReactDOM.render() call with ReactDOM.hydrate() if you want React to attach to the server HTML.",
+  ],
+}
+`;

--- a/test/test-cases/typescript-css-modules/app/src/client.tsx
+++ b/test/test-cases/typescript-css-modules/app/src/client.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { hydrate } from 'react-dom';
+import { render } from 'react-dom';
 import App from './App';
 
-hydrate(<App />, document.getElementById('app'));
+render(<App />, document.getElementById('app'));

--- a/test/test-cases/typescript-css-modules/app/src/client.tsx
+++ b/test/test-cases/typescript-css-modules/app/src/client.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from 'react-dom';
+import { hydrate } from 'react-dom';
 import App from './App';
 
-render(<App />, document.getElementById('app'));
+hydrate(<App />, document.getElementById('app'));

--- a/test/test-cases/typescript-css-modules/typescript-css-modules.test.js
+++ b/test/test-cases/typescript-css-modules/typescript-css-modules.test.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const dirContentsToObject = require('../../utils/dirContentsToObject');
+const waitForUrls = require('../../utils/waitForUrls');
 const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
+const getAppSnapshot = require('../../utils/getAppSnapshot');
 const appDir = path.resolve(__dirname, 'app');
 const distDir = path.resolve(appDir, 'dist');
 const srcDir = path.resolve(appDir, 'src');
@@ -37,6 +39,25 @@ describe('typescript-css-modules', () => {
         ...files,
         ...srcFiles
       }).toMatchSnapshot();
+    });
+  });
+
+  describe('start', () => {
+    const devServerUrl = `http://localhost:8080`;
+    let server;
+
+    beforeAll(async () => {
+      server = await runSkuScriptInDir('start', appDir);
+      await waitForUrls(devServerUrl);
+    });
+
+    afterAll(() => {
+      server.kill();
+    });
+
+    it('should start a development server', async () => {
+      const snapshot = await getAppSnapshot(devServerUrl);
+      expect(snapshot).toMatchSnapshot();
     });
   });
 

--- a/test/test-cases/zero-config/__snapshots__/zero-config.test.js.snap
+++ b/test/test-cases/zero-config/__snapshots__/zero-config.test.js.snap
@@ -22,7 +22,20 @@ Object {
 `;
 
 exports[`zero-config start should start a development server 1`] = `
-"
+Object {
+  "content": "<!DOCTYPE html><html><head>
+      <meta charset=\\"UTF-8\\">
+      <title>hello-world</title>
+      <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
+    <script charset=\\"utf-8\\" src=\\"/0.js\\"></script></head>
+    <body>
+      <div id=\\"app\\" data-message=\\"Hello world!\\">Hello world!</div>
+      <script type=\\"text/javascript\\" src=\\"/main.js\\"></script>
+    
+  
+</body></html>",
+  "errors": Array [],
+  "sourceHtml": "
   <!DOCTYPE html>
   <html>
     <head>
@@ -35,5 +48,7 @@ exports[`zero-config start should start a development server 1`] = `
       <script type=\\"text/javascript\\" src=\\"/main.js\\"></script>
     </body>
   </html>
-"
+",
+  "warnings": Array [],
+}
 `;

--- a/test/test-cases/zero-config/zero-config.test.js
+++ b/test/test-cases/zero-config/zero-config.test.js
@@ -1,6 +1,7 @@
 const dirContentsToObject = require('../../utils/dirContentsToObject');
 const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
 const waitForUrls = require('../../utils/waitForUrls');
+const getAppSnapshot = require('../../utils/getAppSnapshot');
 const fetch = require('node-fetch');
 
 describe('zero-config', () => {
@@ -18,9 +19,8 @@ describe('zero-config', () => {
     });
 
     it('should start a development server', async () => {
-      const response = await fetch(devServerUrl);
-      const responseText = await response.text();
-      expect(responseText).toMatchSnapshot();
+      const snapshot = await getAppSnapshot(devServerUrl);
+      expect(snapshot).toMatchSnapshot();
     });
   });
 

--- a/test/utils/getAppSnapshot.js
+++ b/test/utils/getAppSnapshot.js
@@ -1,0 +1,27 @@
+const puppeteer = require('puppeteer');
+
+module.exports = async url => {
+  const warnings = [];
+  const errors = [];
+
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+
+  page.on('console', msg => {
+    if (msg.type() === 'warning') {
+      warnings.push(msg.text());
+    }
+
+    if (msg.type() === 'error') {
+      errors.push(msg.text());
+    }
+  });
+
+  const response = await page.goto(url);
+  const sourceHtml = await response.text();
+  const content = await page.content();
+
+  await browser.close();
+
+  return { sourceHtml, content, warnings, errors };
+};


### PR DESCRIPTION
Puppeteer allows us to run more realistic tests on the various test cases. I've added to the `sku start` tests for now but can be run against any URL hosting an app. SSR and static render have the same API. 🎉 

The snapshots contain the following:
- `sourceHtml` The HTML returned from the base resource/server
- `content` This captures the HTML after client-side code has activated. (eg. `React.hydrate`)
- `warnings` Any warnings logged to the console
- `errors` Any errors logged to the console