### PR TITLE
Fix empty style tags in CSP mode

### DIFF
--- a/.changeset/odd-birds-occur.md
+++ b/.changeset/odd-birds-occur.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fix empty style tags in rendered HTML when `cspEnabled` is set to `true`

--- a/entry/csp.js
+++ b/entry/csp.js
@@ -79,7 +79,12 @@ export default function createCSPHandler({ extraHosts = [] } = {}) {
   };
 
   const handleHtml = (html) => {
-    const root = parse(html, { script: true });
+    const root = parse(html, {
+      script: true,
+      style: true,
+      pre: true,
+      comment: true,
+    });
 
     if (!root.valid) {
       throw new Error(

--- a/test/test-cases/multiple-routes/__snapshots__/multiple-routes.test.js.snap
+++ b/test/test-cases/multiple-routes/__snapshots__/multiple-routes.test.js.snap
@@ -43,6 +43,9 @@ SOURCE HTML: <!DOCTYPE html>
     <script>
       console.log('Hi');
     </script>
+    <style type="text/css">
+      body{background:pink}
+    </style>
     <link data-chunk="handlers-Details"
           rel="stylesheet"
           href="styles[0]"
@@ -147,6 +150,9 @@ SOURCE HTML: <!DOCTYPE html>
     <script>
       console.log('Hi');
     </script>
+    <style type="text/css">
+      body{background:pink}
+    </style>
     <link data-chunk="handlers-Home"
           rel="stylesheet"
           href="styles[0]"
@@ -239,6 +245,9 @@ SOURCE HTML: <!DOCTYPE html>
     <script>
       console.log('Hi');
     </script>
+    <style type="text/css">
+      body{background:pink}
+    </style>
     <link data-chunk="handlers-Details"
           rel="stylesheet"
           href="styles[0]"
@@ -343,6 +352,9 @@ SOURCE HTML: <!DOCTYPE html>
     <script>
       console.log('Hi');
     </script>
+    <style type="text/css">
+      body{background:pink}
+    </style>
     <link data-chunk="handlers-Home"
           rel="stylesheet"
           href="styles[0]"
@@ -441,6 +453,9 @@ SOURCE HTML: <!DOCTYPE html>
     <script>
       console.log('Hi');
     </script>
+    <style type="text/css">
+      body{background:pink}
+    </style>
     <link data-chunk="handlers-Details"
           rel="stylesheet"
           href="styles[0]"
@@ -558,6 +573,9 @@ SOURCE HTML: <!DOCTYPE html>
     <script>
       console.log('Hi');
     </script>
+    <style type="text/css">
+      body{background:pink}
+    </style>
     <link data-chunk="handlers-Home"
           rel="stylesheet"
           href="styles[0]"
@@ -655,6 +673,9 @@ SOURCE HTML: <!DOCTYPE html>
     <script>
       console.log('Hi');
     </script>
+    <style type="text/css">
+      body{background:pink}
+    </style>
     <link data-chunk="handlers-Details"
           rel="stylesheet"
           href="styles[0]"
@@ -783,6 +804,9 @@ SOURCE HTML: <!DOCTYPE html>
     <script>
       console.log('Hi');
     </script>
+    <style type="text/css">
+      body{background:pink}
+    </style>
     <link data-chunk="handlers-Home"
           rel="stylesheet"
           href="styles[0]"

--- a/test/test-cases/multiple-routes/app/src/render.js
+++ b/test/test-cases/multiple-routes/app/src/render.js
@@ -30,6 +30,7 @@ export default {
           <meta name="viewport" content="width=device-width, initial-scale=1">
           <script src="https://code.jquery.com/jquery-3.5.0.slim.min.js"></script>
           <script>console.log('Hi');</script>
+          <style type="text/css">body{background:pink}</style>
           ${headTags}
         </head>
         <body>


### PR DESCRIPTION
In CSP mode we're using [node-html-parser](https://www.npmjs.com/package/node-html-parser) so that we can process consumers' HTML, but by default it doesn't parse script/style/pre tags and HTML comments. Currently, we've enabled script parsing but nothing else. As a result, any style tags in the rendered HTML were stripped of their contents. Since we don't want to alter the original HTML (other than our explicit CSP-related changes), this PR now ensures that nothing is skipped when parsing.