### PR TITLE
style(eslint): Setup for internal codebase

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+dist/
+node_modules
+report/

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,21 @@
+{
+  "extends": "seek",
+  "rules": {
+    "no-console": 0,
+    "no-process-exit": 0,
+    "no-sync": 0
+  },
+  "globals": {
+    "__SKU_PUBLIC_PATH__": true,
+    "__SKU_SRC_PATHS_0__": true,
+    "__SKU_SRC_PATHS_1__": true,
+    "__SKU_SRC_PATHS_2__": true,
+    "__SKU_SRC_PATHS_3__": true,
+    "__SKU_SRC_PATHS_4__": true,
+    "__SKU_SRC_PATHS_5__": true,
+    "__SKU_SRC_PATHS_6__": true,
+    "__SKU_SRC_PATHS_7__": true,
+    "__SKU_SRC_PATHS_8__": true,
+    "__SKU_SRC_PATHS_9__": true
+  }
+}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,9 +27,5 @@ After:
 EXAMPLE USAGE:
 
 ```js
-{
-  {
-    Code;
-  }
-}
+{{ Example code }}
 ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,5 +27,9 @@ After:
 EXAMPLE USAGE:
 
 ```js
-{{ Code }}
+{
+  {
+    Code;
+  }
+}
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Once you've made the desired changes and you're ready to commit, stage your loca
 
 Before committing, consider the scope of your changes according to [semantic versioning](http://semver.org), noting whether this is a breaking change, a feature release or a patch.
 
-New versions are published automatically from [Travis CI](https://travis-ci.org) using [semantic-release](https://github.com/semantic-release/semantic-release). In order to automatically increment version numbers correctly, commit messages must follow our [semantic commit message convention](https://github.com/seek-oss/commitlint-config-seek). If your commit includes a breaking change, be sure to prefix your commit body with `BREAKING CHANGE: `. To make this process easier, we have a commit script (powered by [commitizen](https://github.com/commitizen/cz-cli)) to help guide you through the commit process:
+New versions are published automatically from [Travis CI](https://travis-ci.org) using [semantic-release](https://github.com/semantic-release/semantic-release). In order to automatically increment version numbers correctly, commit messages must follow our [semantic commit message convention](https://github.com/seek-oss/commitlint-config-seek). If your commit includes a breaking change, be sure to prefix your commit body with `BREAKING CHANGE:`. To make this process easier, we have a commit script (powered by [commitizen](https://github.com/commitizen/cz-cli)) to help guide you through the commit process:
 
 ```bash
 $ npm run commit
@@ -63,9 +63,9 @@ In order for your pull request to be accepted, the [Travis CI](https://travis-ci
 
 Once your work is approved and ready to go, follow these steps:
 
-1) Hit the merge button
-2) Ensure the commit message matches the title of the PR (it may have been edited!)
-3) Copy and paste the text under **"Commit Message For Review"** into the commit body (again, it may have been edited!)
+1. Hit the merge button
+2. Ensure the commit message matches the title of the PR (it may have been edited!)
+3. Copy and paste the text under **"Commit Message For Review"** into the commit body (again, it may have been edited!)
 
 Finally, take a deep breath, hit the green "confirm" button, and we have liftoff—your work should be automatically deployed!
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Front-end development toolkit, powered by [Webpack](https://webpack.js.org/), [B
 Quickly get up and running with a zero-config development environment, or optionally add minimal config when needed. Designed for usage with [seek-style-guide](https://github.com/seek-oss/seek-style-guide), although this isn't a requirement.
 
 This tool is heavily inspired by other work, most notably:
+
 - [facebookincubator/create-react-app](https://github.com/facebookincubator/create-react-app)
 - [insin/nwb](https://github.com/insin/nwb)
 - [NYTimes/kyt](https://github.com/NYTimes/kyt)
@@ -35,14 +36,14 @@ $ npm install -g npx
 
 ### Modern Javascript (via [Babel](https://babeljs.io/))
 
-Use `import`, `const`, `=>`, rest/spread operators, destructuring, classes with class properties, [JSX](https://facebook.github.io/react/docs/jsx-in-depth.html) and all their friends in your code.  It'll all just work, thanks to the following Babel plugins:
+Use `import`, `const`, `=>`, rest/spread operators, destructuring, classes with class properties, [JSX](https://facebook.github.io/react/docs/jsx-in-depth.html) and all their friends in your code. It'll all just work, thanks to the following Babel plugins:
 
-* [@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env/)
-* [@babel/preset-react](https://babeljs.io/docs/en/babel-preset-react/)
-* [@babel/preset-typescript](https://babeljs.io/docs/en/babel-preset-typescript)
-* [@babel/plugin-proposal-object-rest-spread](https://babeljs.io/docs/en/babel-plugin-proposal-object-rest-spread)
-* [@babel/plugin-proposal-class-properties](https://babeljs.io/docs/en/babel-plugin-proposal-class-properties)
-* [babel-preset-react-optimize](https://github.com/thejameskyle/babel-react-optimize)
+- [@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env/)
+- [@babel/preset-react](https://babeljs.io/docs/en/babel-preset-react/)
+- [@babel/preset-typescript](https://babeljs.io/docs/en/babel-preset-typescript)
+- [@babel/plugin-proposal-object-rest-spread](https://babeljs.io/docs/en/babel-plugin-proposal-object-rest-spread)
+- [@babel/plugin-proposal-class-properties](https://babeljs.io/docs/en/babel-plugin-proposal-class-properties)
+- [babel-preset-react-optimize](https://github.com/thejameskyle/babel-react-optimize)
 
 ### TypeScript
 
@@ -68,16 +69,12 @@ You can then import the classes into your JavaScript code like so:
 ```js
 import styles from './example.less';
 
-export default () => (
-  <div className={styles.exampleWrapper}>
-    Hello World!
-  </div>
-);
+export default () => <div className={styles.exampleWrapper}>Hello World!</div>;
 ```
 
 ### Static CSS-in-JS (via [css-in-js-loader](https://github.com/nthtran/css-in-js-loader))
 
-You can import `.css.js` files into your components and use them exactly as you would a regular style sheet.  This is mostly useful when you want to take advantage of JavaScript to compose styles:
+You can import `.css.js` files into your components and use them exactly as you would a regular style sheet. This is mostly useful when you want to take advantage of JavaScript to compose styles:
 
 ```js
 import { standardWrapper } from 'theme/wrappers';
@@ -96,11 +93,7 @@ export default {
 ```js
 import styles from './example.css.js';
 
-export default () => (
-  <div className={styles.exampleWrapper}>
-    Hello World!
-  </div>
-);
+export default () => <div className={styles.exampleWrapper}>Hello World!</div>;
 ```
 
 ### Unit and Snapshot Testing (via [Jest](https://facebook.github.io/jest/))
@@ -112,6 +105,7 @@ Since sku uses Jest as a testing framework, you can read the [Jest documentation
 Note: `sku` will forward all command line args to `jest`.
 
 Example running tests in watch mode:
+
 ```bash
 $ sku test --watch
 ```
@@ -147,9 +141,9 @@ export default ({ publicPath }) => {
   return {
     '/foo': '<html>...</html>',
     '/bar': '<html>...</html>',
-    '/baz/qux': '<html>...</html>',
-  }
-}
+    '/baz/qux': '<html>...</html>'
+  };
+};
 ```
 
 Will result in your `/dist` folder having an output like this:
@@ -175,16 +169,8 @@ import React from 'react';
 import Button from './Button';
 
 storiesOf('Button', module)
-  .add('Primary', () => (
-    <Button variant="primary">
-      Primary
-    </Button>
-  ))
-  .add('Secondary', () => (
-    <Button variant="secondary">
-      Secondary
-    </Button>
-  ));
+  .add('Primary', () => <Button variant="primary">Primary</Button>)
+  .add('Secondary', () => <Button variant="secondary">Secondary</Button>);
 ```
 
 _**NOTE:** To access the Storybook API, you should import from `sku/storybook`, since your project isn't depending on Storybook directly._
@@ -240,7 +226,7 @@ module.exports = {
   public: 'src/public',
   publicPath: '/',
   target: 'dist'
-}
+};
 ```
 
 If you need to specify a different config file you can do so with the `--config` parameter.
@@ -376,7 +362,7 @@ Sometimes you might want to extract and share code between sku projects, but thi
 ```js
 module.exports = {
   compilePackages: ['awesome-shared-components']
-}
+};
 ```
 
 Any `node_modules` passed into this option will be compiled through webpack as if they are part of your app.
@@ -390,24 +376,23 @@ The `locales` option accepts an array of strings representing each locale you wa
 ```js
 module.exports = {
   locales: ['AU', 'NZ']
-}
+};
 ```
 
 For each locale, sku will call your `render.js` function and pass it the locale as a parameter.
 
 ```js
-const render = ({ locale }) => (
-  `<div>Rendered for ${locale}</div>`
-)
+const render = ({ locale }) => `<div>Rendered for ${locale}</div>`;
 ```
 
 The name of the HTML file that is generated will be suffixed by `-{locale}`.
 
 eg.
+
 ```js
 module.exports = {
   locales: ['AU', 'NZ']
-}
+};
 ```
 
 will create `index-AU.html` & `index-NZ.html`.
@@ -426,7 +411,7 @@ module.exports = {
   port: 5000,
   // Optional parameter to set a page to open when the development server starts
   initialPath: '/my-page'
-}
+};
 ```
 
 Note: The app will always run on localhost. The `hosts` option is only for apps that resolve custom hosts to localhost.
@@ -457,7 +442,7 @@ module.exports = [
     public: 'src/pages/world/public',
     target: 'dist/world'
   }
-]
+];
 ```
 
 You will then be prompted to select the project you'd like to work on when starting your development server:
@@ -477,6 +462,7 @@ $ npm start hello
 The default mode for sku is to statically render projects. However, Server-Side Rendering (SSR) can explicitly be turned on, both in development with hot module reloading for React, and in production.
 
 First, you need to create a `sku.config.js` file, which will contain the following setup at minimum:
+
 ```js
 module.exports = {
   entry: {
@@ -487,11 +473,13 @@ module.exports = {
   publicPath: '/',
   target: 'dist',
   port: { client: 3300, backend: 3301 }
-}
+};
 ```
+
 If you have an existing configuration, for example generated with `sku init`, you will need to replace the `render` entry point by a `server` entry point, and add port info as documented above.
 
 Then, you need to create your `server` entry. Sku will automatically provide an [Express](https://expressjs.com/) server for the user. The entry point for SSR, `server`, is used to provide a render callback and any additional middlewares to that server. You can provide either a single middleware or an array. This can be done as follows:
+
 ```js
 import render from './render.js';
 import middleware from './middleware';
@@ -505,6 +493,7 @@ export default {
 ```
 
 If you require to consume the webpack public path, this can done as follows:
+
 ```js
 import render from './render.js';
 import middleware from './middleware';
@@ -518,10 +507,10 @@ export default ({ publicPath }) => ({
 ```
 
 Last but not least, please note that commands for SSR are different to the ones used normally:
+
 - Use `sku start-ssr` to start your development environment. It uses both `port.client` and `port.backend` to spin up hot module reloading servers.
 - Use `sku build-ssr` to build your production assets. You can then run `node ./dist/server.js`. Your server will run at `http://localhost:xxxx`, where `xxxx` is `port.backend`.
 - Use `sku test-ssr` to test your application
-
 
 ## Contributing
 

--- a/bin/sku.js
+++ b/bin/sku.js
@@ -21,7 +21,7 @@ switch (script) {
   case 'start-ssr':
   case 'storybook':
   case 'configure': {
-    const scriptPath = require.resolve('../scripts/' + script);
+    const scriptPath = require.resolve(`../scripts/${script}`);
     require(scriptPath);
     break;
   }

--- a/config/builds.ssr.js
+++ b/config/builds.ssr.js
@@ -48,14 +48,14 @@ const builds = buildConfigs
     const compilePackages = buildConfig.compilePackages || [];
     const hosts = buildConfig.hosts || ['localhost'];
     const initialPath = buildConfig.initialPath || '/';
+    const clientPort =
+      typeof buildConfig.port === 'number' ? buildConfig.port : 8080;
 
     const port = {
       client:
         buildConfig.port && buildConfig.port.client
           ? buildConfig.port.client
-          : typeof buildConfig.port === 'number'
-            ? buildConfig.port
-            : 8080,
+          : clientPort,
       backend:
         buildConfig.port && buildConfig.port.backend
           ? buildConfig.port.backend

--- a/config/server/server.js
+++ b/config/server/server.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const express = require('express');
-const serverExports = require('__sku_alias__serverEntry').default;
+const serverExports = require('__sku_alias__serverEntry').default; // eslint-disable-line import/no-unresolved
 
 const serverOptions =
   typeof serverExports === 'function'
@@ -8,8 +8,6 @@ const serverOptions =
     : serverExports;
 
 const { renderCallback, middleware } = serverOptions;
-
-const port = process.env.SKU_PORT || 8080;
 
 const app = express();
 

--- a/config/storybook/webpack.config.js
+++ b/config/storybook/webpack.config.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const webpack = require('webpack');
 const builds = require('../builds');
 const flatten = require('lodash/flatten');

--- a/config/webpack/utils/resolvePackage.js
+++ b/config/webpack/utils/resolvePackage.js
@@ -1,8 +1,26 @@
 const path = require('path');
 const memoize = require('memoizee');
-const chalk = require('chalk');
 const debug = require('debug')('sku:resolvePackage');
 const { cwd } = require('../../../lib/cwd');
+
+function getProjectDependencies(readFileSync) {
+  let pkg;
+
+  try {
+    pkg = JSON.parse(readFileSync(`${cwd()}/package.json`).toString());
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      pkg = {};
+    } else {
+      throw error;
+    }
+  }
+
+  return {
+    ...(pkg.dependencies || {}),
+    ...(pkg.devDependencies || {})
+  };
+}
 
 /**
  * Create a `resolvePackage` function.
@@ -55,25 +73,6 @@ const createPackageResolver = (fs, resolve) => {
 
   return memoize(resolvePackage);
 };
-
-function getProjectDependencies(readFileSync) {
-  let pkg;
-
-  try {
-    pkg = JSON.parse(readFileSync(`${cwd()}/package.json`).toString());
-  } catch (error) {
-    if (error.code === 'ENOENT') {
-      pkg = {};
-    } else {
-      throw error;
-    }
-  }
-
-  return {
-    ...(pkg.dependencies || {}),
-    ...(pkg.devDependencies || {})
-  };
-}
 
 module.exports = {
   resolvePackage: createPackageResolver(require('fs'), require.resolve),

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,5 +7,5 @@ module.exports = {
   ),
   testURL: 'http://localhost',
   testMatch: ['**/*.test.js'],
-  testPathIgnorePatterns: ['test\/.*\/src']
+  testPathIgnorePatterns: ['test/.*/src']
 };

--- a/lib/parseArgs.js
+++ b/lib/parseArgs.js
@@ -59,7 +59,7 @@ module.exports = args => {
     } else if (argv.length) {
       return argv[0];
     }
-    return null;
+    return undefined; // eslint-disable-line no-undefined
   };
 
   return {

--- a/lib/parseArgs.js
+++ b/lib/parseArgs.js
@@ -1,6 +1,4 @@
-const chalk = require('chalk');
 const commandLineArgs = require('command-line-args');
-const path = require('path');
 
 const optionDefinitions = [
   {
@@ -52,15 +50,16 @@ module.exports = args => {
     partial: true
   });
 
-  let { script, _unknown: argv = [] } = options;
+  const { script, _unknown: argv = [] } = options;
 
-  //Backwards compatibility for unnamed build name argument, to be deprecated
+  // Backwards compatibility for unnamed build name argument, to be deprecated
   const buildName = () => {
     if (options.build) {
       return options.build;
     } else if (argv.length) {
       return argv[0];
     }
+    return null;
   };
 
   return {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
     "node": ">=8.0.0"
   },
   "scripts": {
+    "lint": "eslint .",
     "test": "npm run format-check && OPEN_TAB=false jest --runInBand --verbose",
     "test-manual": "node test/manual",
-    "format": "prettier --single-quote --write '{bin,config,scripts,lib}/**/*.js'",
-    "format-check": "prettier --single-quote --list-different '{bin,config,scripts,lib}/**/*.js'",
+    "format": "prettier --config ./config/prettier/prettierConfig.js --write '**/*.{js,ts,tsx,md,less,css}'",
+    "format-check": "prettier --config ./config/prettier/prettierConfig.js --list-different '**/*.{js,ts,tsx,md,less,css}'",
     "postinstall": "./scripts/postinstall.js",
     "precommit": "lint-staged",
     "commit": "git-cz",
@@ -21,8 +22,12 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "lint-staged": {
-    "{bin,config,scripts}/**/*.js": [
-      "prettier --single-quote --write",
+    "**/*.js": [
+      "npm run lint",
+      "git add"
+    ],
+    "**/*.{js,ts,tsx,md,less,css}": [
+      "npm run format",
       "git add"
     ]
   },

--- a/scripts/start-ssr.js
+++ b/scripts/start-ssr.js
@@ -22,9 +22,10 @@ const devServer = new WebpackDevServer(compiler, {
   headers: { 'Access-Control-Allow-Origin': '*' }
 });
 
-devServer.listen(port.client, '127.0.0.1', (err, result) => {
+devServer.listen(port.client, '127.0.0.1', err => {
   if (err) {
-    return console.log(err);
+    console.log(err);
+    return;
   }
 
   const url = `http://${hosts[0]}:${port.client}`;

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -17,9 +17,10 @@ const devServer = new WebpackDevServer(compiler, {
   allowedHosts: hosts
 });
 
-devServer.listen(port, '0.0.0.0', (err, result) => {
+devServer.listen(port, '0.0.0.0', err => {
   if (err) {
-    return console.log(err);
+    console.log(err);
+    return;
   }
 
   const url = `http://${hosts[0]}:${port}${initialPath}`;

--- a/scripts/test-ssr.js
+++ b/scripts/test-ssr.js
@@ -3,7 +3,7 @@ const baseJestConfig = require('../config/jest/jestConfig');
 const { argv } = require('../config/args');
 const builds = require('../config/builds.ssr');
 
-//Decorate jest config is not supported for monorepo
+// Decorate jest config is not supported for monorepo
 const jestConfig =
   builds.length === 1
     ? builds[0].jestDecorator(baseJestConfig)

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -3,7 +3,7 @@ const baseJestConfig = require('../config/jest/jestConfig');
 const { argv } = require('../config/args');
 const builds = require('../config/builds');
 
-//Decorate jest config is not supported for monorepo
+// Decorate jest config is not supported for monorepo
 const jestConfig =
   builds.length === 1
     ? builds[0].jestDecorator(baseJestConfig)

--- a/test/manual.js
+++ b/test/manual.js
@@ -11,7 +11,10 @@ const LAST_TEST_CASE = 'lastTestCase';
 const LAST_SCRIPT = 'lastScript';
 
 const runScriptForTestCase = (script, testCase) => {
-  return runSkuScriptInDir(script, path.join(__dirname, 'test-cases', testCase));
+  return runSkuScriptInDir(
+    script,
+    path.join(__dirname, 'test-cases', testCase)
+  );
 };
 
 (async () => {
@@ -28,7 +31,8 @@ const runScriptForTestCase = (script, testCase) => {
     ]);
 
     if (useLast) {
-      return await runScriptForTestCase(lastScript, lastTestCase);
+      await runScriptForTestCase(lastScript, lastTestCase);
+      return;
     }
   }
 

--- a/test/test-cases/braid-design-system/app/src/client.js
+++ b/test/test-cases/braid-design-system/app/src/client.js
@@ -2,4 +2,4 @@ import React from 'react';
 import { hydrate } from 'react-dom';
 import App from './App';
 
-hydrate(<App />, document.getElementById("app"));
+hydrate(<App />, document.getElementById('app'));

--- a/test/test-cases/braid-design-system/braid-design-system.test.js
+++ b/test/test-cases/braid-design-system/braid-design-system.test.js
@@ -8,6 +8,22 @@ const appDir = path.resolve(__dirname, 'app');
 const distDir = path.resolve(appDir, 'dist');
 const { cwd } = require('../../../lib/cwd');
 
+function createPackageLink(name) {
+  return fs.symlink(
+    `${cwd()}/node_modules/${name}`,
+    `${__dirname}/app/node_modules/${name}`
+  );
+}
+
+async function linkLocalDependencies() {
+  const nodeModules = `${__dirname}/app/node_modules`;
+  await rimrafAsync(nodeModules);
+  await fs.mkdir(nodeModules);
+  await Promise.all(
+    ['react', 'react-dom', 'braid-design-system'].map(createPackageLink)
+  );
+}
+
 describe('braid-design-system', () => {
   beforeAll(async () => {
     // "Install" React and braid-design-system into this test app so that webpack-node-externals
@@ -25,20 +41,4 @@ describe('braid-design-system', () => {
     const { childProcess } = await runSkuScriptInDir('test', appDir);
     expect(childProcess.exitCode).toEqual(0);
   });
-
-  async function linkLocalDependencies() {
-    const nodeModules = `${__dirname}/app/node_modules`;
-    await rimrafAsync(nodeModules);
-    await fs.mkdir(nodeModules);
-    await Promise.all(
-      ['react', 'react-dom', 'braid-design-system'].map(createPackageLink)
-    );
-  }
-
-  function createPackageLink(name) {
-    return fs.symlink(
-      `${cwd()}/node_modules/${name}`,
-      `${__dirname}/app/node_modules/${name}`
-    );
-  }
 });

--- a/test/test-cases/custom-src-paths/custom-src-paths.test.js
+++ b/test/test-cases/custom-src-paths/custom-src-paths.test.js
@@ -2,7 +2,6 @@ const dirContentsToObject = require('../../utils/dirContentsToObject');
 const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
 const waitForUrls = require('../../utils/waitForUrls');
 const getAppSnapshot = require('../../utils/getAppSnapshot');
-const fetch = require('node-fetch');
 const skuConfig = require('./sku.config');
 
 describe('custom-src-paths', () => {

--- a/test/test-cases/hello-world/hello-world.test.js
+++ b/test/test-cases/hello-world/hello-world.test.js
@@ -2,7 +2,6 @@ const dirContentsToObject = require('../../utils/dirContentsToObject');
 const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
 const waitForUrls = require('../../utils/waitForUrls');
 const getAppSnapshot = require('../../utils/getAppSnapshot');
-const fetch = require('node-fetch');
 const skuConfig = require('./sku.config');
 
 describe('hello-world', () => {

--- a/test/test-cases/react-css-modules/app/src/App.js
+++ b/test/test-cases/react-css-modules/app/src/App.js
@@ -4,8 +4,6 @@ import jsStyles from './jsStyles.css.js';
 
 export default () => (
   <div className={`${lessStyles.root} ${jsStyles.root}`}>
-    <div className={`${lessStyles.nested} ${jsStyles.nested}`}>
-      Hello World
-    </div>
+    <div className={`${lessStyles.nested} ${jsStyles.nested}`}>Hello World</div>
   </div>
 );

--- a/test/test-cases/react-css-modules/app/src/client.js
+++ b/test/test-cases/react-css-modules/app/src/client.js
@@ -2,4 +2,4 @@ import React from 'react';
 import { hydrate } from 'react-dom';
 import App from './App';
 
-hydrate(<App />, document.getElementById("app"));
+hydrate(<App />, document.getElementById('app'));

--- a/test/test-cases/seek-asia-style-guide/app/src/client.js
+++ b/test/test-cases/seek-asia-style-guide/app/src/client.js
@@ -2,4 +2,4 @@ import React from 'react';
 import { hydrate } from 'react-dom';
 import App from './App';
 
-hydrate(<App />, document.getElementById("app"));
+hydrate(<App />, document.getElementById('app'));

--- a/test/test-cases/seek-asia-style-guide/seek-asia-style-guide.test.js
+++ b/test/test-cases/seek-asia-style-guide/seek-asia-style-guide.test.js
@@ -8,6 +8,22 @@ const appDir = path.resolve(__dirname, 'app');
 const distDir = path.resolve(appDir, 'dist');
 const { cwd } = require('../../../lib/cwd');
 
+function createPackageLink(name) {
+  return fs.symlink(
+    `${cwd()}/node_modules/${name}`,
+    `${__dirname}/app/node_modules/${name}`
+  );
+}
+
+async function linkLocalDependencies() {
+  const nodeModules = `${__dirname}/app/node_modules`;
+  await rimrafAsync(nodeModules);
+  await fs.mkdir(nodeModules);
+  await Promise.all(
+    ['react', 'react-dom', 'seek-asia-style-guide'].map(createPackageLink)
+  );
+}
+
 describe('seek-asia-style-guide', () => {
   beforeAll(async () => {
     // "Install" React and seek-asia-style-guide into this test app so that webpack-node-externals
@@ -25,20 +41,4 @@ describe('seek-asia-style-guide', () => {
     const { childProcess } = await runSkuScriptInDir('test', appDir);
     expect(childProcess.exitCode).toEqual(0);
   });
-
-  async function linkLocalDependencies() {
-    const nodeModules = `${__dirname}/app/node_modules`;
-    await rimrafAsync(nodeModules);
-    await fs.mkdir(nodeModules);
-    await Promise.all(
-      ['react', 'react-dom', 'seek-asia-style-guide'].map(createPackageLink)
-    );
-  }
-
-  function createPackageLink(name) {
-    return fs.symlink(
-      `${cwd()}/node_modules/${name}`,
-      `${__dirname}/app/node_modules/${name}`
-    );
-  }
 });

--- a/test/test-cases/seek-style-guide/app/src/App.js
+++ b/test/test-cases/seek-style-guide/app/src/App.js
@@ -1,5 +1,10 @@
 import React from 'react';
-import { StyleGuideProvider, PageBlock, Section, Text } from 'seek-style-guide/react';
+import {
+  StyleGuideProvider,
+  PageBlock,
+  Section,
+  Text
+} from 'seek-style-guide/react';
 
 export default () => (
   <StyleGuideProvider>

--- a/test/test-cases/seek-style-guide/app/src/client.js
+++ b/test/test-cases/seek-style-guide/app/src/client.js
@@ -2,4 +2,4 @@ import React from 'react';
 import { hydrate } from 'react-dom';
 import App from './App';
 
-hydrate(<App />, document.getElementById("app"));
+hydrate(<App />, document.getElementById('app'));

--- a/test/test-cases/seek-style-guide/seek-style-guide.test.js
+++ b/test/test-cases/seek-style-guide/seek-style-guide.test.js
@@ -8,6 +8,22 @@ const appDir = path.resolve(__dirname, 'app');
 const distDir = path.resolve(appDir, 'dist');
 const { cwd } = require('../../../lib/cwd');
 
+function createPackageLink(name) {
+  return fs.symlink(
+    `${cwd()}/node_modules/${name}`,
+    `${__dirname}/app/node_modules/${name}`
+  );
+}
+
+async function linkLocalDependencies() {
+  const nodeModules = `${__dirname}/app/node_modules`;
+  await rimrafAsync(nodeModules);
+  await fs.mkdir(nodeModules);
+  await Promise.all(
+    ['react', 'react-dom', 'seek-style-guide'].map(createPackageLink)
+  );
+}
+
 describe('seek-style-guide', () => {
   beforeAll(async () => {
     // "Install" React and seek-style-guide into this test app so that webpack-node-externals
@@ -25,20 +41,4 @@ describe('seek-style-guide', () => {
     const { childProcess } = await runSkuScriptInDir('test', appDir);
     expect(childProcess.exitCode).toEqual(0);
   });
-
-  async function linkLocalDependencies() {
-    const nodeModules = `${__dirname}/app/node_modules`;
-    await rimrafAsync(nodeModules);
-    await fs.mkdir(nodeModules);
-    await Promise.all(
-      ['react', 'react-dom', 'seek-style-guide'].map(createPackageLink)
-    );
-  }
-
-  function createPackageLink(name) {
-    return fs.symlink(
-      `${cwd()}/node_modules/${name}`,
-      `${__dirname}/app/node_modules/${name}`
-    );
-  }
 });

--- a/test/test-cases/zero-config/zero-config.test.js
+++ b/test/test-cases/zero-config/zero-config.test.js
@@ -2,7 +2,6 @@ const dirContentsToObject = require('../../utils/dirContentsToObject');
 const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
 const waitForUrls = require('../../utils/waitForUrls');
 const getAppSnapshot = require('../../utils/getAppSnapshot');
-const fetch = require('node-fetch');
 
 describe('zero-config', () => {
   describe('start', () => {

--- a/test/utils/dirContentsToObject.js
+++ b/test/utils/dirContentsToObject.js
@@ -6,11 +6,16 @@ module.exports = async (dirname, includeExtensions) => {
   const files = {};
 
   const handleFile = (err, content, filePath, next) => {
-    if (err) throw err;
+    if (err) {
+      throw err;
+    }
 
     const relativeFilePath = relative(dirname, filePath);
-    
-    if (!includeExtensions || includeExtensions.includes(extname(relativeFilePath))) {
+
+    if (
+      !includeExtensions ||
+      includeExtensions.includes(extname(relativeFilePath))
+    ) {
       files[relativeFilePath] = /\.js$/.test(relativeFilePath)
         ? 'CONTENTS IGNORED IN SNAPSHOT TEST'
         : content;
@@ -18,7 +23,7 @@ module.exports = async (dirname, includeExtensions) => {
 
     next();
   };
-  
+
   await readFilesAsync(dirname, handleFile);
 
   return files;

--- a/test/utils/runSkuScriptInDir.js
+++ b/test/utils/runSkuScriptInDir.js
@@ -18,8 +18,12 @@ module.exports = async (script, cwd) => {
     });
   } catch (error) {
     // Print the stdout of a failed command so we can see it in the jest output.
-    error.stdout && console.warn(error.stdout);
-    error.stderr && console.warn(error.stderr);
+    if (error.stdout) {
+      console.warn(error.stdout);
+    }
+    if (error.stderr) {
+      console.warn(error.stderr);
+    }
     throw error;
   }
 };


### PR DESCRIPTION
Implements `eslint` on the internal codebase. This PR goes with the [`eslint-config-seek`](https://github.com/seek-oss/eslint-config-seek) rules, but turns off a few relating to console, file system access and process management. We can revisit these later if required, but keen to get this through as it will help catch some problems earlier.