### PR TITLE
test: Use explicit ipv4 address instead of `localhost` when waiting on URLs

### DIFF
--- a/test-utils/waitForUrls.js
+++ b/test-utils/waitForUrls.js
@@ -6,7 +6,13 @@ const waitForUrls = async (...urls) => {
 
   try {
     return await waitOnAsync({
-      resources: urls.map((url) => url.replace(/http(s?)\:/, 'http$1-get:')),
+      resources: urls.map((url) =>
+        url
+          .replace(/http(s?)\:/, 'http$1-get:')
+          // As of node 17, ipv6 is preferred, so explicitly use ipv4
+          // See https://github.com/jeffbski/wait-on/issues/133
+          .replace(/localhost/, '127.0.0.1'),
+      ),
       headers: { accept: 'text/html, application/javascript' },
       timeout,
       // Log output of wait behaviour timing to allow


### PR DESCRIPTION
All our fixture tests use `localhost` in URLs. Some tests were failing locally for me because of this. This has to do with node 17+ preferring ipv6 over ipv4. See https://github.com/jeffbski/wait-on/issues/133 for more info. We're pinning node 16 in sku though, so it's odd that this is even an issue.

Ideally we'd make webpack dev server listen on both ipv4 localhost and ipv6 localhost, but I'm not sure how to configure that. Others are welcome to try. https://webpack.js.org/configuration/dev-server/#devserverhost