### PR TITLE
Filter files out of `config.srcPaths` before passing them to Storybook

### DIFF
--- a/.changeset/proud-mangos-protect.md
+++ b/.changeset/proud-mangos-protect.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Check only directories for Storybook stories

--- a/packages/sku/config/storybook/config.js
+++ b/packages/sku/config/storybook/config.js
@@ -1,10 +1,11 @@
+const fs = require('fs');
 const path = require('path');
 const { paths, storybookAddons } = require('../../context');
 
 module.exports = {
-  stories: paths.src.map((srcPath) =>
-    path.join(srcPath, '**/*.stories.@(js|ts|tsx)'),
-  ),
+  stories: paths.src
+    .filter((srcPath) => fs.statSync(srcPath).isDirectory())
+    .map((srcPath) => path.join(srcPath, '**/*.stories.@(js|ts|tsx)')),
   addons: storybookAddons,
   core: {
     builder: 'webpack5',


### PR DESCRIPTION
Check only directories for Storybook stories