### PR TITLE
fix(playroom): Ensure build is in production mode

### DIFF
--- a/scripts/build-playroom.js
+++ b/scripts/build-playroom.js
@@ -1,3 +1,6 @@
+// First, ensure the build is running in production mode
+process.env.NODE_ENV = 'production';
+
 const playroom = require('playroom/lib');
 const { cwd } = require('../lib/cwd');
 const makePlayroomConfig = require('../config/playroom/makePlayroomConfig');


### PR DESCRIPTION
Brings playroom into line with the webpack and storybook builds, by setting the `NODE_ENV` to `production` up front. This ensures all the loaders/plugins are consistent between the different builds.