### PR TITLE
fix(storybook): Exclude consumer code from Storybook webpack loaders

### DIFF
--- a/lib/gracefulSpawn.js
+++ b/lib/gracefulSpawn.js
@@ -1,11 +1,19 @@
+const { promisify } = require('util');
 const spawn = require('cross-spawn');
-const treeKill = require('tree-kill');
+const treeKillAsync = promisify(require('tree-kill'));
 const onDeath = require('death');
 
 module.exports = (...args) => {
   const childProcess = spawn(...args);
 
-  childProcess.kill = signal => treeKill(childProcess.pid, signal);
+  childProcess.kill = async signal => {
+    await treeKillAsync(childProcess.pid, signal);
+
+    // Needs a bit more time, for some reason :(
+    // If we don't give it a bit of breathing room,
+    // Jest complains about handles being left open.
+    await new Promise(resolve => setTimeout(resolve, 100));
+  };
 
   onDeath(signal => {
     childProcess.kill(signal);

--- a/test/test-cases/braid-design-system/braid-design-system.test.js
+++ b/test/test-cases/braid-design-system/braid-design-system.test.js
@@ -61,8 +61,8 @@ describe('braid-design-system', () => {
       await waitForUrls(devServerUrl);
     });
 
-    afterAll(() => {
-      server.kill();
+    afterAll(async () => {
+      await server.kill();
     });
 
     it('should start a development server', async () => {

--- a/test/test-cases/custom-src-paths/custom-src-paths.test.js
+++ b/test/test-cases/custom-src-paths/custom-src-paths.test.js
@@ -17,8 +17,8 @@ describe('custom-src-paths', () => {
       await waitForUrls(devServerUrl);
     });
 
-    afterAll(() => {
-      server.kill();
+    afterAll(async () => {
+      await server.kill();
     });
 
     it('should start a development server', async () => {

--- a/test/test-cases/library-build/library-build.test.js
+++ b/test/test-cases/library-build/library-build.test.js
@@ -27,8 +27,8 @@ describe('library-build', () => {
       await waitForUrls(devServerUrl);
     });
 
-    afterAll(() => {
-      server.kill();
+    afterAll(async () => {
+      await server.kill();
     });
 
     it('should start a development server', async () => {

--- a/test/test-cases/multiple-routes/multiple-routes.test.js
+++ b/test/test-cases/multiple-routes/multiple-routes.test.js
@@ -18,8 +18,8 @@ describe('multiple-routes', () => {
       await waitForUrls(devServerUrl);
     });
 
-    afterAll(() => {
-      server.kill();
+    afterAll(async () => {
+      await server.kill();
     });
 
     it('should render home page correctly', async () => {

--- a/test/test-cases/react-css-modules/react-css-modules.test.js
+++ b/test/test-cases/react-css-modules/react-css-modules.test.js
@@ -66,8 +66,8 @@ describe('react-css-modules', () => {
       await waitForUrls(storybookUrl);
     });
 
-    afterAll(() => {
-      server.kill();
+    afterAll(async () => {
+      await server.kill();
     });
 
     it('should start a storybook server', async () => {

--- a/test/test-cases/seek-style-guide/__snapshots__/seek-style-guide.test.js.snap
+++ b/test/test-cases/seek-style-guide/__snapshots__/seek-style-guide.test.js.snap
@@ -18,7 +18,7 @@ Object {
     >
     <link data-chunk="main"
           rel="stylesheet"
-          href="/vendors~main-79c8d8112a325171df91.css"
+          href="/vendors~main-824852c3ed511bca6cff.css"
     >
     <link data-chunk="main"
           rel="preload"
@@ -28,12 +28,12 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="/vendors~main-91aeeae2dd7c5d832979.js"
+          href="/vendors~main-e50f205b52852086f8ec.js"
     >
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="/main-c26bfb31de49330a0d03.js"
+          href="/main-4a1528fa21326f83f6b7.js"
     >
   </head>
   <body>
@@ -49,7 +49,23 @@ Object {
             <div class="GN6nQol">
               <span class="_31viNaz _2R8GxMH _3CnSGKb">
                 <span class>
-                  Hello world!
+                  <span data-automation-svg="true">
+                    <span class="_3q2EWBs">
+                      <svg class="URJCV7U"
+                           xmlns="http://www.w3.org/2000/svg"
+                           width="16"
+                           height="16"
+                           viewbox="0 0 1024 900"
+                           focusable="false"
+                      >
+                        <path d="M718 188q11 0 22 1.5t22 4.5q16 4 30.5 12t28.5 19q15 13 27 28t21 34h1l3 7q13 27 20 59.5t7 68.5v3q0 15-4.5 32.5T881 496q-11 24-26 47.5T821 590q-39 48-85.5 94T636 774q-46 38-85 67.5T480 891q-31-20-70-49.5T325 774h-1q-52-43-98.5-89T139 590q-19-23-34-46.5T79 496q-10-21-14.5-38.5T60 425v-3q0-37 7-69.5T87 293h1q0-2 1-3.5t2-3.5q10-18 21.5-33t26.5-28q14-11 28.5-19t30.5-12q11-3 22.5-4.5T242 188q24 0 45.5 7t43.5 21q15 9 28 21t24 26q12 15 22.5 32.5T425 333l56 129 54-129q9-20 19-37t22-32q11-14 24.5-26t28.5-22h1q21-14 43-21t45-7zm0-60q-32 0-62 9.5T597 165q-38 25-67.5 61T480 309q-21-47-50-83t-66-61q-29-18-59.5-27.5T242 128q-14 0-29 2t-30 6q-22 6-43 16.5T100 179t-34.5 36T38 259q-1 1-1.5 2t-.5 2l-2 2v1q-17 34-25.5 73T0 422v2q0 22 6 46t19 51q12 27 29 54t39 53q42 52 90.5 100T286 820q49 41 90 71.5t74 51.5q14 9 21.5 13.5t8.5 4.5q1 0 8.5-4.5T510 944q33-22 74-53t90-70q55-46 103.5-94t89.5-99q22-26 39-52.5t29-53.5q13-27 19-51.5t6-46.5v-2q-1-44-9-83t-24-72l-4-8q-13-24-28.5-43.5T860 180t-39.5-27-43.5-17q-15-4-30-6t-29-2z">
+                        </path>
+                      </svg>
+                    </span>
+                  </span>
+                  <span data-automation-text="true">
+                    Hello world!
+                  </span>
                 </span>
               </span>
             </div>
@@ -69,19 +85,19 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="/vendors~main-91aeeae2dd7c5d832979.js"
+            src="/vendors~main-e50f205b52852086f8ec.js"
     >
     </script>
     <script async
             data-chunk="main"
-            src="/main-c26bfb31de49330a0d03.js"
+            src="/main-4a1528fa21326f83f6b7.js"
     >
     </script>
   </body>
 </html>,
-  "main-c26bfb31de49330a0d03.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "main-4a1528fa21326f83f6b7.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-2ae9f933930327de819a.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "vendors~main-79c8d8112a325171df91.css": a,
+  "vendors~main-824852c3ed511bca6cff.css": a,
 abbr,
 acronym,
 address,
@@ -607,7 +623,137 @@ html {
 ._33Weyvq {
   font-weight: 400;
 }
+._2f9d9Gi {
+  -webkit-animation-duration: 0.4s;
+  animation-duration: 0.4s;
+  -webkit-animation-name: l73EdLW;
+  animation-name: l73EdLW;
+}
+@-webkit-keyframes l73EdLW {
+  0% {
+    -webkit-transform: scale(0.5);
+    transform: scale(0.5);
+  }
+  65% {
+    -webkit-transform: scale(1.5);
+    transform: scale(1.5);
+  }
+  85% {
+    -webkit-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+  to {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+  }
+}
+@keyframes l73EdLW {
+  0% {
+    -webkit-transform: scale(0.5);
+    transform: scale(0.5);
+  }
+  65% {
+    -webkit-transform: scale(1.5);
+    transform: scale(1.5);
+  }
+  85% {
+    -webkit-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+  to {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+  }
+}
+._3q2EWBs {
+  display: inline-block;
+}
+.URJCV7U {
+  fill: currentColor;
+  width: 16px;
+  height: 16px;
+}
+._2MMt39x {
+  width: 29.4px;
+  height: 29.4px;
+}
+@media only screen and (max-width: 739px) {
+  ._2MMt39x {
+    width: 14.7px;
+    height: 14.7px;
+  }
+}
+._3Q7FqJ4 {
+  width: 19.6px;
+  height: 19.6px;
+}
+@media only screen and (max-width: 739px) {
+  ._3Q7FqJ4 {
+    width: 14.7px;
+    height: 14.7px;
+  }
+}
+._3Lp4JO5 {
+  width: 12.6px;
+  height: 12.6px;
+}
+@media only screen and (max-width: 739px) {
+  ._3Lp4JO5 {
+    width: 12.6px;
+    height: 12.6px;
+  }
+}
+._2mhPJKN {
+  width: 15.4px;
+  height: 15.4px;
+}
+@media only screen and (max-width: 739px) {
+  ._2mhPJKN {
+    width: 14.7px;
+    height: 14.7px;
+  }
+}
+._1my9l-4 {
+  width: 12.6px;
+  height: 12.6px;
+}
+@media only screen and (max-width: 739px) {
+  ._1my9l-4 {
+    width: 12.6px;
+    height: 12.6px;
+  }
+}
+._2aC_WIb {
+  width: 11.2px;
+  height: 11.2px;
+}
+@media only screen and (max-width: 739px) {
+  ._2aC_WIb {
+    width: 11.2px;
+    height: 11.2px;
+  }
+}
+._2RscG1n {
+  width: 9.8px;
+  height: 9.8px;
+}
+@media only screen and (max-width: 739px) {
+  ._2RscG1n {
+    width: 9.8px;
+    height: 9.8px;
+  }
+}
+.kisKgQ5 {
+  width: 12.6px;
+  height: 12.6px;
+}
+@media only screen and (max-width: 739px) {
+  .kisKgQ5 {
+    width: 12.6px;
+    height: 12.6px;
+  }
+}
 ,
-  "vendors~main-91aeeae2dd7c5d832979.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-e50f205b52852086f8ec.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;

--- a/test/test-cases/seek-style-guide/app/src/App.js
+++ b/test/test-cases/seek-style-guide/app/src/App.js
@@ -4,13 +4,19 @@ import {
   PageBlock,
   Section,
   Text,
+  HeartIcon,
 } from 'seek-style-guide/react';
 
 export default () => (
   <StyleGuideProvider>
     <PageBlock>
       <Section>
-        <Text>Hello world!</Text>
+        <Text>
+          <span data-automation-svg>
+            <HeartIcon />
+          </span>
+          <span data-automation-text>Hello world!</span>
+        </Text>
       </Section>
     </PageBlock>
   </StyleGuideProvider>

--- a/test/test-cases/seek-style-guide/app/src/App.stories.js
+++ b/test/test-cases/seek-style-guide/app/src/App.stories.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import App from './App';
+
+// Typically would be importing from 'sku/@storybook/...'
+import { storiesOf } from '../../../../../@storybook/react';
+
+storiesOf('App', module).add('Default', () => <App />);

--- a/test/test-cases/ssr-hello-world/ssr-hello-world.test.js
+++ b/test/test-cases/ssr-hello-world/ssr-hello-world.test.js
@@ -28,8 +28,8 @@ describe('ssr-hello-world', () => {
       await waitForUrls(backendUrl);
     });
 
-    afterAll(() => {
-      server.kill();
+    afterAll(async () => {
+      await server.kill();
     });
 
     it('should start a development server', async () => {
@@ -65,8 +65,8 @@ describe('ssr-hello-world', () => {
         await waitForUrls(backendUrl);
       });
 
-      afterAll(() => {
-        server.kill();
+      afterAll(async () => {
+        await server.kill();
       });
 
       it('should generate a production server based on config', async () => {
@@ -97,8 +97,8 @@ describe('ssr-hello-world', () => {
         await waitForUrls(customPortUrl);
       });
 
-      afterAll(() => {
-        server.kill();
+      afterAll(async () => {
+        await server.kill();
       });
 
       it('should generate a production server running on custom port', async () => {

--- a/test/test-cases/typescript-css-modules/typescript-css-modules.test.js
+++ b/test/test-cases/typescript-css-modules/typescript-css-modules.test.js
@@ -54,8 +54,8 @@ describe('typescript-css-modules', () => {
       await waitForUrls(backendUrl, 'http://localhost:4003');
     });
 
-    afterAll(() => {
-      server.kill();
+    afterAll(async () => {
+      await server.kill();
       closeAssetServer();
     });
 
@@ -83,8 +83,8 @@ describe('typescript-css-modules', () => {
       await waitForUrls(devServerUrl);
     });
 
-    afterAll(() => {
-      server.kill();
+    afterAll(async () => {
+      await server.kill();
     });
 
     it('should start a development server', async () => {
@@ -130,8 +130,8 @@ describe('typescript-css-modules', () => {
       await waitForUrls(storybookUrl);
     });
 
-    afterAll(() => {
-      server.kill();
+    afterAll(async () => {
+      await server.kill();
     });
 
     it('should start a storybook server', async () => {


### PR DESCRIPTION
The latest version of Storybook breaks SVGs from [seek-style-guide](https://github.com/seek-oss/seek-style-guide) because its webpack config points `file-loader` at *all* SVGs in the project, not just those internal to Storybook.

To fix this (and potentially other issues we haven't noticed yet), we now mutate Storybook's webpack config to ensure that their loaders exclude our consumers' source code and compiled packages.

To ensure this works correctly, I've added a Storybook test to the seek-style-guide test case which ensures an `<svg>` element is rendered correctly.

## Development notes

I fixed an issue with open handles after a Jest test suite run by making the `server.kill()` call async. Unfortunately, I had to add an arbitrary `setTimeout` call of 100ms, but couldn't find another way around this. I've at least centralised this workaround so that all `server.kill()` calls know that the call is async.