### PR TITLE
fix(build): Clean up webpack output experience

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -7,7 +7,7 @@ const args = require('../args');
 const config = require('../../context');
 const { bundleAnalyzerPlugin } = require('./plugins/bundleAnalyzer');
 const utils = require('./utils');
-const debug = require('debug')('sku:webpack');
+const debug = require('debug')('sku:webpack:config');
 const { cwd } = require('../../lib/cwd');
 
 const startRenderEntry = require.resolve('../render/startRenderEntry');
@@ -77,8 +77,6 @@ const internalJs = [
   ...paths.src,
   ...paths.compilePackages.map(utils.resolvePackage)
 ];
-
-debug({ build: 'default', internalJs });
 
 // The client file mask is set to just name in start/dev mode as contenthash
 // is not supported for hot reloading. It can also cause non

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -7,7 +7,7 @@ const findUp = require('find-up');
 const StartServerPlugin = require('start-server-webpack-plugin');
 const AssetsPlugin = require('assets-webpack-plugin');
 
-const debug = require('debug')('sku:webpack');
+const debug = require('debug')('sku:webpack:config');
 const args = require('../args');
 const { bundleAnalyzerPlugin } = require('./plugins/bundleAnalyzer');
 const utils = require('./utils');
@@ -53,8 +53,6 @@ const internalJs = [
   ...paths.src,
   ...paths.compilePackages.map(utils.resolvePackage)
 ];
-
-debug({ build: 'default', internalJs });
 
 const resolvedPolyfills = polyfills.map(polyfill => {
   return require.resolve(polyfill, { paths: [cwd()] });

--- a/lib/runWebpack.js
+++ b/lib/runWebpack.js
@@ -1,20 +1,24 @@
+const { yellow } = require('chalk');
+const debug = require('debug')('sku:webpack:compile');
+const args = require('../config/args');
+
 const done = (resolve, reject) => (err, stats) => {
-  console.log(
-    stats.toString({
-      chunks: false, // Makes the build much quieter
-      children: false,
-      colors: true
-    })
-  );
-
-  const info = stats.toJson();
-
   if (err || stats.hasErrors()) {
-    reject(info.errors);
+    reject(stats.toString('errors-only'));
   }
 
   if (stats.hasWarnings()) {
-    info.warnings.forEach(console.warn);
+    const { warnings } = stats.toJson();
+    console.warn(
+      yellow(
+        `Compiled with ${
+          warnings.length
+        } warnings. For more information re-run in debug mode: \`sku ${
+          args.script
+        } --debug\`.`
+      )
+    );
+    warnings.forEach(debug);
   }
 
   resolve();

--- a/scripts/build-ssr.js
+++ b/scripts/build-ssr.js
@@ -2,7 +2,7 @@
 process.env.NODE_ENV = 'production';
 
 const webpack = require('webpack');
-
+const { green, red } = require('chalk');
 const { run } = require('../lib/runWebpack');
 const {
   copyPublicFiles,
@@ -22,9 +22,9 @@ const [
     await run(webpack(serverConfig));
     await copyPublicFiles();
 
-    console.log('Sku build complete!');
+    console.log(green('Sku build complete!'));
   } catch (e) {
-    console.log(e);
+    console.error(red(e));
 
     process.exit(1);
   }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,7 @@
 // First, ensure the build is running in production mode
 process.env.NODE_ENV = 'production';
 
+const { green, red } = require('chalk');
 const {
   copyPublicFiles,
   cleanTargetDirectory,
@@ -18,9 +19,9 @@ const webpackCompiler = require('../config/webpack/webpack.compiler');
     await run(webpackCompiler);
     await cleanRenderJs();
     await copyPublicFiles();
-    console.log('Sku build complete!');
+    console.log(green('Sku build complete!'));
   } catch (error) {
-    console.error(error);
+    console.error(red(error));
     process.exit(1);
   }
 })();


### PR DESCRIPTION
Tidy up the output from `sku build` and `sku build-ssr`, we were logging all the stats after every run and watch of a webpack compile. In addition we were blindly dumping all warnings and errors to the terminal. Here we tidy up and format the output a little, only outputting errors by default with a summary of warnings. For more details about the warnings you can run the build in debug mode.