### PR TITLE
fix(chromatic): Fix Chromatic script

### DIFF
--- a/scripts/chromatic.js
+++ b/scripts/chromatic.js
@@ -1,6 +1,6 @@
 const ci = require('env-ci')();
 const chalk = require('chalk');
-const runBin = require('../lib/runBin');
+const { runBin } = require('../lib/runBin');
 const { storybookPort } = require('../context');
 const skuPath = require.resolve('../bin/sku');
 


### PR DESCRIPTION
The `runBin` function is now a named export from the `runBin` module, but this usage wasn't updated, which is causing the Chromatic script to fail.