### PR TITLE
fix(lint): Support ES5 features when linting TypeScript files

### DIFF
--- a/config/typescript/tsconfig.js
+++ b/config/typescript/tsconfig.js
@@ -22,6 +22,7 @@ module.exports = () => ({
     paths: {
       '*': ['*'],
     },
+    target: 'es5',
   },
   include: paths.src,
   exclude: [getPathFromCwd('node_modules')],


### PR DESCRIPTION
### What
This PR updates `tsconfig.js` to specify a target in the compile options.

The default (unspecified) value to target is es3.

This PR sets it to es5 which still (more than) satisfies our browser requirements.

### Why

sku doesn't compile the code with typescript, it's only used during the `lint` phase to type check the code. With the current setting, the lint check complains when using non-es3 features, e.g. "Accessors are only available when targeting ECMAScript 5 and higher.".  To fix this we increase the target version to es5.  

Since this a lint change only this should not cause a change to consumer's built bundles.