### PR TITLE
Ensure lint and lint staged use same extensions

### DIFF
--- a/.changeset/cold-worms-do.md
+++ b/.changeset/cold-worms-do.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Ensure `sku pre-commit` lints the same files as `sku lint`

--- a/packages/sku/config/lintStaged/lintStagedConfig.js
+++ b/packages/sku/config/lintStaged/lintStagedConfig.js
@@ -1,13 +1,14 @@
 const isYarn = require('../../lib/isYarn');
+const { lintExtensions } = require('../../lib/lint');
 
 const steps = {};
 
 // Yarn lock integrity check
 if (isYarn) {
-  steps['+(package.json|yarn.lock)'] = [() => 'yarn check --integrity'];
+  steps['+(package.json|yarn.lock)'] = [() => 'yarn install --check-files'];
 }
 
 // Format & lint
-steps['**/*.{js,ts,tsx,md,less}'] = ['sku format', 'sku lint'];
+steps[`**/*.{${lintExtensions},md,less}`] = ['sku format', 'sku lint'];
 
 module.exports = steps;

--- a/packages/sku/lib/lint.js
+++ b/packages/sku/lib/lint.js
@@ -1,0 +1,8 @@
+const {
+  js: jsExtensions,
+  ts: tsExtensions,
+} = require('eslint-config-seek/extensions');
+
+const lintExtensions = [...tsExtensions, ...jsExtensions];
+
+module.exports = { lintExtensions };

--- a/packages/sku/lib/runESLint.js
+++ b/packages/sku/lib/runESLint.js
@@ -1,12 +1,9 @@
 const { yellow, cyan, gray } = require('chalk');
 const { ESLint } = require('eslint');
 const eslintConfig = require('../config/eslint/eslintConfig');
-const {
-  js: jsExtensions,
-  ts: tsExtensions,
-} = require('eslint-config-seek/extensions');
+const { lintExtensions } = require('./lint');
 
-const extensions = [...tsExtensions, ...jsExtensions].map((ext) => `.${ext}`);
+const extensions = lintExtensions.map((ext) => `.${ext}`);
 
 /**
  * @param {{ fix?: boolean, paths?: string[] }}


### PR DESCRIPTION
Basically doing the same thing as #784 but for lint staged, which is run during `sku pre-commit`. `md` and `less` are there for `sku format`.