### PR TITLE
chore(deps): Upgrade commit and release packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "sku": "./bin/sku.js"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.6"
   },
   "scripts": {
     "lint": "eslint .",
@@ -16,10 +16,14 @@
     "format": "prettier --config ./config/prettier/prettierConfig.js --write '**/*.{js,ts,tsx,md,less,css}'",
     "format-check": "prettier --config ./config/prettier/prettierConfig.js --list-different '**/*.{js,ts,tsx,md,less,css}'",
     "postinstall": "./scripts/postinstall.js",
-    "precommit": "lint-staged",
     "commit": "git-cz",
-    "commitmsg": "commitlint --edit --extends seek",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint --edit --extends seek",
+      "pre-commit": "lint-staged"
+    }
   },
   "lint-staged": {
     "**/*.js": [
@@ -35,6 +39,9 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "release": {
+    "success": false
   },
   "repository": {
     "type": "git",
@@ -127,17 +134,17 @@
     "webpack-node-externals": "^1.7.2"
   },
   "devDependencies": {
-    "@commitlint/cli": "^6.0.1",
+    "@commitlint/cli": "^7.2.1",
     "@types/react": "^16.4.18",
     "@types/react-dom": "^16.0.9",
     "async-disk-cache": "^1.3.3",
     "braid-design-system": "0.0.2",
     "child-process-promise": "^2.2.1",
-    "commitizen": "^2.9.6",
+    "commitizen": "^3.0.4",
     "commitlint-config-seek": "^1.0.0",
     "cz-conventional-changelog": "^2.1.0",
-    "husky": "^0.14.3",
-    "lint-staged": "^7.2.2",
+    "husky": "^1.1.3",
+    "lint-staged": "^8.0.4",
     "node-dir": "^0.1.17",
     "node-fetch": "^2.1.1",
     "puppeteer": "^1.10.0",
@@ -146,7 +153,7 @@
     "react-helmet": "^5.2.0",
     "seek-asia-style-guide": "6.6.2",
     "seek-style-guide": "37.11.1",
-    "semantic-release": "^8.0.3",
+    "semantic-release": "^15.10.8",
     "wait-on": "^2.1.0",
     "webpack-stats-plugin": "^0.2.1"
   }


### PR DESCRIPTION
Upgrading dependencies in the commit and release flow as we were quite a way behind, particularly with `semantic-release`.

The change to the node version is based on the [release notes for `lint-staged`](https://github.com/okonet/lint-staged/releases/tag/v8.0.0).