### PR TITLE
Fix memory leak in sku start

### DIFF
--- a/.changeset/ten-cups-beam.md
+++ b/.changeset/ten-cups-beam.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fix memory leak in sku start

--- a/config/webpack/plugins/createHtmlRenderPlugin.js
+++ b/config/webpack/plugins/createHtmlRenderPlugin.js
@@ -1,5 +1,5 @@
 const HtmlRenderPlugin = require('html-render-webpack-plugin');
-const memoize = require('memoizee');
+const memoize = require('memoizee/weak');
 
 const product = require('../../../lib/product');
 const {


### PR DESCRIPTION
It is now using a WeakMap based memoization which is ideal for this use case, as it can cache for as long as the relevant stats are in memory. 