### PR TITLE
Fix ESLint warning and error reporting

### DIFF
--- a/.changeset/silly-countries-drive.md
+++ b/.changeset/silly-countries-drive.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fix ESLint warning and error reporting


### PR DESCRIPTION
Linting broke completely in #814. The [ESLint migration guide specifies that they replaced the old class with a new class](https://eslint.org/docs/latest/use/migrate-to-8.0.0#-the-cliengine-class-has-been-removed). However they failed to mention that the returned values from these APIs changed as well. My fault for not looking at the interface of the new class, but IMO they should've been more explicit that these were not just straight renames and actually involved API changes too.

Getting this fix in, have confirmed it works in an app repo, then going to follow up with some testing around lint errors, probably in a new fixture.

Having `// @ts-check` on for this file would've caught this bug 😢. I'm considering adding to some other important files in the rest of the repo, maybe we could eventually turn it on repo-wide.