### PR TITLE
fix(deps): Update to prettier 1.19.1

### DIFF
--- a/lib/isTypeScript.js
+++ b/lib/isTypeScript.js
@@ -9,9 +9,7 @@ const isTypeScript = tsFiles.length > 0;
 
 if (isTypeScript) {
   debug(
-    `Found TypeScript in project. Found ${tsFiles.length} with the first at "${
-      tsFiles[0]
-    }".`,
+    `Found TypeScript in project. Found ${tsFiles.length} with the first at "${tsFiles[0]}".`,
   );
 }
 

--- a/lib/product.test.js
+++ b/lib/product.test.js
@@ -4,7 +4,12 @@ const product = require('./product');
 const testCases = [
   {
     input: { a: [1, 2], b: [1, 2] },
-    output: [{ a: 1, b: 1 }, { a: 1, b: 2 }, { a: 2, b: 1 }, { a: 2, b: 2 }],
+    output: [
+      { a: 1, b: 1 },
+      { a: 1, b: 2 },
+      { a: 2, b: 1 },
+      { a: 2, b: 2 },
+    ],
   },
   {
     input: { a: [], b: [1, 2], c: [] },
@@ -12,7 +17,10 @@ const testCases = [
   },
   {
     input: { a: [1], b: [1, 2] },
-    output: [{ a: 1, b: 1 }, { a: 1, b: 2 }],
+    output: [
+      { a: 1, b: 1 },
+      { a: 1, b: 2 },
+    ],
   },
   {
     input: { a: [1], b: [1, 2], c: [1, 2, 3] },

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "playroom": "^0.10.1",
     "postcss-js": "^2.0.2",
     "postcss-loader": "^3.0.0",
-    "prettier": "1.18.2",
+    "prettier": "1.19.1",
     "raw-loader": "^3.1.0",
     "react-hot-loader": "3.1.3",
     "react-treat": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13645,7 +13645,12 @@ prepend-http@^1.0.0, prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-prettier@1.18.2, prettier@^1.15.3:
+prettier@1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^1.15.3:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==


### PR DESCRIPTION
In this [PR](https://github.com/seek-oss/sku/pull/447), we upgraded to TS 3.7, but prettier also requires an update to parse optional chaining and other [syntax](https://prettier.io/blog/2019/11/09/1.19.0.html#typescript) 

