### PR TITLE
renovate: Disable major version updates for ESM-only packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -79,6 +79,23 @@
       "packagePatterns": ["^(braid-design-system|(seek(-asia)?-style-guide))$"],
       "enabled": true,
       "schedule": ["before 8am on the first day of the month"]
+    },
+    {
+      "groupName": "ESM-only packages",
+      "matchUpdateTypes": "major",
+      "matchPackageNames": [
+        "chalk",
+        "env-ci",
+        "escape-string-regexp",
+        "find-up",
+        "get-port",
+        "indent-string",
+        "inquirer",
+        "open",
+        "pretty-ms",
+        "wrap-ansi"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Specifically trying to address [this renovate PR](https://github.com/seek-oss/sku/pull/721) which primarily consists of ESM-only packages that we can't consume. Disabling major version updates for all these packages allows us to still get patches/minors.