### PR TITLE
Remove `lodash` dependency

### DIFF
--- a/.changeset/breezy-squids-lay.md
+++ b/.changeset/breezy-squids-lay.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Remove `lodash` dependency

--- a/packages/sku/config/storybook/storybookWebpackConfig.js
+++ b/packages/sku/config/storybook/storybookWebpackConfig.js
@@ -1,5 +1,4 @@
 const { paths } = require('../../context');
-const find = require('lodash/find');
 const { merge: webpackMerge } = require('webpack-merge');
 const makeWebpackConfig = require('../webpack/webpack.config');
 const { resolvePackage } = require('../webpack/utils/resolvePackage');
@@ -11,14 +10,11 @@ const hot = process.env.SKU_HOT !== 'false';
  * @param {{isDevServer: boolean}}
  */
 module.exports = (config, { isDevServer }) => {
-  const clientWebpackConfig = find(
-    makeWebpackConfig({
-      isIntegration: true,
-      isDevServer,
-      hot: isDevServer && hot,
-    }),
-    ({ name }) => name === 'client',
-  );
+  const clientWebpackConfig = makeWebpackConfig({
+    isIntegration: true,
+    isDevServer,
+    hot: isDevServer && hot,
+  }).find(({ name }) => name === 'client');
 
   // Ensure Storybook's webpack loaders ignore our code :(
   if (config && config.module && Array.isArray(config.module.rules)) {

--- a/packages/sku/config/webpack/plugins/sku-webpack-plugin/index.js
+++ b/packages/sku/config/webpack/plugins/sku-webpack-plugin/index.js
@@ -1,5 +1,4 @@
 const webpack = require('webpack');
-const uniq = require('lodash/uniq');
 const defaultSupportedBrowsers = require('browserslist-config-seek');
 const { VanillaExtractPlugin } = require('@vanilla-extract/webpack-plugin');
 const {
@@ -32,10 +31,9 @@ class SkuWebpackPlugin {
       rootResolution: false,
       ...options,
     };
-    this.compilePackages = uniq([
-      ...defaultCompilePackages,
-      ...this.options.compilePackages,
-    ]);
+    this.compilePackages = [
+      ...new Set([...defaultCompilePackages, ...this.options.compilePackages]),
+    ];
     this.include = [
       ...this.options.include,
       ...this.compilePackages.map(resolvePackage),

--- a/packages/sku/context/index.js
+++ b/packages/sku/context/index.js
@@ -67,6 +67,9 @@ if (isCompilePackage && skuConfig.rootResolution) {
   process.exit(1);
 }
 
+/**
+ * @type {Record<string, unknown>}
+ */
 const env = {
   ...skuConfig.env,
   SKU_TENANT: args.tenant,

--- a/packages/sku/lib/env.js
+++ b/packages/sku/lib/env.js
@@ -1,0 +1,31 @@
+const args = require('../config/args');
+
+/**
+ * Stringify the values of an object of environment variables, prepending keys with
+ * `process.env.` in the process
+ * @param {Record<string, unknown>} envars An object of environment variables and their values
+ */
+const stringifyEnvarValues = (envars) => {
+  const entries = Object.entries(envars);
+
+  const stringifiedEntries = entries.map(([key, value]) => {
+    const newKey = `process.env.${key}`;
+
+    if (typeof value !== 'object') {
+      return [newKey, JSON.stringify(value)];
+    }
+
+    if (typeof value === 'undefined') {
+      console.log(
+        `WARNING: Environment variable "${key}" is missing a value for the "${args.env}" environment`,
+      );
+      process.exit(1);
+    }
+
+    return [newKey, JSON.stringify(value)];
+  });
+
+  return Object.fromEntries(stringifiedEntries);
+};
+
+module.exports = { stringifyEnvarValues };

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -99,7 +99,6 @@
     "less": "^4.1.0",
     "less-loader": "^11.1.3",
     "lint-staged": "^11.1.1",
-    "lodash": "^4.17.21",
     "memoizee": "^0.4.15",
     "mini-css-extract-plugin": "^2.6.1",
     "node-emoji": "^2.1.0",

--- a/packages/sku/scripts/serve.js
+++ b/packages/sku/scripts/serve.js
@@ -2,7 +2,6 @@ const path = require('path');
 const exists = require('../lib/exists');
 const express = require('express');
 const handler = require('serve-handler');
-const flatMap = require('lodash/flatMap');
 const { blue, bold, underline, red } = require('chalk');
 const didYouMean = require('didyoumean2').default;
 
@@ -94,7 +93,7 @@ const preferredSite = args.site;
 
     const site = getSiteForHost(hostname, preferredSite) || '';
 
-    const rewrites = flatMap(routes, (route) =>
+    const rewrites = routes.flatMap((route) =>
       getValidLanguagesForRoute(route).map((lang) => {
         const langRoute = getRouteWithLanguage(route.route, lang);
 

--- a/packages/sku/scripts/start-ssr.js
+++ b/packages/sku/scripts/start-ssr.js
@@ -3,7 +3,6 @@ process.env.NODE_ENV = 'development';
 const path = require('path');
 const WebpackDevServer = require('webpack-dev-server');
 const webpack = require('webpack');
-const { once } = require('lodash');
 const onDeath = require('death');
 const { blue, underline } = require('chalk');
 const debug = require('debug')('sku:start');
@@ -28,6 +27,20 @@ const hot = process.env.SKU_HOT !== 'false';
 
 const pluginName = 'sku-start-ssr';
 const localhost = '0.0.0.0';
+
+const once = (fn) => {
+  let called = false;
+  let result;
+
+  return (...fnArgs) => {
+    if (!called) {
+      result = fn(...fnArgs);
+      called = true;
+    }
+
+    return result;
+  };
+};
 
 (async () => {
   await watchVocabCompile();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,9 +698,6 @@ importers:
       lint-staged:
         specifier: ^11.1.1
         version: 11.2.6
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
       memoizee:
         specifier: ^0.4.15
         version: 0.4.15
@@ -846,9 +843,6 @@ importers:
       hostile:
         specifier: ^1.3.3
         version: 1.3.3
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
       node-dir:
         specifier: ^0.1.17
         version: 0.1.17

--- a/test-utils/ListExternalsWebpackPlugin.js
+++ b/test-utils/ListExternalsWebpackPlugin.js
@@ -1,5 +1,4 @@
 const { StatsWriterPlugin } = require('webpack-stats-plugin');
-const uniq = require('lodash/uniq');
 
 const externalRegex = /^external node-commonjs "/;
 
@@ -9,13 +8,15 @@ class ListExternalsWebpackPlugin {
       filename,
       fields: ['modules'],
       transform({ modules }) {
-        const externals = uniq(
-          modules
-            .map(({ identifier }) => identifier)
-            .filter((id) => externalRegex.test(id))
-            .map((id) => id.replace(externalRegex, '').replace(/"$/, ''))
-            .sort(),
-        );
+        const externals = [
+          ...new Set(
+            modules
+              .map(({ identifier }) => identifier)
+              .filter((id) => externalRegex.test(id))
+              .map((id) => id.replace(externalRegex, '').replace(/"$/, ''))
+              .sort(),
+          ),
+        ];
 
         return JSON.stringify(externals, null, 2);
       },

--- a/test-utils/package.json
+++ b/test-utils/package.json
@@ -6,7 +6,6 @@
     "diffable-html": "^5.0.0",
     "git-diff": "^2.0.6",
     "hostile": "^1.3.3",
-    "lodash": "^4.17.21",
     "node-dir": "^0.1.17",
     "prettier": "^2.8.8",
     "sku": "workspace:*",


### PR DESCRIPTION
Sku's usage of `lodash` is fairly limited, and I noticed there were a few quick replacements that could be done, so I just gutted it.

Side note: I never knew about the `env` sku config parameter. It's undocumented, and [has been deprecated since `v7`](https://github.com/seek-oss/sku/blob/master/docs/migration-guides/v7.0.0.md#env). I've slated it for removal in the next major in my notes.