### PR TITLE
Lint and format all extensions supported by the ESLint config

### DIFF
--- a/.changeset/khaki-flies-shave.md
+++ b/.changeset/khaki-flies-shave.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Lint all extensions supported by the ESLint config

--- a/packages/sku/lib/runESLint.js
+++ b/packages/sku/lib/runESLint.js
@@ -1,6 +1,12 @@
 const { yellow, cyan, gray } = require('chalk');
 const EslintCLI = require('eslint').CLIEngine;
 const eslintConfig = require('../config/eslint/eslintConfig');
+const {
+  js: jsExtensions,
+  ts: tsExtensions,
+} = require('eslint-config-seek/extensions');
+
+const extensions = [...tsExtensions, ...jsExtensions].map((ext) => `.${ext}`);
 
 const runESLint = ({ fix = false, paths }) =>
   new Promise((resolve, reject) => {
@@ -8,7 +14,7 @@ const runESLint = ({ fix = false, paths }) =>
 
     const cli = new EslintCLI({
       baseConfig: eslintConfig,
-      extensions: ['.ts', '.tsx', '.js', '.jsx'],
+      extensions,
       useEslintrc: false,
       fix,
     });
@@ -16,13 +22,8 @@ const runESLint = ({ fix = false, paths }) =>
     /* Whitelist the file extensions that our ESLint setup currently supports */
     const filteredFilePaths = checkAll
       ? ['.']
-      : paths.filter(
-          (filePath) =>
-            filePath.endsWith('.ts') ||
-            filePath.endsWith('.tsx') ||
-            filePath.endsWith('.js') ||
-            filePath.endsWith('.jsx') ||
-            filePath.endsWith('.json'),
+      : paths.filter((filePath) =>
+          [...extensions, '.json'].some((ext) => filePath.endsWith(ext)),
         );
 
     if (filteredFilePaths.length === 0) {

--- a/packages/sku/lib/runPrettier.js
+++ b/packages/sku/lib/runPrettier.js
@@ -4,6 +4,7 @@ const chalk = require('chalk');
 const { runBin } = require('./runBin');
 const { getPathFromCwd } = require('./cwd');
 const { suggestScript } = require('./suggestScript');
+const extensions = require('eslint-config-seek/extensions');
 
 const prettierIgnorePath = getPathFromCwd('.prettierignore');
 const prettierConfigPath = path.join(
@@ -31,7 +32,9 @@ const runPrettier = async ({ write, listDifferent, paths }) => {
   }
 
   const pathsToCheck =
-    paths && paths.length > 0 ? paths : ['**/*.{js,ts,tsx,md,less,css}'];
+    paths && paths.length > 0
+      ? paths
+      : [`**/*.{${[...extensions.ts, ...extensions.js]},md,less,css}`];
 
   prettierArgs.push(...pathsToCheck);
   /*

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -83,7 +83,7 @@
     "esbuild-register": "^3.3.3",
     "escape-string-regexp": "^4.0.0",
     "eslint": "^7.18.0",
-    "eslint-config-seek": "^11.0.0",
+    "eslint-config-seek": "^11.1.0",
     "exception-formatter": "^2.1.2",
     "express": "^4.16.3",
     "fast-glob": "^3.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,7 +365,7 @@ importers:
       esbuild-register: ^3.3.3
       escape-string-regexp: ^4.0.0
       eslint: ^7.18.0
-      eslint-config-seek: ^11.0.0
+      eslint-config-seek: ^11.1.0
       exception-formatter: ^2.1.2
       express: ^4.16.3
       fast-glob: ^3.2.5
@@ -478,7 +478,7 @@ importers:
       esbuild-register: 3.4.2_esbuild@0.17.16
       escape-string-regexp: 4.0.0
       eslint: 7.32.0
-      eslint-config-seek: 11.0.0_wid5pzwryku7btkwopdb2fye5u
+      eslint-config-seek: 11.1.0_wid5pzwryku7btkwopdb2fye5u
       exception-formatter: 2.1.2
       express: 4.18.2
       fast-glob: 3.2.12
@@ -8772,8 +8772,8 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-config-seek/11.0.0_wid5pzwryku7btkwopdb2fye5u:
-    resolution: {integrity: sha512-HTsXrAt+AeDWd1a8mdzEsjmYm39O/1LsDBHzdTN2iSK1gmaEOjoBOCOdy83KhnurjZ15zo/6h2SDuliwVvZNPw==}
+  /eslint-config-seek/11.1.0_wid5pzwryku7btkwopdb2fye5u:
+    resolution: {integrity: sha512-PQZd9gpeOcO91V8feCpVb+ambVytczikQUl1eEedKxdxGcsE42mcRSR8nr712HJnaEkj2gGhrjvok5i5X8sA3Q==}
     peerDependencies:
       eslint: '>=6'
       typescript: '>=4.5'


### PR DESCRIPTION
`eslint-config-seek` now exports the list of extensions so we don't have to hardcode our own