### PR TITLE
chore(renovate): Update a few settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,13 @@
 {
-  "extends": [
-    "seek"
+  "extends": ["seek"],
+  "prCreation": "not-pending",
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "packagePatterns": ["^(braid-design-system|(seek-style-guide(-asia)?))$"],
+      "schedule": ["at 8:00 am on the first weekday of the month"]
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "packageRules": [
     {
       "packagePatterns": ["^(braid-design-system|(seek-style-guide(-asia)?))$"],
-      "schedule": ["at 8:00 am on the first weekday of the month"]
+      "schedule": ["before 8:00 am on the first weekday of the month"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     {
       "groupName": "Style guide maintenance",
       "packagePatterns": ["^(braid-design-system|(seek-style-guide(-asia)?))$"],
-      "schedule": ["before 8:00 am on the first weekday of the month"]
+      "schedule": ["before 8am on the first weekday of the month"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     {
       "groupName": "Style guide maintenance",
       "packagePatterns": ["^(braid-design-system|(seek-style-guide(-asia)?))$"],
-      "schedule": ["before 8am on the first weekday of the month"]
+      "schedule": ["before 8am on the first day of the month"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,13 @@
 {
   "extends": ["seek"],
   "prCreation": "not-pending",
+  "timezone": "Australia/Melbourne",
   "lockFileMaintenance": {
     "enabled": true
   },
   "packageRules": [
     {
+      "groupName": "Style guide maintenance",
       "packagePatterns": ["^(braid-design-system|(seek-style-guide(-asia)?))$"],
       "schedule": ["before 8:00 am on the first weekday of the month"]
     }


### PR DESCRIPTION
Making a few updates to the renovate config:

#### prCreation: "not-pending"
Only open the PR once all CI checks have run (pass or fail)

#### lockFileMaintenance: true
Will update the lock file to take the the latest versions of deps compatible with specified semver. Uses the default schedule of "before 5am on monday" to keep the lock file fresh.

#### packageRules
Apply a schedule to style guide dependencies to update once a month