### PR TITLE
Fix template formatting

### DIFF
--- a/.changeset/tasty-cougars-check.md
+++ b/.changeset/tasty-cougars-check.md
@@ -1,0 +1,7 @@
+---
+'sku': patch
+---
+
+Fix template formatting
+
+This updates the template files to be in line with new linting rules

--- a/template/src/App/App.tsx
+++ b/template/src/App/App.tsx
@@ -1,7 +1,8 @@
 import 'braid-design-system/reset';
 
-import React from 'react';
 import { BraidLoadableProvider } from 'braid-design-system';
+import React from 'react';
+
 import NextSteps from './NextSteps';
 
 interface AppProps {

--- a/template/src/App/NextSteps.tsx
+++ b/template/src/App/NextSteps.tsx
@@ -1,4 +1,3 @@
-import React, { Fragment } from 'react';
 import {
   Box,
   Heading,
@@ -10,6 +9,7 @@ import {
   Bullet,
   Stack,
 } from 'braid-design-system';
+import React, { Fragment } from 'react';
 
 export default () => (
   <Fragment>

--- a/template/src/client.tsx
+++ b/template/src/client.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { hydrate } from 'react-dom';
-import { ClientContext } from './types';
+
 import App from './App/App';
+import { ClientContext } from './types';
 
 export default ({ site }: ClientContext) => {
   hydrate(<App site={site} />, document.getElementById('app'));

--- a/template/src/render.tsx
+++ b/template/src/render.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom/server';
 import { Render } from 'sku';
 
-import { ClientContext } from './types';
 import App from './App/App';
+import { ClientContext } from './types';
 
 interface RenderContext {
   appHtml: string;


### PR DESCRIPTION
Due to the new eslint config around import ordering, a brand new sku project fails format check out of the box. This updates the template files to match the new linting requirements.