### PR TITLE
Enable caching for ESLint and Prettier

### DIFF
--- a/.changeset/healthy-beds-sniff.md
+++ b/.changeset/healthy-beds-sniff.md
@@ -1,0 +1,5 @@
+---
+'sku': minor
+---
+
+Enable caching for ESLint and Prettier

--- a/fixtures/assertion-removal/.gitignore
+++ b/fixtures/assertion-removal/.gitignore
@@ -1,4 +1,5 @@
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/fixtures/braid-design-system/.gitignore
+++ b/fixtures/braid-design-system/.gitignore
@@ -1,4 +1,5 @@
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/fixtures/custom-src-paths/.gitignore
+++ b/fixtures/custom-src-paths/.gitignore
@@ -1,4 +1,5 @@
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/fixtures/library-build/.gitignore
+++ b/fixtures/library-build/.gitignore
@@ -1,4 +1,5 @@
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/fixtures/library-file/.gitignore
+++ b/fixtures/library-file/.gitignore
@@ -1,4 +1,5 @@
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/fixtures/lint-format/.gitignore
+++ b/fixtures/lint-format/.gitignore
@@ -1,4 +1,5 @@
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/fixtures/multiple-routes/.gitignore
+++ b/fixtures/multiple-routes/.gitignore
@@ -1,4 +1,5 @@
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/fixtures/public-path/.gitignore
+++ b/fixtures/public-path/.gitignore
@@ -1,4 +1,5 @@
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/fixtures/react-css-modules/.gitignore
+++ b/fixtures/react-css-modules/.gitignore
@@ -1,4 +1,5 @@
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/fixtures/sku-test/.gitignore
+++ b/fixtures/sku-test/.gitignore
@@ -1,4 +1,5 @@
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/fixtures/sku-with-https/.gitignore
+++ b/fixtures/sku-with-https/.gitignore
@@ -1,4 +1,5 @@
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .ssl

--- a/fixtures/source-maps/.gitignore
+++ b/fixtures/source-maps/.gitignore
@@ -1,4 +1,5 @@
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/fixtures/ssr-hello-world/.gitignore
+++ b/fixtures/ssr-hello-world/.gitignore
@@ -1,4 +1,5 @@
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/fixtures/storybook-config/.gitignore
+++ b/fixtures/storybook-config/.gitignore
@@ -2,6 +2,7 @@ node_modules
 npm-debug.log
 
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/fixtures/styling/.gitignore
+++ b/fixtures/styling/.gitignore
@@ -1,4 +1,5 @@
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/fixtures/translations/.gitignore
+++ b/fixtures/translations/.gitignore
@@ -2,6 +2,7 @@
 
 # managed by sku
 **/*.vocab/index.ts
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/fixtures/typescript-css-modules/.gitignore
+++ b/fixtures/typescript-css-modules/.gitignore
@@ -1,4 +1,5 @@
 # managed by sku
+.eslintcache
 .eslintrc
 .prettierrc
 .storybook/main.js

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "SKU_TELEMETRY=false SKU_DISABLE_CACHE=true OPEN_TAB=false jest --verbose",
     "setup-test-hosts": "node test-utils/setupTestHosts",
     "format": "prettier --cache --write '**/*.{js,ts,tsx,md,less,css}' && eslint --cache --fix .",
-    "format-check": "prettier --list-different '**/*.{js,ts,tsx,md,less,css}'",
+    "format-check": "prettier --cache --list-different '**/*.{js,ts,tsx,md,less,css}'",
     "deploy-docs": "pnpm run --filter @sku-private/docs deploy",
     "release": "pnpm deploy-docs && changeset publish",
     "version": "changeset version && pnpm install --lockfile-only"

--- a/packages/sku/lib/configure.js
+++ b/packages/sku/lib/configure.js
@@ -56,8 +56,9 @@ module.exports = async () => {
 
   // Generate ESLint configuration
   const eslintConfigFilename = '.eslintrc';
+  const eslintCacheFilename = '.eslintcache';
   await writeFileToCWD(eslintConfigFilename, eslintConfig);
-  gitIgnorePatterns.push(eslintConfigFilename);
+  gitIgnorePatterns.push(eslintConfigFilename, eslintCacheFilename);
 
   // Generate Prettier configuration
   // NOTE: We are not generating a banner as prettier does not support the `JSON

--- a/packages/sku/lib/runESLint.js
+++ b/packages/sku/lib/runESLint.js
@@ -17,6 +17,7 @@ const runESLint = async ({ fix = false, paths }) => {
     extensions,
     useEslintrc: false,
     fix,
+    cache: true,
   });
   const checkAll = typeof paths === 'undefined';
   /* Whitelist the file extensions that our ESLint setup currently supports */

--- a/packages/sku/lib/runPrettier.js
+++ b/packages/sku/lib/runPrettier.js
@@ -20,7 +20,7 @@ const runPrettier = async ({ write, listDifferent, paths }) => {
     chalk.cyan(`${write ? 'Formatting' : 'Checking'} code with Prettier`),
   );
 
-  const prettierArgs = ['--config', prettierConfigPath];
+  const prettierArgs = ['--config', prettierConfigPath, '--cache'];
 
   if (write) {
     prettierArgs.push('--write');

--- a/tests/configure.test.ts
+++ b/tests/configure.test.ts
@@ -77,8 +77,9 @@ describe('configure', () => {
 
     it(`should generate \`.gitignore\``, async () => {
       const ignoreContents = await readIgnore(appFolder, '.gitignore');
-      expect(ignoreContents.length).toEqual(8);
+      expect(ignoreContents.length).toEqual(9);
       expect(ignoreContents).toContain(`.eslintrc`);
+      expect(ignoreContents).toContain(`.eslintcache`);
       expect(ignoreContents).toContain(`.prettierrc`);
       expect(ignoreContents).toContain(`.storybook/main.js`);
       expect(ignoreContents).toContain(`${defaultTargetDir}/`);
@@ -139,8 +140,9 @@ describe('configure', () => {
 
     it(`should generate \`.gitignore\``, async () => {
       const ignoreContents = await readIgnore(appFolderTS, '.gitignore');
-      expect(ignoreContents.length).toEqual(8);
+      expect(ignoreContents.length).toEqual(9);
       expect(ignoreContents).toContain(`.eslintrc`);
+      expect(ignoreContents).toContain(`.eslintcache`);
       expect(ignoreContents).toContain(`.prettierrc`);
       expect(ignoreContents).toContain(`tsconfig.json`);
       expect(ignoreContents).toContain(`.storybook/main.js`);


### PR DESCRIPTION
Not sure why we didn't do this sooner.

Also added `--cache` to the repo's `format-check` script. This can speed up a subsequent `format`.