### PR TITLE
storybook: Re-export `Meta` and `StoryObj` types from `@storybook/react`

### DIFF
--- a/.changeset/weak-seals-admire.md
+++ b/.changeset/weak-seals-admire.md
@@ -1,0 +1,33 @@
+---
+'sku': minor
+---
+
+Re-export `Meta` and `StoryObj` types from `@storybook/react`
+
+The `Meta` and `StoryObj` types are now re-exported under `sku/@storybook/react`.
+
+These types are useful for typing [CSF 3 stories] which are the new recommended way of writing stories.
+
+**EXAMPLE USAGE**:
+
+```ts
+import type { Meta } from 'sku/@storybook/react';
+
+import { MyComponent } from './MyComponent';
+
+const meta: Meta<typeof MyComponent> = {
+  title: 'Path/To/MyComponent',
+  component: MyComponent,
+};
+export default meta;
+
+type Story = StoryObj<typeof MyComponent>;
+
+export const Basic: Story = {};
+
+export const WithProp: Story = {
+  render: () => <MyComponent prop="value" />,
+};
+```
+
+[CSF 3 stories]: https://storybook.js.org/docs/react/api/csf

--- a/fixtures/typescript-css-modules/src/App.stories.tsx
+++ b/fixtures/typescript-css-modules/src/App.stories.tsx
@@ -1,9 +1,14 @@
+import type { Meta, StoryObj } from 'sku/@storybook/react';
 import React from 'react';
 import App from './App';
 
-export default {
+const meta: Meta = {
   title: 'App',
   component: App,
 };
 
-export const Default = () => <App>Hello World</App>;
+export default meta;
+
+type Story = StoryObj<typeof App>;
+
+export const Default: Story = { render: () => <App>Hello World</App> };

--- a/packages/sku/@storybook/react/index.ts
+++ b/packages/sku/@storybook/react/index.ts
@@ -11,6 +11,8 @@ import {
   storiesOf,
   forceReRender,
   getStorybook,
+  type Meta,
+  type StoryObj,
 } from '@storybook/react';
 
 export {
@@ -21,4 +23,6 @@ export {
   storiesOf,
   forceReRender,
   getStorybook,
+  type Meta,
+  type StoryObj,
 };

--- a/packages/sku/@storybook/react/index.ts
+++ b/packages/sku/@storybook/react/index.ts
@@ -1,20 +1,6 @@
 // This is provided so consumers can import `sku/@storybook/react`,
 // since they don't depend on `@storybook/react` directly.
 
-// We can't re-export directly because eslint-plugin-import doesn't understand :(
-
-import {
-  addDecorator,
-  addParameters,
-  configure,
-  setAddon,
-  storiesOf,
-  forceReRender,
-  getStorybook,
-  type Meta,
-  type StoryObj,
-} from '@storybook/react';
-
 export {
   addDecorator,
   addParameters,
@@ -25,4 +11,4 @@ export {
   getStorybook,
   type Meta,
   type StoryObj,
-};
+} from '@storybook/react';


### PR DESCRIPTION
The story story feature in storybook is now [enabled by default in storybook v7](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#storystorev7-enabled-by-default). This feature is not compatible with the `storiesOf` API, so in order to enable sku consumers to move off the `storiesOf` API, we should re-export types that can be used to write [CSF stories](https://storybook.js.org/docs/react/api/csf).