### PR TITLE
Use separate dist folders for build and ssr-build in `typescript-css-modules` fixture

### DIFF
--- a/fixtures/typescript-css-modules/sku-ssr.config.js
+++ b/fixtures/typescript-css-modules/sku-ssr.config.js
@@ -5,4 +5,5 @@ module.exports = {
   serverPort: 8010,
   // Required for test to serve client assets correctly
   publicPath: 'http://localhost:4003/',
+  target: 'dist-ssr',
 };

--- a/fixtures/typescript-css-modules/sku.config.ts
+++ b/fixtures/typescript-css-modules/sku.config.ts
@@ -5,4 +5,5 @@ export default {
   storybookPort: 8042,
   publicPath: '/static/typescript',
   setupTests: 'src/setupTests.ts',
+  target: 'dist',
 };

--- a/tests/typescript-css-modules.test.js
+++ b/tests/typescript-css-modules.test.js
@@ -13,6 +13,7 @@ const appDir = path.dirname(
   require.resolve('@sku-fixtures/typescript-css-modules/sku.config'),
 );
 const distDir = path.resolve(appDir, 'dist');
+const distSsrDir = path.resolve(appDir, 'dist-ssr');
 const srcDir = path.resolve(appDir, 'src');
 const ssrSkuConfig = require('@sku-fixtures/typescript-css-modules/sku-ssr.config.js');
 
@@ -57,10 +58,10 @@ describe('typescript-css-modules', () => {
         '--config=sku-ssr.config.js',
       ]);
       server = gracefulSpawn('node', ['server'], {
-        cwd: distDir,
+        cwd: distSsrDir,
         stdio: 'inherit',
       });
-      closeAssetServer = await startAssetServer(4003, distDir);
+      closeAssetServer = await startAssetServer(4003, distSsrDir);
       await waitForUrls(backendUrl, 'http://localhost:4003');
     });
 
@@ -75,7 +76,7 @@ describe('typescript-css-modules', () => {
     });
 
     it('should generate the expected files', async () => {
-      const files = await dirContentsToObject(distDir, ['.js', '.css']);
+      const files = await dirContentsToObject(distSsrDir, ['.js', '.css']);
       const cssTypeFiles = await dirContentsToObject(srcDir, cssTypes);
       expect({
         ...files,

--- a/tests/typescript-css-modules.test.js
+++ b/tests/typescript-css-modules.test.js
@@ -1,4 +1,6 @@
 const path = require('path');
+const { promisify } = require('util');
+const rimraf = promisify(require('rimraf'));
 const {
   dirContentsToObject,
   waitForUrls,
@@ -33,6 +35,8 @@ describe('typescript-css-modules', () => {
 
     afterAll(async () => {
       await process.kill();
+      // Clean up dist dir to prevent pollution of linted files in lint test
+      await rimraf(distDir);
     });
 
     it('should create valid app', async () => {
@@ -68,6 +72,8 @@ describe('typescript-css-modules', () => {
     afterAll(async () => {
       await server.kill();
       closeAssetServer();
+      // Clean up dist-ssr dir to prevent pollution of linted files in lint test
+      await rimraf(distSsrDir);
     });
 
     it('should create valid app', async () => {


### PR DESCRIPTION
Both `build` and `build-ssr` were outputting to the same `dist` folder in the `typescript-css-modules` tests. This would sometimes result in pollution of the output files in the snapshots if both `build` and `build-ssr` tests ran at the same time (much more likely to happen locally than on CI).

I've added explicit `dist` and `dist-ssr` folders to the sku configs for this fixture to fix this. In addition, the tests now clean up their respective dist folders in order to not cause issues with the lint test. See [this comment](https://github.com/seek-oss/sku/pull/767#issuecomment-1506413322).