### PR TITLE
test: Wait longer before app snapshot

### DIFF
--- a/test/utils/appSnapshot.js
+++ b/test/utils/appSnapshot.js
@@ -62,7 +62,7 @@ const getAppSnapshot = async url => {
     }
   });
 
-  const response = await page.goto(url);
+  const response = await page.goto(url, { waitUntil: 'networkidle0' });
   const sourceHtml = await response.text();
   const clientRenderContent = await page.content();
 


### PR DESCRIPTION
We are occasionally getting app snapshots returning before React has run the expected update. This will hopefully ensure that doesn't happen, at the expense of a slightly longer test run. 