### PR TITLE
feat: Add ‘provideDefaultChromaticViewports’ config option

### DIFF
--- a/config/storybook/start/config.js
+++ b/config/storybook/start/config.js
@@ -2,11 +2,11 @@ import { addParameters } from '@storybook/react';
 import configureStorybook from '../configureStorybook';
 import 'storybook-chromatic';
 
-const screenshotWidths = __SKU_SCREENSHOT_WIDTHS__; // eslint-disable-line no-undef
+const provideDefaultChromaticViewports = __SKU_PROVIDE_DEFAULT_CHROMATIC_VIEWPORTS__; // eslint-disable-line no-undef
 
-if (Array.isArray(screenshotWidths) && screenshotWidths.length > 0) {
+if (provideDefaultChromaticViewports) {
   addParameters({
-    chromatic: { viewports: screenshotWidths },
+    chromatic: { viewports: [320, 1200] },
   });
 }
 

--- a/config/storybook/start/config.js
+++ b/config/storybook/start/config.js
@@ -1,10 +1,13 @@
 import { addParameters } from '@storybook/react';
 import configureStorybook from '../configureStorybook';
-
 import 'storybook-chromatic';
 
-addParameters({
-  chromatic: { viewports: [320, 1200] },
-});
+const screenshotWidths = __SKU_SCREENSHOT_WIDTHS__; // eslint-disable-line no-undef
+
+if (Array.isArray(screenshotWidths) && screenshotWidths.length > 0) {
+  addParameters({
+    chromatic: { viewports: screenshotWidths },
+  });
+}
 
 configureStorybook();

--- a/config/storybook/storybookWebpackConfig.js
+++ b/config/storybook/storybookWebpackConfig.js
@@ -1,5 +1,5 @@
 const webpack = require('webpack');
-const { paths, screenshotWidths } = require('../../context');
+const { paths, provideDefaultChromaticViewports } = require('../../context');
 const find = require('lodash/find');
 const webpackMerge = require('webpack-merge');
 const makeWebpackConfig = require('../webpack/webpack.config');
@@ -55,7 +55,9 @@ module.exports = ({ config }, { isDevServer }) => {
           __SKU_SRC_PATHS_8__: JSON.stringify(paths.src[8] || __dirname),
           __SKU_SRC_PATHS_9__: JSON.stringify(paths.src[9] || __dirname),
 
-          __SKU_SCREENSHOT_WIDTHS__: JSON.stringify(screenshotWidths),
+          __SKU_PROVIDE_DEFAULT_CHROMATIC_VIEWPORTS__: JSON.stringify(
+            provideDefaultChromaticViewports,
+          ),
         }),
       ],
     },

--- a/config/storybook/storybookWebpackConfig.js
+++ b/config/storybook/storybookWebpackConfig.js
@@ -1,5 +1,5 @@
 const webpack = require('webpack');
-const { paths } = require('../../context');
+const { paths, screenshotWidths } = require('../../context');
 const find = require('lodash/find');
 const webpackMerge = require('webpack-merge');
 const makeWebpackConfig = require('../webpack/webpack.config');
@@ -54,6 +54,8 @@ module.exports = ({ config }, { isDevServer }) => {
           __SKU_SRC_PATHS_7__: JSON.stringify(paths.src[7] || __dirname),
           __SKU_SRC_PATHS_8__: JSON.stringify(paths.src[8] || __dirname),
           __SKU_SRC_PATHS_9__: JSON.stringify(paths.src[9] || __dirname),
+
+          __SKU_SCREENSHOT_WIDTHS__: JSON.stringify(screenshotWidths),
         }),
       ],
     },

--- a/context/configSchema.js
+++ b/context/configSchema.js
@@ -83,6 +83,10 @@ module.exports = validator.compile({
   storybookTarget: {
     type: 'string',
   },
+  screenshotWidths: {
+    type: 'array',
+    items: [{ type: 'number' }],
+  },
   target: {
     type: 'string',
   },

--- a/context/configSchema.js
+++ b/context/configSchema.js
@@ -83,9 +83,8 @@ module.exports = validator.compile({
   storybookTarget: {
     type: 'string',
   },
-  screenshotWidths: {
-    type: 'array',
-    items: [{ type: 'number' }],
+  provideDefaultChromaticViewports: {
+    type: 'boolean',
   },
   target: {
     type: 'string',

--- a/context/defaultSkuConfig.js
+++ b/context/defaultSkuConfig.js
@@ -24,6 +24,7 @@ module.exports = {
   setupTests: null,
   storybookPort: 8081,
   storybookTarget: 'dist-storybook',
+  screenshotWidths: [320, 1200],
   initialPath: null,
   public: 'public',
   publicPath: '/',

--- a/context/defaultSkuConfig.js
+++ b/context/defaultSkuConfig.js
@@ -24,7 +24,7 @@ module.exports = {
   setupTests: null,
   storybookPort: 8081,
   storybookTarget: 'dist-storybook',
-  screenshotWidths: [320, 1200],
+  provideDefaultChromaticViewports: true,
   initialPath: null,
   public: 'public',
   publicPath: '/',

--- a/context/index.js
+++ b/context/index.js
@@ -106,6 +106,7 @@ module.exports = {
   isLibrary: Boolean(skuConfig.libraryEntry),
   storybookPort: skuConfig.storybookPort,
   storybookTarget: skuConfig.storybookTarget,
+  screenshotWidths: skuConfig.screenshotWidths,
   polyfills: skuConfig.polyfills,
   initialPath,
   webpackDecorator: skuConfig.dangerouslySetWebpackConfig,

--- a/context/index.js
+++ b/context/index.js
@@ -106,7 +106,7 @@ module.exports = {
   isLibrary: Boolean(skuConfig.libraryEntry),
   storybookPort: skuConfig.storybookPort,
   storybookTarget: skuConfig.storybookTarget,
-  screenshotWidths: skuConfig.screenshotWidths,
+  provideDefaultChromaticViewports: skuConfig.provideDefaultChromaticViewports,
   polyfills: skuConfig.polyfills,
   initialPath,
   webpackDecorator: skuConfig.dangerouslySetWebpackConfig,

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -304,6 +304,14 @@ Default: `dist-storybook`
 
 The directory `sku build-storybook` will output files to.
 
+## screenshotWidths
+
+type: `Array<number>`
+
+Default: `[320, 1200]`
+
+Global configuration for Chromatic screenshot widths.
+
 ## playroomComponents
 
 type `string`

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -304,13 +304,13 @@ Default: `dist-storybook`
 
 The directory `sku build-storybook` will output files to.
 
-## screenshotWidths
+## provideDefaultChromaticViewports
 
-type: `Array<number>`
+type: `boolean`
 
-Default: `[320, 1200]`
+Default: `true`
 
-Global configuration for Chromatic screenshot widths.
+Configures whether a default set of viewports (`320` and `1200`) should be provided to all screenshots. If you'd like to manually configure Chromatic per story, set this to `false`.
 
 ## playroomComponents
 


### PR DESCRIPTION
Currently sku has hard-coded widths of 320px and 1200px for [Chromatic](https://www.chromaticqa.com) screenshots. This PR adds the ability to disable this by setting `provideDefaultChromaticViewports` to `false`.