### PR TITLE
fix(webpack): Clean up webpack API deprecation warnings

### DIFF
--- a/config/webpack/utils/cssInJsLoader.js
+++ b/config/webpack/utils/cssInJsLoader.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+// Original source: https://github.com/naistran/css-in-js-loader/blob/master/index.js
 var path = require('path');
 var fs = require('fs');
 var postcss = require('postcss');

--- a/config/webpack/utils/cssInJsLoader.js
+++ b/config/webpack/utils/cssInJsLoader.js
@@ -1,0 +1,122 @@
+/* eslint-disable */
+var path = require('path');
+var fs = require('fs');
+var postcss = require('postcss');
+var postcssJs = require('postcss-js');
+var NodeTemplatePlugin = require('webpack/lib/node/NodeTemplatePlugin');
+var NodeTargetPlugin = require('webpack/lib/node/NodeTargetPlugin');
+var LibraryTemplatePlugin = require('webpack/lib/LibraryTemplatePlugin');
+var SingleEntryPlugin = require('webpack/lib/SingleEntryPlugin');
+var LimitChunkCountPlugin = require('webpack/lib/optimize/LimitChunkCountPlugin');
+
+const CSSInJsLoader = 'css-in-js-loader';
+
+module.exports = function(source) {
+  if (this.cacheable) this.cacheable();
+  return source;
+};
+
+module.exports.pitch = function(request, prevRequest) {
+  if (this.cacheable) this.cacheable();
+  var callback = this.async();
+  if (['.js', '.ts'].indexOf(path.extname(request)) >= 0) {
+    produce(this, request, callback);
+  } else {
+    var parts = request.split('!');
+    var filename = parts[parts.length - 1];
+    this.addDependency(filename);
+    fs.readFile(filename, 'utf8', callback);
+  }
+};
+
+function produce(loader, request, callback) {
+  var childFilename = 'css-in-js-output-filename';
+  var outputOptions = { filename: childFilename };
+  var childCompiler = getRootCompilation(loader).createChildCompiler(
+    'css-in-js-compiler',
+    outputOptions
+  );
+  new NodeTemplatePlugin(outputOptions).apply(childCompiler);
+  new LibraryTemplatePlugin(null, 'commonjs2').apply(childCompiler);
+  new NodeTargetPlugin().apply(childCompiler);
+  new SingleEntryPlugin(loader.context, '!!' + request).apply(childCompiler);
+  new LimitChunkCountPlugin({ maxChunks: 1 }).apply(childCompiler);
+  var subCache = 'subcache ' + __dirname + ' ' + request;
+  childCompiler.hooks.compilation.tap(CSSInJsLoader, function(compilation) {
+    if (compilation.cache) {
+      if (!compilation.cache[subCache]) compilation.cache[subCache] = {};
+      compilation.cache = compilation.cache[subCache];
+    }
+  });
+  // We set loaderContext[__dirname] = false to indicate we already in
+  // a child compiler so we don't spawn another child compilers from there.
+  childCompiler.hooks.thisCompilation.tap(CSSInJsLoader, function(compilation) {
+    compilation.hooks.normalModuleLoader.tap(CSSInJsLoader, function(
+      loaderContext
+    ) {
+      loaderContext[__dirname] = false;
+    });
+  });
+  var source;
+  childCompiler.hooks.afterCompile.tapAsync(CSSInJsLoader, function(
+    compilation,
+    callback
+  ) {
+    source =
+      compilation.assets[childFilename] &&
+      compilation.assets[childFilename].source();
+
+    // Remove all chunk assets
+    compilation.chunks.forEach(function(chunk) {
+      chunk.files.forEach(function(file) {
+        delete compilation.assets[file];
+      });
+    });
+
+    callback();
+  });
+
+  childCompiler.runAsChild(function(err, entries, compilation) {
+    if (err) return callback(err);
+
+    if (compilation.errors.length > 0) {
+      return callback(compilation.errors[0]);
+    }
+    if (!source) {
+      return callback(new Error("Didn't get a result from child compiler"));
+    }
+    compilation.fileDependencies.forEach(function(dep) {
+      loader.addDependency(dep);
+    }, loader);
+    compilation.contextDependencies.forEach(function(dep) {
+      loader.addContextDependency(dep);
+    }, loader);
+    try {
+      var exports = loader.exec(source, request);
+      if (exports.default && typeof exports.default === 'object') {
+        exports = exports.default;
+      }
+    } catch (e) {
+      return callback(e);
+    }
+    if (exports) {
+      postcss()
+        .process(exports, { parser: postcssJs })
+        .then(function(res) {
+          callback(null, res.css);
+        });
+    } else {
+      callback();
+    }
+  });
+}
+
+function getRootCompilation(loader) {
+  var compiler = loader._compiler;
+  var compilation = loader._compilation;
+  while (compiler.parentCompilation) {
+    compilation = compiler.parentCompilation;
+    compiler = compilation.compiler;
+  }
+  return compilation;
+}

--- a/config/webpack/utils/loaders.js
+++ b/config/webpack/utils/loaders.js
@@ -35,7 +35,7 @@ const makeCssLoaders = (options = {}) => {
       }[name]__[local]___`;
 
   const cssInJsLoaders = [
-    { loader: require.resolve('css-in-js-loader') },
+    { loader: require.resolve('./cssInJsLoader') },
     ...makeJsLoaders({ target: 'node' })
   ];
 

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "command-line-args": "^4.0.7",
     "cross-spawn": "^6.0.5",
     "css-hot-loader": "^1.4.2",
-    "css-in-js-loader": "^0.1.2",
     "css-loader": "^2.1.0",
     "css-modules-typescript-loader": "^1.0.0",
     "cssnano": "^4.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4384,11 +4384,6 @@ css-hot-loader@^1.4.2:
     lodash "^4.17.5"
     normalize-url "^1.9.1"
 
-css-in-js-loader@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/css-in-js-loader/-/css-in-js-loader-0.1.2.tgz#ea7f23eb279f6b5ec2fee784c6c05ca76b11d99e"
-  integrity sha1-6n8j6yefa17C/ueExsBcp2sR2Z4=
-
 css-loader@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-1.0.1.tgz#6885bb5233b35ec47b006057da01cc640b6b79fe"


### PR DESCRIPTION
This PR moves the [css-in-js-loader](https://github.com/naistran/css-in-js-loader) to be an internal file of sku as it is unmaintained and using deprecated webpack APIs. If we continue to use this loader long term we should move it to its own repo, this at least fixes the warnings for now. Also, our test suite does a decent job of catching issues with it.  

The only changes to the loader source code are to update its usage of webpacks plugin API causing the warnings. 