### PR TITLE
Use `v1` release of changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@c2918239208f2162b9d27a87f491375c51592434
+        uses: changesets/action@v1
         with:
           publish: yarn release
         env:


### PR DESCRIPTION
This should address [a few warnings](https://github.com/seek-oss/sku/actions/runs/4190219946), but also I'm hoping it will fix/help debug the docs site deployment issue.