### PR TITLE
Fix weird markdown rendering thing with `$`

### DIFF
--- a/.changeset/breezy-wolves-joke.md
+++ b/.changeset/breezy-wolves-joke.md
@@ -4,7 +4,7 @@
 
 Allow `:` to be used in dynamic paths again.
 
-Previously, dynamic paths were declared using the standard `:param` syntax, but this had been deprecated in favour of `$`.
+Previously, dynamic paths were declared using the standard `:param` syntax, but this had been deprecated in favour of `$param`.
 
 This has now been updated to allow for both.
 This should allow `sku serve` to work for projects using colon syntax.


### PR DESCRIPTION
For whatever reason, inside the changelog generated by changesets, `$` becomes `# sku