### PR TITLE
fix(test): Update jestConfig to not transform json file

### DIFF
--- a/config/jest/jestConfig.js
+++ b/config/jest/jestConfig.js
@@ -38,7 +38,9 @@ module.exports = {
     // Match any `.js` file that isn't a `.css.js` file.
     // We do this by asserting the 4 characters before `.js` aren't `.css`
     // or that it has fewer than 4 characters (e.g. `foo.js`)
-    '((?!(\\.css)).{4}|^.{1,3})\\.jsx?$': require.resolve('./jsBabelTransform.js'),
+    '((?!(\\.css)).{4}|^.{1,3})\\.jsx?$': require.resolve(
+      './jsBabelTransform.js',
+    ),
   },
   transformIgnorePatterns: [
     // Allow 'compilePackages' code to be transformed in tests by overriding

--- a/config/jest/jestConfig.js
+++ b/config/jest/jestConfig.js
@@ -38,7 +38,7 @@ module.exports = {
     // Match any `.js` file that isn't a `.css.js` file.
     // We do this by asserting the 4 characters before `.js` aren't `.css`
     // or that it has fewer than 4 characters (e.g. `foo.js`)
-    '((?!(\\.css)).{4}|^.{1,3})\\.js': require.resolve('./jsBabelTransform.js'),
+    '((?!(\\.css)).{4}|^.{1,3})\\.jsx?$': require.resolve('./jsBabelTransform.js'),
   },
   transformIgnorePatterns: [
     // Allow 'compilePackages' code to be transformed in tests by overriding


### PR DESCRIPTION
## Overview of the change

**Update jestConfig to exclude json file in the transform config.** 

### Reasons behind it 

The existing regex matches `.json` file as well, as a result any json file will be transformed too. This was not a problem before `jest-runtime 24.8`, but after Renovate updated `jest-runtime` in our repo to version 24.8, our test failed, see the error message here https://buildkite.com/seek/adv-account-management-ui/builds/2897#c7d0685f-bde2-4acb-a01c-4e8a3a1e9fa0/158-262. 

I did some search and found this Jest issue (https://github.com/facebook/jest/issues/8426#issuecomment-489988029) similar to the error we got. I fixed the error in our repo by explicitly exclude json file from being transformed, see the commit at here https://github.com/SEEK-Jobs/adv-account-management-ui/pull/500/commits/04f74ba1e750fc7f538c3fbf2c02816ff9b37f4e.

And after that I checked the default jest config for Sku, I think the regex for matching js file was unintentionally matching `json` files based on the comment above the code.  Hence this PR.