### PR TITLE
fix: Bump lodash version to resolve security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "kopy": "^8.3.0",
     "less": "^3.8.1",
     "less-loader": "^4.1.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "memoizee": "^0.4.14",
     "mini-css-extract-plugin": "^0.5.0",
     "node-emoji": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9748,6 +9748,11 @@ lodash@4.17.11, lodash@^4.0.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.2,
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.14:
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
+  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"


### PR DESCRIPTION
Overview
lodash is a modern JavaScript utility library delivering modularity, performance, & extras.

Affected versions of this package are vulnerable to Prototype Pollution. The function defaultsDeep could be tricked into adding or modifying properties of Object.prototype using a constructor payload.