### PR TITLE
chore(renovate): Experiment with scheduled package updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,7 @@
     },
     {
       "groupName": "Tooling maintenance",
-      "packagePatterns": ["jest|puppeteer|tslint|eslint|prettier"],
+      "packagePatterns": ["jest|puppeteer|tslint|eslint"],
       "schedule": ["before 8am on Thursday"]
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "packageRules": [
     {
       "groupName": "Style guide maintenance",
-      "packagePatterns": ["^(braid-design-system|(seek-style-guide(-asia)?))$"],
+      "packagePatterns": ["^(braid-design-system|(seek(-asia)?-style-guide))$"],
       "schedule": ["before 8am on the first day of the month"]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,21 @@
       "groupName": "Style guide maintenance",
       "packagePatterns": ["^(braid-design-system|(seek-style-guide(-asia)?))$"],
       "schedule": ["before 8am on the first day of the month"]
+    },
+    {
+      "groupName": "Webpack maintenance",
+      "packagePatterns": ["webpack|(-loader$)|autoprefixer|less|css|svg"],
+      "schedule": ["before 8am on Thursday"]
+    },
+    {
+      "groupName": "Babel maintenance",
+      "packagePatterns": ["^@?babel[/-]"],
+      "schedule": ["before 8am on Thursday"]
+    },
+    {
+      "groupName": "Tooling maintenance",
+      "packagePatterns": ["jest|puppeteer|tslint|eslint|prettier"],
+      "schedule": ["before 8am on Thursday"]
     }
   ]
 }


### PR DESCRIPTION
We are going to try implementing a couple of package rule sets to keep our dependencies up to date — starting with some obvious sets in `webpack` and `babel`. In addition we have a `tooling` group that is a collection of dependencies for the `test`/`lint`/`format` commands.

Deliberately starting with a higher cadence to allow us to review the behaviour (not necessarily merging PRs).

Also fixes the regex for the `seek-asia-style-guide` which was incorrect.