### PR TITLE
Proof of concept: support storybook middleware

### DIFF
--- a/config/storybook/start/middleware.js
+++ b/config/storybook/start/middleware.js
@@ -1,0 +1,3 @@
+const { paths } = require('../../../context');
+
+module.exports = require(paths.devServerMiddleware);

--- a/test/test-cases/storybook-dev-middleware/__snapshots__/storybook-dev-middleware.test.js.snap
+++ b/test/test-cases/storybook-dev-middleware/__snapshots__/storybook-dev-middleware.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`storybook-dev-middleware storybook should support the supplied middleware 1`] = `
+"OK"
+POST HYDRATE DIFFS: 
+-OK
+\\ No newline at end of file
++<html>
++  <head>
++  </head>
++  <body>
++    OK
++  </body>
++</html>
+\\ No newline at end of file
+
+`;

--- a/test/test-cases/storybook-dev-middleware/app/.eslintignore
+++ b/test/test-cases/storybook-dev-middleware/app/.eslintignore
@@ -1,0 +1,7 @@
+# managed by sku
+*.less.d.ts
+coverage/
+dist-storybook/
+dist/
+report/
+# end managed by sku

--- a/test/test-cases/storybook-dev-middleware/app/.gitignore
+++ b/test/test-cases/storybook-dev-middleware/app/.gitignore
@@ -1,0 +1,9 @@
+# managed by sku
+.eslintrc
+.prettierrc
+coverage/
+dist-storybook/
+dist/
+report/
+tsconfig.json
+# end managed by sku

--- a/test/test-cases/storybook-dev-middleware/app/.prettierignore
+++ b/test/test-cases/storybook-dev-middleware/app/.prettierignore
@@ -1,0 +1,7 @@
+# managed by sku
+*.less.d.ts
+coverage/
+dist-storybook/
+dist/
+report/
+# end managed by sku

--- a/test/test-cases/storybook-dev-middleware/app/dev-middleware.js
+++ b/test/test-cases/storybook-dev-middleware/app/dev-middleware.js
@@ -1,0 +1,5 @@
+module.exports = (app) => {
+  app.get('/test-middleware', (_, res) => {
+    res.status(200).send('OK');
+  });
+};

--- a/test/test-cases/storybook-dev-middleware/app/sku.config.js
+++ b/test/test-cases/storybook-dev-middleware/app/sku.config.js
@@ -1,0 +1,12 @@
+const ListExternalsWebpackPlugin = require('../../../utils/ListExternalsWebpackPlugin');
+
+module.exports = {
+  devServerMiddleware: './dev-middleware.js',
+  dangerouslySetWebpackConfig: (config) => {
+    if (config.name === 'render') {
+      config.plugins.push(new ListExternalsWebpackPlugin());
+    }
+
+    return config;
+  },
+};

--- a/test/test-cases/storybook-dev-middleware/app/src/App.js
+++ b/test/test-cases/storybook-dev-middleware/app/src/App.js
@@ -1,0 +1,2 @@
+import React from 'react';
+export default () => <div>Hello custom src paths</div>;

--- a/test/test-cases/storybook-dev-middleware/app/src/client.js
+++ b/test/test-cases/storybook-dev-middleware/app/src/client.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { hydrate } from 'react-dom';
+import App from './App';
+
+export default () => {
+  hydrate(<App />, document.getElementById('app'));
+};

--- a/test/test-cases/storybook-dev-middleware/app/src/render.js
+++ b/test/test-cases/storybook-dev-middleware/app/src/render.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import dedent from 'dedent';
+import App from './App';
+
+export default {
+  renderApp: ({ SkuProvider }) =>
+    renderToString(
+      <SkuProvider>
+        <App />
+      </SkuProvider>,
+    ),
+
+  renderDocument: ({ app, bodyTags, headTags }) => dedent`
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="UTF-8">
+        <title>hello-world</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        ${headTags}
+      </head>
+      <body>
+        <div id="app">${app}</div>
+        ${bodyTags}
+      </body>
+    </html>
+  `,
+};

--- a/test/test-cases/storybook-dev-middleware/storybook-dev-middleware.test.js
+++ b/test/test-cases/storybook-dev-middleware/storybook-dev-middleware.test.js
@@ -1,0 +1,50 @@
+const path = require('path');
+const { promisify } = require('util');
+const rimrafAsync = promisify(require('rimraf'));
+const fs = require('fs-extra');
+const runSkuScriptInDir = require('../../utils/runSkuScriptInDir');
+const { getAppSnapshot } = require('../../utils/appSnapshot');
+const waitForUrls = require('../../utils/waitForUrls');
+const { getPathFromCwd } = require('../../../lib/cwd');
+const appDir = path.resolve(__dirname, 'app');
+
+async function createPackageLink(name) {
+  await fs.mkdirp(`${__dirname}/app/node_modules`);
+  await fs.symlink(
+    getPathFromCwd(`node_modules/${name}`),
+    `${__dirname}/app/node_modules/${name}`,
+  );
+}
+
+async function setUpLocalDependencies() {
+  const nodeModules = `${__dirname}/app/node_modules`;
+  await rimrafAsync(nodeModules);
+  await Promise.all(['react', 'react-dom'].map(createPackageLink));
+}
+
+describe('storybook-dev-middleware', () => {
+  beforeAll(async () => {
+    // "Install" React and braid-design-system into this test app so that webpack-node-externals
+    // treats them correctly.
+    await setUpLocalDependencies();
+  });
+
+  describe('storybook', () => {
+    const storybookUrl = `http://localhost:8081`;
+    let process;
+
+    beforeAll(async () => {
+      process = await runSkuScriptInDir('storybook', appDir);
+      await waitForUrls(storybookUrl, `${storybookUrl}/test-middleware`);
+    });
+
+    afterAll(async () => {
+      await process.kill();
+    });
+
+    it('should support the supplied middleware', async () => {
+      const snapshot = await getAppSnapshot(`${storybookUrl}/test-middleware`);
+      expect(snapshot).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
The problem: I need a api endpoint to generate auth tokens for local development. With sku I can simply use dev server middleware however this isn't possible when running storybook.

Storybook actually [supports a router middleware](https://github.com/storybookjs/storybook/pull/435) since 2016 however it isn't currently documented as per https://github.com/storybookjs/storybook/issues/15300#issuecomment-866469521 so it 
might be debatable whether we want to support it in sku.

There is probably a larger discussion to be had around a better implementation for storybook as configuring storybook through `.storybook/*` directory isn't supported in sku projects - talked to @askoufis [here](https://seekchat.slack.com/archives/CDL5VP5NU/p1674088704705369?thread_ts=1674064947.112759&cid=CDL5VP5NU)

Todo
- [ ] fix broken tests
- [ ] check if this is something we should actually support
- [ ] make sure it won't break existing storybook projects