### PR TITLE
feat(ssr): Support onStart callback for server entry

### DIFF
--- a/config/server/index.js
+++ b/config/server/index.js
@@ -1,6 +1,6 @@
 import http from 'http';
 import commandLineArgs from 'command-line-args';
-import app from './server';
+import { app, onStart } from './server';
 
 const { port } = commandLineArgs(
   [
@@ -26,5 +26,9 @@ if (module.hot) {
 } else {
   app.listen(port, () => {
     console.log(`App started on port ${port}`);
+
+    if (typeof onStart === 'function') {
+      onStart(app);
+    }
   });
 }

--- a/config/server/server.js
+++ b/config/server/server.js
@@ -22,7 +22,7 @@ const headTags = styles
 
 const serverOptions = serverExports({ publicPath, headTags, bodyTags });
 
-const { renderCallback, middleware } = serverOptions;
+const { renderCallback, middleware, onStart } = serverOptions;
 
 const app = express();
 
@@ -37,4 +37,4 @@ if (middleware) {
 }
 app.get('*', renderCallback);
 
-export default app;
+export { app, onStart };

--- a/test/test-cases/ssr-hello-world/src/server.js
+++ b/test/test-cases/ssr-hello-world/src/server.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import { renderToString } from 'react-dom/server';
+import fs from 'fs';
+import { promisify } from 'util';
+const writeFile = promisify(fs.writeFile);
 
 import App from './App';
 
@@ -23,5 +26,8 @@ export default ({ headTags, bodyTags }) => ({
   renderCallback: (req, res) => {
     const app = renderToString(<App />);
     res.send(template({ headTags, bodyTags, app }));
+  },
+  onStart: async () => {
+    await writeFile('./started.txt', "Server started, here's your callback");
   }
 });

--- a/test/test-cases/ssr-hello-world/ssr-hello-world.test.js
+++ b/test/test-cases/ssr-hello-world/ssr-hello-world.test.js
@@ -1,4 +1,7 @@
 const path = require('path');
+const fs = require('fs');
+const { promisify } = require('util');
+const readFile = promisify(fs.readFile);
 
 const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
 const gracefulSpawn = require('../../../lib/gracefulSpawn');
@@ -71,6 +74,15 @@ describe('ssr-hello-world', () => {
       it('should generate a production server based on config', async () => {
         const snapshot = await getAppSnapshot(backendUrl);
         expect(snapshot).toMatchSnapshot();
+      });
+
+      it("should invoke the provided 'onStart' callback", async () => {
+        const pathToFile = path.join(targetDirectory, 'started.txt');
+        const startedFile = await readFile(pathToFile, { encoding: 'utf-8' });
+
+        expect(startedFile).toMatchInlineSnapshot(
+          `"Server started, here's your callback"`
+        );
       });
     });
 


### PR DESCRIPTION
Provide the ability to pass a callback to the server entry of your app that will be invoked after the server starts. The callback receives the app instance as the first and only parameter.

An example server entry: 
```diff
export default () => ({
  renderCallback: () => { ... },
  middleware: [ ... ],
+ onStart: app => {
+   console.log('My app started 👯‍♀️!');
+   app.keepAliveTimeout = 20000;
+ }  
})
```