### PR TITLE
docs: Fix spacing on migration guide

### DIFF
--- a/docs/migration-guides/v8.0.0.md
+++ b/docs/migration-guides/v8.0.0.md
@@ -97,7 +97,7 @@ module.exports = {
     {
       route: '/',
       name: 'home',
--      entry: './src/home'
+-     entry: './src/home'
     }
   ]
 };


### PR DESCRIPTION
Spacing is slightly off.

![image](https://user-images.githubusercontent.com/4082442/52755035-ac6f4100-3050-11e9-9fb8-fdd4483d1990.png)
