### PR TITLE
Fix unable to find language in URLs that contain query parameters

### DIFF
--- a/.changeset/unlucky-tips-knock.md
+++ b/.changeset/unlucky-tips-knock.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fix unable to find language in URLs that contain query parameters

--- a/lib/language-utils.js
+++ b/lib/language-utils.js
@@ -27,8 +27,8 @@ function getValidLanguagesForRoute(route) {
 
 const LANGUAGE_NAMED_PARAM = 'language';
 
-function getLanguageParamFromUrl(url, route) {
-  const match = routeMatcher(route)(url);
+function getLanguageParamFromUrl(pathname, route) {
+  const match = routeMatcher(route)(pathname);
 
   return match ? match.params[LANGUAGE_NAMED_PARAM] : null;
 }
@@ -36,9 +36,13 @@ function getLanguageParamFromUrl(url, route) {
 function getLanguageFromRoute(req, route) {
   const supportedLanguagesForRoute = getValidLanguagesForRoute(route);
 
-  log('Looking for language in URL', req.url);
+  log('Looking for language in requested path', {
+    url: req.url,
+    path: req.path,
+    route: route.route,
+  });
   const requestedLanguageByRoute = getLanguageParamFromUrl(
-    req.url,
+    req.path,
     route.route,
   );
   if (requestedLanguageByRoute) {

--- a/test/test-cases/translations/__snapshots__/translations.test.js.snap
+++ b/test/test-cases/translations/__snapshots__/translations.test.js.snap
@@ -169,3 +169,88 @@ SOURCE HTML: <!DOCTYPE html>
 </html>
 POST HYDRATE DIFFS: NO DIFF
 `;
+
+exports[`translations should support query parameters 1`] = `
+SCRIPTS: Array [
+  "/runtime-c23b2036f7ddf87040b9.js",
+  "/vendors~main-406f6549a0224792b394.js",
+  "/main-d9d72f1d85db19d1536f.js",
+  "/en-translations-e581123a4492c402af5e.js",
+]
+CSS: Array []
+SOURCE HTML: <!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>
+      My Awesome Project
+    </title>
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1"
+    >
+    <link data-chunk="main"
+          rel="preload"
+          as="script"
+          href="scripts[0]"
+    >
+    <link data-chunk="main"
+          rel="preload"
+          as="script"
+          href="scripts[1]"
+    >
+    <link data-chunk="main"
+          rel="preload"
+          as="script"
+          href="scripts[2]"
+    >
+    <link data-chunk="en-translations"
+          rel="preload"
+          as="script"
+          href="scripts[3]"
+    >
+  </head>
+  <body>
+    <div id="app">
+      <div>
+        Hello sku
+      </div>
+    </div>
+    <script id="__SKU_CLIENT_CONTEXT__"
+            type="application/json"
+    >
+      {"language":"en"}
+    </script>
+    <script id="__LOADABLE_REQUIRED_CHUNKS__"
+            type="application/json"
+    >
+      [0]
+    </script>
+    <script id="__LOADABLE_REQUIRED_CHUNKS___ext"
+            type="application/json"
+    >
+      {"namedChunks":["en-translations"]}
+    </script>
+    <script async
+            data-chunk="main"
+            src="scripts[0]"
+    >
+    </script>
+    <script async
+            data-chunk="main"
+            src="scripts[1]"
+    >
+    </script>
+    <script async
+            data-chunk="main"
+            src="scripts[2]"
+    >
+    </script>
+    <script async
+            data-chunk="en-translations"
+            src="scripts[3]"
+    >
+    </script>
+  </body>
+</html>
+POST HYDRATE DIFFS: NO DIFF
+`;

--- a/test/test-cases/translations/translations.test.js
+++ b/test/test-cases/translations/translations.test.js
@@ -30,4 +30,9 @@ describe('translations', () => {
     const app = await getAppSnapshot(`${baseUrl}/fr`);
     expect(app).toMatchSnapshot();
   });
+
+  it('should support query parameters', async () => {
+    const app = await getAppSnapshot(`${baseUrl}/en?a=1`);
+    expect(app).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
The matcher expects to only recieve the pathname portion of a URL but was being given the entire relative URL