### PR TITLE
fix(configure): Handle array of target directories

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -37,8 +37,8 @@ module.exports = async () => {
   const targetDirectories = uniq(
     builds.map(({ paths }) => addSep(paths.dist.replace(addSep(cwd()), '')))
   );
-  gitIgnorePatterns.push(targetDirectories);
-  prettierIgnorePatterns.push(targetDirectories);
+  gitIgnorePatterns.push(...targetDirectories);
+  prettierIgnorePatterns.push(...targetDirectories);
 
   if (isTypeScript()) {
     // Generate TypeScript configuration


### PR DESCRIPTION
Given `targetDirectories` is an array we should be spreading it into the ignore lists to keep the list flat for `ensure-gitignore`. This is a cleanup PR, the only side affect at the moment is that if a consumer had the `target` directory specified in their ignore file, it would be duplicated with the `managed by sku` block.

This will clean it up on the next run of `sku configure` (or `npm install`)