### PR TITLE
perf(build): Limit stats collection to client build

### DIFF
--- a/config/webpack/plugins/createHtmlRenderPlugin.js
+++ b/config/webpack/plugins/createHtmlRenderPlugin.js
@@ -13,7 +13,7 @@ const {
 } = require('../../../context');
 
 const getClientStats = webpackStats => {
-  return webpackStats.toJson().children.find(({ name }) => name === 'client');
+  return webpackStats.toJson();
 };
 
 const getCachedClientStats = memoize(getClientStats);
@@ -68,6 +68,5 @@ module.exports = () => {
     routes: isStartScript ? getStartRoutes() : getBuildRoutes(),
     transformFilePath: transformOutputPath,
     mapStatsToParams,
-    verbose: false,
   });
 };

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -207,7 +207,7 @@ const makeWebpackConfig = ({
         ],
       },
       plugins: [
-        ...(htmlRenderPlugin ? [htmlRenderPlugin] : []),
+        ...(htmlRenderPlugin ? [htmlRenderPlugin.statsCollectorPlugin] : []),
         ...(renderHtml
           ? [
               new LoadablePlugin({
@@ -273,7 +273,7 @@ const makeWebpackConfig = ({
         ],
       },
       plugins: [
-        ...(htmlRenderPlugin ? [htmlRenderPlugin.render()] : []),
+        ...(htmlRenderPlugin ? [htmlRenderPlugin.rendererPlugin] : []),
         new webpack.DefinePlugin(envVars),
         new webpack.DefinePlugin({
           SKU_LIBRARY_NAME: JSON.stringify(libraryName),

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "fs-extra": "^8.1.0",
     "get-port": "^5.0.0",
     "hostile": "^1.3.2",
-    "html-render-webpack-plugin": "^1.1.1",
+    "html-render-webpack-plugin": "^2.0.1",
     "identity-obj-proxy": "^3.0.0",
     "indent-string": "^4.0.0",
     "inquirer": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9248,13 +9248,13 @@ html-minifier@^4.0.0:
     relateurl "^0.2.7"
     uglify-js "^3.5.1"
 
-html-render-webpack-plugin@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/html-render-webpack-plugin/-/html-render-webpack-plugin-1.1.1.tgz#9982fe8e495bf22e56452eed41726915c8b21d81"
-  integrity sha512-LolCHpVK9F5WJZ41231cHO8cHajboTakh+Ys8O7vS7waY0bjxtkwvUDA7phF0NJkmXRW9VAgkBWmVWnWA1Mluw==
+html-render-webpack-plugin@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/html-render-webpack-plugin/-/html-render-webpack-plugin-2.0.1.tgz#3e2d4e8e16ebe6d2609516bc0431d6c67a36f56c"
+  integrity sha512-TGdgKhnWEnpoTX5204IIFRjwgYpGn5wbvmuS0frLJ8LUZhnRXUd9l7BUXkAbr79C75Qi74d61rgIA8nyDzsJXA==
   dependencies:
-    chalk "^2.4.1"
-    eval "^0.1.2"
+    chalk "^3.0.0"
+    eval "^0.1.4"
 
 html-webpack-plugin@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
Currently the build gathers webpack stats from both render and client builds.

By upgrading to html-render-webpack-plugin v2 we can leverage the new syntax to only collect stats from the client build. This reduces the amount of time spent creating the stats JSON used to render.

We've already implemented caching in https://github.com/seek-oss/sku/pull/459 so this benefit is fairly minor as the code is currently only ran once per build.