### PR TITLE
Dependency updates, bump jest `maxWorkers` to 3 

### DIFF
--- a/.changeset/funny-geese-drive.md
+++ b/.changeset/funny-geese-drive.md
@@ -2,7 +2,7 @@
 'sku': minor
 ---
 
-Remove `babel-plugin-dynamic-import-node` dependency.
+Remove `babel-plugin-dynamic-import-node` dependency
 
 This plugin was used to transform dynamic imports into deferred requires within jest tests.
-However, dynamic imports are well supported in Node now so this plugin is no longer required.
+However, dynamic imports are well supported in Node, so this plugin is no longer required.

--- a/.changeset/funny-geese-drive.md
+++ b/.changeset/funny-geese-drive.md
@@ -1,0 +1,8 @@
+---
+'sku': minor
+---
+
+Remove `babel-plugin-dynamic-import-node` dependency.
+
+This plugin was used to transform dynamic imports into deferred requires within jest tests.
+However, dynamic imports are well supported in Node now so this plugin is no longer required.

--- a/.changeset/hip-avocados-protect.md
+++ b/.changeset/hip-avocados-protect.md
@@ -2,4 +2,4 @@
 'sku': patch
 ---
 
-Remove unused dependency, update `less-loader`
+Update `less-loader` and `node-emoji` dependencies

--- a/.changeset/hip-avocados-protect.md
+++ b/.changeset/hip-avocados-protect.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Remove unused dependency, update `less-loader`

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -66,4 +66,4 @@ jobs:
           key: jest-${{ runner.os }}-${{ hashFiles('./pnpm-lock.yaml') }}
 
       - name: Test
-        run: pnpm run test --maxWorkers=2
+        run: pnpm run test --maxWorkers=3

--- a/packages/sku/config/babel/babelConfig.js
+++ b/packages/sku/config/babel/babelConfig.js
@@ -10,7 +10,6 @@ module.exports = ({
   rootResolution = false,
 }) => {
   const isBrowser = target === 'browser';
-  const isJest = target === 'jest';
   const isProductionBuild = process.env.NODE_ENV === 'production';
 
   const plugins = [
@@ -31,10 +30,6 @@ module.exports = ({
       require.resolve('react-refresh/babel'),
       { skipEnvCheck: true },
     ]);
-  }
-
-  if (isJest) {
-    plugins.push(require.resolve('babel-plugin-dynamic-import-node'));
   }
 
   if (isProductionBuild) {

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -95,7 +95,7 @@
     "jest-environment-jsdom": "^29.0.0",
     "jest-watch-typeahead": "^2.2.0",
     "less": "^4.1.0",
-    "less-loader": "^11.0.0",
+    "less-loader": "^11.1.3",
     "lint-staged": "^11.1.1",
     "lodash": "^4.17.21",
     "memoizee": "^0.4.15",

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -57,7 +57,6 @@
     "babel-jest": "^29.0.0",
     "babel-loader": "^9.1.2",
     "babel-plugin-add-react-displayname": "^0.0.5",
-    "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-macros": "^3.1.0",
     "babel-plugin-module-resolver": "^5.0.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -100,7 +100,7 @@
     "lodash": "^4.17.21",
     "memoizee": "^0.4.15",
     "mini-css-extract-plugin": "^2.6.1",
-    "node-emoji": "^1.10.0",
+    "node-emoji": "^2.1.0",
     "node-html-parser": "^6.1.1",
     "open": "^7.3.1",
     "path-to-regexp": "^6.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -483,9 +483,6 @@ importers:
       babel-plugin-add-react-displayname:
         specifier: ^0.0.5
         version: 0.0.5
-      babel-plugin-dynamic-import-node:
-        specifier: ^2.3.3
-        version: 2.3.3
       babel-plugin-macros:
         specifier: ^3.1.0
         version: 3.1.0
@@ -5539,12 +5536,6 @@ packages:
 
   /babel-plugin-add-react-displayname@0.0.5:
     resolution: {integrity: sha512-LY3+Y0XVDYcShHHorshrDbt4KFWL4bSeniCtl4SYZbask+Syngk1uMPCeN9+nSiZo6zX5s0RTq/J9Pnaaf/KHw==}
-    dev: false
-
-  /babel-plugin-dynamic-import-node@2.3.3:
-    resolution: {integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==}
-    dependencies:
-      object.assign: 4.1.4
     dev: false
 
   /babel-plugin-istanbul@6.1.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -598,8 +598,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.3
       less-loader:
-        specifier: ^11.0.0
-        version: 11.1.0(less@4.1.3)(webpack@5.78.0)
+        specifier: ^11.1.3
+        version: 11.1.3(less@4.1.3)(webpack@5.78.0)
       lint-staged:
         specifier: ^11.1.1
         version: 11.2.6
@@ -10167,14 +10167,13 @@ packages:
       dotenv: 16.0.3
       dotenv-expand: 10.0.0
 
-  /less-loader@11.1.0(less@4.1.3)(webpack@5.78.0):
-    resolution: {integrity: sha512-C+uDBV7kS7W5fJlUjq5mPBeBVhYpTIm5gB09APT9o3n/ILeaXVsiSFTbZpTJCJwQ/Crczfn3DmfQFwxYusWFug==}
+  /less-loader@11.1.3(less@4.1.3)(webpack@5.78.0):
+    resolution: {integrity: sha512-A5b7O8dH9xpxvkosNrP0dFp2i/dISOJa9WwGF3WJflfqIERE2ybxh1BFDj5CovC2+jCE4M354mk90hN6ziXlVw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       less: ^3.5.0 || ^4.0.0
       webpack: ^5.0.0
     dependencies:
-      klona: 2.0.6
       less: 4.1.3
       webpack: 5.78.0(esbuild@0.17.6)(webpack-cli@5.0.1)
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -613,8 +613,8 @@ importers:
         specifier: ^2.6.1
         version: 2.7.5(webpack@5.78.0)
       node-emoji:
-        specifier: ^1.10.0
-        version: 1.11.0
+        specifier: ^2.1.0
+        version: 2.1.0
       node-html-parser:
         specifier: ^6.1.1
         version: 6.1.5
@@ -3399,6 +3399,11 @@ packages:
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
     engines: {node: '>=6'}
     dev: true
+
+  /@sindresorhus/is@3.1.2:
+    resolution: {integrity: sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==}
+    engines: {node: '>=10'}
+    dev: false
 
   /@sinonjs/commons@2.0.0:
     resolution: {integrity: sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==}
@@ -7178,6 +7183,10 @@ packages:
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  /emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+    dev: false
+
   /emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
@@ -10812,10 +10821,13 @@ packages:
       minimatch: 3.1.2
     dev: false
 
-  /node-emoji@1.11.0:
-    resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
+  /node-emoji@2.1.0:
+    resolution: {integrity: sha512-tcsBm9C6FmPN5Wo7OjFi9lgMyJjvkAeirmjR/ax8Ttfqy4N8PoFic26uqFTIgayHPNI5FH4ltUvfh9kHzwcK9A==}
     dependencies:
-      lodash: 4.17.21
+      '@sindresorhus/is': 3.1.2
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
     dev: false
 
   /node-fetch-native@1.1.1:
@@ -12856,6 +12868,13 @@ packages:
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  /skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
+    dev: false
+
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -13671,6 +13690,11 @@ packages:
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
     engines: {node: '>=4'}
     dev: false
 

--- a/tests/__snapshots__/multiple-routes.test.js.snap
+++ b/tests/__snapshots__/multiple-routes.test.js.snap
@@ -8,19 +8,19 @@ exports[`multiple-routes build and serve should generate the expected files 1`] 
   color: blue;
 }
 ,
-  "handlers-Details-9c1864199b6a7016df98.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "handlers-Details-d676f1666d3d25986768.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "handlers-Home-0076e4d4a98910c8f902.css": .dyLY_sb {
   color: red;
 }
 ,
-  "handlers-Home-3e7d301f15c04b169344.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "main-d8f14e095ad2c003e052.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "handlers-Home-2d43a31c58bff9977984.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "main-8fb25263b562b5184cda.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "production/au/details/$id/index.html": SCRIPTS: [
     "https://code.jquery.com/jquery-3.5.0.slim.min.js",
-    "/static/place/runtime-0ed7145f525217f5c0de.js",
+    "/static/place/runtime-d5e227ab707d471ba14c.js",
     "/static/place/283-b65dde74011b05bfcfb2.js",
-    "/static/place/main-d8f14e095ad2c003e052.js",
-    "/static/place/handlers-Details-9c1864199b6a7016df98.js",
+    "/static/place/main-8fb25263b562b5184cda.js",
+    "/static/place/handlers-Details-d676f1666d3d25986768.js",
     "/static/place/AsyncComponent-f564c97a79efa014bb45.js",
   ]
 CSS: [
@@ -148,10 +148,10 @@ SOURCE HTML: <!DOCTYPE html>
 </html>,
   "production/au/index.html": SCRIPTS: [
     "https://code.jquery.com/jquery-3.5.0.slim.min.js",
-    "/static/place/runtime-0ed7145f525217f5c0de.js",
+    "/static/place/runtime-d5e227ab707d471ba14c.js",
     "/static/place/283-b65dde74011b05bfcfb2.js",
-    "/static/place/main-d8f14e095ad2c003e052.js",
-    "/static/place/handlers-Home-3e7d301f15c04b169344.js",
+    "/static/place/main-8fb25263b562b5184cda.js",
+    "/static/place/handlers-Home-2d43a31c58bff9977984.js",
   ]
 CSS: [
     "/static/place/handlers-Home-0076e4d4a98910c8f902.css",
@@ -263,10 +263,10 @@ SOURCE HTML: <!DOCTYPE html>
 </html>,
   "production/nz/nz/details/:id/index.html": SCRIPTS: [
     "https://code.jquery.com/jquery-3.5.0.slim.min.js",
-    "/static/place/runtime-0ed7145f525217f5c0de.js",
+    "/static/place/runtime-d5e227ab707d471ba14c.js",
     "/static/place/283-b65dde74011b05bfcfb2.js",
-    "/static/place/main-d8f14e095ad2c003e052.js",
-    "/static/place/handlers-Details-9c1864199b6a7016df98.js",
+    "/static/place/main-8fb25263b562b5184cda.js",
+    "/static/place/handlers-Details-d676f1666d3d25986768.js",
     "/static/place/AsyncComponent-f564c97a79efa014bb45.js",
   ]
 CSS: [
@@ -394,10 +394,10 @@ SOURCE HTML: <!DOCTYPE html>
 </html>,
   "production/nz/nz/index.html": SCRIPTS: [
     "https://code.jquery.com/jquery-3.5.0.slim.min.js",
-    "/static/place/runtime-0ed7145f525217f5c0de.js",
+    "/static/place/runtime-d5e227ab707d471ba14c.js",
     "/static/place/283-b65dde74011b05bfcfb2.js",
-    "/static/place/main-d8f14e095ad2c003e052.js",
-    "/static/place/handlers-Home-3e7d301f15c04b169344.js",
+    "/static/place/main-8fb25263b562b5184cda.js",
+    "/static/place/handlers-Home-2d43a31c58bff9977984.js",
   ]
 CSS: [
     "/static/place/handlers-Home-0076e4d4a98910c8f902.css",
@@ -507,17 +507,17 @@ SOURCE HTML: <!DOCTYPE html>
     </script>
   </body>
 </html>,
-  "runtime-0ed7145f525217f5c0de.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "runtime-d5e227ab707d471ba14c.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;
 
 exports[`multiple-routes build and serve should return details page 1`] = `
 SCRIPTS: [
   "https://code.jquery.com/jquery-3.5.0.slim.min.js",
-  "/static/place/runtime-0ed7145f525217f5c0de.js",
+  "/static/place/runtime-d5e227ab707d471ba14c.js",
   "/static/place/283-b65dde74011b05bfcfb2.js",
-  "/static/place/main-d8f14e095ad2c003e052.js",
-  "/static/place/handlers-Details-9c1864199b6a7016df98.js",
+  "/static/place/main-8fb25263b562b5184cda.js",
+  "/static/place/handlers-Details-d676f1666d3d25986768.js",
   "/static/place/AsyncComponent-f564c97a79efa014bb45.js",
 ]
 CSS: [
@@ -658,10 +658,10 @@ POST HYDRATE DIFFS:
 exports[`multiple-routes build and serve should return home page 1`] = `
 SCRIPTS: [
   "https://code.jquery.com/jquery-3.5.0.slim.min.js",
-  "/static/place/runtime-0ed7145f525217f5c0de.js",
+  "/static/place/runtime-d5e227ab707d471ba14c.js",
   "/static/place/283-b65dde74011b05bfcfb2.js",
-  "/static/place/main-d8f14e095ad2c003e052.js",
-  "/static/place/handlers-Home-3e7d301f15c04b169344.js",
+  "/static/place/main-8fb25263b562b5184cda.js",
+  "/static/place/handlers-Home-2d43a31c58bff9977984.js",
 ]
 CSS: [
   "/static/place/handlers-Home-0076e4d4a98910c8f902.css",

--- a/tests/__snapshots__/public-path.test.js.snap
+++ b/tests/__snapshots__/public-path.test.js.snap
@@ -4,7 +4,7 @@ exports[`public path build and serve should create valid app with no unresolved 
 SCRIPTS: [
   "/static/runtime-df7fc58286eea709736e.js",
   "/static/258-86dcf2d36390f340021b.js",
-  "/static/main-5c63c7388de2c8ab022d.js",
+  "/static/main-f99a1e88665d307c7ee3.js",
 ]
 CSS: [
   "/static/main-c06e2768c0d8ec21c207.css",

--- a/tests/__snapshots__/react-css-modules.test.js.snap
+++ b/tests/__snapshots__/react-css-modules.test.js.snap
@@ -4,7 +4,7 @@ exports[`react-css-modules should create valid app 1`] = `
 SCRIPTS: [
   "/runtime-df7fc58286eea709736e.js",
   "/235-fed19355ef816e81a74f.js",
-  "/main-22a6e81fd73c910949be.js",
+  "/main-e6f24933c4e3607d786b.js",
 ]
 CSS: [
   "/main-cb8848ae92e1e9d08128.css",
@@ -105,7 +105,7 @@ exports[`react-css-modules should generate the expected files 1`] = `
   "index.html": SCRIPTS: [
     "/runtime-df7fc58286eea709736e.js",
     "/235-fed19355ef816e81a74f.js",
-    "/main-22a6e81fd73c910949be.js",
+    "/main-e6f24933c4e3607d786b.js",
   ]
 CSS: [
     "/main-cb8848ae92e1e9d08128.css",
@@ -188,7 +188,6 @@ SOURCE HTML: <!DOCTYPE html>
     </script>
   </body>
 </html>,
-  "main-22a6e81fd73c910949be.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "main-cb8848ae92e1e9d08128.css": .eRNyDeb {
   display: flex;
 }
@@ -196,6 +195,7 @@ SOURCE HTML: <!DOCTYPE html>
   font-size: 32px;
 }
 ,
+  "main-e6f24933c4e3607d786b.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-df7fc58286eea709736e.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;

--- a/tests/__snapshots__/sku-with-https.test.js.snap
+++ b/tests/__snapshots__/sku-with-https.test.js.snap
@@ -4,7 +4,7 @@ exports[`sku-with-https serve should start a development server 1`] = `
 SCRIPTS: [
   "/runtime-a5c914bdf89f464ecb2e.js",
   "/235-fed19355ef816e81a74f.js",
-  "/main-123654aaf62c8a804659.js",
+  "/main-2f9282bd8317bb7e7d36.js",
 ]
 CSS: [
   "/main-cb8848ae92e1e9d08128.css",

--- a/tests/__snapshots__/ssr-hello-world.test.js.snap
+++ b/tests/__snapshots__/ssr-hello-world.test.js.snap
@@ -4,7 +4,7 @@ exports[`ssr-hello-world build custom port should generate a production server r
 SCRIPTS: [
   "http://localhost:4000/runtime-21ba7ee762f9d6616967.js",
   "http://localhost:4000/258-86dcf2d36390f340021b.js",
-  "http://localhost:4000/main-596c863a4e653c9fb05e.js",
+  "http://localhost:4000/main-4f2a51fe99ba70920a7f.js",
   "https://code.jquery.com/jquery-3.5.0.slim.min.js",
 ]
 CSS: [
@@ -110,7 +110,7 @@ exports[`ssr-hello-world build default port should generate a production server 
 SCRIPTS: [
   "http://localhost:4000/runtime-21ba7ee762f9d6616967.js",
   "http://localhost:4000/258-86dcf2d36390f340021b.js",
-  "http://localhost:4000/main-596c863a4e653c9fb05e.js",
+  "http://localhost:4000/main-4f2a51fe99ba70920a7f.js",
   "https://code.jquery.com/jquery-3.5.0.slim.min.js",
 ]
 CSS: [

--- a/tests/__snapshots__/typescript-css-modules.test.js.snap
+++ b/tests/__snapshots__/typescript-css-modules.test.js.snap
@@ -4,7 +4,7 @@ exports[`typescript-css-modules build should create valid app 1`] = `
 SCRIPTS: [
   "/static/typescript/runtime-df7fc58286eea709736e.js",
   "/static/typescript/235-fed19355ef816e81a74f.js",
-  "/static/typescript/main-6d1257200649b9f86c56.js",
+  "/static/typescript/main-de1d4e09150e0bc9c99c.js",
 ]
 CSS: [
   "/static/typescript/main-cb8848ae92e1e9d08128.css",
@@ -119,7 +119,7 @@ export const root: string;
   "index.html": SCRIPTS: [
     "/static/typescript/runtime-df7fc58286eea709736e.js",
     "/static/typescript/235-fed19355ef816e81a74f.js",
-    "/static/typescript/main-6d1257200649b9f86c56.js",
+    "/static/typescript/main-de1d4e09150e0bc9c99c.js",
   ]
 CSS: [
     "/static/typescript/main-cb8848ae92e1e9d08128.css",
@@ -215,7 +215,6 @@ interface CssExports {
 export const cssExports: CssExports;
 export default cssExports;
 ",
-  "main-6d1257200649b9f86c56.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "main-cb8848ae92e1e9d08128.css": .eRNyDeb {
   display: flex;
 }
@@ -223,6 +222,7 @@ export default cssExports;
   font-size: 32px;
 }
 ,
+  "main-de1d4e09150e0bc9c99c.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-df7fc58286eea709736e.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;
@@ -231,7 +231,7 @@ exports[`typescript-css-modules build-ssr should create valid app 1`] = `
 SCRIPTS: [
   "http://localhost:4003/runtime-424bd133a78585db66ac.js",
   "http://localhost:4003/16-930bbb195bedab324553.js",
-  "http://localhost:4003/main-4f61eaece6b2c126eb62.js",
+  "http://localhost:4003/main-c8ea5e9cdab04ac07aa7.js",
 ]
 CSS: [
   "http://localhost:4003/main-cb8848ae92e1e9d08128.css",
@@ -360,7 +360,7 @@ interface CssExports {
 export const cssExports: CssExports;
 export default cssExports;
 ",
-  "main-4f61eaece6b2c126eb62.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "main-c8ea5e9cdab04ac07aa7.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "main-cb8848ae92e1e9d08128.css": .eRNyDeb {
   display: flex;
 }


### PR DESCRIPTION
- Removed [`babel-plugin-dynamic-import-node`](https://www.npmjs.com/package/babel-plugin-dynamic-import-node). This plugin was only being used in jest, i.e. Node, but [dynamic import has been supported in Node since 13.2.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import#browser_compatibility), so there's no need to transform it anymore.
- Updated `less-loader` version, primarily to prevent consumers getting locked to a version without [this fix that removed an unused, very old dependency](https://github.com/webpack-contrib/less-loader/pull/517) that ended up including various old versions of things, as well as `node-gyp` in `node_modules` 🙅 
- Updated `node-emoji` to [the latest major version](https://github.com/omnidan/node-emoji/releases/tag/v2.1.0). Was waiting for them to release [my change](https://github.com/omnidan/node-emoji/pull/138).
- Set [`maxWorkers`](https://jestjs.io/docs/cli#--maxworkersnumstring) to 3 on CI as [the macos github agents have 3 cores](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources), so we might as well use them. Looks like we can get <5 minute test runs on CI pretty consistently now. This will go away if we eventually move back to ubuntu images, but it's nice to have for now.