### PR TITLE
Remove some usage of `promisify`, replace `fs-extra` usage with plain `fs`

### DIFF
--- a/.changeset/dry-pillows-begin.md
+++ b/.changeset/dry-pillows-begin.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Remove dependency on `fs-extra`

--- a/fixtures/sku-with-https/src/server.js
+++ b/fixtures/sku-with-https/src/server.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { renderToString } from 'react-dom/server';
-import fs from 'fs';
-import { promisify } from 'util';
-const writeFile = promisify(fs.writeFile);
+import { writeFile } from 'fs/promises';
 
 import App from './App';
 

--- a/packages/sku/bin/sku.js
+++ b/packages/sku/bin/sku.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const fs = require('fs-extra');
+const fs = require('fs');
 const debug = require('debug');
 const args = require('../config/args');
 const _validatePeerDeps = require('../lib/validatePeerDeps');

--- a/packages/sku/lib/buildFileUtils.js
+++ b/packages/sku/lib/buildFileUtils.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('fs');
 const { rimraf } = require('rimraf');
 
 const { paths } = require('../context');
@@ -17,7 +17,7 @@ const copyPublicFiles = () => {
 };
 
 const ensureTargetDirectory = () => {
-  fs.ensureDirSync(paths.target);
+  fs.mkdirSync(paths.target, { recursive: true });
 };
 
 const cleanRenderJs = async () => {

--- a/packages/sku/lib/certificate.js
+++ b/packages/sku/lib/certificate.js
@@ -75,7 +75,7 @@ const generateCertificate = async (certificatePath, certificateDirPath) => {
   try {
     await access(certificateDirPath);
   } catch {
-    await mkdir(certificateDirPath, { force: true, recursive: true });
+    await mkdir(certificateDirPath, { recursive: true });
   }
 
   await writeFile(certificatePath, `${pems.private}${pems.cert}`);

--- a/packages/sku/lib/certificate.js
+++ b/packages/sku/lib/certificate.js
@@ -1,7 +1,7 @@
 const selfsigned = require('selfsigned');
 const { blue } = require('chalk');
 const {
-  access: exists,
+  access,
   mkdir,
   unlink,
   writeFile,
@@ -70,10 +70,10 @@ const createSelfSignedCertificate = () => {
 const generateCertificate = async (certificatePath, certificateDirPath) => {
   const startTime = performance.now();
 
-  const pems = await createSelfSignedCertificate();
+  const pems = createSelfSignedCertificate();
 
   try {
-    await exists(certificateDirPath);
+    await access(certificateDirPath);
   } catch {
     await mkdir(certificateDirPath, { force: true, recursive: true });
   }
@@ -92,7 +92,7 @@ const getCertificate = async (certificateDirName = '.ssl') => {
   );
 
   try {
-    await exists(certificatePath);
+    await access(certificatePath);
   } catch {
     return generateCertificate(certificatePath, certificateDirPath);
   }

--- a/packages/sku/lib/certificate.js
+++ b/packages/sku/lib/certificate.js
@@ -72,10 +72,10 @@ const generateCertificate = async (certificatePath, certificateDirPath) => {
 
   const pems = await createSelfSignedCertificate();
 
-  const certificateDirExists = await exists(certificateDirPath);
-
-  if (!certificateDirExists) {
-    await mkdir(certificateDirPath);
+  try {
+    await exists(certificateDirPath);
+  } catch {
+    await mkdir(certificateDirPath, { force: true, recursive: true });
   }
 
   await writeFile(certificatePath, `${pems.private}${pems.cert}`);
@@ -91,9 +91,9 @@ const getCertificate = async (certificateDirName = '.ssl') => {
     `./${certificateDirName}/self-signed.pem`,
   );
 
-  const certificateExists = await exists(certificatePath);
-
-  if (!certificateExists) {
+  try {
+    await exists(certificatePath);
+  } catch {
     return generateCertificate(certificatePath, certificateDirPath);
   }
 
@@ -107,7 +107,7 @@ const getCertificate = async (certificateDirName = '.ssl') => {
     return generateCertificate(certificatePath, certificateDirPath);
   }
 
-  return readFile(certificatePath);
+  return readFile(certificatePath, { encoding: 'utf8' });
 };
 
 module.exports = getCertificate;

--- a/packages/sku/lib/certificate.js
+++ b/packages/sku/lib/certificate.js
@@ -1,13 +1,13 @@
 const selfsigned = require('selfsigned');
 const { blue } = require('chalk');
 const {
-  existsSync,
+  access: exists,
   mkdir,
   unlink,
   writeFile,
   stat,
   readFile,
-} = require('fs-extra');
+} = require('fs/promises');
 
 const { getPathFromCwd } = require('../lib/cwd');
 const { hosts } = require('../context');
@@ -72,7 +72,7 @@ const generateCertificate = async (certificatePath, certificateDirPath) => {
 
   const pems = await createSelfSignedCertificate();
 
-  const certificateDirExists = existsSync(certificateDirPath);
+  const certificateDirExists = await exists(certificateDirPath);
 
   if (!certificateDirExists) {
     await mkdir(certificateDirPath);
@@ -91,7 +91,7 @@ const getCertificate = async (certificateDirName = '.ssl') => {
     `./${certificateDirName}/self-signed.pem`,
   );
 
-  const certificateExists = existsSync(certificatePath);
+  const certificateExists = await exists(certificatePath);
 
   if (!certificateExists) {
     return generateCertificate(certificatePath, certificateDirPath);

--- a/packages/sku/lib/certificate.js
+++ b/packages/sku/lib/certificate.js
@@ -1,13 +1,7 @@
 const selfsigned = require('selfsigned');
 const { blue } = require('chalk');
-const {
-  access,
-  mkdir,
-  unlink,
-  writeFile,
-  stat,
-  readFile,
-} = require('fs/promises');
+const exists = require('./exists');
+const { mkdir, unlink, writeFile, stat, readFile } = require('fs/promises');
 
 const { getPathFromCwd } = require('../lib/cwd');
 const { hosts } = require('../context');
@@ -72,9 +66,9 @@ const generateCertificate = async (certificatePath, certificateDirPath) => {
 
   const pems = createSelfSignedCertificate();
 
-  try {
-    await access(certificateDirPath);
-  } catch {
+  const certificateDirExists = await exists(certificateDirPath);
+
+  if (!certificateDirExists) {
     await mkdir(certificateDirPath, { recursive: true });
   }
 
@@ -91,9 +85,9 @@ const getCertificate = async (certificateDirName = '.ssl') => {
     `./${certificateDirName}/self-signed.pem`,
   );
 
-  try {
-    await access(certificatePath);
-  } catch {
+  const certificateExists = await exists(certificatePath);
+
+  if (!certificateExists) {
     return generateCertificate(certificatePath, certificateDirPath);
   }
 

--- a/packages/sku/lib/configure.js
+++ b/packages/sku/lib/configure.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const fs = require('fs-extra');
+const { writeFile, rm } = require('fs/promises');
 const path = require('path');
 
 const ensureGitignore = require('ensure-gitignore');
@@ -25,7 +25,7 @@ const writeFileToCWD = async (fileName, content, { banner = true } = {}) => {
   const str = JSON.stringify(content, null, 2);
   const contentStr = banner ? prependBanner(str) : str;
 
-  await fs.writeFile(outPath, contentStr);
+  await writeFile(outPath, contentStr);
 };
 
 module.exports = async () => {
@@ -97,7 +97,10 @@ module.exports = async () => {
     await getCertificate(selfSignedCertificateDirName);
     gitIgnorePatterns.push(selfSignedCertificateDirName);
   } else {
-    await fs.remove(getPathFromCwd(selfSignedCertificateDirName));
+    await rm(getPathFromCwd(selfSignedCertificateDirName), {
+      recursive: true,
+      force: true,
+    });
   }
 
   // Write `.gitignore`

--- a/packages/sku/lib/exists.js
+++ b/packages/sku/lib/exists.js
@@ -1,0 +1,18 @@
+const { access } = require('fs/promises');
+
+/**
+ * Convenience wrapper for fs.access that returns `true` if the access check was successful and `false` otherwise
+ * @typedef {import('fs').PathLike} PathLike
+ * @param {PathLike} path A path to a file or directory
+ */
+const exists = async (path) => {
+  try {
+    await access(path);
+
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+module.exports = exists;

--- a/packages/sku/lib/runPrettier.js
+++ b/packages/sku/lib/runPrettier.js
@@ -26,10 +26,8 @@ const runPrettier = async ({ write, listDifferent, paths }) => {
   }
 
   try {
-    const ignoreExists = await exists(prettierIgnorePath);
-    if (ignoreExists) {
-      prettierArgs.push('--ignore-path', prettierIgnorePath);
-    }
+    await exists(prettierIgnorePath);
+    prettierArgs.push('--ignore-path', prettierIgnorePath);
   } catch (err) {
     // don't error if `.prettierignore` not found
   }

--- a/packages/sku/lib/runPrettier.js
+++ b/packages/sku/lib/runPrettier.js
@@ -1,12 +1,10 @@
-const fs = require('fs');
+const { access: exists } = require('fs/promises');
 const path = require('path');
-const { promisify } = require('util');
 const chalk = require('chalk');
 const { runBin } = require('./runBin');
 const { getPathFromCwd } = require('./cwd');
 const { suggestScript } = require('./suggestScript');
 
-const exists = promisify(fs.stat);
 const prettierIgnorePath = getPathFromCwd('.prettierignore');
 const prettierConfigPath = path.join(
   __dirname,

--- a/packages/sku/lib/runPrettier.js
+++ b/packages/sku/lib/runPrettier.js
@@ -1,4 +1,4 @@
-const { access: exists } = require('fs/promises');
+const { access } = require('fs/promises');
 const path = require('path');
 const chalk = require('chalk');
 const { runBin } = require('./runBin');
@@ -26,7 +26,7 @@ const runPrettier = async ({ write, listDifferent, paths }) => {
   }
 
   try {
-    await exists(prettierIgnorePath);
+    await access(prettierIgnorePath);
     prettierArgs.push('--ignore-path', prettierIgnorePath);
   } catch (err) {
     // don't error if `.prettierignore` not found

--- a/packages/sku/lib/runPrettier.js
+++ b/packages/sku/lib/runPrettier.js
@@ -1,4 +1,4 @@
-const { access } = require('fs/promises');
+const exists = require('./exists');
 const path = require('path');
 const chalk = require('chalk');
 const { runBin } = require('./runBin');
@@ -25,11 +25,9 @@ const runPrettier = async ({ write, listDifferent, paths }) => {
     prettierArgs.push('--list-different');
   }
 
-  try {
-    await access(prettierIgnorePath);
+  const ignoreExists = await exists(prettierIgnorePath);
+  if (ignoreExists) {
     prettierArgs.push('--ignore-path', prettierIgnorePath);
-  } catch (err) {
-    // don't error if `.prettierignore` not found
   }
 
   const pathsToCheck =

--- a/packages/sku/lib/suggestScript.js
+++ b/packages/sku/lib/suggestScript.js
@@ -19,7 +19,12 @@ const findPackageScript = (scriptContents) => {
 
 const getSuggestedScript = async (scriptName, options = { sudo: false }) => {
   let script = options.sudo ? 'sudo ' : '';
-  const isYarnProject = await exists(getPathFromCwd('yarn.lock'));
+  let isYarnProject = false;
+
+  try {
+    await exists(getPathFromCwd('yarn.lock'));
+    isYarnProject = true;
+  } catch {}
 
   try {
     const packageScript = findPackageScript(`sku ${scriptName}`);

--- a/packages/sku/lib/suggestScript.js
+++ b/packages/sku/lib/suggestScript.js
@@ -1,4 +1,4 @@
-const { access: exists } = require('fs/promises');
+const { access } = require('fs/promises');
 const chalk = require('chalk');
 const { getPathFromCwd, requireFromCwd } = require('./cwd');
 
@@ -22,7 +22,7 @@ const getSuggestedScript = async (scriptName, options = { sudo: false }) => {
   let isYarnProject = false;
 
   try {
-    await exists(getPathFromCwd('yarn.lock'));
+    await access(getPathFromCwd('yarn.lock'));
     isYarnProject = true;
   } catch {}
 

--- a/packages/sku/lib/suggestScript.js
+++ b/packages/sku/lib/suggestScript.js
@@ -1,5 +1,4 @@
-const { promisify } = require('util');
-const exists = promisify(require('fs').exists);
+const { access: exists } = require('fs/promises');
 const chalk = require('chalk');
 const { getPathFromCwd, requireFromCwd } = require('./cwd');
 

--- a/packages/sku/lib/suggestScript.js
+++ b/packages/sku/lib/suggestScript.js
@@ -1,4 +1,4 @@
-const { access } = require('fs/promises');
+const exists = require('./exists');
 const chalk = require('chalk');
 const { getPathFromCwd, requireFromCwd } = require('./cwd');
 
@@ -19,12 +19,7 @@ const findPackageScript = (scriptContents) => {
 
 const getSuggestedScript = async (scriptName, options = { sudo: false }) => {
   let script = options.sudo ? 'sudo ' : '';
-  let isYarnProject = false;
-
-  try {
-    await access(getPathFromCwd('yarn.lock'));
-    isYarnProject = true;
-  } catch {}
+  const isYarnProject = await exists(getPathFromCwd('yarn.lock'));
 
   try {
     const packageScript = findPackageScript(`sku ${scriptName}`);

--- a/packages/sku/lib/validatePeerDeps.js
+++ b/packages/sku/lib/validatePeerDeps.js
@@ -1,4 +1,4 @@
-const fs = require('fs-extra');
+const { readFile } = require('fs/promises');
 const glob = require('fast-glob');
 const semver = require('semver');
 const chalk = require('chalk');
@@ -69,7 +69,7 @@ module.exports = async () => {
     const compilePackages = new Map();
 
     await asyncMap(packages, async (p) => {
-      const contents = await fs.readFile(getPathFromCwd(p), {
+      const contents = await readFile(getPathFromCwd(p), {
         encoding: 'utf8',
       });
 

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -89,7 +89,6 @@
     "fast-glob": "^3.2.5",
     "fastest-validator": "^1.9.0",
     "find-up": "^5.0.0",
-    "fs-extra": "^11.0.0",
     "get-port": "^5.0.0",
     "hostile": "^1.3.3",
     "html-render-webpack-plugin": "^3.0.1",

--- a/packages/sku/scripts/init.js
+++ b/packages/sku/scripts/init.js
@@ -193,7 +193,7 @@ const getTemplateFileDestinationFromRoot =
       const destination = getTemplateFileDestination(file);
 
       // Ensure folders exist before writing files to them
-      await fs.mkdirp(path.dirname(destination));
+      await fs.ensureDir(path.dirname(destination));
       await fs.writeFile(destination, fileContents);
     }),
   );

--- a/packages/sku/scripts/init.js
+++ b/packages/sku/scripts/init.js
@@ -148,7 +148,7 @@ const getTemplateFileDestinationFromRoot =
   };
   const packageJsonString = JSON.stringify(packageJson, null, 2);
 
-  fs.writeFile(path.join(root, 'package.json'), packageJsonString);
+  await fs.writeFile(path.join(root, 'package.json'), packageJsonString);
   process.chdir(root);
 
   const useYarn = detectYarn();

--- a/packages/sku/scripts/init.js
+++ b/packages/sku/scripts/init.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const chalk = require('chalk');
-const fs = require('fs-extra');
+const fs = require('fs/promises');
 const path = require('path');
 const emptyDir = require('empty-dir');
 const validatePackageName = require('validate-npm-package-name');
@@ -118,7 +118,7 @@ const getTemplateFileDestinationFromRoot =
     process.exit(1);
   }
 
-  fs.ensureDirSync(projectName);
+  await fs.mkdir(projectName, { recursive: true });
 
   if (!emptyDir.sync(root)) {
     console.log(`The directory ${chalk.green(projectName)} is not empty.`);
@@ -148,7 +148,7 @@ const getTemplateFileDestinationFromRoot =
   };
   const packageJsonString = JSON.stringify(packageJson, null, 2);
 
-  fs.writeFileSync(path.join(root, 'package.json'), packageJsonString);
+  fs.writeFile(path.join(root, 'package.json'), packageJsonString);
   process.chdir(root);
 
   const useYarn = detectYarn();
@@ -193,7 +193,7 @@ const getTemplateFileDestinationFromRoot =
       const destination = getTemplateFileDestination(file);
 
       // Ensure folders exist before writing files to them
-      await fs.ensureDir(path.dirname(destination));
+      await fs.mkdir(path.dirname(destination), { recursive: true });
       await fs.writeFile(destination, fileContents);
     }),
   );

--- a/packages/sku/scripts/serve.js
+++ b/packages/sku/scripts/serve.js
@@ -33,9 +33,9 @@ const preferredSite = args.site;
 (async () => {
   track.count('serve');
 
-  const targetFolderExists = await exists(paths.target);
-
-  if (!targetFolderExists) {
+  try {
+    await exists(paths.target);
+  } catch {
     console.log(
       red(
         `${bold('sku build')} must be run before running ${bold('sku serve')}`,

--- a/packages/sku/scripts/serve.js
+++ b/packages/sku/scripts/serve.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const express = require('express');
-const { access: exists } = require('fs/promises');
+const { access } = require('fs/promises');
 const handler = require('serve-handler');
 const flatMap = require('lodash/flatMap');
 const { blue, bold, underline, red } = require('chalk');
@@ -34,7 +34,7 @@ const preferredSite = args.site;
   track.count('serve');
 
   try {
-    await exists(paths.target);
+    await access(paths.target);
   } catch {
     console.log(
       red(

--- a/packages/sku/scripts/serve.js
+++ b/packages/sku/scripts/serve.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const express = require('express');
-const fs = require('fs-extra');
+const { access: exists } = require('fs/promises');
 const handler = require('serve-handler');
 const flatMap = require('lodash/flatMap');
 const { blue, bold, underline, red } = require('chalk');
@@ -33,7 +33,7 @@ const preferredSite = args.site;
 (async () => {
   track.count('serve');
 
-  const targetFolderExists = fs.existsSync(paths.target);
+  const targetFolderExists = await exists(paths.target);
 
   if (!targetFolderExists) {
     console.log(

--- a/packages/sku/scripts/serve.js
+++ b/packages/sku/scripts/serve.js
@@ -1,6 +1,6 @@
 const path = require('path');
+const exists = require('../lib/exists');
 const express = require('express');
-const { access } = require('fs/promises');
 const handler = require('serve-handler');
 const flatMap = require('lodash/flatMap');
 const { blue, bold, underline, red } = require('chalk');
@@ -33,9 +33,9 @@ const preferredSite = args.site;
 (async () => {
   track.count('serve');
 
-  try {
-    await access(paths.target);
-  } catch {
+  const targetFolderExists = await exists(paths.target);
+
+  if (!targetFolderExists) {
     console.log(
       red(
         `${bold('sku build')} must be run before running ${bold('sku serve')}`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,7 +343,6 @@ importers:
       fast-glob: ^3.2.5
       fastest-validator: ^1.9.0
       find-up: ^5.0.0
-      fs-extra: ^11.0.0
       get-port: ^5.0.0
       hostile: ^1.3.3
       html-render-webpack-plugin: ^3.0.1
@@ -457,7 +456,6 @@ importers:
       fast-glob: 3.2.12
       fastest-validator: 1.16.0
       find-up: 5.0.0
-      fs-extra: 11.1.1
       get-port: 5.1.1
       hostile: 1.3.3
       html-render-webpack-plugin: 3.0.2_express@4.18.2
@@ -566,7 +564,6 @@ importers:
       '@sku-fixtures/typescript-css-modules': workspace:*
       '@sku-private/test-utils': workspace:*
       dedent: ^0.7.0
-      fs-extra: ^11.0.0
       jsonc-parser: ^3.0.0
       rimraf: ^5.0.0
       webpack: ^5.52.0
@@ -592,7 +589,6 @@ importers:
       '@sku-fixtures/typescript-css-modules': link:../fixtures/typescript-css-modules
       '@sku-private/test-utils': link:../test-utils
       dedent: 0.7.0
-      fs-extra: 11.1.1
       jsonc-parser: 3.2.0
       rimraf: 5.0.0
       webpack: 5.78.0_webpack-cli@5.0.1
@@ -9984,14 +9980,6 @@ packages:
       universalify: 2.0.0
     dev: false
 
-  /fs-extra/11.1.1:
-    resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
-    engines: {node: '>=14.14'}
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.0
-
   /fs-extra/7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -12276,6 +12264,7 @@ packages:
       universalify: 2.0.0
     optionalDependencies:
       graceful-fs: 4.2.11
+    dev: false
 
   /jsx-ast-utils/3.3.3:
     resolution: {integrity: sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==}
@@ -17650,6 +17639,7 @@ packages:
   /universalify/2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
+    dev: false
 
   /unpipe/1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}

--- a/test-utils/waitForUrls.js
+++ b/test-utils/waitForUrls.js
@@ -1,11 +1,10 @@
-const { promisify } = require('util');
-const waitOnAsync = promisify(require('wait-on'));
+const waitOn = require('wait-on');
 
 const waitForUrls = async (...urls) => {
   const timeout = 200000;
 
   try {
-    return await waitOnAsync({
+    return await waitOn({
       resources: urls.map((url) =>
         url
           .replace(/http(s?)\:/, 'http$1-get:')

--- a/tests/import-order.test.js
+++ b/tests/import-order.test.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('fs/promises');
 const dedent = require('dedent');
 const { runSkuScriptInDir } = require('@sku-private/test-utils');
 
@@ -50,11 +50,11 @@ const files = {
 
 describe('import order', () => {
   beforeAll(async () => {
-    await fs.ensureDir(srcDirectory);
+    await fs.mkdir(srcDirectory, { recursive: true });
   });
 
   afterAll(async () => {
-    await fs.remove(srcDirectory);
+    await fs.rm(srcDirectory, { recursive: true, force: true });
   });
 
   test.each(Object.keys(files))('imports are ordered: %s', async (fileName) => {

--- a/tests/package.json
+++ b/tests/package.json
@@ -30,7 +30,6 @@
     "@sku-fixtures/sku-webpack-plugin": "workspace:*",
     "@sku-private/test-utils": "workspace:*",
     "dedent": "^0.7.0",
-    "fs-extra": "^11.0.0",
     "jsonc-parser": "^3.0.0",
     "rimraf": "^5.0.0",
     "webpack": "^5.52.0",


### PR DESCRIPTION
With recent, and not so recent, dependency updates (e.g. #768), some packages now export async versions of their functions, removing the need to use `promisify` in some situations.

Also, some `fs-extra` usage can be replaced with plain `fs` or `fs/promises`. ~There are some `fs-extra` functions that don't have equivalents in plain `fs`, particularly `ensureExists`, but they could be recreated if need be, and we could potentially remove our dependency on `fs-extra`, if there's any value in doing that.~

After addressing [the comment below](https://github.com/seek-oss/sku/pull/770#discussion_r1166241956), `fs-extra` has been removed as a dependency 🎉 .