### PR TITLE
fix(startssr): Make SKU_PORT runtime configurable

### DIFF
--- a/config/server/index.js
+++ b/config/server/index.js
@@ -1,6 +1,6 @@
 import http from 'http';
 import app from './server';
-const port = process.env.SKU_PORT || 8080;
+const port = process.env.SKU_PORT || __SKU_DEFAULT_SERVER_PORT__; // eslint-disable-line no-undef
 
 if (module.hot) {
   const server = http.createServer(app);

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -45,7 +45,6 @@ const makeWebpackConfig = ({ clientPort, serverPort }) => {
       return JSON.stringify(valueForEnv);
     })
     .set('SKU_ENV', JSON.stringify(args.env))
-    .set('SKU_PORT', JSON.stringify(serverPort))
     .mapKeys((value, key) => `process.env.${key}`)
     .value();
 
@@ -279,6 +278,7 @@ const makeWebpackConfig = ({ clientPort, serverPort }) => {
       plugins: [
         new webpack.DefinePlugin(envVars),
         new webpack.DefinePlugin({
+          __SKU_DEFAULT_SERVER_PORT__: JSON.stringify(serverPort),
           __SKU_PUBLIC_PATH__: JSON.stringify(publicPath)
         })
       ].concat(

--- a/context/index.js
+++ b/context/index.js
@@ -65,7 +65,7 @@ module.exports = {
   hosts: skuConfig.hosts,
   port: {
     client: skuConfig.port,
-    server: skuConfig.serverPort
+    server: parseInt(process.env.SKU_PORT, 10) || skuConfig.serverPort
   },
   libraryName: skuConfig.libraryName,
   isLibrary: Boolean(skuConfig.libraryEntry),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1644,6 +1644,11 @@
     "@svgr/plugin-svgo" "^4.0.3"
     loader-utils "^1.1.0"
 
+"@types/anymatch@*":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.0.tgz#d1d55958d1fccc5527d4aba29fc9c4b942f563ff"
+  integrity sha512-7WcbyctkE8GTzogDb0ulRAEw7v8oIS54ft9mQTU7PfM0hp5e+8kpa+HeQ7IQrFbKtJXBKcZ4bh+Em9dTw5L6AQ==
+
 "@types/dedent@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@types/dedent/-/dedent-0.7.0.tgz#155f339ca404e6dd90b9ce46a3f78fd69ca9b050"
@@ -1679,6 +1684,18 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/tapable@*":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.4.tgz#b4ffc7dc97b498c969b360a41eee247f82616370"
+  integrity sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==
+
+"@types/uglify-js@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.0.4.tgz#96beae23df6f561862a830b4288a49e86baac082"
+  integrity sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==
+  dependencies:
+    source-map "^0.6.1"
+
 "@types/unist@*", "@types/unist@^2.0.0":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.2.tgz#5dc0a7f76809b7518c0df58689cd16a19bd751c6"
@@ -1700,6 +1717,17 @@
     "@types/node" "*"
     "@types/unist" "*"
     "@types/vfile-message" "*"
+
+"@types/webpack@^4.4.22":
+  version "4.4.22"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.4.22.tgz#c4a5ea8b74a31b579537515bcfe86d2b2a34382c"
+  integrity sha512-PxAAzli3krZX9rCeONSR5Z9v4CR/2HPsKsiVRFNDo9OZefN+dTemteMHZnYkddOu4bqoYqJTJ724gLy0ZySXOw==
+  dependencies:
+    "@types/anymatch" "*"
+    "@types/node" "*"
+    "@types/tapable" "*"
+    "@types/uglify-js" "*"
+    source-map "^0.6.0"
 
 "@webassemblyjs/ast@1.7.11":
   version "1.7.11"


### PR DESCRIPTION
Previously `SKU_PORT` was baked into ssr the same way we currently support `env` in the sku config, but critically it didnt support changing the port at runtime. Now we honour `SKU_PORT` from the environment as an override for the `serverPort` that is specified in the sku config file.

This supports more advanced use cases, like starting the server once per cpu core using pm2 with a different port number for each — preventing port collisions.