### PR TITLE
docs: Fix migration guide link

### DIFF
--- a/docs/migration-guides/v8.0.0.md
+++ b/docs/migration-guides/v8.0.0.md
@@ -74,7 +74,7 @@ import App from './App/App';
 +};
 ```
 
-> Statically rendered apps should checkout the new [provideClientContext](./docs/static-rendering#provideclientcontext) feature, for passing config and other state from render to the client.
+> Statically rendered apps should checkout the new [provideClientContext](../docs/static-rendering.md#provideclientcontext) feature, for passing config and other state from render to the client.
 
 ## Storybook
 


### PR DESCRIPTION
Currently this link in the sku 8 migration guide is broken.

![image](https://user-images.githubusercontent.com/4082442/52921044-147e9980-3367-11e9-9d23-6ab0ec71a778.png)
