### PR TITLE
Swap back to ubuntu agent

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,7 @@ jobs:
     name: Lint & Test
     needs: skip_check
     if: needs.skip_check.outputs.should_skip != 'true'
-    runs-on: macos-13
+    runs-on: ubuntu-latest
     env:
       CI: true
     timeout-minutes: 30
@@ -74,4 +74,4 @@ jobs:
           key: jest-${{ runner.os }}-${{ hashFiles('./pnpm-lock.yaml') }}
 
       - name: Test
-        run: pnpm run test --maxWorkers=3
+        run: pnpm run test --maxWorkers=2


### PR DESCRIPTION
Since Remus did [some work to make snapshots more stable](https://github.com/seek-oss/sku/pull/853), we no longer have hash differences between ubuntu and macos ([context](https://github.com/seek-oss/sku/pull/743#issuecomment-1556514139)). This means we can move back to ubuntu images for the `Lint & Test` step.

This comes with the drawback of slower tests because we can now only run 2 test suites at once rather than 3 (ubuntu agents have 2 cores vs macos agent's 3), but they still run in less than 10 minutes, and I'm hoping to get in a nice speedup soon 🤞.