### PR TITLE
chore(eslint): Centralise unresolved module ignores

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,21 @@
 {
   "extends": "seek",
   "rules": {
-    "no-console": 0,
-    "no-process-exit": 0,
-    "no-sync": 0
+    "no-console": "off",
+    "no-process-exit": "off",
+    "no-sync": "off",
+    "import/no-unresolved": [
+      "error",
+      {
+        "commonjs": true,
+        "amd": true,
+        "ignore": [
+          "__sku_alias__renderEntry",
+          "__sku_alias__serverEntry",
+          "__sku_alias__assets"
+        ]
+      }
+    ]
   },
   "globals": {
     "__SKU_SRC_PATHS_0__": true,

--- a/config/render/buildRenderEntry.js
+++ b/config/render/buildRenderEntry.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-unresolved */
-
 // __sku_alias__renderEntry is a webpack alias
 // pointing to the consuming apps render entry
 import render from '__sku_alias__renderEntry';

--- a/config/render/startRenderEntry.js
+++ b/config/render/startRenderEntry.js
@@ -1,11 +1,9 @@
-/* eslint-disable import/no-unresolved */
-
 // '__sku_alias__renderEntry' is a webpack alias
 // pointing to the consuming apps render entry
 import render from '__sku_alias__renderEntry';
 // 'startConfig.json' is a file created by the htmlRenderPlugin
 // it contains the current site/environment config to be rendered
-import config from './startConfig.json';
+import config from './startConfig.json'; // eslint-disable-line import/no-unresolved
 
 const libraryName = SKU_LIBRARY_NAME; // eslint-disable-line no-undef
 

--- a/config/server/server.js
+++ b/config/server/server.js
@@ -1,8 +1,8 @@
 const path = require('path');
 const express = require('express');
 const renderScriptTag = require('../../lib/renderScriptTag');
-const serverExports = require('__sku_alias__serverEntry').default; // eslint-disable-line import/no-unresolved
-const assets = require('__sku_alias__assets'); // eslint-disable-line import/no-unresolved
+const serverExports = require('__sku_alias__serverEntry').default;
+const assets = require('__sku_alias__assets');
 
 const publicPath = __SKU_PUBLIC_PATH__; // eslint-disable-line no-undef
 


### PR DESCRIPTION
Rather than littering the codebase with ignores, this centralises the ignoring of unresolved imports for the webpack aliases we have setup.