### PR TITLE
fix(storybook): Ensure bottom margins are preserved in screenshots

### DIFF
--- a/config/storybook/config.js
+++ b/config/storybook/config.js
@@ -8,7 +8,19 @@ addParameters({
 });
 
 addDecorator(withKnobs);
-addDecorator(story => React.createElement('div', null, story()));
+addDecorator(story =>
+  // When applying a CSS transform to the root element of a component,
+  // e.g. when using Basekick (https://github.com/michaeltaranto/basekick),
+  // screenshot services (such a Chromatic) would render the element
+  // but not at the translated position. To fix this, we wrap each story
+  // in a div, which implicitly doesn't have a transform, but serves as the
+  // element presented in the screenshot.
+  // We also provide a near-zero bottom padding value in order to
+  // prevent margins from collapsing, otherwise screenshot services will
+  // ignore bottom margins, leading to missed changes when margin values
+  // change, or unwanted diffs when migrating from margin to padding.
+  React.createElement('div', { style: { paddingBottom: '0.05px' } }, story())
+);
 
 const reqs = [
   // These values are defined in `webpack.config.js` in this


### PR DESCRIPTION
As the comment says:
>When applying a CSS transform to the root element of a component, e.g. when using Basekick (https://github.com/michaeltaranto/basekick), screenshot services (such a Chromatic) would render the element but not at the translated position. To fix this, we wrap each story in a div, which implicitly doesn't have a transform, but serves as the element presented in the screenshot.
>
>We also provide a near-zero bottom padding value in order to prevent margins from collapsing, otherwise screenshot services will ignore bottom margins, leading to missed changes when margin values change, or unwanted diffs when migrating from margin to padding.