### PR TITLE
jest: Transform `.cjs` and `.mjs` files via babel

### DIFF
--- a/.changeset/late-forks-act.md
+++ b/.changeset/late-forks-act.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fixes a bug where `.cjs` and `.mjs` files where not being transformed by babel in jest tests

--- a/packages/sku/config/jest/jest-preset.js
+++ b/packages/sku/config/jest/jest-preset.js
@@ -31,7 +31,7 @@ module.exports = jestDecorator({
     '\\.less$': require.resolve('./cssModulesTransform.js'),
     '\\.css\\.ts$': require.resolve('@vanilla-extract/jest-transform'),
     '\\.tsx?$': require.resolve('./tsBabelTransform.js'),
-    '\\.js$': require.resolve('./jsBabelTransform.js'),
+    '\\.[cm]?js$': require.resolve('./jsBabelTransform.js'),
   },
   transformIgnorePatterns: [
     // Allow 'compilePackages' code to be transformed in tests by overriding


### PR DESCRIPTION
While working with packages compiled with crackle, I noticed that side-effect CSS imports were not being removed in jest tests, resulting in test failures, despite the work done in #865. This was occurring because we were only running our babel transform on `.js` files, not `.cjs` or `.mjs` files, which are what crackle outputs in order to simultaneously support CJS and ESM.