### PR TITLE
Add `lint-stage` to ESM-only list in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -90,6 +90,7 @@
         "find-up",
         "get-port",
         "indent-string",
+        "lint-staged",
         "open",
         "pretty-ms",
         "wrap-ansi"

--- a/test-utils/waitForUrls.js
+++ b/test-utils/waitForUrls.js
@@ -11,7 +11,7 @@ const waitForUrls = async (...urls) => {
           .replace(/http(s?)\:/, 'http$1-get:')
           // As of node 17, ipv6 is preferred, so explicitly use ipv4
           // See https://github.com/jeffbski/wait-on/issues/133
-          .replace(/localhost/, '127.0.0.1'),
+          .replace(/localhost/, '0.0.0.0'),
       ),
       headers: { accept: 'text/html, application/javascript' },
       timeout,


### PR DESCRIPTION
`lint-staged` became ESM-only in [v12](https://github.com/okonet/lint-staged/releases/tag/v12.0.0), and we're on v11, so adding it to the renovate list of ESM-only packages. Also incorporating [Remus' feedback from the previous PR](https://github.com/seek-oss/sku/pull/763#discussion_r1162227000).