### PR TITLE
Add missing fixture dev dep, small code removal

### DIFF
--- a/fixtures/braid-design-system/package.json
+++ b/fixtures/braid-design-system/package.json
@@ -7,5 +7,8 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "sku": "workspace:*"
+  },
+  "devDependencies": {
+    "@vanilla-extract/css": "^1.0.0"
   }
 }

--- a/packages/sku/config/storybook/storybookWebpackConfig.js
+++ b/packages/sku/config/storybook/storybookWebpackConfig.js
@@ -1,22 +1,12 @@
-const webpack = require('webpack');
 const { paths } = require('../../context');
 const find = require('lodash/find');
 const { merge: webpackMerge } = require('webpack-merge');
-const isCI = require('../../lib/isCI');
 const makeWebpackConfig = require('../webpack/webpack.config');
 const { resolvePackage } = require('../webpack/utils/resolvePackage');
 
 const hot = process.env.SKU_HOT !== 'false';
 
 module.exports = ({ config }, { isDevServer }) => {
-  if (isCI) {
-    // Remove noisy progress plugin in CI, currently no official option to disable
-    // https://github.com/storybookjs/storybook/issues/1260#issuecomment-308036626
-    config.plugins = config.plugins.filter(
-      (plugin) => !(plugin instanceof webpack.ProgressPlugin),
-    );
-  }
-
   const clientWebpackConfig = find(
     makeWebpackConfig({
       isIntegration: true,

--- a/packages/sku/context/index.js
+++ b/packages/sku/context/index.js
@@ -151,7 +151,6 @@ const paths = {
     : null,
   serverEntry: getPathFromCwd(skuConfig.serverEntry),
   public: getPathFromCwd(skuConfig.public),
-  relativeTarget: skuConfig.target,
   target: getPathFromCwd(skuConfig.target),
   relativeTarget: skuConfig.target,
   publicPath: isStartScript ? '/' : publicPath,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,7 @@ importers:
   fixtures/braid-design-system:
     specifiers:
       '@sku-private/test-utils': workspace:*
+      '@vanilla-extract/css': ^1.0.0
       braid-design-system: ^31.0.0
       react: ^17.0.1
       react-dom: ^17.0.1
@@ -77,6 +78,8 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       sku: link:../../packages/sku
+    devDependencies:
+      '@vanilla-extract/css': 1.11.0
 
   fixtures/configure:
     specifiers:


### PR DESCRIPTION
- Added a missing `@vanilla-extract/css` dev dep to the `braid-design-system` fixture. It needs the dep because it has a `css.ts` file.
- Remove duplicate `relativeTarget` entry
- Removed a CI check in the storybook webpack config that was used to remove some noise in CI. There is now a `--quiet` flag, as mentioned in [the issue in the comment](https://github.com/storybookjs/storybook/issues/1260#issuecomment-641866661), which suppress  suppresseses this output, and we already set it for the [`storybook`](https://github.com/seek-oss/sku/blob/1acc7c960d9a3383b0fde071ac0f7ed04a6cb5ef/packages/sku/scripts/storybook.js#L11) and [`storybook-build`](https://github.com/seek-oss/sku/blob/1acc7c960d9a3383b0fde071ac0f7ed04a6cb5ef/packages/sku/scripts/build-storybook.js#L19) commands, so this code can be removed.