### PR TITLE
fix(start): Address warnings and speed up start script

### DIFF
--- a/config/webpack/utils/cssInJsLoader.js
+++ b/config/webpack/utils/cssInJsLoader.js
@@ -102,7 +102,7 @@ function produce(loader, request, callback) {
     }
     if (exports) {
       postcss()
-        .process(exports, { parser: postcssJs })
+        .process(exports, { from: this.resourcePath, parser: postcssJs })
         .then(function(res) {
           callback(null, res.css);
         });

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -167,27 +167,36 @@ const makeWebpackConfig = ({ isStorybook = false, port = 0 } = {}) => {
             include: internalJs,
             use: utils.makeJsLoaders({ target: 'browser' })
           },
-          {
-            test: /(?!\.css)\.js$/,
-            exclude: internalJs,
-            use: [
-              {
-                loader: require.resolve('babel-loader'),
-                options: {
-                  babelrc: false,
-                  presets: [
-                    [
-                      require.resolve('@babel/preset-env'),
-                      {
-                        modules: false,
-                        targets: supportedBrowsers
+          ...(isStartScript
+            ? []
+            : [
+                {
+                  test: /(?!\.css)\.js$/,
+                  exclude: [
+                    internalJs,
+                    // Prevent running `react-dom` through babel as it's
+                    // too large and already meets our browser support policy
+                    path.dirname(require.resolve('react-dom/package.json'))
+                  ],
+                  use: [
+                    {
+                      loader: require.resolve('babel-loader'),
+                      options: {
+                        babelrc: false,
+                        presets: [
+                          [
+                            require.resolve('@babel/preset-env'),
+                            {
+                              modules: false,
+                              targets: supportedBrowsers
+                            }
+                          ]
+                        ]
                       }
-                    ]
+                    }
                   ]
                 }
-              }
-            ]
-          },
+              ]),
           {
             test: /\.mjs$/,
             include: /node_modules/,

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -128,27 +128,36 @@ const makeWebpackConfig = ({ clientPort, serverPort }) => {
             include: internalJs,
             use: utils.makeJsLoaders({ target: 'browser' })
           },
-          {
-            test: /(?!\.css)\.js$/,
-            exclude: internalJs,
-            use: [
-              {
-                loader: require.resolve('babel-loader'),
-                options: {
-                  babelrc: false,
-                  presets: [
-                    [
-                      require.resolve('@babel/preset-env'),
-                      {
-                        modules: false,
-                        targets: supportedBrowsers
+          ...(isStartScript
+            ? []
+            : [
+                {
+                  test: /(?!\.css)\.js$/,
+                  exclude: [
+                    internalJs,
+                    // Prevent running `react-dom` through babel as it's
+                    // too large and already meets our browser support policy
+                    path.dirname(require.resolve('react-dom/package.json'))
+                  ],
+                  use: [
+                    {
+                      loader: require.resolve('babel-loader'),
+                      options: {
+                        babelrc: false,
+                        presets: [
+                          [
+                            require.resolve('@babel/preset-env'),
+                            {
+                              modules: false,
+                              targets: supportedBrowsers
+                            }
+                          ]
+                        ]
                       }
-                    ]
+                    }
                   ]
                 }
-              }
-            ]
-          },
+              ]),
           {
             test: /\.mjs$/,
             include: /node_modules/,

--- a/test/test-cases/braid-design-system/__snapshots__/braid-design-system.test.js.snap
+++ b/test/test-cases/braid-design-system/__snapshots__/braid-design-system.test.js.snap
@@ -42,7 +42,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="https://somecdn.com/vendors~main-75c75c01e0c8cd51bb14.js"
+          href="https://somecdn.com/vendors~main-3e2770ddfa0117486b51.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -221,7 +221,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="https://somecdn.com/vendors~main-75c75c01e0c8cd51bb14.js"
+            src="https://somecdn.com/vendors~main-3e2770ddfa0117486b51.js"
             crossorigin="anonymous"
     >
     </script>
@@ -270,7 +270,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="https://somecdn.com/vendors~main-75c75c01e0c8cd51bb14.js"
+          href="https://somecdn.com/vendors~main-3e2770ddfa0117486b51.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -449,7 +449,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="https://somecdn.com/vendors~main-75c75c01e0c8cd51bb14.js"
+            src="https://somecdn.com/vendors~main-3e2770ddfa0117486b51.js"
             crossorigin="anonymous"
     >
     </script>
@@ -1525,6 +1525,6 @@ Object {
   flex-shrink: 0;
 }
 ,
-  "vendors~main-75c75c01e0c8cd51bb14.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-3e2770ddfa0117486b51.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;

--- a/test/test-cases/braid-design-system/__snapshots__/braid-design-system.test.js.snap
+++ b/test/test-cases/braid-design-system/__snapshots__/braid-design-system.test.js.snap
@@ -42,7 +42,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="https://somecdn.com/vendors~main-3e2770ddfa0117486b51.js"
+          href="https://somecdn.com/vendors~main-14189cdd7dfc6197ed05.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -221,7 +221,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="https://somecdn.com/vendors~main-3e2770ddfa0117486b51.js"
+            src="https://somecdn.com/vendors~main-14189cdd7dfc6197ed05.js"
             crossorigin="anonymous"
     >
     </script>
@@ -270,7 +270,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="https://somecdn.com/vendors~main-3e2770ddfa0117486b51.js"
+          href="https://somecdn.com/vendors~main-14189cdd7dfc6197ed05.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -449,7 +449,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="https://somecdn.com/vendors~main-3e2770ddfa0117486b51.js"
+            src="https://somecdn.com/vendors~main-14189cdd7dfc6197ed05.js"
             crossorigin="anonymous"
     >
     </script>
@@ -1525,6 +1525,6 @@ Object {
   flex-shrink: 0;
 }
 ,
-  "vendors~main-3e2770ddfa0117486b51.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-14189cdd7dfc6197ed05.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;

--- a/test/test-cases/custom-src-paths/__snapshots__/custom-src-paths.test.js.snap
+++ b/test/test-cases/custom-src-paths/__snapshots__/custom-src-paths.test.js.snap
@@ -21,7 +21,7 @@ SOURCE HTML:
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4002/vendors~main-c0689d8bf3651a8ccac3.js"
+          href="http://localhost:4002/vendors~main-618579b08dc20130efab.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -48,7 +48,7 @@ SOURCE HTML:
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4002/vendors~main-c0689d8bf3651a8ccac3.js"
+            src="http://localhost:4002/vendors~main-618579b08dc20130efab.js"
             crossorigin="anonymous"
     >
     </script>
@@ -88,7 +88,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4002/vendors~main-c0689d8bf3651a8ccac3.js"
+          href="http://localhost:4002/vendors~main-618579b08dc20130efab.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -115,7 +115,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4002/vendors~main-c0689d8bf3651a8ccac3.js"
+            src="http://localhost:4002/vendors~main-618579b08dc20130efab.js"
             crossorigin="anonymous"
     >
     </script>
@@ -130,7 +130,7 @@ Object {
 ,
   "main-55ef0393adc164f6ae61.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-0ea2528cf0b6ed101089.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-c0689d8bf3651a8ccac3.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-618579b08dc20130efab.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;
 
@@ -190,10 +190,6 @@ SOURCE HTML:
 </html>
 
 POST HYDRATE DIFFS: NO DIFF
-WARNINGS: Array [
-  "[WDS] Warnings while compiling.",
-  "/Users/mdalgleish/Projects/sku/node_modules/@loadable/server/lib/util.js 26:9-28
-Critical dependency: the request of a dependency is an expression",
-]
+WARNINGS: Array []
 ERRORS: Array []
 `;

--- a/test/test-cases/custom-src-paths/__snapshots__/custom-src-paths.test.js.snap
+++ b/test/test-cases/custom-src-paths/__snapshots__/custom-src-paths.test.js.snap
@@ -21,7 +21,7 @@ SOURCE HTML:
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4002/vendors~main-158a692b0e7ed53a3166.js"
+          href="http://localhost:4002/vendors~main-c0689d8bf3651a8ccac3.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -48,7 +48,7 @@ SOURCE HTML:
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4002/vendors~main-158a692b0e7ed53a3166.js"
+            src="http://localhost:4002/vendors~main-c0689d8bf3651a8ccac3.js"
             crossorigin="anonymous"
     >
     </script>
@@ -88,7 +88,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4002/vendors~main-158a692b0e7ed53a3166.js"
+          href="http://localhost:4002/vendors~main-c0689d8bf3651a8ccac3.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -115,7 +115,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4002/vendors~main-158a692b0e7ed53a3166.js"
+            src="http://localhost:4002/vendors~main-c0689d8bf3651a8ccac3.js"
             crossorigin="anonymous"
     >
     </script>
@@ -130,7 +130,7 @@ Object {
 ,
   "main-55ef0393adc164f6ae61.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-0ea2528cf0b6ed101089.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-158a692b0e7ed53a3166.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-c0689d8bf3651a8ccac3.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;
 
@@ -190,6 +190,10 @@ SOURCE HTML:
 </html>
 
 POST HYDRATE DIFFS: NO DIFF
-WARNINGS: Array []
+WARNINGS: Array [
+  "[WDS] Warnings while compiling.",
+  "/Users/mdalgleish/Projects/sku/node_modules/@loadable/server/lib/util.js 26:9-28
+Critical dependency: the request of a dependency is an expression",
+]
 ERRORS: Array []
 `;

--- a/test/test-cases/multiple-routes/__snapshots__/multiple-routes.test.js.snap
+++ b/test/test-cases/multiple-routes/__snapshots__/multiple-routes.test.js.snap
@@ -31,7 +31,7 @@ SOURCE HTML:
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4004/vendors~main-fd06739d49f1c27f03d5.js"
+          href="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -68,7 +68,7 @@ SOURCE HTML:
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4004/vendors~main-fd06739d49f1c27f03d5.js"
+            src="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
             crossorigin="anonymous"
     >
     </script>
@@ -139,7 +139,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4004/vendors~main-fd06739d49f1c27f03d5.js"
+          href="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -185,7 +185,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4004/vendors~main-fd06739d49f1c27f03d5.js"
+            src="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
             crossorigin="anonymous"
     >
     </script>
@@ -228,7 +228,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4004/vendors~main-fd06739d49f1c27f03d5.js"
+          href="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -265,7 +265,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4004/vendors~main-fd06739d49f1c27f03d5.js"
+            src="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
             crossorigin="anonymous"
     >
     </script>
@@ -314,7 +314,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4004/vendors~main-fd06739d49f1c27f03d5.js"
+          href="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -360,7 +360,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4004/vendors~main-fd06739d49f1c27f03d5.js"
+            src="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
             crossorigin="anonymous"
     >
     </script>
@@ -403,7 +403,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4004/vendors~main-fd06739d49f1c27f03d5.js"
+          href="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -440,7 +440,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4004/vendors~main-fd06739d49f1c27f03d5.js"
+            src="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
             crossorigin="anonymous"
     >
     </script>
@@ -454,7 +454,7 @@ Object {
 </html>
 ,
   "runtime-b91dbaa2fd4f016b313a.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-fd06739d49f1c27f03d5.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-41a82351c794edfe634a.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;
 

--- a/test/test-cases/multiple-routes/__snapshots__/multiple-routes.test.js.snap
+++ b/test/test-cases/multiple-routes/__snapshots__/multiple-routes.test.js.snap
@@ -31,7 +31,7 @@ SOURCE HTML:
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
+          href="http://localhost:4004/vendors~main-f5d240030ff34559ef68.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -68,7 +68,7 @@ SOURCE HTML:
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
+            src="http://localhost:4004/vendors~main-f5d240030ff34559ef68.js"
             crossorigin="anonymous"
     >
     </script>
@@ -139,7 +139,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
+          href="http://localhost:4004/vendors~main-f5d240030ff34559ef68.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -185,7 +185,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
+            src="http://localhost:4004/vendors~main-f5d240030ff34559ef68.js"
             crossorigin="anonymous"
     >
     </script>
@@ -228,7 +228,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
+          href="http://localhost:4004/vendors~main-f5d240030ff34559ef68.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -265,7 +265,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
+            src="http://localhost:4004/vendors~main-f5d240030ff34559ef68.js"
             crossorigin="anonymous"
     >
     </script>
@@ -314,7 +314,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
+          href="http://localhost:4004/vendors~main-f5d240030ff34559ef68.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -360,7 +360,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
+            src="http://localhost:4004/vendors~main-f5d240030ff34559ef68.js"
             crossorigin="anonymous"
     >
     </script>
@@ -403,7 +403,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
+          href="http://localhost:4004/vendors~main-f5d240030ff34559ef68.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -440,7 +440,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4004/vendors~main-41a82351c794edfe634a.js"
+            src="http://localhost:4004/vendors~main-f5d240030ff34559ef68.js"
             crossorigin="anonymous"
     >
     </script>
@@ -454,7 +454,7 @@ Object {
 </html>
 ,
   "runtime-b91dbaa2fd4f016b313a.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-41a82351c794edfe634a.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-f5d240030ff34559ef68.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;
 

--- a/test/test-cases/public-path/__snapshots__/public-path.test.js.snap
+++ b/test/test-cases/public-path/__snapshots__/public-path.test.js.snap
@@ -24,7 +24,7 @@ SOURCE HTML:
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="/static/vendors~main-158a692b0e7ed53a3166.js"
+          href="/static/vendors~main-c0689d8bf3651a8ccac3.js"
     >
     <link data-chunk="main"
           rel="preload"
@@ -47,7 +47,7 @@ SOURCE HTML:
     </script>
     <script async
             data-chunk="main"
-            src="/static/vendors~main-158a692b0e7ed53a3166.js"
+            src="/static/vendors~main-c0689d8bf3651a8ccac3.js"
     >
     </script>
     <script async

--- a/test/test-cases/public-path/__snapshots__/public-path.test.js.snap
+++ b/test/test-cases/public-path/__snapshots__/public-path.test.js.snap
@@ -24,7 +24,7 @@ SOURCE HTML:
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="/static/vendors~main-c0689d8bf3651a8ccac3.js"
+          href="/static/vendors~main-618579b08dc20130efab.js"
     >
     <link data-chunk="main"
           rel="preload"
@@ -47,7 +47,7 @@ SOURCE HTML:
     </script>
     <script async
             data-chunk="main"
-            src="/static/vendors~main-c0689d8bf3651a8ccac3.js"
+            src="/static/vendors~main-618579b08dc20130efab.js"
     >
     </script>
     <script async

--- a/test/test-cases/react-css-modules/__snapshots__/react-css-modules.test.js.snap
+++ b/test/test-cases/react-css-modules/__snapshots__/react-css-modules.test.js.snap
@@ -24,7 +24,7 @@ SOURCE HTML:
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="/vendors~main-27633c8a16b552ed91d7.js"
+          href="/vendors~main-ebc0059b8e6723cbd264.js"
     >
     <link data-chunk="main"
           rel="preload"
@@ -52,7 +52,7 @@ SOURCE HTML:
     </script>
     <script async
             data-chunk="main"
-            src="/vendors~main-27633c8a16b552ed91d7.js"
+            src="/vendors~main-ebc0059b8e6723cbd264.js"
     >
     </script>
     <script async
@@ -102,7 +102,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="/vendors~main-27633c8a16b552ed91d7.js"
+          href="/vendors~main-ebc0059b8e6723cbd264.js"
     >
     <link data-chunk="main"
           rel="preload"
@@ -130,7 +130,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="/vendors~main-27633c8a16b552ed91d7.js"
+            src="/vendors~main-ebc0059b8e6723cbd264.js"
     >
     </script>
     <script async
@@ -160,6 +160,6 @@ Object {
 }
 ,
   "runtime-135ea29ecc719f03a91d.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-27633c8a16b552ed91d7.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-ebc0059b8e6723cbd264.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;

--- a/test/test-cases/react-css-modules/__snapshots__/react-css-modules.test.js.snap
+++ b/test/test-cases/react-css-modules/__snapshots__/react-css-modules.test.js.snap
@@ -24,7 +24,7 @@ SOURCE HTML:
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="/vendors~main-26cf3858f11a885886e4.js"
+          href="/vendors~main-27633c8a16b552ed91d7.js"
     >
     <link data-chunk="main"
           rel="preload"
@@ -52,7 +52,7 @@ SOURCE HTML:
     </script>
     <script async
             data-chunk="main"
-            src="/vendors~main-26cf3858f11a885886e4.js"
+            src="/vendors~main-27633c8a16b552ed91d7.js"
     >
     </script>
     <script async
@@ -102,7 +102,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="/vendors~main-26cf3858f11a885886e4.js"
+          href="/vendors~main-27633c8a16b552ed91d7.js"
     >
     <link data-chunk="main"
           rel="preload"
@@ -130,7 +130,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="/vendors~main-26cf3858f11a885886e4.js"
+            src="/vendors~main-27633c8a16b552ed91d7.js"
     >
     </script>
     <script async
@@ -160,6 +160,6 @@ Object {
 }
 ,
   "runtime-135ea29ecc719f03a91d.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-26cf3858f11a885886e4.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-27633c8a16b552ed91d7.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;

--- a/test/test-cases/seek-asia-style-guide/__snapshots__/seek-asia-style-guide.test.js.snap
+++ b/test/test-cases/seek-asia-style-guide/__snapshots__/seek-asia-style-guide.test.js.snap
@@ -31,7 +31,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="/vendors~main-cc9ce339f638610b68ce.js"
+          href="/vendors~main-6fb040480778c8c83cba.js"
     >
     <link data-chunk="main"
           rel="preload"
@@ -70,7 +70,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="/vendors~main-cc9ce339f638610b68ce.js"
+            src="/vendors~main-6fb040480778c8c83cba.js"
     >
     </script>
     <script async
@@ -83,6 +83,7 @@ Object {
 ,
   "main-bae4ca4e15565892d9d8.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-135ea29ecc719f03a91d.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-6fb040480778c8c83cba.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "vendors~main-8fe1a6f58f40d873f200.css": a,
 abbr,
 acronym,
@@ -4028,6 +4029,5 @@ html {
   outline: none;
 }
 ,
-  "vendors~main-cc9ce339f638610b68ce.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;

--- a/test/test-cases/seek-asia-style-guide/__snapshots__/seek-asia-style-guide.test.js.snap
+++ b/test/test-cases/seek-asia-style-guide/__snapshots__/seek-asia-style-guide.test.js.snap
@@ -31,7 +31,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="/vendors~main-6fb040480778c8c83cba.js"
+          href="/vendors~main-4018766ddbe55893e3ad.js"
     >
     <link data-chunk="main"
           rel="preload"
@@ -70,7 +70,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="/vendors~main-6fb040480778c8c83cba.js"
+            src="/vendors~main-4018766ddbe55893e3ad.js"
     >
     </script>
     <script async
@@ -83,7 +83,7 @@ Object {
 ,
   "main-bae4ca4e15565892d9d8.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-135ea29ecc719f03a91d.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-6fb040480778c8c83cba.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-4018766ddbe55893e3ad.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "vendors~main-8fe1a6f58f40d873f200.css": a,
 abbr,
 acronym,

--- a/test/test-cases/seek-style-guide/__snapshots__/seek-style-guide.test.js.snap
+++ b/test/test-cases/seek-style-guide/__snapshots__/seek-style-guide.test.js.snap
@@ -31,7 +31,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="/vendors~main-3b8a5ec185dd6c241e71.js"
+          href="/vendors~main-0598efe8458c82e56ad5.js"
     >
     <link data-chunk="main"
           rel="preload"
@@ -70,7 +70,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="/vendors~main-3b8a5ec185dd6c241e71.js"
+            src="/vendors~main-0598efe8458c82e56ad5.js"
     >
     </script>
     <script async
@@ -83,7 +83,7 @@ Object {
 ,
   "main-6d049a35621f4ea5e659.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-135ea29ecc719f03a91d.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-3b8a5ec185dd6c241e71.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-0598efe8458c82e56ad5.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "vendors~main-c09502ce674a7b18ccd6.css": a,
 abbr,
 acronym,

--- a/test/test-cases/seek-style-guide/__snapshots__/seek-style-guide.test.js.snap
+++ b/test/test-cases/seek-style-guide/__snapshots__/seek-style-guide.test.js.snap
@@ -31,7 +31,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="/vendors~main-0598efe8458c82e56ad5.js"
+          href="/vendors~main-7da30edd2d895bdbfcb5.js"
     >
     <link data-chunk="main"
           rel="preload"
@@ -70,7 +70,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="/vendors~main-0598efe8458c82e56ad5.js"
+            src="/vendors~main-7da30edd2d895bdbfcb5.js"
     >
     </script>
     <script async
@@ -83,7 +83,7 @@ Object {
 ,
   "main-6d049a35621f4ea5e659.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-135ea29ecc719f03a91d.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-0598efe8458c82e56ad5.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-7da30edd2d895bdbfcb5.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "vendors~main-c09502ce674a7b18ccd6.css": a,
 abbr,
 acronym,

--- a/test/test-cases/source-maps/__snapshots__/source-maps.test.js.snap
+++ b/test/test-cases/source-maps/__snapshots__/source-maps.test.js.snap
@@ -22,7 +22,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4005/vendors~main-c0689d8bf3651a8ccac3.js"
+          href="http://localhost:4005/vendors~main-618579b08dc20130efab.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -49,7 +49,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4005/vendors~main-c0689d8bf3651a8ccac3.js"
+            src="http://localhost:4005/vendors~main-618579b08dc20130efab.js"
             crossorigin="anonymous"
     >
     </script>
@@ -66,7 +66,7 @@ Object {
   "main-cfcedd9bc8c81d6d316d.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-0ce2ce2fbc2586ce70ce.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-0ce2ce2fbc2586ce70ce.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-c0689d8bf3651a8ccac3.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-c0689d8bf3651a8ccac3.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-618579b08dc20130efab.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-618579b08dc20130efab.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;

--- a/test/test-cases/source-maps/__snapshots__/source-maps.test.js.snap
+++ b/test/test-cases/source-maps/__snapshots__/source-maps.test.js.snap
@@ -22,7 +22,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4005/vendors~main-158a692b0e7ed53a3166.js"
+          href="http://localhost:4005/vendors~main-c0689d8bf3651a8ccac3.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -49,7 +49,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4005/vendors~main-158a692b0e7ed53a3166.js"
+            src="http://localhost:4005/vendors~main-c0689d8bf3651a8ccac3.js"
             crossorigin="anonymous"
     >
     </script>
@@ -66,7 +66,7 @@ Object {
   "main-cfcedd9bc8c81d6d316d.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-0ce2ce2fbc2586ce70ce.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-0ce2ce2fbc2586ce70ce.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-158a692b0e7ed53a3166.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-158a692b0e7ed53a3166.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-c0689d8bf3651a8ccac3.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-c0689d8bf3651a8ccac3.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;

--- a/test/test-cases/ssr-hello-world/__snapshots__/ssr-hello-world.test.js.snap
+++ b/test/test-cases/ssr-hello-world/__snapshots__/ssr-hello-world.test.js.snap
@@ -25,7 +25,7 @@ SOURCE HTML:
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4000/vendors~main-4f8d5485ef44642901c7.js"
+          href="http://localhost:4000/vendors~main-692435115b48f8cbe6ea.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -54,7 +54,7 @@ SOURCE HTML:
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4000/vendors~main-4f8d5485ef44642901c7.js"
+            src="http://localhost:4000/vendors~main-692435115b48f8cbe6ea.js"
             crossorigin="anonymous"
     >
     </script>
@@ -97,7 +97,7 @@ SOURCE HTML:
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4000/vendors~main-4f8d5485ef44642901c7.js"
+          href="http://localhost:4000/vendors~main-692435115b48f8cbe6ea.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -126,7 +126,7 @@ SOURCE HTML:
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4000/vendors~main-4f8d5485ef44642901c7.js"
+            src="http://localhost:4000/vendors~main-692435115b48f8cbe6ea.js"
             crossorigin="anonymous"
     >
     </script>

--- a/test/test-cases/ssr-hello-world/__snapshots__/ssr-hello-world.test.js.snap
+++ b/test/test-cases/ssr-hello-world/__snapshots__/ssr-hello-world.test.js.snap
@@ -25,7 +25,7 @@ SOURCE HTML:
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4000/vendors~main-f369861a06d11a1913a1.js"
+          href="http://localhost:4000/vendors~main-4f8d5485ef44642901c7.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -54,7 +54,7 @@ SOURCE HTML:
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4000/vendors~main-f369861a06d11a1913a1.js"
+            src="http://localhost:4000/vendors~main-4f8d5485ef44642901c7.js"
             crossorigin="anonymous"
     >
     </script>
@@ -97,7 +97,7 @@ SOURCE HTML:
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4000/vendors~main-f369861a06d11a1913a1.js"
+          href="http://localhost:4000/vendors~main-4f8d5485ef44642901c7.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -126,7 +126,7 @@ SOURCE HTML:
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4000/vendors~main-f369861a06d11a1913a1.js"
+            src="http://localhost:4000/vendors~main-4f8d5485ef44642901c7.js"
             crossorigin="anonymous"
     >
     </script>

--- a/test/test-cases/typescript-css-modules/__snapshots__/typescript-css-modules.test.js.snap
+++ b/test/test-cases/typescript-css-modules/__snapshots__/typescript-css-modules.test.js.snap
@@ -25,7 +25,7 @@ SOURCE HTML:
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4003/vendors~main-9a34ead4d4ded1e93edd.js"
+          href="http://localhost:4003/vendors~main-ddb229777eec8a7a373e.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -56,7 +56,7 @@ SOURCE HTML:
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4003/vendors~main-9a34ead4d4ded1e93edd.js"
+            src="http://localhost:4003/vendors~main-ddb229777eec8a7a373e.js"
             crossorigin="anonymous"
     >
     </script>
@@ -100,7 +100,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4003/vendors~main-9a34ead4d4ded1e93edd.js"
+          href="http://localhost:4003/vendors~main-ddb229777eec8a7a373e.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -131,7 +131,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4003/vendors~main-9a34ead4d4ded1e93edd.js"
+            src="http://localhost:4003/vendors~main-ddb229777eec8a7a373e.js"
             crossorigin="anonymous"
     >
     </script>
@@ -173,7 +173,7 @@ export const root: string;
 }
 ,
   "runtime-dfda6aa3edd4b5fc5f37.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-9a34ead4d4ded1e93edd.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-ddb229777eec8a7a373e.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;
 
@@ -351,10 +351,6 @@ SOURCE HTML:
 </html>
 
 POST HYDRATE DIFFS: NO DIFF
-WARNINGS: Array [
-  "[WDS] Warnings while compiling.",
-  "/Users/mdalgleish/Projects/sku/node_modules/@loadable/server/lib/util.js 26:9-28
-Critical dependency: the request of a dependency is an expression",
-]
+WARNINGS: Array []
 ERRORS: Array []
 `;

--- a/test/test-cases/typescript-css-modules/__snapshots__/typescript-css-modules.test.js.snap
+++ b/test/test-cases/typescript-css-modules/__snapshots__/typescript-css-modules.test.js.snap
@@ -25,7 +25,7 @@ SOURCE HTML:
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4003/vendors~main-8ce149c34deb24c05e87.js"
+          href="http://localhost:4003/vendors~main-9a34ead4d4ded1e93edd.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -56,7 +56,7 @@ SOURCE HTML:
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4003/vendors~main-8ce149c34deb24c05e87.js"
+            src="http://localhost:4003/vendors~main-9a34ead4d4ded1e93edd.js"
             crossorigin="anonymous"
     >
     </script>
@@ -100,7 +100,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4003/vendors~main-8ce149c34deb24c05e87.js"
+          href="http://localhost:4003/vendors~main-9a34ead4d4ded1e93edd.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -131,7 +131,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4003/vendors~main-8ce149c34deb24c05e87.js"
+            src="http://localhost:4003/vendors~main-9a34ead4d4ded1e93edd.js"
             crossorigin="anonymous"
     >
     </script>
@@ -173,7 +173,7 @@ export const root: string;
 }
 ,
   "runtime-dfda6aa3edd4b5fc5f37.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-8ce149c34deb24c05e87.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-9a34ead4d4ded1e93edd.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;
 
@@ -202,7 +202,7 @@ SOURCE HTML:
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="http://localhost:4003/vendors~main-61296964ab5747dec9b4.js"
+          href="http://localhost:4003/vendors~main-db4e64159786832628b1.js"
           crossorigin="anonymous"
     >
     <link data-chunk="main"
@@ -233,7 +233,7 @@ SOURCE HTML:
     </script>
     <script async
             data-chunk="main"
-            src="http://localhost:4003/vendors~main-61296964ab5747dec9b4.js"
+            src="http://localhost:4003/vendors~main-db4e64159786832628b1.js"
             crossorigin="anonymous"
     >
     </script>
@@ -283,7 +283,7 @@ export const root: string;
   "main-d77f47c2a5b9d4421a76.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-dfda6aa3edd4b5fc5f37.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "server.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-61296964ab5747dec9b4.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-db4e64159786832628b1.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;
 
@@ -351,6 +351,10 @@ SOURCE HTML:
 </html>
 
 POST HYDRATE DIFFS: NO DIFF
-WARNINGS: Array []
+WARNINGS: Array [
+  "[WDS] Warnings while compiling.",
+  "/Users/mdalgleish/Projects/sku/node_modules/@loadable/server/lib/util.js 26:9-28
+Critical dependency: the request of a dependency is an expression",
+]
 ERRORS: Array []
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,17 +30,17 @@
     source-map "^0.5.0"
 
 "@babel/core@^7.1.0", "@babel/core@^7.1.2", "@babel/core@^7.1.6":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.3.3.tgz#d090d157b7c5060d05a05acaebc048bd2b037947"
-  integrity sha512-w445QGI2qd0E0GlSnq6huRZWPMmQGCp5gd5ZWS4hagn0EiwzxD5QMFkpchyusAyVC1n27OKXzQ0/88aVU9n4xQ==
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.3.4.tgz#921a5a13746c21e32445bf0798680e9d11a6530b"
+  integrity sha512-jRsuseXBo9pN197KnDwhhaaBzyZr2oIcLHHTt2oDdQrej5Qp57dCCJafWx5ivU8/alEYDpssYqv1MUqcxwQlrA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.3.3"
+    "@babel/generator" "^7.3.4"
     "@babel/helpers" "^7.2.0"
-    "@babel/parser" "^7.3.3"
+    "@babel/parser" "^7.3.4"
     "@babel/template" "^7.2.2"
-    "@babel/traverse" "^7.2.2"
-    "@babel/types" "^7.3.3"
+    "@babel/traverse" "^7.3.4"
+    "@babel/types" "^7.3.4"
     convert-source-map "^1.1.0"
     debug "^4.1.0"
     json5 "^2.1.0"
@@ -49,12 +49,12 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.0.0", "@babel/generator@^7.2.2", "@babel/generator@^7.3.3":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.3.3.tgz#185962ade59a52e00ca2bdfcfd1d58e528d4e39e"
-  integrity sha512-aEADYwRRZjJyMnKN7llGIlircxTCofm3dtV5pmY6ob18MSIuipHpA2yZWkPlycwu5HJcx/pADS3zssd8eY7/6A==
+"@babel/generator@^7.0.0", "@babel/generator@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.3.4.tgz#9aa48c1989257877a9d971296e5b73bfe72e446e"
+  integrity sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==
   dependencies:
-    "@babel/types" "^7.3.3"
+    "@babel/types" "^7.3.4"
     jsesc "^2.5.1"
     lodash "^4.17.11"
     source-map "^0.5.0"
@@ -92,16 +92,17 @@
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@babel/helper-create-class-features-plugin@^7.3.0":
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.2.tgz#ba1685603eb1c9f2f51c9106d5180135c163fe73"
-  integrity sha512-tdW8+V8ceh2US4GsYdNVNoohq5uVwOf9k6krjwW4E1lINcHgttnWcNqgdoessn12dAy8QkbezlbQh2nXISNY+A==
+"@babel/helper-create-class-features-plugin@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.4.tgz#092711a7a3ad8ea34de3e541644c2ce6af1f6f0c"
+  integrity sha512-uFpzw6L2omjibjxa8VGZsJUPL5wJH0zzGKpoz0ccBkzIa6C8kWNUbiBmQ0rgOKWlHJ6qzmfa6lTiGchiV8SC+g==
   dependencies:
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-member-expression-to-functions" "^7.0.0"
     "@babel/helper-optimise-call-expression" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-replace-supers" "^7.2.3"
+    "@babel/helper-replace-supers" "^7.3.4"
+    "@babel/helper-split-export-declaration" "^7.0.0"
 
 "@babel/helper-define-map@^7.1.0":
   version "7.1.0"
@@ -199,15 +200,15 @@
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@babel/helper-replace-supers@^7.1.0", "@babel/helper-replace-supers@^7.2.3":
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.2.3.tgz#19970020cf22677d62b3a689561dbd9644d8c5e5"
-  integrity sha512-GyieIznGUfPXPWu0yLS6U55Mz67AZD9cUk0BfirOWlPrXlBcan9Gz+vHGz+cPfuoweZSnPzPIm67VtQM0OWZbA==
+"@babel/helper-replace-supers@^7.1.0", "@babel/helper-replace-supers@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.3.4.tgz#a795208e9b911a6eeb08e5891faacf06e7013e13"
+  integrity sha512-pvObL9WVf2ADs+ePg0jrqlhHoxRXlOa+SHRHzAXIz2xkYuOHfGl+fKxPMaS4Fq+uje8JQPobnertBBvyrWnQ1A==
   dependencies:
     "@babel/helper-member-expression-to-functions" "^7.0.0"
     "@babel/helper-optimise-call-expression" "^7.0.0"
-    "@babel/traverse" "^7.2.3"
-    "@babel/types" "^7.0.0"
+    "@babel/traverse" "^7.3.4"
+    "@babel/types" "^7.3.4"
 
 "@babel/helper-simple-access@^7.1.0":
   version "7.1.0"
@@ -252,10 +253,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.3", "@babel/parser@^7.2.2", "@babel/parser@^7.2.3", "@babel/parser@^7.3.3":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.3.tgz#092d450db02bdb6ccb1ca8ffd47d8774a91aef87"
-  integrity sha512-xsH1CJoln2r74hR+y7cg2B5JCPaTh+Hd+EbBRk9nWGSNspuo6krjhX0Om6RnRQuIvFq8wVXCLKH3kwKDYhanSg==
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.3", "@babel/parser@^7.2.2", "@babel/parser@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.4.tgz#a43357e4bbf4b92a437fb9e465c192848287f27c"
+  integrity sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==
 
 "@babel/plugin-proposal-async-generator-functions@^7.1.0", "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
@@ -279,11 +280,11 @@
     "@babel/plugin-syntax-class-properties" "^7.0.0"
 
 "@babel/plugin-proposal-class-properties@^7.1.0", "@babel/plugin-proposal-class-properties@^7.2.0":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.3.3.tgz#e69ee114a834a671293ace001708cc1682ed63f9"
-  integrity sha512-XO9eeU1/UwGPM8L+TjnQCykuVcXqaO5J1bkRPIygqZ/A2L1xVMJ9aZXrY31c0U4H2/LHKL4lbFQLsxktSrc/Ng==
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.3.4.tgz#410f5173b3dc45939f9ab30ca26684d72901405e"
+  integrity sha512-lUf8D3HLs4yYlAo8zjuneLvfxN7qfKv1Yzbj5vjqaqMJxgJA3Ipwp4VUJ+OrOdz53Wbww6ahwB8UhB2HQyLotA==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.3.0"
+    "@babel/helper-create-class-features-plugin" "^7.3.4"
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-proposal-decorators@7.1.2":
@@ -312,10 +313,10 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
 
-"@babel/plugin-proposal-object-rest-spread@^7.0.0", "@babel/plugin-proposal-object-rest-spread@^7.3.1":
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.2.tgz#6d1859882d4d778578e41f82cc5d7bf3d5daf6c1"
-  integrity sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==
+"@babel/plugin-proposal-object-rest-spread@^7.0.0", "@babel/plugin-proposal-object-rest-spread@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.4.tgz#47f73cf7f2a721aad5c0261205405c642e424654"
+  integrity sha512-j7VQmbbkA+qrzNqbKHrBsW3ddFnOeva6wzSe/zB7T+xaxGc+RCpwo44wCmRixAIGRoIpmVgvzFzNJqQcO3/9RA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
@@ -421,10 +422,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-async-to-generator@^7.1.0", "@babel/plugin-transform-async-to-generator@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.2.0.tgz#68b8a438663e88519e65b776f8938f3445b1a2ff"
-  integrity sha512-CEHzg4g5UraReozI9D4fblBYABs7IM6UerAVG7EJVrTLC5keh00aEuLUT+O40+mJCEzaXkYfTCUKIyeDfMOFFQ==
+"@babel/plugin-transform-async-to-generator@^7.1.0", "@babel/plugin-transform-async-to-generator@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.3.4.tgz#4e45408d3c3da231c0e7b823f407a53a7eb3048c"
+  integrity sha512-Y7nCzv2fw/jEZ9f678MuKdMo99MFDJMT/PvD9LisrR5JDFcJH6vYeH6RnjVt3p5tceyGRvTtEN0VOlU+rgHZjA==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -437,13 +438,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-block-scoping@^7.0.0", "@babel/plugin-transform-block-scoping@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.2.0.tgz#f17c49d91eedbcdf5dd50597d16f5f2f770132d4"
-  integrity sha512-vDTgf19ZEV6mx35yiPJe4fS02mPQUUcBNwWQSZFXSzTSbsJFQvHt7DqyS3LK8oOWALFOsJ+8bbqBgkirZteD5Q==
+"@babel/plugin-transform-block-scoping@^7.0.0", "@babel/plugin-transform-block-scoping@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.3.4.tgz#5c22c339de234076eee96c8783b2fed61202c5c4"
+  integrity sha512-blRr2O8IOZLAOJklXLV4WhcEzpYafYQKSGT3+R26lWG41u/FODJuBggehtOwilVAcFu393v3OFj+HmaE6tVjhA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    lodash "^4.17.10"
+    lodash "^4.17.11"
 
 "@babel/plugin-transform-classes@7.1.0":
   version "7.1.0"
@@ -459,17 +460,17 @@
     "@babel/helper-split-export-declaration" "^7.0.0"
     globals "^11.1.0"
 
-"@babel/plugin-transform-classes@^7.1.0", "@babel/plugin-transform-classes@^7.2.0":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.3.3.tgz#a0532d6889c534d095e8f604e9257f91386c4b51"
-  integrity sha512-n0CLbsg7KOXsMF4tSTLCApNMoXk0wOPb0DYfsOO1e7SfIb9gOyfbpKI2MZ+AXfqvlfzq2qsflJ1nEns48Caf2w==
+"@babel/plugin-transform-classes@^7.1.0", "@babel/plugin-transform-classes@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.3.4.tgz#dc173cb999c6c5297e0b5f2277fdaaec3739d0cc"
+  integrity sha512-J9fAvCFBkXEvBimgYxCjvaVDzL6thk0j0dBvCeZmIUDBwyt+nv6HfbImsSrWsYXfDNDivyANgJlFXDUWRTZBuA==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.0.0"
     "@babel/helper-define-map" "^7.1.0"
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-optimise-call-expression" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-replace-supers" "^7.1.0"
+    "@babel/helper-replace-supers" "^7.3.4"
     "@babel/helper-split-export-declaration" "^7.0.0"
     globals "^11.1.0"
 
@@ -527,9 +528,9 @@
     "@babel/plugin-syntax-flow" "^7.0.0"
 
 "@babel/plugin-transform-flow-strip-types@^7.0.0":
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.2.3.tgz#e3ac2a594948454e7431c7db33e1d02d51b5cd69"
-  integrity sha512-xnt7UIk9GYZRitqCnsVMjQK1O2eKZwFB3CvvHjf5SGx6K6vr/MScCKQDnf1DxRaj501e3pXjti+inbSXX2ZUoQ==
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.3.4.tgz#00156236defb7dedddc2d3c9477dcc01a4494327"
+  integrity sha512-PmQC9R7DwpBFA+7ATKMyzViz3zCaMNouzZMPZN2K5PnbBbtL3AXFYTkDk+Hey5crQq2A90UG5Uthz0mel+XZrA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-flow" "^7.2.0"
@@ -573,10 +574,10 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-simple-access" "^7.1.0"
 
-"@babel/plugin-transform-modules-systemjs@^7.0.0", "@babel/plugin-transform-modules-systemjs@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.2.0.tgz#912bfe9e5ff982924c81d0937c92d24994bb9068"
-  integrity sha512-aYJwpAhoK9a+1+O625WIjvMY11wkB/ok0WClVwmeo3mCjcNRjt+/8gHWrB5i+00mUju0gWsBkQnPpdvQ7PImmQ==
+"@babel/plugin-transform-modules-systemjs@^7.0.0", "@babel/plugin-transform-modules-systemjs@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.3.4.tgz#813b34cd9acb6ba70a84939f3680be0eb2e58861"
+  integrity sha512-VZ4+jlGOF36S7TjKs8g4ojp4MEI+ebCQZdswWb/T9I4X84j8OtFAyjXjt/M16iIm5RIZn0UMQgg/VgIwo/87vw==
   dependencies:
     "@babel/helper-hoist-variables" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -683,12 +684,12 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-jsx" "^7.2.0"
 
-"@babel/plugin-transform-regenerator@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz#5b41686b4ed40bef874d7ed6a84bdd849c13e0c1"
-  integrity sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==
+"@babel/plugin-transform-regenerator@^7.0.0", "@babel/plugin-transform-regenerator@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.3.4.tgz#1601655c362f5b38eead6a52631f5106b29fa46a"
+  integrity sha512-hvJg8EReQvXT6G9H2MvNPXkv9zK36Vxa1+csAVTpE1J3j0zlHplw76uudEbJxgvqZzAq9Yh45FLD4pk5mKRFQA==
   dependencies:
-    regenerator-transform "^0.13.3"
+    regenerator-transform "^0.13.4"
 
 "@babel/plugin-transform-runtime@7.1.0":
   version "7.1.0"
@@ -701,9 +702,9 @@
     semver "^5.5.1"
 
 "@babel/plugin-transform-runtime@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz#566bc43f7d0aedc880eaddbd29168d0f248966ea"
-  integrity sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.3.4.tgz#57805ac8c1798d102ecd75c03b024a5b3ea9b431"
+  integrity sha512-PaoARuztAdd5MgeVjAxnIDAIUet5KpogqaefQvPOmPYCxYoaPhautxDh3aO8a4xHsKgT/b9gSxR0BKK1MIewPA==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -812,15 +813,15 @@
     semver "^5.3.0"
 
 "@babel/preset-env@^7.1.0", "@babel/preset-env@^7.1.6", "@babel/preset-env@^7.2.0":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.3.1.tgz#389e8ca6b17ae67aaf9a2111665030be923515db"
-  integrity sha512-FHKrD6Dxf30e8xgHQO0zJZpUPfVZg+Xwgz5/RdSWCbza9QLNk4Qbp40ctRoqDxml3O8RMzB1DU55SXeDG6PqHQ==
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.3.4.tgz#887cf38b6d23c82f19b5135298bdb160062e33e1"
+  integrity sha512-2mwqfYMK8weA0g0uBKOt4FE3iEodiHy9/CW0b+nWXcbL+pGzLx8ESYc+j9IIxr6LTDHWKgPm71i9smo02bw+gA==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-proposal-async-generator-functions" "^7.2.0"
     "@babel/plugin-proposal-json-strings" "^7.2.0"
-    "@babel/plugin-proposal-object-rest-spread" "^7.3.1"
+    "@babel/plugin-proposal-object-rest-spread" "^7.3.4"
     "@babel/plugin-proposal-optional-catch-binding" "^7.2.0"
     "@babel/plugin-proposal-unicode-property-regex" "^7.2.0"
     "@babel/plugin-syntax-async-generators" "^7.2.0"
@@ -828,10 +829,10 @@
     "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
     "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
     "@babel/plugin-transform-arrow-functions" "^7.2.0"
-    "@babel/plugin-transform-async-to-generator" "^7.2.0"
+    "@babel/plugin-transform-async-to-generator" "^7.3.4"
     "@babel/plugin-transform-block-scoped-functions" "^7.2.0"
-    "@babel/plugin-transform-block-scoping" "^7.2.0"
-    "@babel/plugin-transform-classes" "^7.2.0"
+    "@babel/plugin-transform-block-scoping" "^7.3.4"
+    "@babel/plugin-transform-classes" "^7.3.4"
     "@babel/plugin-transform-computed-properties" "^7.2.0"
     "@babel/plugin-transform-destructuring" "^7.2.0"
     "@babel/plugin-transform-dotall-regex" "^7.2.0"
@@ -842,13 +843,13 @@
     "@babel/plugin-transform-literals" "^7.2.0"
     "@babel/plugin-transform-modules-amd" "^7.2.0"
     "@babel/plugin-transform-modules-commonjs" "^7.2.0"
-    "@babel/plugin-transform-modules-systemjs" "^7.2.0"
+    "@babel/plugin-transform-modules-systemjs" "^7.3.4"
     "@babel/plugin-transform-modules-umd" "^7.2.0"
     "@babel/plugin-transform-named-capturing-groups-regex" "^7.3.0"
     "@babel/plugin-transform-new-target" "^7.0.0"
     "@babel/plugin-transform-object-super" "^7.2.0"
     "@babel/plugin-transform-parameters" "^7.2.0"
-    "@babel/plugin-transform-regenerator" "^7.0.0"
+    "@babel/plugin-transform-regenerator" "^7.3.4"
     "@babel/plugin-transform-shorthand-properties" "^7.2.0"
     "@babel/plugin-transform-spread" "^7.2.0"
     "@babel/plugin-transform-sticky-regex" "^7.2.0"
@@ -903,9 +904,9 @@
     regenerator-runtime "^0.12.0"
 
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
-  integrity sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.4.tgz#73d12ba819e365fcf7fd152aed56d6df97d21c83"
+  integrity sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==
   dependencies:
     regenerator-runtime "^0.12.0"
 
@@ -918,25 +919,25 @@
     "@babel/parser" "^7.2.2"
     "@babel/types" "^7.2.2"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.1.5", "@babel/traverse@^7.2.2", "@babel/traverse@^7.2.3":
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.2.3.tgz#7ff50cefa9c7c0bd2d81231fdac122f3957748d8"
-  integrity sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.1.5", "@babel/traverse@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.3.4.tgz#1330aab72234f8dea091b08c4f8b9d05c7119e06"
+  integrity sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.2.2"
+    "@babel/generator" "^7.3.4"
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-split-export-declaration" "^7.0.0"
-    "@babel/parser" "^7.2.3"
-    "@babel/types" "^7.2.2"
+    "@babel/parser" "^7.3.4"
+    "@babel/types" "^7.3.4"
     debug "^4.1.0"
     globals "^11.1.0"
-    lodash "^4.17.10"
+    lodash "^4.17.11"
 
-"@babel/types@^7.0.0", "@babel/types@^7.1.6", "@babel/types@^7.2.0", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.3.3.tgz#6c44d1cdac2a7625b624216657d5bc6c107ab436"
-  integrity sha512-2tACZ80Wg09UnPg5uGAOUvvInaqLk3l/IAhQzlxLQOIXacr6bMsra5SH6AWw/hIDRCSbCdHP2KzSOD+cT7TzMQ==
+"@babel/types@^7.0.0", "@babel/types@^7.1.6", "@babel/types@^7.2.0", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.3.4.tgz#bf482eaeaffb367a28abbf9357a94963235d90ed"
+  integrity sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.11"
@@ -1214,16 +1215,16 @@
     "@babel/plugin-syntax-dynamic-import" "^7.2.0"
 
 "@loadable/component@^5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@loadable/component/-/component-5.6.0.tgz#28f79caeccc956205a0e38494ea26c49428461d7"
-  integrity sha512-GeVzzAiKLC+CFr/Pf7uIsbRmzDLJ9XC4rb6AM2zIns6yziOvJTjKsO31PUuIxuMwNEKwlOpUkkBarBbwb45bHA==
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@loadable/component/-/component-5.6.1.tgz#7c4cc7619280ae39a770583e05c3e9980bb3a615"
+  integrity sha512-lkRMQiekLmBIANxdx/Ybod8s2KQKnS0yAHl6abv1MenSjV9OmtLMjeOMz3RB7AItgOo6D7GPTWIJr1eHswV/Iw==
   dependencies:
-    hoist-non-react-statics "^3.2.1"
+    hoist-non-react-statics "^3.3.0"
 
 "@loadable/server@^5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@loadable/server/-/server-5.6.0.tgz#c1a31273ef2263f39a3f049e16d6d1f00d5505a0"
-  integrity sha512-fmo1P0FKNqEagp8soR/dqd+pZlOTzY1CkQozdStn78rtdZnysYkmMW81g9gYzl+3ZZUYoZSzotGYV8t9xuPsow==
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@loadable/server/-/server-5.6.1.tgz#b3425c34f4e56411965aaac070e2573ab1f2cbf0"
+  integrity sha512-XTonaoyiGtoNCQyQYy1z8wHghaJ/JAD6MJWO+r9GoOBnjO2P76zhn9+XqVQpE5OEiWQOE02hsWptqPvXIxKtEQ==
   dependencies:
     lodash "^4.17.11"
 
@@ -1739,9 +1740,9 @@
   integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
 
 "@types/jest@^24.0.0":
-  version "24.0.6"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.6.tgz#ba4c8c7900ce098a82ca99293cbe4192bde4f355"
-  integrity sha512-NE7FBG/F4cMDKdCBqgyd+Sa6JZ5GiMOyA5QwJdeS4Ii/Z9a18WgGbFrHbcr48/7I9HdnkaAYP+S2MmQ27qoqJA==
+  version "24.0.9"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.9.tgz#74ce9cf337f25e189aa18f76ab3d65e8669b55f2"
+  integrity sha512-k3OOeevcBYLR5pdsOv5g3OP94h3mrJmLPHFEPWgbbVy2tGv0TZ/TlygiC848ogXhK8NL0I5up7YYtwpCp8xCJA==
   dependencies:
     "@types/jest-diff" "*"
 
@@ -1775,9 +1776,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.8.2":
-  version "16.8.4"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.4.tgz#134307f5266e866d5e7c25e47f31f9abd5b2ea34"
-  integrity sha512-Mpz1NNMJvrjf0GcDqiK8+YeOydXfD8Mgag3UtqQ5lXYTsMnOiHcKmO48LiSWMb1rSHB9MV/jlgyNzeAVxWMZRQ==
+  version "16.8.5"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.5.tgz#03b9a6597bc20f6eaaed43f377a160f7e41c2b90"
+  integrity sha512-8LRySaaSJVLNZb2dbOGvGmzn88cbAfrgDpuWy+6lLgQ0OJFgHHvyuaCX4/7ikqJlpmCPf4uazJAZcfTQRdJqdQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -2517,12 +2518,12 @@ atob@^2.1.1:
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 autoprefixer@^9.3.1, autoprefixer@^9.4.5:
-  version "9.4.8"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.4.8.tgz#575dcdfd984228c7bccbc08c5fe53f0ea6915593"
-  integrity sha512-DIhd0KMi9Nql3oJkJ2HCeOVihrXFPtWXc6ckwaUNwliDOt9OGr0fk8vV8jCLWXnZc1EXvQ2uLUzGpcPxFAQHEQ==
+  version "9.4.9"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.4.9.tgz#0d3eb86bc1d1228551abcf55220d6fd246b6cb31"
+  integrity sha512-OyUl7KvbGBoFQbGQu51hMywz1aaVeud/6uX8r1R1DNcqFvqGUUy6+BDHnAZE8s5t5JyEObaSw+O1DpAdjAmLuw==
   dependencies:
-    browserslist "^4.4.1"
-    caniuse-lite "^1.0.30000938"
+    browserslist "^4.4.2"
+    caniuse-lite "^1.0.30000939"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
     postcss "^7.0.14"
@@ -3195,9 +3196,9 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
 bottleneck@^2.0.1:
-  version "2.16.2"
-  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.16.2.tgz#0ece0fda316ca8d41aaf55772584f722a2de0716"
-  integrity sha512-671wkIKV9K3yO/nfGw8tB4ihJazmZyd6DYEWxF1fuE7gzobk4w4atepHuYXoUHk78xLknjAGko8dXRcFO7iCoA==
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.17.0.tgz#4654c78ea6333bf41a77faa4b4909a57f05c2ac3"
+  integrity sha512-0WpG/tVEBkhl9LLAFcjMTWhzQvLCYTD4wNlvtf+BZ9Q9xkMVpP5TbGPKkj2sADZtC/GQqgUMF2ij/7nD3abFLg==
 
 boxen@^1.2.1:
   version "1.3.0"
@@ -3348,7 +3349,7 @@ browserslist@4.1.1:
     electron-to-chromium "^1.3.62"
     node-releases "^1.0.0-alpha.11"
 
-browserslist@^4.0.0, browserslist@^4.1.0, browserslist@^4.3.4, browserslist@^4.4.0, browserslist@^4.4.1:
+browserslist@^4.0.0, browserslist@^4.1.0, browserslist@^4.3.4, browserslist@^4.4.0, browserslist@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.4.2.tgz#6ea8a74d6464bb0bd549105f659b41197d8f0ba2"
   integrity sha512-ISS/AIAiHERJ3d45Fz0AVYKkgcy+F/eJHzKEvv1j0wwKGKD9T3BrwKr/5g45L+Y4XIK5PlTqefHciRFcfE1Jxg==
@@ -3575,7 +3576,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000884, caniuse-lite@^1.0.30000938, caniuse-lite@^1.0.30000939:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000884, caniuse-lite@^1.0.30000939:
   version "1.0.30000939"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000939.tgz#b9ab7ac9e861bf78840b80c5dfbc471a5cd7e679"
   integrity sha512-oXB23ImDJOgQpGjRv1tCtzAvJr4/OvrHi5SO2vUgB0g0xpdZZoA/BxfImiWfdwoYdUTtQrPsXsvYU/dmCSM8gg==
@@ -4776,9 +4777,9 @@ deepmerge@3.2.0:
   integrity sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==
 
 default-gateway@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-4.0.1.tgz#3a7d071ca610a2831190341bd0666382b9dbc340"
-  integrity sha512-JnSsMUgrBFy9ycs+tmOvLHN1GpILe+hNSUrIVM8mXjymfcBH9a7LJjOdoHLuUqKGuCUk6mSIPJjZ11Zszrg3oQ==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-4.1.2.tgz#b49196b51b26609e5d1af636287517a11a9aaf42"
+  integrity sha512-xhJUAp3u02JsBGovj0V6B6uYhKCUOmiNc8xGmReUwGu77NmvcpxPVB0pCielxMFumO7CmXBG02XjM8HB97k8Hw==
   dependencies:
     execa "^1.0.0"
     ip-regex "^2.1.0"
@@ -5480,9 +5481,9 @@ eslint-plugin-import@^2.14.0:
     resolve "^1.9.0"
 
 eslint-plugin-react-hooks@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.2.0.tgz#a1c78e792b8d7d3e9c2a2aad28df80b9b5cd1101"
-  integrity sha512-pb/pwyHg0K3Ss/8loSwCGRSXIsvPBHWfzcP/6jeei0SgWBOyXRbcKFpGxolg0xSmph0jQKLyM27B74clbZM/YQ==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.3.0.tgz#d73f1a61d8dd6a14f15159ab1c6e8e3aeabb6da8"
+  integrity sha512-hjgyNq0sfDXaLkXHkmo3vRh+p+42lwQIU3r56hVoomMYRMToJ2D/PGhwL2EPyB5ZEMlbLsRm3s5v4gm5FIjlvg==
 
 eslint-plugin-react@^7.11.1:
   version "7.12.4"
@@ -6954,7 +6955,7 @@ hoist-non-react-statics@^2.5.0:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.2.1:
+hoist-non-react-statics@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
   integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
@@ -7208,11 +7209,11 @@ icss-utils@^2.1.0:
     postcss "^6.0.1"
 
 icss-utils@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-4.0.0.tgz#d52cf4bcdcfa1c45c2dbefb4ffdf6b00ef608098"
-  integrity sha512-bA/xGiwWM17qjllIs9X/y0EjsB7e0AV08F3OL8UPsoNkNRibIuu8f1eKTnQ8QO1DteKKTxTUAn+IEWUToIwGOA==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-4.1.0.tgz#339dbbffb9f8729a243b701e1c29d4cc58c52f0e"
+  integrity sha512-3DEun4VOeMvSczifM3F2cKQrDQ5Pj6WKhkOq6HD4QTnDUAq8MQRxy5TX6Sy1iY6WPBe4gQ3p5vTECjbIkglkkQ==
   dependencies:
-    postcss "^7.0.5"
+    postcss "^7.0.14"
 
 identity-obj-proxy@^3.0.0:
   version "3.0.0"
@@ -7426,7 +7427,7 @@ inquirer@^6.0.0, inquirer@^6.2.0, inquirer@^6.2.2:
     strip-ansi "^5.0.0"
     through "^2.3.6"
 
-internal-ip@^4.0.0:
+internal-ip@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.2.0.tgz#46e81b638d84c338e5c67e42b1a17db67d0814fa"
   integrity sha512-ZY8Rk+hlvFeuMmG5uH1MXhhdeMntmIaxaInvAmzMq/SHV8rv4Kh+6GiQNNDQd0wZFrcO+FiTBo8lui/osKOyJw==
@@ -8406,9 +8407,9 @@ js-tokens@^3.0.2:
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
 js-yaml@^3.12.0, js-yaml@^3.7.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
-  integrity sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.2.tgz#ef1d067c5a9d9cb65bd72f285b5d8105c77f14fc"
+  integrity sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -10199,7 +10200,6 @@ npm@6.5.0:
     cmd-shim "~2.0.2"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -10214,7 +10214,6 @@ npm@6.5.0:
     has-unicode "~2.0.1"
     hosted-git-info "^2.7.1"
     iferr "^1.0.2"
-    imurmurhash "*"
     inflight "~1.0.6"
     inherits "~2.0.3"
     ini "^1.3.5"
@@ -10227,14 +10226,8 @@ npm@6.5.0:
     libnpx "^10.2.0"
     lock-verify "^2.0.2"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -10273,7 +10266,6 @@ npm@6.5.0:
     read-package-json "^2.0.13"
     read-package-tree "^5.2.1"
     readable-stream "^2.3.6"
-    readdir-scoped-modules "*"
     request "^2.88.0"
     retry "^0.12.0"
     rimraf "~2.6.2"
@@ -12013,9 +12005,9 @@ react-themeable@^1.1.0:
     object-assign "^3.0.0"
 
 react-transition-group@^2.0.0:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.3.tgz#26de363cab19e5c88ae5dbae105c706cf953bb92"
-  integrity sha512-2DGFck6h99kLNr8pOFk+z4Soq3iISydwOFeeEVPjTN6+Y01CmvbWmnN02VuTWyFdnRtIDPe+wy2q6Ui8snBPZg==
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.6.0.tgz#3c41cbdd9c044c5f8604d4e8d319e860919c9fae"
+  integrity sha512-VzZ+6k/adL3pJHo4PU/MHEPjW59/TGQtRsXC+wnxsx2mxjQKNHnDdJL/GpYuPJIsyHGjYbBQfIJ2JNOAdPc8GQ==
   dependencies:
     dom-helpers "^3.3.1"
     loose-envify "^1.4.0"
@@ -12323,7 +12315,7 @@ regenerator-runtime@^0.12.0, regenerator-runtime@^0.12.1:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
-regenerator-transform@^0.13.3:
+regenerator-transform@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.13.4.tgz#18f6763cf1382c69c36df76c6ce122cc694284fb"
   integrity sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==
@@ -13121,9 +13113,9 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
 signale@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/signale/-/signale-1.3.0.tgz#1b4917c2c7a8691550adca0ad1da750a662b4497"
-  integrity sha512-TyFhsQ9wZDYDfsPqWMyjCxsDoMwfpsT0130Mce7wDiVCSDdtWSg83dOqoj8aGpGCs3n1YPcam6sT1OFPuGT/OQ==
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/signale/-/signale-1.4.0.tgz#c4be58302fb0262ac00fc3d886a7c113759042f1"
+  integrity sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==
   dependencies:
     chalk "^2.3.2"
     figures "^2.0.0"
@@ -13947,9 +13939,9 @@ term-size@^1.2.0:
     execa "^0.7.0"
 
 terser-webpack-plugin@^1.1.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.2.2.tgz#9bff3a891ad614855a7dde0d707f7db5a927e3d9"
-  integrity sha512-1DMkTk286BzmfylAvLXwpJrI7dWa5BnFmscV/2dCr8+c56egFcbaeFAl7+sujAjdmpLam21XRdhA4oifLyiWWg==
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz#3f98bc902fac3e5d0de730869f50668561262ec8"
+  integrity sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==
   dependencies:
     cacache "^11.0.2"
     find-cache-dir "^2.0.0"
@@ -14783,9 +14775,9 @@ webpack-dev-middleware@^3.4.0, webpack-dev-middleware@^3.5.1:
     webpack-log "^2.0.0"
 
 webpack-dev-server@^3.1.14:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.2.0.tgz#cf22c8819e0d41736ba1922dde985274716f1214"
-  integrity sha512-CUGPLQsUBVKa/qkZl1MMo8krm30bsOHAP8jtn78gUICpT+sR3esN4Zb0TSBzOEEQJF0zHNEbwx5GHInkqcmlsA==
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.2.1.tgz#1b45ce3ecfc55b6ebe5e36dab2777c02bc508c4e"
+  integrity sha512-sjuE4mnmx6JOh9kvSbPYw3u/6uxCLHNWfhWaIPwcXWsvWOPN+nc5baq4i9jui3oOBRXGonK9+OI0jVkaz6/rCw==
   dependencies:
     ansi-html "0.0.7"
     bonjour "^3.5.0"
@@ -14798,7 +14790,7 @@ webpack-dev-server@^3.1.14:
     html-entities "^1.2.0"
     http-proxy-middleware "^0.19.1"
     import-local "^2.0.0"
-    internal-ip "^4.0.0"
+    internal-ip "^4.2.0"
     ip "^1.1.5"
     killable "^1.0.0"
     loglevel "^1.4.1"


### PR DESCRIPTION
This PR addresses two warnings that appear in the console when starting a sku app:

`Without 'from' option PostCSS could generate wrong source map and will not find Browserslist config. Set it to CSS file path or to 'undefined' to prevent this warning."`
and
`[BABEL] Note: The code generator has deoptimised the styling of .../node_modules/react-dom/cjs/react-dom.development.js as it exceeds the max of 500KB.`

We now no longer run the consuming apps node_modules through `babel-loader` in start mode, and as a side effect the app should boot 15-20% faster.