### PR TITLE
fix(lint): Return correct exit code for format errors

### DIFF
--- a/lib/runPrettier.js
+++ b/lib/runPrettier.js
@@ -58,20 +58,23 @@ const runPrettier = async ({ write, listDifferent, paths }) => {
       options: processOptions,
     });
   } catch (exitCode) {
-    if (listDifferent && exitCode === 1) {
-      console.error(
-        chalk.red('Error: The file(s) listed above failed the prettier check'),
-      );
-
-      await suggestScript('format');
-    } else if (exitCode === 2) {
+    if (exitCode === 2) {
       console.warn(
         chalk.yellow('Warning: No files matching', pathsToCheck.join(' ')),
       );
     } else {
-      console.error(
-        chalk.red('Error: Prettier check exited with exit code', exitCode),
-      );
+      if (listDifferent && exitCode === 1) {
+        console.error(
+          chalk.red(
+            'Error: The file(s) listed above failed the prettier check',
+          ),
+        );
+        await suggestScript('format');
+      } else {
+        console.error(
+          chalk.red('Error: Prettier check exited with exit code', exitCode),
+        );
+      }
       throw new Error();
     }
   }

--- a/lib/suggestScript.js
+++ b/lib/suggestScript.js
@@ -27,9 +27,9 @@ const getSuggestedScript = async (scriptName, options = { sudo: false }) => {
 
     if (packageScript) {
       script += `${isYarnProject ? 'yarn' : 'npm run'} ${packageScript}`;
+    } else {
+      script += `${isYarnProject ? 'yarn' : 'npx'} sku ${scriptName}`;
     }
-
-    script += `${isYarnProject ? 'yarn' : 'npx'} sku ${scriptName}`;
   } catch (err) {
     script += `npx sku ${scriptName}`;
   }


### PR DESCRIPTION
Formatting errors were not consistently throwing errors and as such not returning the correct error code. Result was false positives in CI.

This fix ensures that formatting errors always throw errors, unless prettier finds no matching files to check (most commonly occurs when running `sku pre-commit`), in which case it logs a warning. The bug was introduced in `v8.10.0` as part of the [introduction of the `pre-commit` script](https://github.com/seek-oss/sku/pull/418).

Also fixes a formatting issue on the suggested script resulting in double concatenation of scripts.