### PR TITLE
fix(hot): Resolve react-hot-loader with node require

### DIFF
--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -61,7 +61,7 @@ const makeWebpackConfig = ({ clientPort, serverPort }) => {
   const clientServer = `http://localhost:${clientPort}/`;
 
   const clientDevServerEntries = [
-    'react-hot-loader/patch',
+    `${require.resolve('react-hot-loader/patch')}`,
     `${require.resolve('webpack-dev-server/client')}?${clientServer}`,
     `${require.resolve('webpack/hot/only-dev-server')}`
   ];


### PR DESCRIPTION
Other plugins are resolved with node's require.resolve to ensure the package can be found even when the dependency is found on it's parent.

When an SSR project does not have a react-hot-loader in it's own dependencies the sku's version is hoisted to the top and therefore can't be found.
This change ensures the loader can be found regardless of hoisting.
