### PR TITLE
Update missing vanilla-extract setup

### DIFF
--- a/.changeset/five-singers-watch.md
+++ b/.changeset/five-singers-watch.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Group `.css.ts` files with styles when ordering imports

--- a/.changeset/weak-tips-begin.md
+++ b/.changeset/weak-tips-begin.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Update minimum playroom version

--- a/config/eslint/importOrderConfig.js
+++ b/config/eslint/importOrderConfig.js
@@ -29,7 +29,7 @@ module.exports = {
         ],
         pathGroups: [
           {
-            pattern: '*.+(treat|less)',
+            pattern: '*.+(treat|less|css)',
             group: 'index',
             position: 'after',
             patternOptions: { matchBase: true },

--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -1,5 +1,33 @@
 # Styling
 
+## vanilla-extract
+
+The `@vanilla-extract/css` package is not available out of the box so it needs to be installed.
+
+```bash
+$ yarn add @vanilla-extract/css
+```
+
+Now you can create `.css.ts` files in your project.
+
+```js
+// BigBox.css.ts
+import { style } from '@vanilla-extract/css';
+
+export const bigBox = style({ width: 500, height: 500 });
+```
+
+```js
+// BigBox.tsx
+import * as styles from './BigBox.css';
+
+export function BigBox() {
+  return <div className={styles.bigBox}>I am a big box</div>;
+}
+```
+
+See [vanilla-extract](https://vanilla-extract.style/documentation/) for full documentation.
+
 ## Locally Scoped CSS
 
 (via [CSS Modules](https://github.com/css-modules/css-modules) and [Less](http://lesscss.org/))
@@ -24,6 +52,8 @@ export default () => <div className={styles.exampleWrapper}>Hello World!</div>;
 ```
 
 ## treat
+
+> Usage of treat is deprecated in favour of vanilla-extract
 
 Note: You must access all treat imports through the sku prefix. e.g. `sku/treat`, `sku/react-treat`;
 

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "node-html-parser": "^2.0.2",
     "open": "^7.3.1",
     "path-to-regexp": "^6.2.0",
-    "playroom": "^0.22.4",
+    "playroom": "^0.25.0",
     "postcss-js": "^3.0.3",
     "postcss-loader": "^3.0.0",
     "prettier": "2.2.1",

--- a/renovate.json
+++ b/renovate.json
@@ -16,11 +16,9 @@
     {
       "groupName": "webpack packages",
       "packagePatterns": [
-        "webpack|(-loader$)|autoprefixer|less|css|svg|treat"
+        "webpack|(-loader$)|autoprefixer|less|css|svg|treat|@vanilla-extract"
       ],
-      "excludePackagePatterns": [
-        "^@loadable\/webpack"
-      ],
+      "excludePackagePatterns": ["^@loadable/webpack"],
       "enabled": true,
       "schedule": ["before 9am on Tuesday"]
     },

--- a/test/test-cases/lint-rules/import-order.test.js
+++ b/test/test-cases/lint-rules/import-order.test.js
@@ -19,6 +19,7 @@ const tests = [
       `import LocalComponent from './LocalComponent';`,
       `import Parent from '../parent';`,
       `import someModule from 'some-module';`,
+      `import vanillaStyles from './vanillaStyles.css';`,
       `import distantParent from '../../../parent';`,
       `import path from 'path';`,
       `import styles from './styles.less';`,
@@ -39,6 +40,7 @@ const tests = [
       `import LocalComponent from './LocalComponent';`, // sibling
       ``,
       `import styles from './styles.less';`, // styles
+      `import vanillaStyles from './vanillaStyles.css';`, // styles
     ],
   ),
   makeTest(

--- a/yarn.lock
+++ b/yarn.lock
@@ -12364,10 +12364,10 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
-playroom@^0.22.4:
-  version "0.22.4"
-  resolved "https://registry.yarnpkg.com/playroom/-/playroom-0.22.4.tgz#59465a91abe160f776f11cd15420587e161163a8"
-  integrity sha512-dlMTu8hVZ5Co+txhPMZci/3jR+i1pD9OBZGsVM7PnuweTKHO3/RvO1ovncbxIWKJG9NnqnhgV0ChP8W8XqqQjw==
+playroom@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/playroom/-/playroom-0.25.0.tgz#0733932ca1b88deae08bb31af426ace20e6b5b40"
+  integrity sha512-cHE9Imc+llsz8qpqIUiuEHuzoRPYsT5o6hDgXvLtlw8dfadtUFNgJmgjxKYliO/l6AOibap0rpFx8JVgZwT4lA==
   dependencies:
     "@babel/cli" "^7.8.3"
     "@babel/core" "^7.8.3"
@@ -12415,6 +12415,7 @@ playroom@^0.22.4:
     mini-css-extract-plugin "^0.9.0"
     open "^7.0.0"
     parse-prop-types "^0.3.0"
+    portfinder "^1.0.26"
     postcss-loader "^3.0.0"
     prettier "^2.0.5"
     prop-types "^15.7.2"


### PR DESCRIPTION
- Document vanilla-extract usage
- Deprecate treat files
- Update renovate config 
- Apply import order config (and add to tests)
- Update minimum playroom version