### PR TITLE
fix(pre-commit): Remove dependency on local npm script

### DIFF
--- a/config/lintStaged/lintStagedConfig.js
+++ b/config/lintStaged/lintStagedConfig.js
@@ -5,7 +5,7 @@ const steps = {};
 // Yarn lock integrity check
 if (isYarn) {
   steps['+(package.json|yarn.lock)'] = [
-    'yarn check-integrity',
+    () => 'yarn check --integrity',
     'git add package.json yarn.lock',
   ];
 }

--- a/lib/preCommit.js
+++ b/lib/preCommit.js
@@ -1,4 +1,16 @@
+const chalk = require('chalk');
 const lintStaged = require('lint-staged');
 const configPath = require.resolve('../config/lintStaged/lintStagedConfig');
 
-module.exports = async () => await lintStaged({ configPath });
+module.exports = async () => {
+  let success = false;
+  try {
+    success = await lintStaged({ configPath });
+  } catch (e) {
+    console.error(chalk.red(e));
+  }
+
+  if (!success) {
+    throw new Error('Error: Pre-commit failed');
+  }
+};

--- a/scripts/pre-commit.js
+++ b/scripts/pre-commit.js
@@ -1,12 +1,10 @@
 #!/usr/bin/env node
-const chalk = require('chalk');
 const preCommit = require('../lib/preCommit');
 
 (async () => {
   try {
     await preCommit();
   } catch (e) {
-    console.error(chalk.red(e));
     process.exit(1);
   }
 })();


### PR DESCRIPTION
Removes dependency on having a local npm script for `yarn check-integrity` and add better handling of lint-staged errors.