### PR TITLE
fix(render): Ensure only CSS and JS assets are rendered

### DIFF
--- a/config/webpack/plugins/htmlRenderPlugin.js
+++ b/config/webpack/plugins/htmlRenderPlugin.js
@@ -1,4 +1,3 @@
-const { partition } = require('lodash');
 const HtmlRenderPlugin = require('html-render-webpack-plugin');
 
 const renderScriptTag = require('../../../lib/renderScriptTag');
@@ -31,7 +30,9 @@ const mapStatsToParams = ({ webpackStats, routeName }) => {
     ? entrypoints[routeName].assets
     : entrypoints[defaultClientEntry].assets;
 
-  const [styles, scripts] = partition(assets, asset => asset.endsWith('.css'));
+  const styles = assets.filter(asset => asset.endsWith('.css'));
+  const scripts = assets.filter(asset => asset.endsWith('.js'));
+
   const bodyTags = scripts
     .map(chunkFile =>
       renderScriptTag(createPublicUrl(paths.publicPath, chunkFile))


### PR DESCRIPTION
We previously used Lodash's `partition` function on the assumption that only `.css` and `.js` files were being provided, but it turns out that's not the case. This fix ensures that we filter for the *exact* file type we're looking for, rather than assuming we want to render every asset.