### PR TITLE
Add missing `extends` key to the docs for the `languages` config type

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -201,7 +201,7 @@ The browser URL to open when running `sku start` or `sku start-ssr`. It will def
 
 ## languages
 
-type `Array<string | { name: string }>`
+type `Array<string | { name: string, extends: string }>`
 
 The languages your application supports.
 


### PR DESCRIPTION
Was missing the `extends` key. It's optional, but followed the convention of the docs which appears to be not indicating optionality in the type.