### PR TITLE
fix(storybook): Add TypeScript module resolution to Storybook

### DIFF
--- a/config/storybook/webpack.config.js
+++ b/config/storybook/webpack.config.js
@@ -18,6 +18,7 @@ module.exports = webpackMerge(
     // mainly because it configures entries and outputs,
     // which would break the Storybook build.
     module: clientWebpackConfig.module,
+    resolve: clientWebpackConfig.resolve,
     plugins: clientWebpackConfig.plugins
   },
   {


### PR DESCRIPTION
## Why?

The module resolution rules from `webpack.config.js` weren't being provided to Storybook's webpack config, so TypeScript modules weren't being resolved correctly.