### PR TITLE
docs: Fix link to v11 release notes

### DIFF
--- a/docs/migration-guides/v11.0.0.md
+++ b/docs/migration-guides/v11.0.0.md
@@ -1,3 +1,3 @@
 # v11.0.0 Migration guide
 
-[All release notes and migration guides now live in github releases](https://github.com/seek-oss/sku/releases/tag/sku%4011.0.0).
+[All release notes and migration guides now live in github releases](https://github.com/seek-oss/sku/releases/tag/v11.0.0).


### PR DESCRIPTION
Tag syntax is different from the v10 release. point migration guide link to v11.0.0 tag