### PR TITLE
feat(test): Support test framework setup via ‘setupTests’ script

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,24 @@ Example running tests in watch mode:
 $ sku test --watch
 ```
 
+If you need to set up your test framework, you can provide a `setupTests` script in your config:
+
+```js
+module.exports = {
+  setupTests: 'src/setupTests.js'
+};
+```
+
+For example, if you're using [Enzyme](https://airbnb.io/enzyme/), your `setupTests` script would look like this:
+
+```js
+import 'jest-enzyme';
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });
+```
+
 ### Linting and Formatting (via [ESLint](http://eslint.org/), [TSLint](https://palantir.github.io/tslint/) and [Prettier](https://github.com/prettier/prettier))
 
 Running `sku lint` will execute the ESLint/TSLint rules over the code in your `src` directory, depending on the type of file. You can see the ESLint rules defined for sku projects in [eslint-config-seek](https://github.com/seek-oss/eslint-config-seek). Similarly you can see the TSLint rules defined in [tslint-config-seek](https://github.com/seek-oss/tslint-config-seek).

--- a/config/jest/jestConfig.js
+++ b/config/jest/jestConfig.js
@@ -4,6 +4,11 @@ const slash = '[/\\\\]'; // Cross-platform path delimiter regex
 const compilePackagesRegex = paths.compilePackages.map(escapeRegex).join('|');
 
 module.exports = {
+  ...(paths.setupTests
+    ? {
+        setupTestFrameworkScriptFile: paths.setupTests
+      }
+    : {}),
   prettierPath: require.resolve('prettier'),
   testPathIgnorePatterns: [
     `<rootDir>${slash}(${paths.target}|node_modules)${slash}`

--- a/context/defaultSkuConfig.js
+++ b/context/defaultSkuConfig.js
@@ -13,6 +13,7 @@ module.exports = {
   port: 8080,
   serverPort: 8181,
   target: 'dist',
+  setupTests: null,
   storybookPort: 8081,
   initialPath: '/',
   public: 'public',

--- a/context/index.js
+++ b/context/index.js
@@ -46,7 +46,8 @@ const paths = {
   serverEntry: getPathFromCwd(skuConfig.entry.server),
   public: getPathFromCwd(skuConfig.public),
   target: getPathFromCwd(skuConfig.target),
-  publicPath: isStartScript ? '/' : skuConfig.publicPath
+  publicPath: isStartScript ? '/' : skuConfig.publicPath,
+  setupTests: skuConfig.setupTests ? getPathFromCwd(skuConfig.setupTests) : null
 };
 
 module.exports = {

--- a/test/test-cases/react-css-modules/app/sku.config.js
+++ b/test/test-cases/react-css-modules/app/sku.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  setupTests: 'src/setupTests.js'
+};

--- a/test/test-cases/react-css-modules/app/src/App.test.js
+++ b/test/test-cases/react-css-modules/app/src/App.test.js
@@ -2,6 +2,10 @@ import lessStyles from './lessStyles.less';
 import jsStyles from './jsStyles.css.js';
 
 describe('react-css-modules styles', () => {
+  test('"setupTests" script', () => {
+    expect(global.SETUP_TESTS_SCRIPT_RAN).toEqual(true);
+  });
+
   test('Less Styles', () => {
     expect(lessStyles.root).toEqual('lessStyles__root');
     expect(lessStyles.nested).toEqual('lessStyles__nested');

--- a/test/test-cases/react-css-modules/app/src/setupTests.js
+++ b/test/test-cases/react-css-modules/app/src/setupTests.js
@@ -1,0 +1,1 @@
+global.SETUP_TESTS_SCRIPT_RAN = true;


### PR DESCRIPTION
If you need to set up your test framework, you can provide a `setupTests` script in your config:

```js
module.exports = {
  setupTests: 'src/setupTests.js'
};
```

For example, if you're using [Enzyme](https://airbnb.io/enzyme/), your `setupTests` script would look like this:

 ```js
import 'jest-enzyme';
import { configure } from 'enzyme';
import Adapter from 'enzyme-adapter-react-16';

configure({ adapter: new Adapter() });
```