### PR TITLE
Start dev server middleware alongside Storybook

### DIFF
--- a/.changeset/mighty-ghosts-enjoy.md
+++ b/.changeset/mighty-ghosts-enjoy.md
@@ -1,0 +1,7 @@
+---
+'sku': minor
+---
+
+Start sku dev server middleware when running storybook
+
+When running `sku storybook`, if you have configured `devServerMiddleware` in your sku config, that middleware will now be passed through to storybook and injected into its own middleware stack.

--- a/docs/docs/storybook.md
+++ b/docs/docs/storybook.md
@@ -1,5 +1,7 @@
 # [Storybook](https://storybook.js.org/)
 
+## Start Storybook
+
 Running `sku storybook` will open up a local component explorer, displaying all component instances declared in files named `*.stories.js` (or `.ts`, or `.tsx`), for example:
 
 ```js
@@ -16,6 +18,25 @@ export const Secondary = () => <Button variant="secondary">Secondary</Button>;
 ```
 
 _**NOTE:** To access the Storybook API, you should import from `sku/@storybook/...`, since your project isn't depending on Storybook packages directly._
+
+### DevServer Middleware
+
+When running `sku storybook`, if you have configured [`devServerMiddleware`][devserver middleware] in your sku config, that middleware will be passed through to storybook and injected into its own middleware stack.
+
+[devserver middleware]: ./docs/extra-features.md#devserver-middleware
+
+### Storybook Port
+
+By default, Storybook runs on port `8081`.
+If you'd like to use a different port, you can provide it via the `storybookPort` option in `sku.config.js`:
+
+```js
+module.exports = {
+  storybookPort: 9000,
+};
+```
+
+## Addons
 
 There are no storybook addons configured by default in sku but they can be added through the `storybookAddons` option in `sku.config.js`.
 
@@ -34,15 +55,9 @@ module.exports = {
 };
 ```
 
-By default, Storybook runs on port `8081`. If you'd like to use a different port, you can provide it via the `storybookPort` option in `sku.config.js`:
+## Build Storybook
 
-```js
-module.exports = {
-  storybookPort: 9000,
-};
-```
-
-To build the Storybook, first add the following npm script:
+To build your Storybook, first add the following npm script:
 
 ```js
 {
@@ -54,7 +69,8 @@ To build the Storybook, first add the following npm script:
 
 Then run `npm run build-storybook`.
 
-By default, Storybook assets are generated in the `dist-storybook` directory in your project root folder. If you would like to specify a custom target directory, you can provide it via the `storybookTarget` option in `sku.config.js`:
+By default, Storybook assets are generated in the `dist-storybook` directory in your project root folder.
+If you would like to specify a custom target directory, you can provide it via the `storybookTarget` option in `sku.config.js`:
 
 ```js
 module.exports = {

--- a/fixtures/storybook-config/dev-middleware.js
+++ b/fixtures/storybook-config/dev-middleware.js
@@ -1,0 +1,5 @@
+module.exports = (app) => {
+  app.get('/test-middleware', (_, res) => {
+    res.status(200).send('OK');
+  });
+};

--- a/fixtures/storybook-config/sku.config.ts
+++ b/fixtures/storybook-config/sku.config.ts
@@ -6,6 +6,7 @@ const skuConfig: SkuConfig = {
   environments: ['development', 'production'],
   storybookPort: 8089,
   orderImports: true,
+  devServerMiddleware: './dev-middleware.js',
 };
 
 export default skuConfig;

--- a/packages/sku/config/storybook/start/middleware.js
+++ b/packages/sku/config/storybook/start/middleware.js
@@ -1,0 +1,10 @@
+const { paths, useDevServerMiddleware } = require('../../../context');
+
+const dummyMiddleware = (app) => app;
+let middleware = dummyMiddleware;
+
+if (useDevServerMiddleware) {
+  middleware = require(paths.devServerMiddleware);
+}
+
+module.exports = middleware;

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -143,7 +143,6 @@
     "@vocab/react": "^1.0.1",
     "assert": "^2.0.0",
     "braid-design-system": "^31.0.0",
-    "node-fetch": "^2.6.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -749,9 +749,6 @@ importers:
       braid-design-system:
         specifier: ^31.0.0
         version: 31.24.2(@types/react@17.0.57)(react-dom@17.0.2)(react@17.0.2)(sku@packages+sku)
-      node-fetch:
-        specifier: ^2.6.1
-        version: 2.6.9
       react:
         specifier: ^17.0.1
         version: 17.0.2
@@ -872,6 +869,9 @@ importers:
       jsonc-parser:
         specifier: ^3.0.0
         version: 3.2.0
+      node-fetch:
+        specifier: ^2.6.9
+        version: 2.6.9
       rimraf:
         specifier: ^5.0.0
         version: 5.0.0

--- a/tests/package.json
+++ b/tests/package.json
@@ -32,6 +32,7 @@
     "@sku-private/test-utils": "workspace:*",
     "dedent": "^0.7.0",
     "jsonc-parser": "^3.0.0",
+    "node-fetch": "^2.6.9",
     "rimraf": "^5.0.0",
     "webpack": "^5.52.0",
     "webpack-dev-server": "4.11.1",

--- a/tests/storybook-config.test.js
+++ b/tests/storybook-config.test.js
@@ -5,6 +5,7 @@ const {
   startAssetServer,
   getStorybookContent,
 } = require('@sku-private/test-utils');
+const fetch = require('node-fetch');
 
 const appDir = path.dirname(
   require.resolve('@sku-fixtures/storybook-config/sku.config.ts'),
@@ -14,11 +15,12 @@ const storybookDistDir = path.resolve(appDir, 'dist-storybook');
 describe('storybook-config', () => {
   describe('storybook', () => {
     const storybookUrl = 'http://localhost:8089';
+    const middlewareUrl = `${storybookUrl}/test-middleware`;
     let server;
 
     beforeAll(async () => {
       server = await runSkuScriptInDir('storybook', appDir, ['--ci']);
-      await waitForUrls(storybookUrl);
+      await waitForUrls(storybookUrl, middlewareUrl);
     }, 200000);
 
     afterAll(async () => {
@@ -32,6 +34,13 @@ describe('storybook-config', () => {
       );
       expect(text).toEqual('Hello world');
       expect(fontSize).toEqual('16px');
+    });
+
+    it('should start sku dev middleware if configured', async () => {
+      const response = await fetch(middlewareUrl);
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe('OK');
     });
   });
 


### PR DESCRIPTION
Doing some QOL storybook uplift before the storybook 7 release.

Storybook will inject middleware found in `.storybook/middleware.js` into its own middleware stack. This is an [intentionally undocumented feature](https://github.com/storybookjs/storybook/issues/15300#issuecomment-866469521), but given that it has been stable for [at least 5 years](https://github.com/storybookjs/storybook/blame/e22ac0d0e8f5cec6cd8e10ef34aa66f758335fbf/code/lib/core-server/src/utils/middleware.ts#L17), I don't think it will disappear any time soon, so I'm happy to depend on it.

Adding this feature neatly solves the issue where the new `seekJobs` braid theme needs a webfont. Shared web assets exposes a middleware for serving the webfont locally, and with this feature the middleware will also be available when running storybook.

This feature has also been requested by teams that would like to run other middleware alongside storybook.

I also did a small docs pass to add some subheadings to the storybook docs, as well as document this new feature. Will do another docs pass for storybook 7.

Finally, I moved the `node-fetch` dev dep from sku to test utils, where it belongs.