### PR TITLE
fix(prettier): Use config directly in scripts

### DIFF
--- a/lib/runPrettier.js
+++ b/lib/runPrettier.js
@@ -7,13 +7,17 @@ const { cwd } = require('./cwd');
 
 const exists = promisify(fs.access);
 const prettierIgnorePath = path.join(cwd(), '.prettierignore');
+const prettierConfigPath = path.join(
+  __dirname,
+  '../config/prettier/prettierConfig.js'
+);
 
 const runPrettier = async ({ write, listDifferent }) => {
   console.log(
     chalk.cyan(`${write ? 'Formatting' : 'Checking'} source code with Prettier`)
   );
 
-  const prettierArgs = [];
+  const prettierArgs = ['--config', prettierConfigPath];
 
   if (write) {
     prettierArgs.push('--write');


### PR DESCRIPTION
Following the introduction of the `configure` step, `prettier` currently depends on the presence of a `.prettierrc` in the root of the project. While this should be safe given we run `configure` on `postinstall`, there are instances inside docker containers where this may not be true.

Both `sku lint` and `sku format` now point to the internal config file directly, leaving the generated `.prettierrc` in the root directory to solely serve editors.

