### PR TITLE
feat: Transform ‘compilePackages’ code in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "dedent": "^0.7.0",
     "empty-dir": "^1.0.0",
     "ensure-gitignore": "^1.1.2",
+    "escape-string-regexp": "^1.0.5",
     "eslint": "^5.8.0",
     "eslint-config-seek": "^3.2.1",
     "express": "^4.16.3",

--- a/test/test-cases/braid-design-system/app/src/App.test.js
+++ b/test/test-cases/braid-design-system/app/src/App.test.js
@@ -1,7 +1,12 @@
+import { seekAnz } from 'braid-design-system/lib/themes';
 import { Box } from 'braid-design-system';
 
 describe('braid-design-system', () => {
-  test('mocks', () => {
-    expect(Box).toEqual('Box');
+  test('atoms', () => {
+    expect(seekAnz.atoms.paddingTop.large).toEqual('paddingTop__large');
+  });
+
+  test('components', () => {
+    expect(typeof Box).toEqual('function');
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: `braid-design-system` is no longer auto-mocked in tests.