### PR TITLE
fix(treat): Fix "import declaration conflicts" error

### DIFF
--- a/test/test-cases/braid-design-system/__snapshots__/braid-design-system.test.js.snap
+++ b/test/test-cases/braid-design-system/__snapshots__/braid-design-system.test.js.snap
@@ -23,7 +23,7 @@ SOURCE HTML: <!DOCTYPE html>
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="/vendors~main-adf22b41d79c9d93c41b.js"
+          href="/vendors~main-a2b8c6bfe5cdbc301a4e.js"
     >
     <link data-chunk="main"
           rel="preload"
@@ -156,7 +156,7 @@ SOURCE HTML: <!DOCTYPE html>
     </script>
     <script async
             data-chunk="main"
-            src="/vendors~main-adf22b41d79c9d93c41b.js"
+            src="/vendors~main-a2b8c6bfe5cdbc301a4e.js"
     >
     </script>
     <script async
@@ -219,7 +219,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="/vendors~main-adf22b41d79c9d93c41b.js"
+          href="/vendors~main-a2b8c6bfe5cdbc301a4e.js"
     >
     <link data-chunk="main"
           rel="preload"
@@ -352,7 +352,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="/vendors~main-adf22b41d79c9d93c41b.js"
+            src="/vendors~main-a2b8c6bfe5cdbc301a4e.js"
     >
     </script>
     <script async
@@ -391,7 +391,7 @@ Object {
     <link data-chunk="main"
           rel="preload"
           as="script"
-          href="/vendors~main-adf22b41d79c9d93c41b.js"
+          href="/vendors~main-a2b8c6bfe5cdbc301a4e.js"
     >
     <link data-chunk="main"
           rel="preload"
@@ -524,7 +524,7 @@ Object {
     </script>
     <script async
             data-chunk="main"
-            src="/vendors~main-adf22b41d79c9d93c41b.js"
+            src="/vendors~main-a2b8c6bfe5cdbc301a4e.js"
     >
     </script>
     <script async
@@ -8376,7 +8376,7 @@ Object {
   display: block;
 }
 ,
-  "vendors~main-adf22b41d79c9d93c41b.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vendors~main-a2b8c6bfe5cdbc301a4e.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;
 

--- a/treat/index.ts
+++ b/treat/index.ts
@@ -11,12 +11,12 @@ import {
   globalStyle,
   resolveStyles,
   resolveClassName,
-  Style,
-  GlobalStyle,
-  CSSProperties,
-  ThemeRef,
-  ClassRef,
-  TreatModule,
+  Style as _Style,
+  GlobalStyle as _GlobalStyle,
+  CSSProperties as _CSSProperties,
+  ThemeRef as _ThemeRef,
+  ClassRef as _ClassRef,
+  TreatModule as _TreatModule,
 } from 'treat';
 
 // Provided for backwards compatibility. Remove in sku 9
@@ -36,9 +36,9 @@ export {
 };
 
 // We need to re-export types separately or they won't work in webpack :(((
-export type Style = Style;
-export type GlobalStyle = GlobalStyle;
-export type CSSProperties = CSSProperties;
-export type ThemeRef = ThemeRef;
-export type ClassRef = ClassRef;
-export type TreatModule = TreatModule;
+export type Style = _Style;
+export type GlobalStyle = _GlobalStyle;
+export type CSSProperties = _CSSProperties;
+export type ThemeRef = _ThemeRef;
+export type ClassRef = _ClassRef;
+export type TreatModule = _TreatModule;


### PR DESCRIPTION
This fixes an issue with the latest version of TypeScript, which throws the following errors for consumers:

```
node_modules/sku/treat/index.ts:14:3 - error TS2440: Import declaration conflicts with local declaration of 'Style'.
node_modules/sku/treat/index.ts:15:3 - error TS2440: Import declaration conflicts with local declaration of 'GlobalStyle'.
node_modules/sku/treat/index.ts:16:3 - error TS2440: Import declaration conflicts with local declaration of 'CSSProperties'.
node_modules/sku/treat/index.ts:17:3 - error TS2440: Import declaration conflicts with local declaration of 'ThemeRef'.
node_modules/sku/treat/index.ts:18:3 - error TS2440: Import declaration conflicts with local declaration of 'ClassRef'.
node_modules/sku/treat/index.ts:19:3 - error TS2440: Import declaration conflicts with local declaration of 'TreatModule'.
```