### PR TITLE
fix(lint): Add debug command to isTypeScript check

### DIFF
--- a/lib/isTypeScript.js
+++ b/lib/isTypeScript.js
@@ -1,9 +1,18 @@
 const glob = require('fast-glob');
 const { cwd } = require('./cwd');
+const debug = require('debug')('sku:isTypeScript');
 
 module.exports = () => {
   const tsFiles = glob.sync(['**/*.{ts,tsx}', '!**/node_modules/**'], {
     cwd: cwd(),
   });
-  return tsFiles.length > 0;
+  const isTypeScript = tsFiles.length > 0;
+  if (isTypeScript) {
+    debug(
+      `Found TypeScript in project. Found ${
+        tsFiles.length
+      } with the first at "${tsFiles[0]}".`,
+    );
+  }
+  return isTypeScript;
 };


### PR DESCRIPTION
Projects that do not use TypeScript but find (through some build process) a file ending in `.ts` is created in the project directory don't have an easy way to identify why the TypeScript tools are being triggered.

Adds a debug statement to allow consumers to use `--debug` to see why their project is being marked as a TypeScript project.

Example usecase:
<img width="1227" alt="Screen Shot 2019-04-03 at 8 08 30 pm" src="https://user-images.githubusercontent.com/13903378/55467255-9e02d600-564c-11e9-8597-3f43ceb20bd3.png">
