### PR TITLE
fix(svg): Correct exclusion of `removeViewBox` plugin

### DIFF
--- a/.changeset/many-bottles-allow.md
+++ b/.changeset/many-bottles-allow.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Correct exclusion of `removeViewBox` svgo plugin

--- a/config/webpack/utils/loaders.js
+++ b/config/webpack/utils/loaders.js
@@ -143,8 +143,10 @@ const makeSvgLoaders = () => [
       plugins: [
         {
           name: 'preset-default',
-          overrides: {
-            removeViewBox: false,
+          params: {
+            overrides: {
+              removeViewBox: false,
+            },
           },
         },
         {


### PR DESCRIPTION
### Change

`params` section was missed which resulted in `removeViewBox` plugin not being excluded. Because of that `viewBox` was removed from some svgs and they were not displayed correctly.

Please see: https://github.com/svg/svgo#configuration

