### PR TITLE
fix(lint): Suppress global type clash between Jest and Cypress

### DIFF
--- a/config/typescript/tsconfig.js
+++ b/config/typescript/tsconfig.js
@@ -3,6 +3,7 @@ const { paths } = require('../../context');
 
 module.exports = () => ({
   compilerOptions: {
+    skipLibCheck: true, // Fixes https://github.com/cypress-io/cypress/issues/1087
     esModuleInterop: true,
     allowSyntheticDefaultImports: true,
     resolveJsonModule: true,


### PR DESCRIPTION
Cypress installs global type definitions for Mocha which clash with Jest's globals, which means that `sku lint` fails for any consumer that also depends on Cypress.

Unfortunately, due to the nature of globals (😞), there's no easy way to solve the underlying issue, but a workaround is to enable the `skipLibCheck` flag on the TypeScript compiler (https://github.com/Microsoft/TypeScript-wiki/blob/master/What's-new-in-TypeScript.md#new---skiplibcheck).

When applying this workaround, the global types for Jest are still resolved correctly in `*.test.tsx` / `*.test.tsx` files. If consumers want to use TypeScript in their Cypress tests, they'll likely need to provide a custom `tsconfig.json` in their Cypress subdirectory.