### PR TITLE
fix(babel): Only use sourceType unambiguous for browsers

### DIFF
--- a/config/babel/babelConfig.js
+++ b/config/babel/babelConfig.js
@@ -58,7 +58,7 @@ module.exports = ({ target, lang = 'js' }) => {
 
   return {
     babelrc: false,
-    sourceType: 'unambiguous',
+    sourceType: isBrowser ? 'unambiguous' : 'module',
     presets: [
       languagePreset,
       [require.resolve('@babel/preset-env'), envPresetOptions],


### PR DESCRIPTION
This fixes an issue where flow prop-type generation would break when running in a node context. e.g. `jest`.