### PR TITLE
feat(webpack): Add feature to enable source maps in production

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -22,6 +22,7 @@ const {
   isLibrary,
   libraryName,
   isStartScript,
+  sourceMapsProd,
   supportedBrowsers
 } = config;
 
@@ -96,12 +97,15 @@ const makeWebpackConfig = ({ isStorybook = false, port = 0 } = {}) => {
     ? `${libraryFileMask}.css`
     : `${clientFileMask}.css`;
 
+  const sourceMapStyle = isStartScript ? 'inline-source-map' : 'source-map';
+  const useSourceMaps = isStartScript || sourceMapsProd;
+
   const webpackConfigs = [
     {
       name: 'client',
       mode: webpackMode,
       entry,
-      devtool: isStartScript ? 'inline-source-map' : false,
+      devtool: useSourceMaps ? sourceMapStyle : false,
       output: {
         path: paths.target,
         publicPath: paths.publicPath,

--- a/context/configSchema.js
+++ b/context/configSchema.js
@@ -146,5 +146,8 @@ module.exports = new Schema({
       required: true
     },
     required: true
+  },
+  sourceMapsProd: {
+    type: Boolean
   }
 });

--- a/context/defaultSkuConfig.js
+++ b/context/defaultSkuConfig.js
@@ -28,6 +28,7 @@ module.exports = {
   publicPath: '/',
   polyfills: [],
   libraryName: null,
+  sourceMapsProd: false,
   dangerouslySetWebpackConfig: defaultDecorator,
   dangerouslySetJestConfig: defaultDecorator,
   dangerouslySetESLintConfig: defaultDecorator,

--- a/context/index.js
+++ b/context/index.js
@@ -82,5 +82,6 @@ module.exports = {
   defaultClientEntry,
   isStartScript,
   isBuildScript,
-  supportedBrowsers: skuConfig.supportedBrowsers
+  supportedBrowsers: skuConfig.supportedBrowsers,
+  sourceMapsProd: Boolean(skuConfig.sourceMapsProd)
 };

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,9 +78,9 @@ An array of routes for the app. Each route must specify a name and a route corre
 Example:
 
 ```js
-{
-  routes: [{ name: 'home', route: '/' }];
-}
+const config = {
+  routes: [{ name: 'home', route: '/' }]
+};
 ```
 
 ## `sites` [`Array<string>`]
@@ -208,12 +208,12 @@ Reliance on this setting will cause issues when upgrading sku as any custom sett
 Example:
 
 ```js
-{
+const config = {
   dangerouslySetWebpackConfig: skuWebpackConfig => ({
     ...skuWebpackConfig,
     someOtherConfig: 'dangerousValue'
-  });
-}
+  })
+};
 ```
 
 ## `dangerouslySetJestConfig` [`function`]
@@ -225,12 +225,12 @@ Please speak with the `sku-support` group before using.
 Example:
 
 ```js
-{
+const config = {
   dangerouslySetJestConfig: skuJestConfig => ({
     ...skuJestConfig,
     someOtherConfig: 'dangerousValue'
-  });
-}
+  })
+};
 ```
 
 ## `dangerouslySetESLintConfig` [`function`]
@@ -240,12 +240,12 @@ Similar to `dangerouslySetWebpackConfig` but for [eslint](https://eslint.org/) c
 Example:
 
 ```js
-{
+const config = {
   dangerouslySetESLintConfig: skuEslintConfig => ({
     ...skuEslintConfig,
     someOtherConfig: 'dangerousValue'
-  });
-}
+  })
+};
 ```
 
 ## `sourceMapsProd` [`boolean`]
@@ -256,7 +256,7 @@ Set to `true` to enable source maps in production.
 Example:
 
 ```js
-{
-  sourceMapsProd: true;
-}
+const config = {
+  sourceMapsProd: true
+};
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@
   - [`dangerouslySetWebpackConfig` [`function`]](#dangerouslysetwebpackconfig-function)
   - [`dangerouslySetJestConfig` [`function`]](#dangerouslysetjestconfig-function)
   - [`dangerouslySetESLintConfig` [`function`]](#dangerouslyseteslintconfig-function)
+  - [`sourceMapsProd` [`boolean`]](#source-maps)
 
 ## `clientEntry` [`string`]
 
@@ -244,5 +245,18 @@ Example:
     ...skuEslintConfig,
     someOtherConfig: 'dangerousValue'
   });
+}
+```
+
+## `sourceMapsProd` [`boolean`]
+
+By default source maps will be generated only for development builds.
+Set to `true` to enable source maps in production.
+
+Example:
+
+```js
+{
+  sourceMapsProd: true;
 }
 ```

--- a/test/test-cases/source-maps/.eslintignore
+++ b/test/test-cases/source-maps/.eslintignore
@@ -1,0 +1,5 @@
+# managed by sku
+coverage/
+dist/
+report/
+# end managed by sku

--- a/test/test-cases/source-maps/.gitignore
+++ b/test/test-cases/source-maps/.gitignore
@@ -1,0 +1,7 @@
+# managed by sku
+.eslintrc
+.prettierrc
+coverage/
+dist/
+report/
+# end managed by sku

--- a/test/test-cases/source-maps/.prettierignore
+++ b/test/test-cases/source-maps/.prettierignore
@@ -1,0 +1,5 @@
+# managed by sku
+coverage/
+dist/
+report/
+# end managed by sku

--- a/test/test-cases/source-maps/__snapshots__/source-maps.test.js.snap
+++ b/test/test-cases/source-maps/__snapshots__/source-maps.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`source-maps build should generate the expected files 1`] = `
+Object {
+  "index.html": "<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=\\"UTF-8\\">
+    <title>hello-world</title>
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
+    
+  </head>
+  <body>
+    <div id=\\"app\\"><div data-reactroot=\\"\\">Hello source maps</div></div>
+    <script type=\\"text/javascript\\" src=\\"http://localhost:4005/runtime-985e5e30cbdd19a8ea5d.js\\" crossorigin=\\"anonymous\\"></script>
+<script type=\\"text/javascript\\" src=\\"http://localhost:4005/vendors~main-9aa20d39de042df69f71.js\\" crossorigin=\\"anonymous\\"></script>
+<script type=\\"text/javascript\\" src=\\"http://localhost:4005/main-d9b93070ae828b2cd8b9.js\\" crossorigin=\\"anonymous\\"></script>
+  </body>
+</html>",
+  "main-d9b93070ae828b2cd8b9.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "main-d9b93070ae828b2cd8b9.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "runtime-985e5e30cbdd19a8ea5d.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "runtime-985e5e30cbdd19a8ea5d.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-9aa20d39de042df69f71.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-9aa20d39de042df69f71.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
+}
+`;

--- a/test/test-cases/source-maps/sku.config.js
+++ b/test/test-cases/source-maps/sku.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  publicPath: 'http://localhost:4005',
+  port: 8303,
+  target: 'dist',
+  sourceMapsProd: true
+};

--- a/test/test-cases/source-maps/source-maps.test.js
+++ b/test/test-cases/source-maps/source-maps.test.js
@@ -1,0 +1,15 @@
+const dirContentsToObject = require('../../utils/dirContentsToObject');
+const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
+
+describe('source-maps', () => {
+  describe('build', () => {
+    beforeAll(async () => {
+      await runSkuScriptInDir('build', __dirname);
+    });
+
+    it('should generate the expected files', async () => {
+      const files = await dirContentsToObject(`${__dirname}/dist`);
+      expect(files).toMatchSnapshot();
+    });
+  });
+});

--- a/test/test-cases/source-maps/src/App.js
+++ b/test/test-cases/source-maps/src/App.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default () => <div>Hello source maps</div>;

--- a/test/test-cases/source-maps/src/client.js
+++ b/test/test-cases/source-maps/src/client.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { hydrate } from 'react-dom';
+import App from './App';
+
+hydrate(<App />, document.getElementById('app'));

--- a/test/test-cases/source-maps/src/render.js
+++ b/test/test-cases/source-maps/src/render.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import dedent from 'dedent';
+import App from './App';
+
+export default {
+  renderApp: () => renderToString(<App />),
+
+  renderDocument: ({ app, bodyTags, headTags }) => dedent`
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="UTF-8">
+        <title>hello-world</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        ${headTags}
+      </head>
+      <body>
+        <div id="app">${app}</div>
+        ${bodyTags}
+      </body>
+    </html>
+  `
+};

--- a/test/utils/dirContentsToObject.js
+++ b/test/utils/dirContentsToObject.js
@@ -2,6 +2,14 @@ const { promisify } = require('util');
 const readFilesAsync = promisify(require('node-dir').readFiles);
 const { relative } = require('path');
 
+// Ignore contents of files where the content changes
+// regularly or is non-deterministic.
+const IGNORED_FILE_EXTENSIONS = ['js', 'map'];
+const ignoredFilePattern = new RegExp(
+  `\\.(${IGNORED_FILE_EXTENSIONS.join('|')})$`,
+  'i'
+);
+
 module.exports = async (dirname, includeExtensions) => {
   const files = {};
 
@@ -16,7 +24,7 @@ module.exports = async (dirname, includeExtensions) => {
       !includeExtensions ||
       includeExtensions.filter(ext => relativeFilePath.endsWith(ext)).length > 0
     ) {
-      files[relativeFilePath] = /\.js$/.test(relativeFilePath)
+      files[relativeFilePath] = ignoredFilePattern.test(relativeFilePath)
         ? 'CONTENTS IGNORED IN SNAPSHOT TEST'
         : content;
     }


### PR DESCRIPTION
Some projects may want to publish source maps for their compiled code.
Currently we only create source maps for the development environment.

Builds source maps could be seen to have a negative effect:
 - Increase in build time
 - Increase visibility of source code

Therefore adding source maps by default could be considered a breaking change. This change adds source maps behind a configuration feature toggle.

A later major release could then change the default.