### PR TITLE
fix(lint): Use .eslintignore when linting TypeScript files

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -80,13 +80,6 @@ module.exports = async () => {
   });
   gitIgnorePatterns.push(prettierConfigFilename);
 
-  // Write `.gitignore`
-  await ensureGitignore({
-    filepath: getPathFromCwd('.gitignore'),
-    comment: 'managed by sku',
-    patterns: gitIgnorePatterns.map(convertToForwardSlashPaths),
-  });
-
   // Write `.eslintignore`
   const eslintignorePath = getPathFromCwd('.eslintignore');
   await ensureGitignore({
@@ -126,4 +119,11 @@ module.exports = async () => {
     await writeFileToCWD(tslintConfigFileName, tslintConfig);
     gitIgnorePatterns.push(tslintConfigFileName);
   }
+
+  // Write `.gitignore`
+  await ensureGitignore({
+    filepath: getPathFromCwd('.gitignore'),
+    comment: 'managed by sku',
+    patterns: gitIgnorePatterns.map(convertToForwardSlashPaths),
+  });
 };

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -6,6 +6,7 @@ const ensureGitignore = require('ensure-gitignore');
 const { cwd, getPathFromCwd } = require('./cwd');
 
 const writeFile = promisify(fs.writeFile);
+const readFile = promisify(fs.readFile);
 
 const isTypeScript = require('./isTypeScript');
 const { paths } = require('../context');
@@ -63,18 +64,6 @@ module.exports = async () => {
     playroomTargetDirectory,
   );
 
-  if (isTypeScript) {
-    // Generate TypeScript configuration
-    const tsConfigFileName = 'tsconfig.json';
-    await writeFileToCWD(tsConfigFileName, createTSConfig());
-    gitIgnorePatterns.push(tsConfigFileName);
-
-    // Generate TSLint configuration
-    const tslintConfigFileName = 'tslint.json';
-    await writeFileToCWD(tslintConfigFileName, tslintConfig);
-    gitIgnorePatterns.push(tslintConfigFileName);
-  }
-
   // Generate ESLint configuration
   const eslintConfigFilename = '.eslintrc';
   await writeFileToCWD(eslintConfigFilename, eslintConfig);
@@ -99,8 +88,9 @@ module.exports = async () => {
   });
 
   // Write `.eslintignore`
+  const eslintignorePath = getPathFromCwd('.eslintignore');
   await ensureGitignore({
-    filepath: getPathFromCwd('.eslintignore'),
+    filepath: eslintignorePath,
     comment: 'managed by sku',
     patterns: lintIgnorePatterns.map(convertToForwardSlashPaths),
   });
@@ -111,4 +101,29 @@ module.exports = async () => {
     comment: 'managed by sku',
     patterns: lintIgnorePatterns.map(convertToForwardSlashPaths),
   });
+
+  if (isTypeScript) {
+    // Generate TypeScript configuration
+    const tsConfigFileName = 'tsconfig.json';
+    await writeFileToCWD(tsConfigFileName, createTSConfig());
+    gitIgnorePatterns.push(tsConfigFileName);
+
+    // Generate TSLint configuration
+    const tslintConfigFileName = 'tslint.json';
+    // Re-use ESLint ignore paths for TSLint
+    const eslintignoreSource = await readFile(eslintignorePath, 'utf-8');
+    const tslintExcludePaths = eslintignoreSource
+      .split('\n')
+      .filter(line => line.trim() && !/^#/.test(line));
+
+    if (tslintExcludePaths.length > 0) {
+      tslintConfig.linterOptions = tslintConfig.linterOptions || {};
+      tslintConfig.linterOptions.exclude = [
+        ...(tslintConfig.linterOptions.exclude || []),
+        ...tslintExcludePaths,
+      ];
+    }
+    await writeFileToCWD(tslintConfigFileName, tslintConfig);
+    gitIgnorePatterns.push(tslintConfigFileName);
+  }
 };

--- a/test/test-cases/configure-test/__snapshots__/configure.test.js.snap
+++ b/test/test-cases/configure-test/__snapshots__/configure.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`configure custom should generate tslint config 1`] = `
+Object {
+  "extends": "tslint-config-seek",
+  "linterOptions": Object {
+    "exclude": Array [
+      "**/*.json",
+      "*.css.js.d.ts",
+      "*.less.d.ts",
+      "coverage/",
+      "foo/bar/",
+      "playroom/foobar/",
+      "report/",
+      "storybook/foobar/",
+    ],
+  },
+  "rules": Object {
+    "no-implicit-dependencies": false,
+  },
+}
+`;

--- a/test/test-cases/configure-test/configure.test.js
+++ b/test/test-cases/configure-test/configure.test.js
@@ -11,7 +11,6 @@ const {
   bundleReportFolder,
 } = require('../../../config/webpack/plugins/bundleAnalyzer');
 const prettierConfig = require('../../../config/prettier/prettierConfig');
-const tslintConfig = require('../../../config/typescript/tslint.json');
 const defaultTargetDir = 'dist';
 const defaultStorybookTargetDir = 'dist-storybook';
 const defaultPlayroomTargetDir = 'dist-playroom';
@@ -141,7 +140,7 @@ describe('configure', () => {
 
     it('should generate tslint config', async () => {
       const tslintContents = await readJsonC(appFolderTS, 'tslint.json');
-      expect(tslintContents).toEqual(tslintConfig);
+      expect(tslintContents).toMatchSnapshot();
     });
 
     it(`should generate \`.gitignore\``, async () => {


### PR DESCRIPTION
This change allows consumers to ignore TypeScript files during `sku lint` by adding glob patterns to their existing `.eslintignore` file. This also sets them up for a future migration away from TSLint towards ESLint.