### PR TITLE
fix(svg): Added prefix to id attribute to avoid global namespace clashes

### DIFF
--- a/config/webpack/utils/loaders.js
+++ b/config/webpack/utils/loaders.js
@@ -135,6 +135,11 @@ const makeSvgLoaders = () => [
         {
           removeViewBox: false,
         },
+        {
+          cleanupIDs: {
+            prefix: 'svg-',
+          },
+        },
       ],
     },
   },


### PR DESCRIPTION
#### What does this PR do?

Adds a prefix to all `id` attributes from SVGs with `svg-`, as not to clash with anything on the global scope.


#### Why is this needed?

So `svgo` is pretty rad at squishing down the size of our SVGs. One optimisation it does is remove unused `id` attributes from SVG elements. Awesome!
Although sometimes these IDs are needed for reference in other parts of the SVG like fills and masks. So instead of removing them completely, `svgo` just renames them into single letter IDs.

The issue arises with conflicts on the global scope... Did you know that elements with ids are actually accessible through `window.${id}`? I didn't.

So for our specific issue- we had a page that includes the element `<path id="s" />`. Also on that page we load in omniture, which for those lucky enough to have never worked with Abobe's magnum opus of a library, also likes to pollute our global scope by assigning its guts to `window.s`. This causes us issues in the async loading of omniture, as our checking for the libraries existence at `window.s` gives off a false-positive, so we never initialise the module, which our analytics team is keeps telling me is less than ideal.

While we tightened up our check of omniture being loaded in our repo, the likelihood of further conflicts still remain. So this fix is to prefix all `id` attributes from SVGs with `svg-` so this hopefully won't be an issue again.