### PR TITLE
Restrict TypeScript version

### DIFF
--- a/.changeset/nervous-ducks-breathe.md
+++ b/.changeset/nervous-ducks-breathe.md
@@ -4,6 +4,7 @@
 
 Prevents typescript from being upgraded to 4.5.x
 
-Typescript 4.5 has caused a lot of issues with packages included with sku (braid, vanilla-extract) that are caused by a regression that's been introduced in the type checker. It seems to be fixed in 4.6.0-dev, but that won't be available until late February.
+Typescript 4.5 has caused a lot of issues with packages included with sku (braid, vanilla-extract) that are caused by a regression that's been introduced in the type checker.
+It seems to be fixed in 4.6.0-dev, but that won't be available until late February.
 
 To prevent things blowing up in the meantime, the version of typescript has been update to keep it below 4.5, at least until a patch is released in 4.5

--- a/.changeset/nervous-ducks-breathe.md
+++ b/.changeset/nervous-ducks-breathe.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Prevents typescript from being upgraded to 4.5.x

--- a/.changeset/nervous-ducks-breathe.md
+++ b/.changeset/nervous-ducks-breathe.md
@@ -3,3 +3,7 @@
 ---
 
 Prevents typescript from being upgraded to 4.5.x
+
+Typescript 4.5 has caused a lot of issues with packages included with sku (braid, vanilla-extract) that are caused by a regression that's been introduced in the type checker. It seems to be fixed in 4.6.0-dev, but that won't be available until late February.
+
+To prevent things blowing up in the meantime, the version of typescript has been update to keep it below 4.5, at least until a patch is released in 4.5

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "traverse": "^0.6.6",
     "treat": "^2.0.4",
     "tree-kill": "^1.2.1",
-    "typescript": "^4.1.3",
+    "typescript": ">=4.1.3 <4.5.0",
     "validate-npm-package-name": "^3.0.0",
     "webpack": "^5.47.1",
     "webpack-bundle-analyzer": "^4.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16686,10 +16686,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+"typescript@>=4.1.3 <4.5.0":
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Typescript 4.5 has caused a lot of issues with packages included with sku (braid, vanilla-extract) that are caused by a regression that's been introduced in the type checker. It seems to be fixed in 4.6.0-dev, but that won't be available until late February.

To prevent things blowing up in the meantime, the version of typescript has been update to keep it below 4.5, at least until a patch is released in 4.5