### PR TITLE
Check that paths exist before looking for `*.less` files in them

### DIFF
--- a/.changeset/grumpy-oranges-speak.md
+++ b/.changeset/grumpy-oranges-speak.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Check that paths exist before looking for `*.less` files in them

--- a/packages/sku/bin/sku.js
+++ b/packages/sku/bin/sku.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const debug = require('debug');
 const args = require('../config/args');
 const _validatePeerDeps = require('../lib/validatePeerDeps');
+const validateLessFiles = require('../lib/validateLessFiles');
 const { getPathFromCwd } = require('../lib/cwd');
 const log = debug('sku:bin');
 
@@ -62,8 +63,10 @@ log(`Starting script: ${script}`);
     case 'setup-hosts':
     case 'init':
     case 'configure': {
-      runScript(script);
-      break;
+      if (script !== 'init') {
+        validateLessFiles();
+      }
+      return runScript(script);
     }
 
     case 'test':
@@ -72,8 +75,8 @@ log(`Starting script: ${script}`);
     case 'pre-commit':
     case 'translations': {
       await configureProject();
-      runScript(script);
-      break;
+      validateLessFiles();
+      return runScript(script);
     }
 
     case 'start':
@@ -84,10 +87,9 @@ log(`Starting script: ${script}`);
     case 'build-ssr':
     case 'serve': {
       await configureProject();
-
+      validateLessFiles();
       validatePeerDeps();
-      runScript(script);
-      break;
+      return runScript(script);
     }
 
     default: {

--- a/packages/sku/lib/configure.js
+++ b/packages/sku/lib/configure.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 const { writeFile, rm } = require('fs/promises');
 const path = require('path');
-const glob = require('fast-glob');
-const fs = require('fs');
 
 const ensureGitignore = require('ensure-gitignore');
 const { cwd, getPathFromCwd } = require('./cwd');
@@ -11,8 +9,6 @@ const { paths, httpsDevServer, languages } = require('../context');
 const {
   bundleReportFolder,
 } = require('../config/webpack/plugins/bundleAnalyzer');
-const printBanner = require('../lib/banner');
-const chalk = require('chalk');
 const prettierConfig = require('../config/prettier/prettierConfig');
 const eslintConfig = require('../config/eslint/eslintConfig');
 const createTSConfig = require('../config/typescript/tsconfig.js');
@@ -32,12 +28,7 @@ const writeFileToCWD = async (fileName, content, { banner = true } = {}) => {
   await writeFile(outPath, contentStr);
 };
 
-/**
- * @typedef {object} Options
- * @property {boolean | undefined} isPostInit
- * @param {Options}
- */
-module.exports = async ({ isPostInit } = {}) => {
+module.exports = async () => {
   // Ignore webpack bundle report output
   const gitIgnorePatterns = [
     addSep(bundleReportFolder),
@@ -118,32 +109,4 @@ module.exports = async ({ isPostInit } = {}) => {
     comment: 'managed by sku',
     patterns: gitIgnorePatterns.map(convertToForwardSlashPaths),
   });
-
-  // Check for `.less` files only if we haven't just done an init
-  if (!isPostInit) {
-    const lessFileGlobResults = await Promise.all(
-      paths.src
-        .filter((srcPath) => fs.statSync(srcPath).isDirectory())
-        .map(async (srcPath) => await glob(path.join(srcPath, '**/*.less'))),
-    );
-    const srcHasLessFiles = lessFileGlobResults.some(
-      (fileArray) => fileArray.length > 0,
-    );
-    if (srcHasLessFiles) {
-      printBanner('warning', 'LESS styles detected', [
-        `Support for ${chalk.bold('LESS')} has been deprecated.`,
-        `${chalk.bold(
-          'Vanilla Extract',
-        )} is the preferred styling solution supported by ${chalk.bold(
-          'sku',
-        )}, and support for ${chalk.bold(
-          'LESS',
-        )} will be removed in a future release.`,
-        `Consumers are encouraged to migrate to ${chalk.bold(
-          'Vanilla Extract',
-        )} at the earliest opportunity.`,
-        'https://seek-oss.github.io/sku/#/./docs/styling?id=vanilla-extract',
-      ]);
-    }
-  }
 };

--- a/packages/sku/lib/validateLessFiles.js
+++ b/packages/sku/lib/validateLessFiles.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+const glob = require('fast-glob');
+const chalk = require('chalk');
+
+const printBanner = require('./banner');
+const exists = require('./exists');
+const { paths } = require('../context');
+
+module.exports = async () => {
+  const srcPathsExist = await Promise.all(
+    paths.src.map(async (srcPath) => (await exists(srcPath)) && srcPath),
+  );
+  const lessFileGlobResults = await Promise.all(
+    srcPathsExist
+      .filter((srcPath) => srcPath && fs.statSync(srcPath).isDirectory())
+      .map(async (srcPath) => await glob(path.join(srcPath, '**/*.less'))),
+  );
+  const srcHasLessFiles = lessFileGlobResults.some(
+    (fileArray) => fileArray.length > 0,
+  );
+  if (srcHasLessFiles) {
+    printBanner('warning', 'LESS styles detected', [
+      `Support for ${chalk.bold('LESS')} has been deprecated.`,
+      `${chalk.bold(
+        'Vanilla Extract',
+      )} is the preferred styling solution supported by ${chalk.bold(
+        'sku',
+      )}, and support for ${chalk.bold(
+        'LESS',
+      )} will be removed in a future release.`,
+      `Consumers are encouraged to migrate to ${chalk.bold(
+        'Vanilla Extract',
+      )} at the earliest opportunity.`,
+      'https://seek-oss.github.io/sku/#/./docs/styling?id=vanilla-extract',
+    ]);
+  }
+};

--- a/packages/sku/scripts/init.js
+++ b/packages/sku/scripts/init.js
@@ -214,7 +214,7 @@ const getTemplateFileDestinationFromRoot =
   await install({ deps, verbose, useYarn });
   await install({ deps: devDeps, type: 'dev', exact: false, verbose, useYarn });
 
-  await configure({ isPostInit: true });
+  await configure();
   await esLintFix();
   await prettierWrite();
 


### PR DESCRIPTION
This also moves the logic to check for `.less` files into a separate module, so it's easier to remove when we drop support.