### PR TITLE
Fix ReferenceError in compilePackages validation

### DIFF
--- a/.changeset/serious-teachers-live.md
+++ b/.changeset/serious-teachers-live.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fix ReferenceError in compilePackages validation

--- a/lib/validatePeersDeps.js
+++ b/lib/validatePeersDeps.js
@@ -87,7 +87,7 @@ module.exports = async () => {
 
         if (dep && !semver.satisfies(dep.version, peerVersionRange)) {
           track.count('peer_dep_version_mismatch', {
-            compile_package: compilePackage,
+            compile_package: packageName,
           });
 
           const peerIsBehind = semver.gtr(dep.version, peerVersionRange);


### PR DESCRIPTION
```
Error validating peer dependencies
ReferenceError: compilePackage is not defined
    at module.exports (/workdir/node_modules/sku/lib/validatePeersDeps.js:90:30)
```