### PR TITLE
Revert storybook config to CJS

### DIFF
--- a/.changeset/cool-seahorses-check.md
+++ b/.changeset/cool-seahorses-check.md
@@ -1,0 +1,7 @@
+---
+'sku': patch
+---
+
+Revert storybook config to CJS
+
+Fixes a bug where newer storybook versions (>=7.1.0) could not load sku's storybook config

--- a/packages/sku/config/storybook/build/main.js
+++ b/packages/sku/config/storybook/build/main.js
@@ -1,1 +1,1 @@
-export { default } from '../config';
+module.exports = require('../config');

--- a/packages/sku/config/storybook/config.js
+++ b/packages/sku/config/storybook/config.js
@@ -1,12 +1,13 @@
-import fs from 'fs';
-import path from 'path';
-import { createRequire } from 'module';
-import { paths, storybookAddons, storybookStoryStore } from '../../context';
-
-const require = createRequire(import.meta.url);
+const fs = require('fs');
+const path = require('path');
+const {
+  paths,
+  storybookAddons,
+  storybookStoryStore,
+} = require('../../context');
 
 /** @type {import("@storybook/react-webpack5").StorybookConfig} */
-export default {
+module.exports = {
   stories: paths.src
     .filter((srcPath) => fs.statSync(srcPath).isDirectory())
     .map((srcPath) => path.join(srcPath, '**/*.stories.@(js|ts|tsx)')),

--- a/packages/sku/config/storybook/start/main.js
+++ b/packages/sku/config/storybook/start/main.js
@@ -1,1 +1,1 @@
-export { default } from '../config';
+module.exports = require('../config');


### PR DESCRIPTION
`sku storybook`/`sku build-storybook` were failing on storybook>7.1.0, specifically when loading sku's storybook files (`main.js` which imports `config.js`). These files were both converts to ESM during [the storybook 7 migration](https://github.com/seek-oss/sku/pull/810/files#diff-cbef970a47c624f5b1af4609d7388f97ff80a2bbe96e81fd5732c03c10c85534) when [support for ESM was added for `main.js`](https://github.com/storybookjs/storybook/blob/d20d1db32097d3a7075e2e5c49f6bb185f8f41de/MIGRATION.md#esm-format-in-mainjs). However, as of storybook 7.1.0, it appears that [storybook no longer runs `esbuild/register` on files from `node_modules`](https://github.com/storybookjs/storybook/pull/23018), which is likely how they were supporting ESM config, thus breaking the way sku injects storybook config.

Short of changing how sku injects its storybook config (potentially emitting config to a `.storybook` folder and gitignoring it), the easiest solution in the meantime is to just revert these configs back to CJS.

**NOTE:** I wasn't able to replicate this within sku's storybook fixture. Upgrading past storybook 7.1.0 results in the storybook CLI attempting to do things, but never finishing and showing no errors. However, I have replicated this issue in a sku consumer's app, and validated that the fix works.