### PR TITLE
Add default `public-hoist-pattern` config values.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,7 @@
+# Make sure the default patterns are still included (https://pnpm.io/npmrc#public-hoist-pattern)
+public-hoist-pattern[]="*eslint*"
+public-hoist-pattern[]="*prettier*"
+
 # `treat` needs this to be hoisted
 public-hoist-pattern[]="virtual-resource-loader"
 


### PR DESCRIPTION
The [default values](https://pnpm.io/npmrc#public-hoist-pattern) for the `public-hoist-pattern` config item in `.npmrc` are not preserved when adding new values, so this change just ensures that they are still included.  This is required for ESLint to function correctly in some contexts, most notably in IntelliJ/WebStorm.
