### PR TITLE
Allow docs to be deployed without a changeset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Deploy docs
+        run: pnpm deploy-docs
+
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1
         with:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --cache --write '**/*.{js,ts,tsx,md,less,css}' && eslint --cache --fix .",
     "format-check": "prettier --list-different '**/*.{js,ts,tsx,md,less,css}'",
     "deploy-docs": "pnpm run --filter @sku-private/docs deploy",
-    "release": "pnpm deploy-docs && changeset publish",
+    "release": "changeset publish",
     "version": "changeset version && pnpm install --lockfile-only"
   },
   "packageManager": "pnpm@8.4.0",


### PR DESCRIPTION
Right now a changeset + **Version Packages** PR is required to be able to make an update to the docs.
See [here](https://github.com/seek-oss/sku/actions/runs/5651226167/job/15308971217#step:6:155) how docs were not deployed until the **Version Packages** PR was [merged](https://github.com/seek-oss/sku/actions/runs/5651319335/job/15309233463#step:6:30).