### PR TITLE
Surface unhandled ESLint errors

### DIFF
--- a/.changeset/fair-jobs-eat.md
+++ b/.changeset/fair-jobs-eat.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Surface unhandled ESLint errors

--- a/packages/sku/lib/runESLint.js
+++ b/packages/sku/lib/runESLint.js
@@ -59,6 +59,8 @@ const runESLint = async ({ fix = false, paths }) => {
       if (e && e.message && e.message.includes('No files matching')) {
         console.warn(yellow(`Warning: ${e.message}`));
       } else {
+        console.warn(yellow('ESLint encountered an error:'));
+        console.log(e.message);
         return Promise.reject();
       }
     }


### PR DESCRIPTION
Provide more context when ESLint reports an error. Because this isn't very helpful:

```
Linting
Running Vocab compile
Checking code with TypeScript compiler
Path: /some/path
Checking code with Prettier
Paths: **/*.{ts,cts,mts,tsx,js,cjs,mjs,jsx,md,less,css}
Checking code with ESLint
Paths: .
error Command failed with exit code 1.
```

It doesn't say what the error is.