### PR TITLE
feat(babel): Add Babel Macros support

### DIFF
--- a/config/babel/babelConfig.js
+++ b/config/babel/babelConfig.js
@@ -26,7 +26,8 @@ module.exports = ({ target, lang = 'js' }) => {
       {
         root: [cwd()]
       }
-    ]
+    ],
+    require.resolve('babel-plugin-macros')
   ];
 
   if (isBrowser) {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "babel-loader": "^8.0.4",
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-plugin-flow-react-proptypes": "^24.1.2",
+    "babel-plugin-macros": "^2.4.2",
     "babel-plugin-module-resolver": "^3.1.1",
     "babel-plugin-seek-style-guide": "^1.0.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",


### PR DESCRIPTION
Does what it says on the tin!

See https://github.com/kentcdodds/babel-plugin-macros.

There's pretty wide support for this now, including Create React App 2.0.

Using this branch has enabled us to use emotion via [it's macro](https://github.com/emotion-js/emotion/tree/master/packages/babel-plugin-emotion#babel-macros).

You can try this branch out with:

```sh
npm install --save-dev seek-oss/sku#beta-babel-macros-1
```