### PR TITLE
fix(storybook): Disable HTML rendering for storybook

### DIFF
--- a/config/storybook/storybookWebpackConfig.js
+++ b/config/storybook/storybookWebpackConfig.js
@@ -7,7 +7,7 @@ const { resolvePackage } = require('../webpack/utils/resolvePackage');
 
 module.exports = ({ config }, { isDevServer }) => {
   const clientWebpackConfig = find(
-    makeWebpackConfig({ isIntegration: true, isDevServer }),
+    makeWebpackConfig({ isStoryBook: true, isIntegration: true, isDevServer }),
     ({ name }) => name === 'client',
   );
 

--- a/config/storybook/storybookWebpackConfig.js
+++ b/config/storybook/storybookWebpackConfig.js
@@ -7,7 +7,7 @@ const { resolvePackage } = require('../webpack/utils/resolvePackage');
 
 module.exports = ({ config }, { isDevServer }) => {
   const clientWebpackConfig = find(
-    makeWebpackConfig({ isStoryBook: true, isIntegration: true, isDevServer }),
+    makeWebpackConfig({ isIntegration: true, isDevServer }),
     ({ name }) => name === 'client',
   );
 

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -37,7 +37,7 @@ const makeWebpackConfig = ({
 } = {}) => {
   const { isProductionBuild } = utils;
   const webpackMode = isProductionBuild ? 'production' : 'development';
-  const isRenderHtml = () => {
+  const shouldRenderHtml = () => {
     if (isIntegration) {
       return false;
     }
@@ -46,7 +46,7 @@ const makeWebpackConfig = ({
     }
     return true;
   };
-  const renderHtml = isRenderHtml();
+  const renderHtml = shouldRenderHtml();
   const htmlRenderPlugin = renderHtml ? createHtmlRenderPlugin() : null;
 
   const envVars = lodash

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -31,20 +31,22 @@ const {
 
 // port is only required for dev builds
 const makeWebpackConfig = ({
-  isStoryBook = false,
   isIntegration = false,
   port = 0,
   isDevServer = false,
 } = {}) => {
   const { isProductionBuild } = utils;
   const webpackMode = isProductionBuild ? 'production' : 'development';
-  const shouldRenderHtml = () => {
-    if (isStoryBook) {
+  const isRenderHtml = () => {
+    if (isIntegration) {
       return false;
     }
-    return isLibrary ? isDevServer : !isIntegration;
+    if (isLibrary) {
+      return isDevServer;
+    }
+    return true;
   };
-  const renderHtml = shouldRenderHtml();
+  const renderHtml = isRenderHtml();
   const htmlRenderPlugin = renderHtml ? createHtmlRenderPlugin() : null;
 
   const envVars = lodash

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -31,14 +31,20 @@ const {
 
 // port is only required for dev builds
 const makeWebpackConfig = ({
+  isStoryBook = false,
   isIntegration = false,
   port = 0,
   isDevServer = false,
 } = {}) => {
   const { isProductionBuild } = utils;
   const webpackMode = isProductionBuild ? 'production' : 'development';
-
-  const renderHtml = isLibrary ? isDevServer : !isIntegration;
+  const shouldRenderHtml = () => {
+    if (isStoryBook) {
+      return false;
+    }
+    return isLibrary ? isDevServer : !isIntegration;
+  };
+  const renderHtml = shouldRenderHtml();
   const htmlRenderPlugin = renderHtml ? createHtmlRenderPlugin() : null;
 
   const envVars = lodash


### PR DESCRIPTION
Fixed `npx sku storybook` error in library mode

```
98% after emitting HtmlRenderPlugin🚨 HtmlRenderPlugin: Unable to find render compiler. Add `.render()` to any one configuration.
✖ ｢wdm｣: Error: Unable to find render compiler. Add `.render()` to any one configuration.
    at HtmlRenderPlugin.onRender (/Users/akosolapova/Repos/bx-shared-ui/node_modules/html-render-webpack-plugin/src/index.js:54:13)
```