### PR TITLE
Fix config validation for playroomParamType

### DIFF
--- a/config/playroom/makePlayroomConfig.js
+++ b/config/playroom/makePlayroomConfig.js
@@ -1,5 +1,6 @@
 const { red, yellow, bold } = require('chalk');
 const find = require('lodash/find');
+const omitBy = require('lodash/omitBy');
 const { paths, playroom } = require('../../context');
 const makeWebpackConfig = require('../webpack/webpack.config');
 
@@ -24,22 +25,26 @@ try {
   process.exit(1);
 }
 
-module.exports = () => ({
-  port: playroom.port,
-  title: playroom.title,
-  outputPath: paths.playroomTarget,
-  components: paths.playroomComponents,
-  themes: paths.playroomThemes,
-  snippets: paths.playroomSnippets,
-  frameComponent: paths.playroomFrameComponent,
-  openBrowser: process.env.OPEN_TAB !== 'false',
-  ...playroom,
-  webpackConfig: () => ({
-    module: clientWebpackConfig.module,
-    resolve: clientWebpackConfig.resolve,
-    plugins: clientWebpackConfig.plugins,
-    optimization: {
-      concatenateModules: false,
+module.exports = () =>
+  omitBy(
+    {
+      port: playroom.port,
+      title: playroom.title,
+      outputPath: paths.playroomTarget,
+      components: paths.playroomComponents,
+      themes: paths.playroomThemes,
+      snippets: paths.playroomSnippets,
+      frameComponent: paths.playroomFrameComponent,
+      openBrowser: process.env.OPEN_TAB !== 'false',
+      ...playroom,
+      webpackConfig: () => ({
+        module: clientWebpackConfig.module,
+        resolve: clientWebpackConfig.resolve,
+        plugins: clientWebpackConfig.plugins,
+        optimization: {
+          concatenateModules: false,
+        },
+      }),
     },
-  }),
-});
+    (v) => typeof v === 'undefined' || v === null,
+  );

--- a/context/defaultSkuConfig.js
+++ b/context/defaultSkuConfig.js
@@ -44,6 +44,7 @@ module.exports = {
   playroomFrameComponent: null,
   playroomTitle: null,
   playroomPort: 8082,
+  playroomParamType: null,
   orderImports: false,
   cspEnabled: false,
   cspExtraScriptSrcHosts: [],


### PR DESCRIPTION
The `omitBy` ensures we only pass valid config through to playroom. 