### PR TITLE
Upgrade to Prettier 2.3

### DIFF
--- a/.changeset/rude-cobras-accept.md
+++ b/.changeset/rude-cobras-accept.md
@@ -1,0 +1,14 @@
+---
+'sku': major
+---
+
+Upgrade to Prettier 2.3
+
+This fixes an issue where `.node_modules/bin/prettier` points to
+`sku#playroom#prettier@2.3` while Sku lints using `prettier@2.2`.
+
+In particular, this confuses the Visual Studio Code Prettier extension
+in to formatting using 2.3 which then fails 2.2's lint.
+
+This will require consumers to run `yarn format` to adopt the new
+Prettier rules.

--- a/.changeset/rude-cobras-accept.md
+++ b/.changeset/rude-cobras-accept.md
@@ -1,5 +1,5 @@
 ---
-'sku': major
+'sku': minor
 ---
 
 Upgrade to Prettier 2.3

--- a/.changeset/rude-cobras-accept.md
+++ b/.changeset/rude-cobras-accept.md
@@ -4,11 +4,4 @@
 
 Upgrade to Prettier 2.3
 
-This fixes an issue where `.node_modules/bin/prettier` points to
-`sku#playroom#prettier@2.3` while Sku lints using `prettier@2.2`.
-
-In particular, this confuses the Visual Studio Code Prettier extension
-in to formatting using 2.3 which then fails 2.2's lint.
-
-This will require consumers to run `yarn format` to adopt the new
-Prettier rules.
+This will require consumers to run `yarn format` to adopt the new Prettier rules. To reduce the mismatch of prettier versions in the future we are unpinning sku's required version, allowing consumers to relock and accept minor and patch updates.

--- a/config/jest/jestConfig.js
+++ b/config/jest/jestConfig.js
@@ -17,9 +17,8 @@ module.exports = {
   ],
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
   moduleNameMapper: {
-    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|svg)$': require.resolve(
-      './fileMock',
-    ),
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|svg)$':
+      require.resolve('./fileMock'),
 
     // Mock seek-style-guide and seek-asia-style-guide components
     // with a proxy object that echoes back the import name as a string,

--- a/config/storybook/start/config.js
+++ b/config/storybook/start/config.js
@@ -2,7 +2,8 @@ import { addParameters } from '@storybook/react';
 import configureStorybook from '../configureStorybook';
 import 'storybook-chromatic';
 
-const provideDefaultChromaticViewports = __SKU_PROVIDE_DEFAULT_CHROMATIC_VIEWPORTS__; // eslint-disable-line no-undef
+const provideDefaultChromaticViewports =
+  __SKU_PROVIDE_DEFAULT_CHROMATIC_VIEWPORTS__; // eslint-disable-line no-undef
 
 if (provideDefaultChromaticViewports) {
   addParameters({

--- a/docs/docs/server-rendering.md
+++ b/docs/docs/server-rendering.md
@@ -85,7 +85,7 @@ export default () => ({
     res.end();
   },
   middleware: middleware,
-  onStart: app => {
+  onStart: (app) => {
     console.log('My app started 👯‍♀️!');
     app.keepAliveTimeout = 20000;
   },

--- a/entry/server/server.js
+++ b/entry/server/server.js
@@ -40,13 +40,8 @@ app.get('*', (...args) => {
     });
   }
 
-  const {
-    SkuProvider,
-    extractor,
-    flushHeadTags,
-    getHeadTags,
-    getBodyTags,
-  } = makeExtractor(webpackStats, publicPath, cspHandler);
+  const { SkuProvider, extractor, flushHeadTags, getHeadTags, getBodyTags } =
+    makeExtractor(webpackStats, publicPath, cspHandler);
   const addLanguageChunk = (language) =>
     extractor.addChunk(getChunkName(language));
 

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "playroom": "^0.25.0",
     "postcss-js": "^3.0.3",
     "postcss-loader": "^3.0.0",
-    "prettier": "2.3.2",
+    "prettier": "^2.3.2",
     "pretty-ms": "^7.0.1",
     "raw-loader": "^4.0.2",
     "react-refresh": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "playroom": "^0.25.0",
     "postcss-js": "^3.0.3",
     "postcss-loader": "^3.0.0",
-    "prettier": "2.2.1",
+    "prettier": "2.3.2",
     "pretty-ms": "^7.0.1",
     "raw-loader": "^4.0.2",
     "react-refresh": "^0.9.0",

--- a/scripts/chromatic.js
+++ b/scripts/chromatic.js
@@ -7,11 +7,8 @@ const skuPath = require.resolve('../bin/sku');
 (async () => {
   // Handle Travis CI setup: http://docs.chromaticqa.com/setup_ci#travis
   if (ci.service === 'travis') {
-    const {
-      TRAVIS_EVENT_TYPE,
-      TRAVIS_PULL_REQUEST_SLUG,
-      TRAVIS_REPO_SLUG,
-    } = process.env;
+    const { TRAVIS_EVENT_TYPE, TRAVIS_PULL_REQUEST_SLUG, TRAVIS_REPO_SLUG } =
+      process.env;
 
     const isInitialPrBuild = TRAVIS_EVENT_TYPE === 'pull_request';
     const isInternalPr = TRAVIS_PULL_REQUEST_SLUG === TRAVIS_REPO_SLUG;

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -144,9 +144,10 @@ const hot = process.env.SKU_HOT !== 'false';
             if (renderError.webpackStats && !isLibrary) {
               const webpackStats = renderError.webpackStats.toJson();
 
-              devServerScripts = webpackStats.entrypoints.devServerOnly.assets.map(
-                (asset) => `<script src="/${asset}"></script>`,
-              );
+              devServerScripts =
+                webpackStats.entrypoints.devServerOnly.assets.map(
+                  (asset) => `<script src="/${asset}"></script>`,
+                );
             }
 
             res.status(500).send(

--- a/yarn.lock
+++ b/yarn.lock
@@ -12941,15 +12941,15 @@ prepend-http@^1.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-prettier@2.3.2, prettier@^2.0.5, prettier@^2.1.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
-  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
-
 prettier@^1.18.2, prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.0.5, prettier@^2.1.2, prettier@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 pretty-error@^2.1.1:
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2659,9 +2659,9 @@
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/prettier@^2.0.0":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.6.tgz#f4b1efa784e8db479cdb8b14403e2144b1e9ff03"
-  integrity sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.0.tgz#2e8332cc7363f887d32ec5496b207d26ba8052bb"
+  integrity sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==
 
 "@types/prop-types@*":
   version "15.7.3"
@@ -12941,7 +12941,7 @@ prepend-http@^1.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-prettier@2.3.2:
+prettier@2.3.2, prettier@^2.0.5, prettier@^2.1.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
   integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
@@ -12950,11 +12950,6 @@ prettier@^1.18.2, prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
-
-prettier@^2.0.5, prettier@^2.1.2:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 pretty-error@^2.1.1:
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12941,15 +12941,20 @@ prepend-http@^1.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-prettier@2.2.1, prettier@^2.0.5, prettier@^2.1.2:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 prettier@^1.18.2, prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.0.5, prettier@^2.1.2:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 pretty-error@^2.1.1:
   version "2.1.2"


### PR DESCRIPTION
This fixes an issue where `.node_modules/bin/prettier` points to `sku#playroom#prettier@2.3` while Sku lints using `prettier@2.2`.

In particular, this confuses the Visual Studio Code Prettier extension in to formatting using 2.3 which then fails 2.2's lint.

This will require consumers to run `yarn format` to adopt the new Prettier rules.
