### PR TITLE
Fix transpilation of typescript-specific class keywords

### DIFF
--- a/.changeset/tiny-walls-wink.md
+++ b/.changeset/tiny-walls-wink.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fix transpilation of typescript-specific class keywords

--- a/config/babel/babelConfig.js
+++ b/config/babel/babelConfig.js
@@ -58,6 +58,13 @@ module.exports = ({
   }
 
   const presets = [
+    [
+      require.resolve('@babel/preset-env'),
+      {
+        targets: browserslist,
+        shippedProposals: true,
+      },
+    ],
     lang === 'ts'
       ? [
           require.resolve('@babel/preset-typescript'),
@@ -67,13 +74,6 @@ module.exports = ({
           },
         ]
       : null,
-    [
-      require.resolve('@babel/preset-env'),
-      {
-        targets: browserslist,
-        shippedProposals: true,
-      },
-    ],
     [
       require.resolve('@babel/preset-react'),
       {

--- a/test/test-cases/typescript-css-modules/__snapshots__/typescript-css-modules.test.js.snap
+++ b/test/test-cases/typescript-css-modules/__snapshots__/typescript-css-modules.test.js.snap
@@ -343,7 +343,7 @@ export default cssExports;
 exports[`typescript-css-modules start should start a development server 1`] = `
 SCRIPTS: [
   "/runtime.js",
-  "/vendors-node_modules_loadable_component_dist_loadable_esm_js-node_modules_pmmmwh_react-refres-5eef63.js",
+  "/vendors-node_modules_loadable_component_dist_loadable_esm_js-node_modules_pmmmwh_react-refres-bd1afe.js",
   "/main.js",
 ]
 CSS: [

--- a/test/test-cases/typescript-css-modules/app/src/App.tsx
+++ b/test/test-cases/typescript-css-modules/app/src/App.tsx
@@ -13,6 +13,12 @@ interface Props {
   children?: ReactNode;
 }
 
+// This is a test for ensuring typescript-specific keywords are stripped out
+// by babel during transpilation, in this case the `protected` keyword
+export class MyClass {
+  constructor(protected foo: number) {}
+}
+
 const App = ({ children }: Props) => {
   const [renderLabel, setRenderLabel] = useState('Initial');
 


### PR DESCRIPTION
Something in `@babel/babel-plugin-transform-typescript@7.18.0` broke transpilation of typescript-specific class keywords. Users could run into this issue when updating to `sku@11.6.0` because the version range of `@babel/babel-plugin-transform-typescript` was updated.

Something like:
```ts
export class MyClass {
  constructor(protected foo: number) {}
}
```

is being transpiled to:
```js
var MyClass = /*#__PURE__*/_createClass(function MyClass(protected foo) {
//                               not valid javascript -> ^^^^^^^^^
  _classCallCheck(this, MyClass);
});
```
`protected` is a typescript-specific keyword, so this is invalid code.

I'm unsure as to why this has suddenly become an issue in that version of the babel plugin, but it turns out that [babel presets are executed in reverse](https://babeljs.io/docs/en/presets#preset-ordering), and we had `preset-typescript` before `preset-env` in the `presets` array, meaning `preset-tyepscript` was executing _after_ `preset-env`, but `preset-env` doesn't understand the `protected` keyword (because it's typescript), so 💥 .

This PR fixes the ordering of presets so `preset-typescript` executes before `preset-env`, and adds a test class in one of the test cases with a typescript file because there isn't really a good place to put it (suggestions welcome) and I didn't want to make the test run any longer than it already is.