### PR TITLE
Fix compile package detection

### DIFF
--- a/.changeset/four-steaks-carry.md
+++ b/.changeset/four-steaks-carry.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Don't use `.git` folder to find root, only glob PNPM virtual store if PNPM is detected as the package manager

--- a/packages/sku/context/defaultCompilePackages.js
+++ b/packages/sku/context/defaultCompilePackages.js
@@ -38,7 +38,6 @@ try {
       cwd,
     })
     .map((packagePath) => {
-      console.log({ packagePath });
       const packageJson = require(path.join(cwd, packagePath));
 
       return {

--- a/packages/sku/context/defaultCompilePackages.js
+++ b/packages/sku/context/defaultCompilePackages.js
@@ -1,37 +1,44 @@
 const { posix: path } = require('path');
 const chalk = require('chalk');
 const glob = require('fast-glob');
-const { execSync } = require('child_process');
 
 const { cwd: skuCwd } = require('../lib/cwd');
 const toPosixPath = require('../lib/toPosixPath');
+
+const { findRootSync } = require('@manypkg/find-root');
 
 /** @type {string[]} */
 let detectedCompilePackages = [];
 
 try {
+  const globs = ['node_modules/@seek/*/package.json'];
   const cwd = skuCwd();
-  const gitRepoRoot = execSync('git rev-parse --show-toplevel', { cwd })
-    .toString()
-    .trim();
 
-  const pnpmVirtualStorePath = path.join(
-    toPosixPath(gitRepoRoot),
-    'node_modules/.pnpm',
-  );
-  const pnpmVirtualStoreRelativePath = path.relative('.', pnpmVirtualStorePath);
-  const pnpmVirtualStoreGlob = path.join(
-    pnpmVirtualStoreRelativePath,
-    '@seek*/node_modules/@seek/*/package.json',
-  );
+  const { rootDir, tool } = findRootSync(cwd);
 
-  const packageDependenciesGlob = 'node_modules/@seek/*/package.json';
+  if (tool === 'pnpm') {
+    const pnpmVirtualStorePath = path.join(
+      toPosixPath(rootDir),
+      'node_modules/.pnpm',
+    );
+    const pnpmVirtualStoreRelativePath = path.relative(
+      '.',
+      pnpmVirtualStorePath,
+    );
+    const pnpmVirtualStoreGlob = path.join(
+      pnpmVirtualStoreRelativePath,
+      '@seek*/node_modules/@seek/*/package.json',
+    );
+
+    globs.push(pnpmVirtualStoreGlob);
+  }
 
   detectedCompilePackages = glob
-    .sync([pnpmVirtualStoreGlob, packageDependenciesGlob], {
+    .sync(globs, {
       cwd,
     })
     .map((packagePath) => {
+      console.log({ packagePath });
       const packageJson = require(path.join(cwd, packagePath));
 
       return {
@@ -45,7 +52,6 @@ try {
   console.log(
     chalk.red`Warning: Failed to detect compile packages. Contact #sku-support.`,
   );
-  console.error(e);
 }
 
 module.exports = [

--- a/packages/sku/context/defaultCompilePackages.js
+++ b/packages/sku/context/defaultCompilePackages.js
@@ -51,6 +51,7 @@ try {
   console.log(
     chalk.red`Warning: Failed to detect compile packages. Contact #sku-support.`,
   );
+  console.error(e);
 }
 
 module.exports = [

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -40,6 +40,7 @@
     "@loadable/component": "^5.14.1",
     "@loadable/server": "^5.14.0",
     "@loadable/webpack-plugin": "^5.14.0",
+    "@manypkg/find-root": "^2.2.0",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
     "@storybook/builder-webpack5": "^7.0.17",
     "@storybook/cli": "^7.0.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,6 +432,9 @@ importers:
       '@loadable/webpack-plugin':
         specifier: ^5.14.0
         version: 5.15.2(webpack@5.78.0)
+      '@manypkg/find-root':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.10
         version: 0.5.10(react-refresh@0.14.0)(webpack-dev-server@4.11.1)(webpack@5.78.0)
@@ -3222,6 +3225,16 @@ packages:
       fs-extra: 8.1.0
     dev: true
 
+  /@manypkg/find-root@2.2.0:
+    resolution: {integrity: sha512-NET+BNIMmBWUUUfFtuDgaTIav6pVlkkSdI2mt+2rFWPd6TQ0DXyhQH47Ql+d7x2oIkJ69dkVKwsTErRt2ROPbw==}
+    engines: {node: '>=14.18.0'}
+    dependencies:
+      '@manypkg/tools': 1.1.0
+      '@types/node': 12.20.55
+      find-up: 4.1.0
+      fs-extra: 8.1.0
+    dev: false
+
   /@manypkg/get-packages@1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
     dependencies:
@@ -3232,6 +3245,16 @@ packages:
       globby: 11.1.0
       read-yaml-file: 1.1.0
     dev: true
+
+  /@manypkg/tools@1.1.0:
+    resolution: {integrity: sha512-SkAyKAByB9l93Slyg8AUHGuM2kjvWioUTCckT/03J09jYnfEzMO/wSXmEhnKGYs6qx9De8TH4yJCl0Y9lRgnyQ==}
+    engines: {node: '>=14.18.0'}
+    dependencies:
+      fs-extra: 8.1.0
+      globby: 11.1.0
+      jju: 1.4.0
+      read-yaml-file: 1.1.0
+    dev: false
 
   /@ndelangen/get-tarball@3.0.7:
     resolution: {integrity: sha512-NqGfTZIZpRFef1GoVaShSSRwDC3vde3ThtTeqFdcYd6ipKqnfEVhjK2hUeHjCQUcptyZr2TONqcloFXM+5QBrQ==}
@@ -4578,7 +4601,6 @@ packages:
 
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-    dev: true
 
   /@types/node@16.18.23:
     resolution: {integrity: sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g==}
@@ -8360,7 +8382,6 @@ packages:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
-    dev: true
 
   /fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
@@ -9980,6 +10001,10 @@ packages:
       - supports-color
       - ts-node
 
+  /jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+    dev: false
+
   /joi@17.9.1:
     resolution: {integrity: sha512-FariIi9j6QODKATGBrEX7HZcja8Bsh3rfdGYy/Sb65sGlZWK/QWesU1ghk7aJWDj95knjXlQfSmzFSPPkLVsfw==}
     dependencies:
@@ -10124,7 +10149,6 @@ packages:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
       graceful-fs: 4.2.11
-    dev: true
 
   /jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -12325,7 +12349,6 @@ packages:
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
-    dev: true
 
   /readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -13728,7 +13751,6 @@ packages:
   /universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
-    dev: true
 
   /universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}

--- a/tests/sku-init.test.js
+++ b/tests/sku-init.test.js
@@ -42,6 +42,6 @@ export default skuConfig;
 `);
     },
     // `sku init` is a long running task and can take some time to complete
-    200 * 1000,
+    250 * 1000,
   );
 });


### PR DESCRIPTION
The `.git` folder may not be available in some situations where you want to run `sku`. Swapping to use `@manypkg/find-root` instead, as this gives us the name of the package manager as well as the root directory.

EDIT: Tested in the repo where the bug was originally found, confirmed that the fix works