### PR TITLE
fix(chromatic): Fix Chromatic PR build messaging

### DIFF
--- a/scripts/chromatic.js
+++ b/scripts/chromatic.js
@@ -20,10 +20,7 @@ const skuPath = require.resolve('../bin/sku');
     if (isInitialPrBuild && isInternalPr) {
       console.log('');
       console.log(
-        'Skipping Chromatic for initial pull request build on Travis CI: http://docs.chromaticqa.com/setup_ci#travis'
-      );
-      console.log(
-        'You should disable "Build on Pull Requests" in your repository settings: https://docs.travis-ci.com/user/pull-requests/#how-pull-requests-are-built'
+        'Skipping Chromatic for internal pull request build on Travis CI: http://docs.chromaticqa.com/setup_ci#travis'
       );
       console.log('');
       process.exit(0);


### PR DESCRIPTION
When skipping Chromatic for PR builds on Travis CI, the console messages weren't quite right. You don't need to disable "Build on Pull Requests", which may in fact cause other issues (in the case of [Braid](https://github.com/seek-oss/braid-design-system), it disabled our static preview deployments 🙈).

Luckily, the Chromatic code is still doing the right thing though.