### PR TITLE
fix(lint): Ensure TSLint ignores JSON files

### DIFF
--- a/config/typescript/tslint.json
+++ b/config/typescript/tslint.json
@@ -1,5 +1,8 @@
 {
   "extends": "tslint-config-seek",
+  "linterOptions": {
+    "exclude": ["**/*.json"]
+  },
   "rules": {
     "no-implicit-dependencies": false
   }


### PR DESCRIPTION
For some reason, TSLint tries to validate JSON files. This fixes that.