### PR TITLE
test: Don't load storybook on-demand

### DIFF
--- a/fixtures/storybook-config/sku.config.ts
+++ b/fixtures/storybook-config/sku.config.ts
@@ -8,6 +8,7 @@ const skuConfig: SkuConfig = {
   orderImports: true,
   devServerMiddleware: './dev-middleware.js',
   storybookAddons: ['@storybook/addon-controls'],
+  storybookStoryStore: false,
 };
 
 export default skuConfig;


### PR DESCRIPTION
By default, Storybook 7 loads stories on-demand. This behaviour is a nice default, but it results in the storybook page loading very quickly, which can potentially result in a timeout before the actual story loads. By disabling [the storybook story store](https://storybook.js.org/docs/react/configure/overview#feature-flags), we can force storybook to load all stories upfront before making the storybook page available. This should hopefully make the storybook tests less flakey.