### PR TITLE
docs: Fix languages type in config docs

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -201,7 +201,7 @@ The browser URL to open when running `sku start` or `sku start-ssr`. It will def
 
 ## languages
 
-type `Array<string>`
+type `Array<string | {name: string}>`
 
 The languages your application supports.
 


### PR DESCRIPTION
Config doc has incorrect type for the `languages` field

Valid config is shown here:
https://github.com/seek-oss/sku/blob/c303ec3705eccbb68c70d5add2d15a1667cf6079/context/configSchema.js#L8-L14

It's also valid to pass `{ name: 'en' }` as an option in `languages`