### PR TITLE
docs: Fix broken static-rendering links

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -107,7 +107,7 @@ type `Array<string>`
 
 Default: `[]`
 
-An array of environments the app supports. Apps should have one environment for local development plus one for each environment they're deployed to. Use this value to drive app config (e.g. `analyticsEnabled` or `apiEndpoint`). See [static-rendering](./static-rendering.md) for more info.
+An array of environments the app supports. Apps should have one environment for local development plus one for each environment they're deployed to. Use this value to drive app config (e.g. `analyticsEnabled` or `apiEndpoint`). See [static-rendering](./docs/static-rendering.md) for more info.
 
 ## hosts
 

--- a/docs/migration-guides/v7.0.0.md
+++ b/docs/migration-guides/v7.0.0.md
@@ -39,11 +39,11 @@ ESLint is now run across your entire project, not just the `src` directory (or t
 
 This release changes the way sku handles HTML rendering and asset generation for both server rendered and statically rendered apps.
 
-Please read through our newly added documentation on [static rendering](../static-rendering.md) before attempting migration.
+Please read through our newly added documentation on [static rendering](../docs/static-rendering.md) before attempting migration.
 
 ### Static apps
 
-Build output folder structure has changed in some circumstances. After making the following changes, please check your `target` directory and update any testing and deployment strategies to suit. See our documentation on [static rendering](../static-rendering.md) for details on the new structure.
+Build output folder structure has changed in some circumstances. After making the following changes, please check your `target` directory and update any testing and deployment strategies to suit. See our documentation on [static rendering](../docs/static-rendering.md) for details on the new structure.
 
 #### Rendering
 


### PR DESCRIPTION
A few references to the static-rendering page were busted after the docs update.
Have tested these locally