### PR TITLE
fix(jest): Remove trailing slash on transform ignore paths

### DIFF
--- a/config/jest/jestConfig.js
+++ b/config/jest/jestConfig.js
@@ -47,7 +47,7 @@ module.exports = {
   transformIgnorePatterns: [
     // Allow 'compilePackages' code to be transformed in tests by overriding
     // the default, which normally excludes everything in node_modules.
-    `node_modules${slash}(?!(${compilePackagesRegex}))${slash}.+`
+    `node_modules${slash}(?!(${compilePackagesRegex}))`
   ],
   testURL: 'http://localhost', // @see https://github.com/facebook/jest/issues/6766
   watchPlugins: [


### PR DESCRIPTION
Removing the trailing slash on the `transformIgnorePattterns` in jest config. This trailing slash was breaking a consumer migrating to sku, and not sure it provides any additional value beyond the package name itself.