### PR TITLE
Bump storybook test util timeout

### DIFF
--- a/test-utils/storybook.js
+++ b/test-utils/storybook.js
@@ -40,7 +40,9 @@ const getTextContentFromStorybookFrame = async (
   storybookFrame,
   elementSelector,
 ) => {
-  const element = await storybookFrame.waitForSelector(elementSelector);
+  const element = await storybookFrame.waitForSelector(elementSelector, {
+    timeout: 100_000,
+  });
 
   return element.evaluate((e) => ({
     text: e.innerText,

--- a/test-utils/storybook.js
+++ b/test-utils/storybook.js
@@ -8,6 +8,7 @@
  */
 const getStorybookFrame = async (storybookUrl) => {
   const page = await browser.newPage();
+  page.setDefaultNavigationTimeout(100_000);
   await page.goto(storybookUrl, { waitUntil: 'networkidle2' });
 
   const firstStoryButton = await page.waitForSelector(


### PR DESCRIPTION
This `waitForSelector` call has been timing out [recently](https://github.com/seek-oss/sku/actions/runs/5779549707/job/15661993549?pr=867#step:13:1801). Increasing this timeout alongside the page navigation timeout to hopefully reduce the need to retry tests as often.