### PR TITLE
Allow Webpack to interpret all `.mjs` files as modules, not just those from `node_modules`

### DIFF
--- a/.changeset/honest-taxis-shop.md
+++ b/.changeset/honest-taxis-shop.md
@@ -1,0 +1,7 @@
+---
+'sku': patch
+---
+
+Allow Webpack to interpret all `.mjs` files as modules, not just those from `node_modules`
+
+This fixes an error with compiled Vocab translation files because Webpack would not parse `require.resolveWeak` in `.mjs` files.

--- a/fixtures/translations/src/App.tsx
+++ b/fixtures/translations/src/App.tsx
@@ -2,9 +2,16 @@ import React from 'react';
 import { useTranslations } from '@vocab/react';
 
 import translations from './App.vocab';
+// @ts-expect-error no types
+import compiledTranslations from './compiled.vocab/index.mjs';
 
 export default () => {
   const { t } = useTranslations(translations);
+  const compiled = useTranslations(compiledTranslations);
 
-  return <div>{t('hello')}</div>;
+  return (
+    <div>
+      {t('hello')} {compiled.t('Company name')}
+    </div>
+  );
 };

--- a/fixtures/translations/src/compiled.vocab/fr.translations.json
+++ b/fixtures/translations/src/compiled.vocab/fr.translations.json
@@ -1,0 +1,6 @@
+{
+  "Company name": {
+    "message": "บริษัท",
+    "description": "Label for company name"
+  }
+}

--- a/fixtures/translations/src/compiled.vocab/index.mjs
+++ b/fixtures/translations/src/compiled.vocab/index.mjs
@@ -1,0 +1,13 @@
+import { createTranslationFile, createLanguage } from '@vocab/core/runtime';
+const translations = createTranslationFile({
+  en: createLanguage({
+    'Company name': 'Company name',
+  }),
+  fr: createLanguage({
+    'Company name': 'บริษัท',
+  }),
+  'en-PSEUDO': createLanguage({
+    'Company name': '[Çööm̂ƥăăกี้ýý กี้ăăm̂ẽẽ]',
+  }),
+});
+export { translations as default };

--- a/fixtures/translations/src/compiled.vocab/translations.json
+++ b/fixtures/translations/src/compiled.vocab/translations.json
@@ -1,0 +1,6 @@
+{
+  "Company name": {
+    "message": "Company name",
+    "description": "Label for company name"
+  }
+}

--- a/packages/sku/config/webpack/webpack.config.js
+++ b/packages/sku/config/webpack/webpack.config.js
@@ -204,7 +204,7 @@ const makeWebpackConfig = ({
                   ],
                 },
               ]),
-          { test: /\.mjs$/, include: /node_modules/, type: 'javascript/auto' },
+          { test: /\.mjs$/, type: 'javascript/auto' },
         ],
       },
       plugins: [
@@ -307,9 +307,7 @@ const makeWebpackConfig = ({
         modules,
       },
       module: {
-        rules: [
-          { test: /\.mjs$/, include: /node_modules/, type: 'javascript/auto' },
-        ],
+        rules: [{ test: /\.mjs$/, type: 'javascript/auto' }],
       },
       plugins: [
         ...(htmlRenderPlugin ? [htmlRenderPlugin.rendererPlugin] : []),

--- a/packages/sku/config/webpack/webpack.config.ssr.js
+++ b/packages/sku/config/webpack/webpack.config.ssr.js
@@ -169,11 +169,7 @@ const makeWebpackConfig = ({
                   ],
                 },
               ]),
-          {
-            test: /\.mjs$/,
-            include: /node_modules/,
-            type: 'javascript/auto',
-          },
+          { test: /\.mjs$/, type: 'javascript/auto' },
         ],
       },
       plugins: [
@@ -269,13 +265,7 @@ const makeWebpackConfig = ({
         concatenateModules: false,
       },
       module: {
-        rules: [
-          {
-            test: /\.mjs$/,
-            include: /node_modules/,
-            type: 'javascript/auto',
-          },
-        ],
+        rules: [{ test: /\.mjs$/, type: 'javascript/auto' }],
       },
       plugins: [
         new webpack.DefinePlugin(envVars),

--- a/tests/__snapshots__/ssr-translations.test.js.snap
+++ b/tests/__snapshots__/ssr-translations.test.js.snap
@@ -52,6 +52,7 @@ SOURCE HTML: <!DOCTYPE html>
     <div id="app">
       <div>
         Hello sku
+        Company name
       </div>
     </div>
     <script
@@ -153,6 +154,7 @@ SOURCE HTML: <!DOCTYPE html>
     <div id="app">
       <div>
         [Ḩẽẽẽƚƚööö šķǚǚǚ]
+        [Çööm̂ƥăăกี้ýý กี้ăăm̂ẽẽ]
       </div>
     </div>
     <script
@@ -254,6 +256,7 @@ SOURCE HTML: <!DOCTYPE html>
     <div id="app">
       <div>
         Bonjour sku
+        บริษัท
       </div>
     </div>
     <script

--- a/tests/__snapshots__/translations.test.js.snap
+++ b/tests/__snapshots__/translations.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`translations should render en 1`] = `
 SCRIPTS: [
-  "/runtime-373678e24e415d97d48a.js",
+  "/runtime-c90bedc6c1e41d593d60.js",
   "/579-82f09b8f4068b7b87cca.js",
-  "/main-b33751bd6bdd1424382d.js",
-  "/en-translations-28027b3b2d76574f2835.js",
+  "/main-e30a4c5e58673756167f.js",
+  "/en-translations-b17efc1aa5d571ed56f2.js",
 ]
 CSS: []
 SOURCE HTML: <!DOCTYPE html>
@@ -48,6 +48,7 @@ SOURCE HTML: <!DOCTYPE html>
     <div id="app">
       <div>
         Hello sku
+        Company name
       </div>
     </div>
     <script
@@ -99,10 +100,10 @@ POST HYDRATE DIFFS: NO DIFF
 
 exports[`translations should render en-PSEUDO post-hydration 1`] = `
 SCRIPTS: [
-  "/runtime-373678e24e415d97d48a.js",
+  "/runtime-c90bedc6c1e41d593d60.js",
   "/579-82f09b8f4068b7b87cca.js",
-  "/main-b33751bd6bdd1424382d.js",
-  "/en-translations-28027b3b2d76574f2835.js",
+  "/main-e30a4c5e58673756167f.js",
+  "/en-translations-b17efc1aa5d571ed56f2.js",
 ]
 CSS: []
 SOURCE HTML: <!DOCTYPE html>
@@ -145,6 +146,7 @@ SOURCE HTML: <!DOCTYPE html>
     <div id="app">
       <div>
         Hello sku
+        Company name
       </div>
     </div>
     <script
@@ -196,7 +198,8 @@ POST HYDRATE DIFFS:
      <div id="app">
        <div>
 -        Hello sku
-+        [Ḩẽẽẽƚƚööö šķǚǚǚ]
+-        Company name
++        [Ḩẽẽẽƚƚööö šķǚǚǚ] [Çööm̂ƥăăกี้ýý กี้ăăm̂ẽẽ]
        </div>
      </div>
      <script
@@ -205,10 +208,10 @@ POST HYDRATE DIFFS:
 
 exports[`translations should render fr 1`] = `
 SCRIPTS: [
-  "/runtime-373678e24e415d97d48a.js",
+  "/runtime-c90bedc6c1e41d593d60.js",
   "/579-82f09b8f4068b7b87cca.js",
-  "/main-b33751bd6bdd1424382d.js",
-  "/fr-translations-066c40d8ddd4e4079126.js",
+  "/main-e30a4c5e58673756167f.js",
+  "/fr-translations-8d39ba177a70a2aa4224.js",
 ]
 CSS: []
 SOURCE HTML: <!DOCTYPE html>
@@ -251,6 +254,7 @@ SOURCE HTML: <!DOCTYPE html>
     <div id="app">
       <div>
         Bonjour sku
+        บริษัท
       </div>
     </div>
     <script
@@ -302,10 +306,10 @@ POST HYDRATE DIFFS: NO DIFF
 
 exports[`translations should support query parameters 1`] = `
 SCRIPTS: [
-  "/runtime-373678e24e415d97d48a.js",
+  "/runtime-c90bedc6c1e41d593d60.js",
   "/579-82f09b8f4068b7b87cca.js",
-  "/main-b33751bd6bdd1424382d.js",
-  "/en-translations-28027b3b2d76574f2835.js",
+  "/main-e30a4c5e58673756167f.js",
+  "/en-translations-b17efc1aa5d571ed56f2.js",
 ]
 CSS: []
 SOURCE HTML: <!DOCTYPE html>
@@ -348,6 +352,7 @@ SOURCE HTML: <!DOCTYPE html>
     <div id="app">
       <div>
         Hello sku
+        Company name
       </div>
     </div>
     <script


### PR DESCRIPTION
This fixes an error with compiled Vocab translation files because Webpack would not parse `require.resolveWeak` in `.mjs` files.

<img width="670" alt="screenshot of error" src="https://github.com/seek-oss/sku/assets/3297808/4efe6996-7b70-44d7-8990-f59b5777daa3">
