### PR TITLE
fix(format): Allow paths to be passed to sku format

### DIFF
--- a/lib/runPrettier.js
+++ b/lib/runPrettier.js
@@ -13,7 +13,7 @@ const prettierConfigPath = path.join(
   '../config/prettier/prettierConfig.js',
 );
 
-const runPrettier = async ({ write, listDifferent }) => {
+const runPrettier = async ({ write, listDifferent, paths }) => {
   console.log(
     chalk.cyan(
       `${write ? 'Formatting' : 'Checking'} source code with Prettier`,
@@ -38,8 +38,11 @@ const runPrettier = async ({ write, listDifferent }) => {
     // don't error if `.prettierignore` not found
   }
 
-  prettierArgs.push('**/*.{js,ts,tsx,md,less,css}');
-
+  if (paths && paths.length > 0) {
+    prettierArgs.push(...paths);
+  } else {
+    prettierArgs.push('**/*.{js,ts,tsx,md,less,css}');
+  }
   /*
    * Show Prettier output with stdio: inherit
    * The child process will use the parent process's stdin/stdout/stderr
@@ -76,6 +79,6 @@ const runPrettier = async ({ write, listDifferent }) => {
 };
 
 module.exports = {
-  check: () => runPrettier({ listDifferent: true }),
-  write: () => runPrettier({ write: true }),
+  check: paths => runPrettier({ listDifferent: true, paths }),
+  write: paths => runPrettier({ write: true, paths }),
 };


### PR DESCRIPTION
To support patterns such as [lint-staged](https://github.com/okonet/lint-staged#configuration) we need to pass additional arguments to `sku format` to the underlying prettier command.