### PR TITLE
Only generate .ssl directory when httpsDevServer is enabled

### DIFF
--- a/.changeset/rotten-seas-hunt.md
+++ b/.changeset/rotten-seas-hunt.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Only generate `.ssl` directory when `httpsDevServer` is enabled

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -6,7 +6,7 @@ const ensureGitignore = require('ensure-gitignore');
 const { cwd, getPathFromCwd } = require('./cwd');
 
 const isTypeScript = require('./isTypeScript');
-const { paths } = require('../context');
+const { paths, httpsDevServer } = require('../context');
 const {
   bundleReportFolder,
 } = require('../config/webpack/plugins/bundleAnalyzer');
@@ -103,10 +103,13 @@ module.exports = async () => {
   }
 
   // Generate self-signed certificate and ignore
-
   const selfSignedCertificateDirName = '.ssl';
-  await getCertificate(selfSignedCertificateDirName);
-  gitIgnorePatterns.push(selfSignedCertificateDirName);
+  if (httpsDevServer) {
+    await getCertificate(selfSignedCertificateDirName);
+    gitIgnorePatterns.push(selfSignedCertificateDirName);
+  } else {
+    await fs.remove(getPathFromCwd(selfSignedCertificateDirName));
+  }
 
   // Write `.gitignore`
   await ensureGitignore({

--- a/test/test-cases/assertion-removal/app/.gitignore
+++ b/test/test-cases/assertion-removal/app/.gitignore
@@ -1,7 +1,6 @@
 # managed by sku
 .eslintrc
 .prettierrc
-.ssl
 coverage/
 dist-playroom/
 dist-storybook/

--- a/test/test-cases/braid-design-system/app/.gitignore
+++ b/test/test-cases/braid-design-system/app/.gitignore
@@ -1,7 +1,6 @@
 # managed by sku
 .eslintrc
 .prettierrc
-.ssl
 coverage/
 dist-playroom/
 dist-storybook/

--- a/test/test-cases/configure-test/configure.test.js
+++ b/test/test-cases/configure-test/configure.test.js
@@ -76,10 +76,9 @@ describe('configure', () => {
 
     it(`should generate \`.gitignore\``, async () => {
       const ignoreContents = await readIgnore(appFolder, '.gitignore');
-      expect(ignoreContents.length).toEqual(8);
+      expect(ignoreContents.length).toEqual(7);
       expect(ignoreContents).toContain(`.eslintrc`);
       expect(ignoreContents).toContain(`.prettierrc`);
-      expect(ignoreContents).toContain(`.ssl`);
       expect(ignoreContents).toContain(`${defaultTargetDir}/`);
       expect(ignoreContents).toContain(`${defaultStorybookTargetDir}/`);
       expect(ignoreContents).toContain(`${defaultPlayroomTargetDir}/`);
@@ -135,10 +134,9 @@ describe('configure', () => {
 
     it(`should generate \`.gitignore\``, async () => {
       const ignoreContents = await readIgnore(appFolderTS, '.gitignore');
-      expect(ignoreContents.length).toEqual(9);
+      expect(ignoreContents.length).toEqual(8);
       expect(ignoreContents).toContain(`.eslintrc`);
       expect(ignoreContents).toContain(`.prettierrc`);
-      expect(ignoreContents).toContain(`.ssl`);
       expect(ignoreContents).toContain(`tsconfig.json`);
       expect(ignoreContents).toContain(`${skuConfig.target}/`);
       expect(ignoreContents).toContain(`${skuConfig.storybookTarget}/`);

--- a/test/test-cases/custom-src-paths/.gitignore
+++ b/test/test-cases/custom-src-paths/.gitignore
@@ -1,7 +1,6 @@
 # managed by sku
 .eslintrc
 .prettierrc
-.ssl
 coverage/
 dist-playroom/
 dist-storybook/

--- a/test/test-cases/library-build/app/.gitignore
+++ b/test/test-cases/library-build/app/.gitignore
@@ -1,7 +1,6 @@
 # managed by sku
 .eslintrc
 .prettierrc
-.ssl
 coverage/
 dist-playroom/
 dist-storybook/

--- a/test/test-cases/multiple-routes/app/.gitignore
+++ b/test/test-cases/multiple-routes/app/.gitignore
@@ -1,7 +1,6 @@
 # managed by sku
 .eslintrc
 .prettierrc
-.ssl
 coverage/
 dist-playroom/
 dist-storybook/

--- a/test/test-cases/public-path/.gitignore
+++ b/test/test-cases/public-path/.gitignore
@@ -1,7 +1,6 @@
 # managed by sku
 .eslintrc
 .prettierrc
-.ssl
 coverage/
 dist-playroom/
 dist-storybook/

--- a/test/test-cases/react-css-modules/app/.gitignore
+++ b/test/test-cases/react-css-modules/app/.gitignore
@@ -1,7 +1,6 @@
 # managed by sku
 .eslintrc
 .prettierrc
-.ssl
 coverage/
 dist-playroom/
 dist-storybook/

--- a/test/test-cases/seek-asia-style-guide/app/.gitignore
+++ b/test/test-cases/seek-asia-style-guide/app/.gitignore
@@ -1,7 +1,6 @@
 # managed by sku
 .eslintrc
 .prettierrc
-.ssl
 coverage/
 dist-playroom/
 dist-storybook/

--- a/test/test-cases/seek-style-guide/app/.gitignore
+++ b/test/test-cases/seek-style-guide/app/.gitignore
@@ -1,7 +1,6 @@
 # managed by sku
 .eslintrc
 .prettierrc
-.ssl
 coverage/
 dist-playroom/
 dist-storybook/

--- a/test/test-cases/sku-with-https/sku-with-https.test.js
+++ b/test/test-cases/sku-with-https/sku-with-https.test.js
@@ -102,10 +102,11 @@ describe('sku-with-https', () => {
 
   describe('.gitignore', () => {
     it('should add the .ssl directory to .gitignore', async () => {
-      const ignoreContents = await fs
-        .readFile(path.join(appDir, '.gitignore'), 'utf-8')
-        .split('\n');
-      expect(ignoreContents).toContain(`.ssl`);
+      const ignoreContents = await fs.readFile(
+        path.join(appDir, '.gitignore'),
+        'utf-8',
+      );
+      expect(ignoreContents.split('\n')).toContain(`.ssl`);
     });
   });
 });

--- a/test/test-cases/sku-with-https/sku-with-https.test.js
+++ b/test/test-cases/sku-with-https/sku-with-https.test.js
@@ -99,4 +99,13 @@ describe('sku-with-https', () => {
       expect(snapshot).toMatchSnapshot();
     });
   });
+
+  describe('.gitignore', () => {
+    it('should add the .ssl directory to .gitignore', async () => {
+      const ignoreContents = await fs
+        .readFile(path.join(appDir, '.gitignore'), 'utf-8')
+        .split('\n');
+      expect(ignoreContents).toContain(`.ssl`);
+    });
+  });
 });

--- a/test/test-cases/source-maps/.gitignore
+++ b/test/test-cases/source-maps/.gitignore
@@ -1,7 +1,6 @@
 # managed by sku
 .eslintrc
 .prettierrc
-.ssl
 coverage/
 dist-playroom/
 dist-storybook/

--- a/test/test-cases/ssr-hello-world/.gitignore
+++ b/test/test-cases/ssr-hello-world/.gitignore
@@ -1,7 +1,6 @@
 # managed by sku
 .eslintrc
 .prettierrc
-.ssl
 coverage/
 dist-build/
 dist-playroom/

--- a/test/test-cases/typescript-css-modules/app/.gitignore
+++ b/test/test-cases/typescript-css-modules/app/.gitignore
@@ -1,7 +1,6 @@
 # managed by sku
 .eslintrc
 .prettierrc
-.ssl
 coverage/
 dist-playroom/
 dist-storybook/


### PR DESCRIPTION
If you're not using the `httpsDevServer` option, this directory and its entry in `.gitignore` is just noise.