### PR TITLE
Add `delete-unused-keys` flag to `translations push` command

### DIFF
--- a/.changeset/polite-pigs-sing.md
+++ b/.changeset/polite-pigs-sing.md
@@ -1,0 +1,11 @@
+---
+'sku': minor
+---
+
+Add an optional `delete-unused-keys` flag to the `translations push` command. If set to `true`, unused keys will be deleted from Phrase after translations are pushed.
+
+**EXAMPLE USAGE**:
+
+```bash
+sku translations push --delete-unused-keys
+```

--- a/.changeset/polite-pigs-sing.md
+++ b/.changeset/polite-pigs-sing.md
@@ -2,9 +2,9 @@
 'sku': minor
 ---
 
-Add an optional `delete-unused-keys` flag to the `translations push` command. If set to `true`, unused keys will be deleted from Phrase after translations are pushed.
+Add optional `delete-unused-keys` flag to the `translations push` command
 
-**EXAMPLE USAGE**:
+If this flag is set, unused keys will be deleted from Phrase after translations are pushed.
 
 ```bash
 sku translations push --delete-unused-keys

--- a/.changeset/witty-dancers-wave.md
+++ b/.changeset/witty-dancers-wave.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Display a better error message when no `sku translations` command is provided

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@vanilla-extract/babel-plugin": "^1.0.0",
     "@vanilla-extract/webpack-plugin": "^2.0.0",
     "@vocab/core": "^1.1.0",
-    "@vocab/phrase": "^1.0.0",
+    "@vocab/phrase": "^1.1.0",
     "@vocab/pseudo-localize": "^1.0.0",
     "@vocab/webpack": "^1.1.0",
     "autoprefixer": "^10.3.1",

--- a/scripts/translations.js
+++ b/scripts/translations.js
@@ -7,9 +7,17 @@ const { compile, validate } = require('@vocab/core');
 const { push, pull } = require('@vocab/phrase');
 const { getVocabConfig } = require('../config/vocab/vocab');
 
-const vocabCommands = args.length > 0 ? args : undefined;
+const translationSubCommands = ['compile', 'push', 'pull', 'validate'];
 
-const subCommands = ['compile', 'push', 'pull', 'validate'];
+const commandArguments = args.length > 0 ? args : undefined;
+
+if (!commandArguments) {
+  throw new Error(
+    `No translations command provided. Available commands are: ${translationSubCommands.join(
+      ', ',
+    )}.`,
+  );
+}
 
 const ensureBranch = () => {
   if (!branch) {
@@ -21,7 +29,7 @@ const ensureBranch = () => {
 };
 
 (async () => {
-  const translationSubCommand = vocabCommands[0];
+  const translationSubCommand = commandArguments[0];
 
   console.log(chalk.cyan('Translations', translationSubCommand));
 
@@ -33,9 +41,9 @@ const ensureBranch = () => {
     );
   }
 
-  if (!subCommands.includes(translationSubCommand)) {
+  if (!translationSubCommands.includes(translationSubCommand)) {
     throw new Error(
-      `Unknown command ${translationSubCommand}. Available options are ${subCommands.join(
+      `Unknown command ${translationSubCommand}. Available options are ${translationSubCommands.join(
         ', ',
       )}`,
     );
@@ -49,8 +57,12 @@ const ensureBranch = () => {
       validate(vocabConfig);
     }
     if (translationSubCommand === 'push') {
+      const deleteUnusedKeys = commandArguments.includes(
+        '--delete-unused-keys',
+      );
+
       ensureBranch();
-      push({ branch }, vocabConfig);
+      push({ branch, deleteUnusedKeys }, vocabConfig);
     }
     if (translationSubCommand === 'pull') {
       ensureBranch();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3975,10 +3975,10 @@
     intl-messageformat "^9.9.0"
     prettier "^2.1.2"
 
-"@vocab/phrase@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@vocab/phrase/-/phrase-1.0.0.tgz#856d55ce892ebe0c0a4b17cb906ac870ae920055"
-  integrity sha512-a1+bb9X0eeLiQ4xkM+VT7nM72qpFXTBZ/yYm3DdIuW6V9p7epzIF/FOyfonrJmQrwDLzSW6LTaaRLoKRNFnTjg==
+"@vocab/phrase@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@vocab/phrase/-/phrase-1.1.0.tgz#8814440506dd5ba40f864025ac3d469c48b440eb"
+  integrity sha512-CMLrFC9yHKaniIH7cQ6w1ouKJ5Iln1ZLyYcm3JyB2JXJxRn2jSz25kXU8rPWGCpFYCpcf7sCgY9OYAD1YQ7OAg==
   dependencies:
     "@vocab/core" "^1.0.0"
     "@vocab/types" "^1.0.0"


### PR DESCRIPTION
- Expose the feature added in https://github.com/seek-oss/vocab/pull/93 via `sku translations push --delete-unused-keys`.
- Handle the case where no sub-command is passed to `sku translations` by throwing an error with a message containing all available commands

The CLI arg parsing is kinda janky for `sku translations`. If it gets any more complicated it might be worth using yargs or something.