### PR TITLE
Validate that there is only a single copy of react-treat

### DIFF
--- a/.changeset/clean-worms-glow.md
+++ b/.changeset/clean-worms-glow.md
@@ -2,4 +2,4 @@
 'sku': patch
 ---
 
-Validate that there is only one copy of react-treat
+Validate that there is only a single copy of react-treat

--- a/.changeset/clean-worms-glow.md
+++ b/.changeset/clean-worms-glow.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Validate that there is only one copy of react-treat

--- a/lib/validatePeersDeps.js
+++ b/lib/validatePeersDeps.js
@@ -13,15 +13,20 @@ const asyncMap = (list, fn) => {
   return Promise.all(list.map((item) => fn(item)));
 };
 
+const singletonPackages = ['react-treat'];
+
 module.exports = async () => {
   try {
     const packages = [];
 
-    for (const compilePackage of paths.compilePackages) {
+    for (const packageName of [
+      ...paths.compilePackages,
+      ...singletonPackages,
+    ]) {
       const results = await glob(
         [
-          `node_modules/${compilePackage}/package.json`,
-          `node_modules/**/node_modules/${compilePackage}/package.json`,
+          `node_modules/${packageName}/package.json`,
+          `node_modules/**/node_modules/${packageName}/package.json`,
         ],
         {
           cwd: cwd(),
@@ -30,7 +35,7 @@ module.exports = async () => {
 
       if (results.length > 1) {
         const messages = [
-          chalk`Multiple copies of {bold ${compilePackage}} are present in node_modules. This is likely to cause errors, but even if it works, it will probably result in an unnecessarily large bundle size.`,
+          chalk`Multiple copies of {bold ${packageName}} are present in node_modules. This is likely to cause errors, but even if it works, it will probably result in an unnecessarily large bundle size.`,
         ];
 
         messages.push(
@@ -48,12 +53,12 @@ module.exports = async () => {
 
         if (detectYarn()) {
           messages.push(
-            chalk`Try running "{blue.bold yarn why} {bold ${compilePackage}}" to diagnose the issue`,
+            chalk`Try running "{blue.bold yarn why} {bold ${packageName}}" to diagnose the issue`,
           );
         }
 
         track.count('duplicate_compile_package', {
-          compile_package: compilePackage,
+          compile_package: packageName,
         });
         banner('error', 'Error: Duplicate packages detected', messages);
       }


### PR DESCRIPTION
Having multiple copies of react-treat in the same app causes issues where a `useStyles(styleRefs)` call will throw an error because it can't find a matching provider.

To fix this, we now have a concept of "singleton packages" to check for, not just those found in `compilePackages`.