### PR TITLE
Upgrade `@vocab/core` to `^1.0.4`

### DIFF
--- a/.changeset/gorgeous-dodos-speak.md
+++ b/.changeset/gorgeous-dodos-speak.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Upgrade `@vocab/core` to `^1.0.4`

--- a/.changeset/gorgeous-dodos-speak.md
+++ b/.changeset/gorgeous-dodos-speak.md
@@ -2,4 +2,4 @@
 'sku': patch
 ---
 
-Upgrade `@vocab/core` to `^1.0.4`
+Force upgrade `@vocab/core` to `^1.0.4` to fix a language hierarchy bug that can result in incorrect translation messages being used for a language.

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@types/loadable__component": "^5.13.1",
     "@vanilla-extract/babel-plugin": "^1.0.0",
     "@vanilla-extract/webpack-plugin": "^2.0.0",
-    "@vocab/core": "^1.0.1",
+    "@vocab/core": "^1.0.4",
     "@vocab/phrase": "^1.0.0",
     "@vocab/webpack": "^1.0.0",
     "autoprefixer": "^10.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1801,12 +1801,51 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@formatjs/ecma402-abstract@1.11.4":
+  version "1.11.4"
+  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz#b962dfc4ae84361f9f08fbce411b4e4340930eda"
+  integrity sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==
+  dependencies:
+    "@formatjs/intl-localematcher" "0.2.25"
+    tslib "^2.1.0"
+
 "@formatjs/ecma402-abstract@1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.5.1.tgz#629324d2bfdc570ed210fec7700ce20bbd872bed"
   integrity sha512-io9XhgIpEbc6jSdn4QVnJeFaUzy6gS5fGiIRCUJ7QKqCNp69JS8EJPW8gCtvwz+JQtx2SJvhaMJbzz3rGkTXBA==
   dependencies:
     tslib "^2.0.1"
+
+"@formatjs/fast-memoize@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz#e6f5aee2e4fd0ca5edba6eba7668e2d855e0fc21"
+  integrity sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==
+  dependencies:
+    tslib "^2.1.0"
+
+"@formatjs/icu-messageformat-parser@2.0.19", "@formatjs/icu-messageformat-parser@^2.0.10":
+  version "2.0.19"
+  resolved "https://registry.yarnpkg.com/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.19.tgz#3a9ae986b9e42b6a833aceab010ee88e36020d26"
+  integrity sha512-8HsLm9YLyVVIDMyBJb7wmve2wGd461cUwJ470eUog5YH5ZsF4p5lgvaJ+oGKxz1mrSMNNdDHU9v/NDsS+z+ilg==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.11.4"
+    "@formatjs/icu-skeleton-parser" "1.3.6"
+    tslib "^2.1.0"
+
+"@formatjs/icu-skeleton-parser@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.6.tgz#4ce8c0737d6f07b735288177049e97acbf2e8964"
+  integrity sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.11.4"
+    tslib "^2.1.0"
+
+"@formatjs/intl-localematcher@0.2.25":
+  version "0.2.25"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-localematcher/-/intl-localematcher-0.2.25.tgz#60892fe1b271ec35ba07a2eb018a2dd7bca6ea3a"
+  integrity sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==
+  dependencies:
+    tslib "^2.1.0"
 
 "@hapi/address@^4.0.1":
   version "4.1.0"
@@ -3920,20 +3959,20 @@
     intl-messageformat-parser "^6.0.16"
     prettier "^2.1.2"
 
-"@vocab/core@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@vocab/core/-/core-1.0.1.tgz#2b6d645012c038213cabf5a371a817f13130f04d"
-  integrity sha512-o+Vq8PX5PBD4Q+uqgRFfq95DR3fsl69MialFgzqV40sOMqIr7f8JXB+zKn0ECpL3aJCTyosVxrkif5urvm0ODg==
+"@vocab/core@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@vocab/core/-/core-1.0.4.tgz#d1562ad387d82db810a29ea13e61f5b62f2f0ddc"
+  integrity sha512-LwKv4pzHl8rdF2lV6sxNChZ98uV0WsAkp4EhmMWcofFPPYFup+wdmhhZ/RsRc1EGwMtuUHNasQCBiO5o0OP+aA==
   dependencies:
-    "@vocab/types" "^1.0.0"
+    "@formatjs/icu-messageformat-parser" "^2.0.10"
+    "@vocab/types" "^1.0.1"
     chalk "^4.1.0"
     chokidar "^3.4.3"
     debug "^4.3.1"
     fast-glob "^3.2.4"
     fastest-validator "^1.9.0"
     find-up "^5.0.0"
-    intl-messageformat "^9.3.18"
-    intl-messageformat-parser "^6.0.16"
+    intl-messageformat "^9.9.0"
     prettier "^2.1.2"
 
 "@vocab/phrase@^1.0.0":
@@ -3962,6 +4001,13 @@
   integrity sha512-ag1KXsI5kLWuDe1wMhjUpcffBPsb3v9OE88f+6vJIo7gNU7B1uDNHBvZQ3IaZSGtIWpAvFMRJXTxaYq+lehXqA==
   dependencies:
     intl-messageformat "^9.3.18"
+
+"@vocab/types@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@vocab/types/-/types-1.0.1.tgz#501874c1d0917d75443138abfcd630b2dc06836b"
+  integrity sha512-oqcosddvBKf4FF9DKebqMV6iRworemwOcPgEHymJU22CLdeBHRp4yE9eGZ3rbkfCBa4VzN5VHT3oOkPYYM2R3Q==
+  dependencies:
+    intl-messageformat "^9.9.0"
 
 "@vocab/webpack@^1.0.0":
   version "1.0.0"
@@ -9912,6 +9958,16 @@ intl-messageformat@^9.3.18:
     fast-memoize "^2.5.2"
     intl-messageformat-parser "6.1.3"
     tslib "^2.0.1"
+
+intl-messageformat@^9.9.0:
+  version "9.12.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-9.12.0.tgz#b69d042fa7db229e799eaf3afb09f8ceadd306e7"
+  integrity sha512-5Q9j21JreB1G27/CqMYsA+pvJ19JjHyhiTSeUuvZK9BCDJGHtOLgpUUcGM+GLHiUuoVMKVeeX1smamiVHQrSKQ==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.11.4"
+    "@formatjs/fast-memoize" "1.2.1"
+    "@formatjs/icu-messageformat-parser" "2.0.19"
+    tslib "^2.1.0"
 
 invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
@@ -16592,6 +16648,11 @@ tslib@^2.0.1, tslib@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tslib@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.17.1:
   version "3.19.1"


### PR DESCRIPTION
[`@vocab/core` 1.0.4](https://github.com/seek-oss/vocab/releases/tag/%40vocab%2Fcore%401.0.4) fixed a language hierarchy bug that could cause issues for consumers depending on their sku `languages` config.