### PR TITLE
Fix root resolution within `.css.ts` files during tests

### DIFF
--- a/.changeset/proud-tips-build.md
+++ b/.changeset/proud-tips-build.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fix a bug that broke root resolution within `.css.ts` files during tests

--- a/config/jest/jestConfig.js
+++ b/config/jest/jestConfig.js
@@ -1,5 +1,6 @@
 const escapeRegex = require('escape-string-regexp');
-const { paths } = require('../../context');
+const { cwd } = require('../../lib/cwd');
+const { paths, rootResolution } = require('../../context');
 const slash = '[/\\\\]'; // Cross-platform path delimiter regex
 const compilePackagesRegex = paths.compilePackages
   .map((pkg) => `.*${escapeRegex(pkg)}`)
@@ -10,6 +11,7 @@ module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: paths.setupTests,
   prettierPath: require.resolve('prettier'),
+  modulePaths: rootResolution ? [cwd()] : undefined,
   testMatch: [
     // Default values, but with 'ts' + 'tsx' support
     // (https://jestjs.io/docs/en/configuration.html#testmatch-array-string)

--- a/test/test-cases/braid-design-system/__snapshots__/braid-design-system.test.js.snap
+++ b/test/test-cases/braid-design-system/__snapshots__/braid-design-system.test.js.snap
@@ -19,7 +19,7 @@ exports[`braid-design-system build should generate the expected files 1`] = `
         <meta charset="UTF-8">
         <title>My Awesome Project</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link data-chunk="main" rel="stylesheet" href="/main-7d22a3a78ab90e444f0e.css">
+        <link data-chunk="main" rel="stylesheet" href="/main-2be00ff2ba3bd35e23b8.css">
 <link data-chunk="main" rel="preload" as="script" href="/runtime-6ddc02ee59b341569712.js">
 <link data-chunk="main" rel="preload" as="script" href="/main-fc74cddff511d1ee5234.js">
         <script>
@@ -38,7 +38,7 @@ exports[`braid-design-system build should generate the expected files 1`] = `
       </body>
     </html>
   ",
-  "main-7d22a3a78ab90e444f0e.css": ._54r4c40 {
+  "main-2be00ff2ba3bd35e23b8.css": ._54r4c40 {
   -webkit-tap-highlight-color: transparent;
   border: 0;
   box-sizing: border-box;
@@ -1963,7 +1963,8 @@ html:not(.snqh4ez) .snqh4e4o {
     0 20px 20px -12px rgba(28, 35, 48, 0.2);
 }
 ._1akvwaz0 {
-  background-color: #8a2be2;
+  --_1d4bx8l0: #8a2be2;
+  background-color: var(--_1d4bx8l0);
   color: #fff;
   font-size: 20px;
   padding: 100px;
@@ -2961,7 +2962,7 @@ html.snqh4ez .x2z54wf {
         <meta charset="UTF-8">
         <title>My Awesome Project</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link data-chunk="main" rel="stylesheet" href="/main-7d22a3a78ab90e444f0e.css">
+        <link data-chunk="main" rel="stylesheet" href="/main-2be00ff2ba3bd35e23b8.css">
 <link data-chunk="main" rel="preload" as="script" href="/runtime-6ddc02ee59b341569712.js">
 <link data-chunk="main" rel="preload" as="script" href="/main-fc74cddff511d1ee5234.js">
         <script>
@@ -2989,7 +2990,7 @@ SCRIPTS: [
   "/main-fc74cddff511d1ee5234.js",
 ]
 CSS: [
-  "/main-7d22a3a78ab90e444f0e.css",
+  "/main-2be00ff2ba3bd35e23b8.css",
 ]
 SOURCE HTML: <!DOCTYPE html>
 <html>
@@ -3207,7 +3208,7 @@ SCRIPTS: [
   "/main-fc74cddff511d1ee5234.js",
 ]
 CSS: [
-  "/main-7d22a3a78ab90e444f0e.css",
+  "/main-2be00ff2ba3bd35e23b8.css",
 ]
 SOURCE HTML: <!DOCTYPE html>
 <html>

--- a/test/test-cases/braid-design-system/app/src/App.css.ts
+++ b/test/test-cases/braid-design-system/app/src/App.css.ts
@@ -1,7 +1,11 @@
 import { style } from '@vanilla-extract/css';
+import { backgroundColor } from 'src/vars.css';
 
 export const vanillaBox = style({
-  backgroundColor: 'blueviolet',
+  vars: {
+    [backgroundColor]: 'blueviolet',
+  },
+  backgroundColor,
   color: 'white',
   fontSize: 20,
   padding: 100,

--- a/test/test-cases/braid-design-system/app/src/App.test.tsx
+++ b/test/test-cases/braid-design-system/app/src/App.test.tsx
@@ -2,20 +2,21 @@ import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { Box } from 'braid-design-system';
 import { BraidTestProvider } from 'braid-design-system/test';
+import { vanillaBox } from './App.css';
 
 describe('braid-design-system', () => {
   test('components', () => {
     expect(
       renderToString(
         <BraidTestProvider themeName="apac">
-          <Box paddingTop="large" />
+          <Box paddingTop="large" className={vanillaBox} />
         </BraidTestProvider>,
       ),
     ).toMatchInlineSnapshot(`
       "<style type="text/css">
                   html,body{margin:0;padding:0;background:#F7F8FB}
                   html.sprinkles_darkMode__snqh4ez,html.sprinkles_darkMode__snqh4ez body{color-scheme:dark;background:#0E131B}
-                </style><div class="apacTheme_default__fkgxba0 typography_lightModeTone_light__1wxfcta18 typography_darkModeTone_dark__1wxfcta1b"><div class="reset_base__54r4c40 sprinkles_paddingTop_large_mobile__snqh4e6q"></div></div>"
+                </style><div class="apacTheme_default__fkgxba0 typography_lightModeTone_light__1wxfcta18 typography_darkModeTone_dark__1wxfcta1b"><div class="reset_base__54r4c40 sprinkles_paddingTop_large_mobile__snqh4e6q App_vanillaBox__1akvwaz0"></div></div>"
     `);
   });
 });

--- a/test/test-cases/braid-design-system/app/src/vars.css.ts
+++ b/test/test-cases/braid-design-system/app/src/vars.css.ts
@@ -1,0 +1,3 @@
+import { createVar } from '@vanilla-extract/css';
+
+export const backgroundColor = createVar();


### PR DESCRIPTION
Replacing the [VE babel plugin](https://github.com/seek-oss/sku/pull/738/files#diff-10b70ee3d83bd30c0159313993c58ca5a8595009c84491159ac8f9aa589a4a44L27) with the [VE jest transform](https://github.com/seek-oss/sku/pull/738/files#diff-cd013def59a6ab8f5f61b6f4af62a0ae3a6986fce54db6bdcca140108109002cR37-R38) resulted in `.css.ts` files no longer going through our babel transformation stack during jest tests. This ended up breaking root resolution (importing from `src/*`) within `.css.ts` files during tests.

Luckily, jest has a config value just for this: [`modulePaths`](https://jestjs.io/docs/configuration#modulepaths-arraystring). Setting this to the result of `cwd` when `rootResolution` is true (like we do in [the babel transform stack](https://github.com/seek-oss/sku/blob/f1c41a126ee1a131a8cbdf6ce2cf0eac82fd370a/config/babel/babelConfig.js#L20)) fixes the issue.