### PR TITLE
fix(render): Add rest of types for render.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.1.0",
     "@storybook/react": "^4.0.0-alpha.24",
+    "@types/webpack": "^4.4.22",
     "assets-webpack-plugin": "^3.9.7",
     "autoprefixer": "^7.1.5",
     "babel-core": "^7.0.0-bridge.0",

--- a/sku-types.d.ts
+++ b/sku-types.d.ts
@@ -1,9 +1,18 @@
+import { Stats } from 'webpack';
+
 interface RenderAppProps {
+  routeName: string;
+  route: string;
   environment: string;
   site: string;
+  libraryName: string;
+  webpackStats: {
+    stats: Stats[];
+    hash: string;
+  };
 }
 
-interface renderDocumentProps<T> extends RenderAppProps {
+interface RenderDocumentProps<T> extends RenderAppProps {
   app: T;
   headTags: string;
   bodyTags: string;
@@ -12,5 +21,5 @@ interface renderDocumentProps<T> extends RenderAppProps {
 export interface Render<T = string> {
   renderApp(p: RenderAppProps): T;
 
-  renderDocument(p: renderDocumentProps<T>): string;
+  renderDocument(p: RenderDocumentProps<T>): string;
 }


### PR DESCRIPTION
Have added the rest of the type definitions for the default exported function in `render.js`.
