### PR TITLE
feat(webpack): Add feature to enable source maps in production

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -22,6 +22,7 @@ const {
   isLibrary,
   libraryName,
   isStartScript,
+  sourceMapsProd,
   supportedBrowsers
 } = config;
 
@@ -96,12 +97,15 @@ const makeWebpackConfig = ({ isStorybook = false, port = 0 } = {}) => {
     ? `${libraryFileMask}.css`
     : `${clientFileMask}.css`;
 
+  const sourceMapStyle = isStartScript ? 'inline-source-map' : 'source-map';
+  const useSourceMaps = isStartScript || sourceMapsProd;
+
   const webpackConfigs = [
     {
       name: 'client',
       mode: webpackMode,
       entry,
-      devtool: isStartScript ? 'inline-source-map' : false,
+      devtool: useSourceMaps ? sourceMapStyle : false,
       output: {
         path: paths.target,
         publicPath: paths.publicPath,

--- a/context/index.js
+++ b/context/index.js
@@ -82,5 +82,6 @@ module.exports = {
   defaultClientEntry,
   isStartScript,
   isBuildScript,
-  supportedBrowsers: skuConfig.supportedBrowsers
+  supportedBrowsers: skuConfig.supportedBrowsers,
+  sourceMapsProd: Boolean(skuConfig.sourceMapsProd)
 };

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@
   - [`dangerouslySetWebpackConfig` [`function`]](#dangerouslysetwebpackconfig-function)
   - [`dangerouslySetJestConfig` [`function`]](#dangerouslysetjestconfig-function)
   - [`dangerouslySetESLintConfig` [`function`]](#dangerouslyseteslintconfig-function)
+  - [`sourceMapsProd` [`boolean`]](#source-maps)
 
 ## `clientEntry` [`string`]
 
@@ -244,5 +245,18 @@ Example:
     ...skuEslintConfig,
     someOtherConfig: 'dangerousValue'
   });
+}
+```
+
+## `sourceMapsProd` [`boolean`]
+
+By default source maps will be generated only for development builds.
+Set to `true` to enable source maps in production.
+
+Example:
+
+```js
+{
+  sourceMapsProd: true;
 }
 ```


### PR DESCRIPTION
Some projects may want to publish source maps for their compiled code.
Currently we only create source maps for the development environment.

Builds source maps could be seen to have a negative effect:
 - Increase in build time
 - Increase visibility of source code

Therefore adding source maps by default could be considered a breaking change. This change adds source maps behind a configuration feature toggle.

A later major release could then change the default.