### PR TITLE
Add warning banner when `.less` files are detected

### DIFF
--- a/.changeset/spicy-teachers-stare.md
+++ b/.changeset/spicy-teachers-stare.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Add warning banner about `.less` files

--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -32,6 +32,10 @@ See [vanilla-extract](https://vanilla-extract.style/documentation/getting-starte
 
 (via [CSS Modules](https://github.com/css-modules/css-modules) and [Less](http://lesscss.org/))
 
+> Support for LESS has been deprecated.
+> [Vanilla Extract](#vanilla-extract) is the preferred styling solution supported by sku, and support for LESS will be removed in a future release.
+> Consumers are encouraged to migrate to Vanilla Extract at the earliest opportunity.
+
 Import any `.less` file into your Javascript as a `styles` object and use its properties as class names.
 
 For example, given the following Less file:
@@ -53,7 +57,7 @@ export default () => <div className={styles.exampleWrapper}>Hello World!</div>;
 
 ## treat
 
-> Usage of treat is deprecated in favour of vanilla-extract
+> Usage of treat is deprecated in favour of [Vanilla Extract](#vanilla-extract)
 
 Note: You must access all treat imports through the sku prefix. e.g. `sku/treat`, `sku/react-treat`;
 

--- a/packages/sku/lib/configure.js
+++ b/packages/sku/lib/configure.js
@@ -135,7 +135,7 @@ module.exports = async () => {
       )} will be removed in a future release.`,
       `Consumers are encouraged to migrate to ${chalk.bold(
         'Vanilla Extract',
-      )} at their earliest opportunity.`,
+      )} at the earliest opportunity.`,
       'https://seek-oss.github.io/sku/#/./docs/styling?id=vanilla-extract',
     ]);
   }

--- a/packages/sku/lib/configure.js
+++ b/packages/sku/lib/configure.js
@@ -32,7 +32,12 @@ const writeFileToCWD = async (fileName, content, { banner = true } = {}) => {
   await writeFile(outPath, contentStr);
 };
 
-module.exports = async () => {
+/**
+ * @typedef {object} Options
+ * @property {boolean | undefined} isPostInit
+ * @param {Options}
+ */
+module.exports = async ({ isPostInit } = {}) => {
   // Ignore webpack bundle report output
   const gitIgnorePatterns = [
     addSep(bundleReportFolder),
@@ -114,29 +119,34 @@ module.exports = async () => {
     patterns: gitIgnorePatterns.map(convertToForwardSlashPaths),
   });
 
-  // Check for `.less` files
-  const lessFileGlobResults = await Promise.all(
-    paths.src
-      .filter((srcPath) => fs.statSync(srcPath).isDirectory())
-      .map(async (srcPath) => await glob(path.join(srcPath, '**/*.less'))),
-  );
-  const srcHasLessFiles = lessFileGlobResults.some(
-    (fileArray) => fileArray.length > 0,
-  );
-  if (srcHasLessFiles) {
-    printBanner('warning', 'LESS styles detected', [
-      `Support for ${chalk.bold('LESS')} has been deprecated.`,
-      `${chalk.bold(
-        'Vanilla Extract',
-      )} is the preferred styling solution supported by ${chalk.bold(
-        'sku',
-      )}, and support for ${chalk.bold(
-        'LESS',
-      )} will be removed in a future release.`,
-      `Consumers are encouraged to migrate to ${chalk.bold(
-        'Vanilla Extract',
-      )} at the earliest opportunity.`,
-      'https://seek-oss.github.io/sku/#/./docs/styling?id=vanilla-extract',
-    ]);
+  // Check for `.less` files only if we haven't just done an init
+  if (!isPostInit) {
+    const lessFileGlobResults = await Promise.all(
+      paths.src
+        .filter((srcPath) => fs.statSync(srcPath).isDirectory())
+        .map(async (srcPath) => {
+          console.log('actually globbing');
+          return await glob(path.join(srcPath, '**/*.less'));
+        }),
+    );
+    const srcHasLessFiles = lessFileGlobResults.some(
+      (fileArray) => fileArray.length > 0,
+    );
+    if (srcHasLessFiles) {
+      printBanner('warning', 'LESS styles detected', [
+        `Support for ${chalk.bold('LESS')} has been deprecated.`,
+        `${chalk.bold(
+          'Vanilla Extract',
+        )} is the preferred styling solution supported by ${chalk.bold(
+          'sku',
+        )}, and support for ${chalk.bold(
+          'LESS',
+        )} will be removed in a future release.`,
+        `Consumers are encouraged to migrate to ${chalk.bold(
+          'Vanilla Extract',
+        )} at the earliest opportunity.`,
+        'https://seek-oss.github.io/sku/#/./docs/styling?id=vanilla-extract',
+      ]);
+    }
   }
 };

--- a/packages/sku/lib/configure.js
+++ b/packages/sku/lib/configure.js
@@ -120,16 +120,22 @@ module.exports = async () => {
       .filter((srcPath) => fs.statSync(srcPath).isDirectory())
       .map(async (srcPath) => await glob(path.join(srcPath, '**/*.less'))),
   );
-  const srcHasLessFiles = lessFileGlobResults.some((fileArray) => {
-    return fileArray.length > 0;
-  });
+  const srcHasLessFiles = lessFileGlobResults.some(
+    (fileArray) => fileArray.length > 0,
+  );
   if (srcHasLessFiles) {
-    printBanner('warning', 'Less styles detected', [
-      `Vanilla Extract is the preferred styling solution supported by sku. Support for ${chalk.bold(
-        '.less',
-      )} styles may be removed in the future. Please migrate all ${chalk.bold(
-        '.less',
-      )} styles to Vanilla Extract styles.`,
+    printBanner('warning', 'LESS styles detected', [
+      `Support for ${chalk.bold('LESS')} has been deprecated.`,
+      `${chalk.bold(
+        'Vanilla Extract',
+      )} is the preferred styling solution supported by ${chalk.bold(
+        'sku',
+      )}, and support for ${chalk.bold(
+        'LESS',
+      )} will be removed in a future release.`,
+      `Consumers are encouraged to migrate to ${chalk.bold(
+        'Vanilla Extract',
+      )} at their earliest opportunity.`,
       'https://seek-oss.github.io/sku/#/./docs/styling?id=vanilla-extract',
     ]);
   }

--- a/packages/sku/scripts/init.js
+++ b/packages/sku/scripts/init.js
@@ -219,7 +219,7 @@ const getTemplateFileDestinationFromRoot =
   await install({ deps, verbose, useYarn });
   await install({ deps: devDeps, type: 'dev', exact: false, verbose, useYarn });
 
-  await configure();
+  await configure({ isPostInit: true });
   await esLintFix();
   await prettierWrite();
 

--- a/tests/configure.test.js
+++ b/tests/configure.test.js
@@ -51,7 +51,8 @@ describe('configure', () => {
   describe('default', () => {
     beforeAll(async () => {
       await makeDir(appFolder);
-      await copyToApp('App.js', appFolder);
+      await makeDir(path.join(appFolder, './src'));
+      await copyToApp('App.js', path.join(appFolder, './src'));
       await copyToApp('package.json', appFolder);
       await runSkuScriptInDir('configure', appFolder);
     });
@@ -103,7 +104,8 @@ describe('configure', () => {
   describe('custom', () => {
     beforeAll(async () => {
       await makeDir(appFolderTS);
-      await copyToApp('App.tsx', appFolderTS);
+      await makeDir(path.join(appFolderTS, './src'));
+      await copyToApp('App.tsx', path.join(appFolderTS, './src'));
       await copyToApp('package.json', appFolderTS);
       await copyToApp('sku.config.js', appFolderTS);
       await runSkuScriptInDir('configure', appFolderTS);


### PR DESCRIPTION
While we're still going to support `.less` files for now, we should encourage consumers to move to VE styles, as it is the preferred styling solution. The docs page for styling has been updated with the same deprecation message.

![image](https://github.com/seek-oss/sku/assets/5663042/b3b56a4c-b1c8-4625-a854-0ae780b18146)