### PR TITLE
fix: Use `fs.copyFile` instead of `fs.copySync`, make some file utils async

### DIFF
--- a/.changeset/gold-ducks-call.md
+++ b/.changeset/gold-ducks-call.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fix a bug where a function that didn't exist was being called

--- a/packages/sku/lib/buildFileUtils.js
+++ b/packages/sku/lib/buildFileUtils.js
@@ -1,23 +1,24 @@
 const path = require('path');
-const fs = require('fs');
+const { copyFile, mkdir } = require('fs/promises');
 const { rimraf } = require('rimraf');
 
 const { paths } = require('../context');
+const exists = require('./exists');
 
 const cleanTargetDirectory = () => rimraf(`${paths.target}/*`, { glob: true });
 
-const copyPublicFiles = () => {
-  if (fs.existsSync(paths.public)) {
+const copyPublicFiles = async () => {
+  if (await exists(paths.public)) {
     console.log(`Copying ${paths.public} to ${paths.target}`);
 
-    fs.copySync(paths.public, paths.target, {
+    await copyFile(paths.public, paths.target, {
       dereference: true,
     });
   }
 };
 
-const ensureTargetDirectory = () => {
-  fs.mkdirSync(paths.target, { recursive: true });
+const ensureTargetDirectory = async () => {
+  await mkdir(paths.target, { recursive: true });
 };
 
 const cleanRenderJs = async () => {

--- a/packages/sku/scripts/start-ssr.js
+++ b/packages/sku/scripts/start-ssr.js
@@ -54,7 +54,7 @@ const localhost = '0.0.0.0';
   const appHosts = getAppHosts();
 
   // Make sure target directory exists before starting
-  ensureTargetDirectory();
+  await ensureTargetDirectory();
   await cleanTargetDirectory();
   await copyPublicFiles();
 


### PR DESCRIPTION
`fs.copySync` doesn't exist 🤦 , so replaced it with `fs.copyFile`. Also made the `copyPublicFiles` and `ensureTargetDirectory` utilities async as they mostly already had `await`s on them at their call sites.