### PR TITLE
feat: Generate ESLint config files

### DIFF
--- a/config/eslint/eslintConfig.js
+++ b/config/eslint/eslintConfig.js
@@ -1,0 +1,6 @@
+const { eslintDecorator } = require('../../context');
+const baseConfig = {
+  extends: require.resolve('eslint-config-seek')
+};
+
+module.exports = eslintDecorator(baseConfig);

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -57,7 +57,6 @@ module.exports = async () => {
 
   // Generate ESLint configuration
   const eslintConfigFilename = '.eslintrc';
-  console.log('eslintConfig', eslintConfig);
   await writeFileToCWD(eslintConfigFilename, eslintConfig);
   gitIgnorePatterns.push(eslintConfigFilename);
 

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -14,6 +14,7 @@ const {
 } = require('../config/webpack/plugins/bundleAnalyzer');
 const tslintConfig = require('../config/typescript/tslint.json');
 const prettierConfig = require('../config/prettier/prettierConfig');
+const eslintConfig = require('../config/eslint/eslintConfig');
 
 const addSep = p => `${p}${path.sep}`;
 const prependBanner = str =>
@@ -30,12 +31,12 @@ const writeFileToCWD = async (fileName, content, { banner = true } = {}) => {
 module.exports = async () => {
   // Ignore webpack bundle report output
   const gitIgnorePatterns = [addSep(bundleReportFolder)];
-  const prettierIgnorePatterns = [addSep(bundleReportFolder)];
+  const lintIgnorePatterns = [addSep(bundleReportFolder)];
 
   // Ignore webpack target directories
   const targetDirectory = addSep(paths.target.replace(addSep(cwd()), ''));
   gitIgnorePatterns.push(targetDirectory);
-  prettierIgnorePatterns.push(targetDirectory);
+  lintIgnorePatterns.push(targetDirectory);
 
   if (isTypeScript()) {
     // Generate TypeScript configuration
@@ -53,6 +54,12 @@ module.exports = async () => {
     await writeFileToCWD(tslintConfigFileName, tslintConfig);
     gitIgnorePatterns.push(tslintConfigFileName);
   }
+
+  // Generate ESLint configuration
+  const eslintConfigFilename = '.eslintrc';
+  console.log('eslintConfig', eslintConfig);
+  await writeFileToCWD(eslintConfigFilename, eslintConfig);
+  gitIgnorePatterns.push(eslintConfigFilename);
 
   // Generate Prettier configuration
   // NOTE: We are not generating a banner as prettier does not support the `JSON
@@ -72,10 +79,17 @@ module.exports = async () => {
     patterns: gitIgnorePatterns
   });
 
+  // Write `.eslintignore`
+  await ensureGitignore({
+    filepath: getPathFromCwd('.eslintignore'),
+    comment: 'managed by sku',
+    patterns: lintIgnorePatterns
+  });
+
   // Write `.prettierignore`
   await ensureGitignore({
     filepath: getPathFromCwd('.prettierignore'),
     comment: 'managed by sku',
-    patterns: prettierIgnorePatterns
+    patterns: lintIgnorePatterns
   });
 };

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "commitlint-config-seek": "^1.0.0",
     "cz-conventional-changelog": "^2.1.0",
     "husky": "^1.1.3",
+    "jsonc-parser": "^2.0.2",
     "lint-staged": "^8.0.4",
     "node-dir": "^0.1.17",
     "node-fetch": "^2.1.1",

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -1,13 +1,10 @@
 const chalk = require('chalk');
-const baseESlintConfig = require('eslint-config-seek');
 const EslintCLI = require('eslint').CLIEngine;
-
+const eslintConfig = require('../config/eslint/eslintConfig');
 const isTypeScript = require('../lib/isTypeScript');
 const prettierCheck = require('../lib/runPrettier').check;
 const runTsc = require('../lib/runTsc');
 const runTSLint = require('../lib/runTSLint');
-
-const { paths, eslintDecorator } = require('../context');
 const args = require('../config/args').argv;
 
 (async () => {
@@ -25,11 +22,11 @@ const args = require('../config/args').argv;
   }
 
   const cli = new EslintCLI({
-    baseConfig: eslintDecorator(baseESlintConfig),
+    baseConfig: eslintConfig,
     useEslintrc: false
   });
 
-  const pathsToCheck = args.length === 0 ? paths.src : args;
+  const pathsToCheck = args.length === 0 ? ['.'] : args;
 
   const formatter = cli.getFormatter();
   console.log(chalk.gray(`eslint ${pathsToCheck.join(' ')}`));

--- a/test/test-cases/custom-src-paths/.eslintignore
+++ b/test/test-cases/custom-src-paths/.eslintignore
@@ -1,8 +1,4 @@
 # managed by sku
-.eslintrc
-.prettierrc
 dist/
 report/
-tsconfig.json
-tslint.json
 # end managed by sku

--- a/test/test-cases/custom-src-paths/.gitignore
+++ b/test/test-cases/custom-src-paths/.gitignore
@@ -3,6 +3,4 @@
 .prettierrc
 dist/
 report/
-tsconfig.json
-tslint.json
 # end managed by sku

--- a/test/test-cases/custom-src-paths/.prettierignore
+++ b/test/test-cases/custom-src-paths/.prettierignore
@@ -1,8 +1,4 @@
 # managed by sku
-.eslintrc
-.prettierrc
 dist/
 report/
-tsconfig.json
-tslint.json
 # end managed by sku

--- a/test/test-cases/custom-src-paths/custom-src-paths.test.js
+++ b/test/test-cases/custom-src-paths/custom-src-paths.test.js
@@ -5,6 +5,10 @@ const getAppSnapshot = require('../../utils/getAppSnapshot');
 const skuConfig = require('./sku.config');
 
 describe('custom-src-paths', () => {
+  beforeAll(async () => {
+    await runSkuScriptInDir('configure', __dirname);
+  });
+
   describe('start', () => {
     const devServerUrl = `http://localhost:${skuConfig.port}`;
     let server;

--- a/test/test-cases/typescript-css-modules/app/.eslintignore
+++ b/test/test-cases/typescript-css-modules/app/.eslintignore
@@ -1,8 +1,4 @@
 # managed by sku
-.eslintrc
-.prettierrc
 dist/
 report/
-tsconfig.json
-tslint.json
 # end managed by sku

--- a/test/test-cases/typescript-css-modules/app/sku.config.js
+++ b/test/test-cases/typescript-css-modules/app/sku.config.js
@@ -3,5 +3,13 @@ module.exports = {
     client: 'src/client.tsx',
     render: 'src/render.tsx',
     server: 'src/server.tsx'
+  },
+  // Use 'dangerouslySetESLintConfig' so we can
+  // check that overrides are written to disk.
+  dangerouslySetESLintConfig: config => {
+    config.rules = config.rules || {};
+    config.rules['no-console'] = 0;
+
+    return config;
   }
 };

--- a/test/test-cases/typescript-css-modules/typescript-css-modules.test.js
+++ b/test/test-cases/typescript-css-modules/typescript-css-modules.test.js
@@ -1,4 +1,7 @@
+const { promisify } = require('util');
+const readFile = promisify(require('fs').readFile);
 const path = require('path');
+const jsonc = require('jsonc-parser');
 const dirContentsToObject = require('../../utils/dirContentsToObject');
 const waitForUrls = require('../../utils/waitForUrls');
 const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
@@ -10,6 +13,17 @@ const srcDir = path.resolve(appDir, 'src');
 describe('typescript-css-modules', () => {
   beforeAll(async () => {
     await runSkuScriptInDir('configure', appDir);
+  });
+
+  describe('configure', () => {
+    it('should generate a custom ESLint config', async () => {
+      const eslintRc = await readFile(path.join(appDir, '.eslintrc'), 'utf-8');
+      const eslintConfig = jsonc.parse(eslintRc);
+      expect(eslintConfig.extends).toEqual(
+        require.resolve('eslint-config-seek')
+      );
+      expect(eslintConfig.rules['no-console']).toEqual(0);
+    });
   });
 
   describe('build', () => {

--- a/test/test-cases/zero-config/.eslintignore
+++ b/test/test-cases/zero-config/.eslintignore
@@ -1,8 +1,4 @@
 # managed by sku
-.eslintrc
-.prettierrc
 dist/
 report/
-tsconfig.json
-tslint.json
 # end managed by sku

--- a/test/test-cases/zero-config/.gitignore
+++ b/test/test-cases/zero-config/.gitignore
@@ -3,6 +3,4 @@
 .prettierrc
 dist/
 report/
-tsconfig.json
-tslint.json
 # end managed by sku

--- a/test/test-cases/zero-config/.prettierignore
+++ b/test/test-cases/zero-config/.prettierignore
@@ -1,8 +1,4 @@
 # managed by sku
-.eslintrc
-.prettierrc
 dist/
 report/
-tsconfig.json
-tslint.json
 # end managed by sku

--- a/test/test-cases/zero-config/zero-config.test.js
+++ b/test/test-cases/zero-config/zero-config.test.js
@@ -4,6 +4,10 @@ const waitForUrls = require('../../utils/waitForUrls');
 const getAppSnapshot = require('../../utils/getAppSnapshot');
 
 describe('zero-config', () => {
+  beforeAll(async () => {
+    await runSkuScriptInDir('configure', __dirname);
+  });
+
   describe('start', () => {
     const devServerUrl = `http://localhost:8080`;
     let server;


### PR DESCRIPTION
To support ESLint editor integrations, we now generate config files in the root of the project directory.

Similar to Prettier, we now run ESLint across the whole project, ignoring files with `.eslintignore` which is generated automatically.

Any modifications to the ESLint config in `dangerouslySetESLintConfig` are written to disk as part of your `.eslintrc`.