### PR TITLE
Fix webpack image loader scoping

### DIFF
--- a/.changeset/old-papayas-divide.md
+++ b/.changeset/old-papayas-divide.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Only target internal images/svgs with loaders

--- a/config/webpack/plugins/sku-webpack-plugin/index.js
+++ b/config/webpack/plugins/sku-webpack-plugin/index.js
@@ -112,11 +112,17 @@ class SkuWebpackPlugin {
       },
       {
         test: IMAGE,
+        include: this.include,
         use: makeImageLoaders({ target }),
       },
-      { test: SVG, use: makeSvgLoaders() },
+      {
+        test: SVG,
+        include: this.include,
+        use: makeSvgLoaders(),
+      },
       {
         test: DEPRECATED_CSS_IN_JS,
+        include: this.include,
         use: require.resolve('../deprecatedCssInJsFileLoader'),
       },
     ];


### PR DESCRIPTION
Previously, this was targeting any images in the build. This is especially problematic for consumers of the sku-webpack-plugin. 