### PR TITLE
Fix `sku init` on Windows

### DIFF
--- a/.changeset/tender-cobras-provide.md
+++ b/.changeset/tender-cobras-provide.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fix `sku init` on Windows

--- a/packages/sku/lib/toPosixPath.js
+++ b/packages/sku/lib/toPosixPath.js
@@ -1,0 +1,11 @@
+// @ts-check
+const path = require('path');
+
+/**
+ * Replaces all win32 path separators (\) with posix path separators (/)
+ * @param {string} inputPath
+ */
+const toPosixPath = (inputPath) =>
+  inputPath.split(path.win32.sep).join(path.posix.sep);
+
+module.exports = toPosixPath;

--- a/packages/sku/lib/toPosixPath.js
+++ b/packages/sku/lib/toPosixPath.js
@@ -6,6 +6,6 @@ const path = require('path');
  * @param {string} inputPath
  */
 const toPosixPath = (inputPath) =>
-  inputPath.split(path.win32.sep).join(path.posix.sep);
+  inputPath.replaceAll(path.win32.sep, path.posix.sep);
 
 module.exports = toPosixPath;

--- a/packages/sku/lib/toPosixPath.test.js
+++ b/packages/sku/lib/toPosixPath.test.js
@@ -1,0 +1,15 @@
+const toPosixPath = require('./toPosixPath');
+
+describe('toPosixPath', () => {
+  it('should leave a posix path as-is', () => {
+    const inputPath = '/foo/bar/123';
+
+    expect(toPosixPath(inputPath)).toBe(inputPath);
+  });
+
+  it('should convert windows paths to posix paths', () => {
+    const inputPath = 'D:\\foo\\bar\\123';
+
+    expect(toPosixPath(inputPath)).toBe('D:/foo/bar/123');
+  });
+});

--- a/packages/sku/scripts/init.js
+++ b/packages/sku/scripts/init.js
@@ -2,7 +2,7 @@
 
 const chalk = require('chalk');
 const fs = require('fs/promises');
-const path = require('path');
+const { posix: path } = require('path');
 const emptyDir = require('empty-dir');
 const validatePackageName = require('validate-npm-package-name');
 const dedent = require('dedent');
@@ -13,6 +13,7 @@ const esLintFix = require('../lib/runESLint').fix;
 const configure = require('../lib/configure');
 const install = require('../lib/install');
 const banner = require('../lib/banner');
+const toPosixPath = require('../lib/toPosixPath');
 const trace = require('debug')('sku:init');
 const glob = require('fast-glob');
 const ejs = require('ejs');
@@ -148,7 +149,7 @@ const getTemplateFileDestinationFromRoot =
 
   const useYarn = detectYarn();
 
-  const templateDirectory = path.join(__dirname, '../template');
+  const templateDirectory = path.join(toPosixPath(__dirname), '../template');
   const templateFiles = await glob(`${templateDirectory}/**/*`, {
     onlyFiles: true,
   });


### PR DESCRIPTION
`npx sku init <name>` was broken on windows. The app folder would be created, but the `src` directory containing the sku template files was never created.

This was occurring because [`fast-glob` expects `/` as a path separator](https://github.com/mrmlnc/fast-glob/tree/c8f0a6065ffdd9e0411c2a216e63d9dd6213cb75#how-to-write-patterns-on-windows), so windows paths with `\` are interpreted as paths with escaped characters, resulting in an empty array from the glob. The `init` script uses `__dirname` to drive the template creation, so by ensuring we convert it to a posix path, and use the posix implementations of the path methods, the glob should receive correct input.

We currently do not run our CI on windows agents, and there are no plans to do so in the future. However, this fix has been tested on my personal windows machine, as well as on the widnows machine of the user that reported the bug.