### PR TITLE
fix: Add sku to ‘compilePackages’ list

### DIFF
--- a/context/index.js
+++ b/context/index.js
@@ -65,6 +65,7 @@ const publicPath = skuConfig.publicPath.endsWith('/')
 const paths = {
   src: skuConfig.srcPaths.map(getPathFromCwd),
   compilePackages: [
+    'sku',
     'seek-style-guide',
     'seek-asia-style-guide',
     'braid-design-system',


### PR DESCRIPTION
Since consumers are now importing code from within sku (e.g. `sku/@loadable/component`), we need to ensure that it uses the full set of sku loaders/transforms, particularly in test environments where ES Modules aren't (yet) supported. Otherwise, importing `sku/@loadable/component` within a test will throw a syntax error.