### PR TITLE
Add `--packageManager` flag, support `pnpm` in `sku init`

### DIFF
--- a/.changeset/lucky-meals-grab.md
+++ b/.changeset/lucky-meals-grab.md
@@ -1,0 +1,13 @@
+---
+'sku': minor
+---
+
+Add `--packageManager` flag
+
+Sku detects package managers in the following order: `yarn` -> `pnpm` -> `npm`.
+The `--packageManager` flag can be used to override the package manager used for the `sku init` script.
+This affects what package manager is used to install dependencies, as well as the scripts present in the initialized app template.
+
+```sh
+$ pnpm dlx sku init --packageManager pnpm my-app
+```

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -2,14 +2,18 @@
 
 Create a new project and start a local development environment:
 
-```sh
+```bash
 $ npx sku init my-app
 $ cd my-app
-$ npm start
+$ yarn start
 ```
 
-Don't have [npx](https://www.npmjs.com/package/npx)?
+By default, a new project's dependencies will be installed with the first supported package manager detected on your system.
+Package managers are detected in the following order: `yarn` -> `pnpm` -> `npm`.
+This can be overridden via the `--packageManager` flag:
 
-```sh
-$ npm install -g npx
+```bash
+$ pnpm dlx sku init --packageManager pnpm my-app
+$ cd my-app
+$ pnpm start
 ```

--- a/packages/sku/README.md
+++ b/packages/sku/README.md
@@ -23,13 +23,17 @@ Create a new project and start a local development environment:
 ```bash
 $ npx sku init my-app
 $ cd my-app
-$ npm start
+$ yarn start
 ```
 
-Don't have [npx](https://www.npmjs.com/package/npx)?
+By default, a new project's dependencies will be installed with the first supported package manager detected on your system.
+Package managers are detected in the following order: `yarn` -> `pnpm` -> `npm`.
+This can be overridden via the `--packageManager` flag:
 
 ```bash
-$ npm install -g npx
+$ pnpm dlx sku init --packageManager pnpm my-app
+$ cd my-app
+$ pnpm start
 ```
 
 ## [Documentation](https://seek-oss.github.io/sku)

--- a/packages/sku/lib/hosts.js
+++ b/packages/sku/lib/hosts.js
@@ -57,7 +57,7 @@ const checkHosts = async () => {
         );
       });
 
-      await suggestScript('setup-hosts', { sudo: true });
+      suggestScript('setup-hosts', { sudo: true });
     }
   } catch (e) {
     // swallow error as this just a warning check

--- a/packages/sku/lib/install.js
+++ b/packages/sku/lib/install.js
@@ -1,29 +1,14 @@
+const { getAddCommand } = require('./packageManager');
+
 const spawn = require('cross-spawn');
 
-module.exports = ({ deps, type, exact = true, verbose, useYarn }) =>
+/**
+ * @param {import("../lib/packageManager").GetAddCommandOptions} options
+ */
+module.exports = ({ deps, type, logLevel, exact = true }) =>
   new Promise((resolve, reject) => {
-    const command = useYarn ? 'yarn' : 'npm';
-    const isDev = type === 'dev';
-
-    const args = useYarn
-      ? [
-          'add',
-          isDev ? '--dev' : null,
-          exact ? '--exact' : null,
-          ...deps,
-        ].filter((arg) => arg !== null)
-      : [
-          'install',
-          `--save${isDev ? '-dev' : ''}`,
-          exact ? '--save-exact' : null,
-          '--loglevel',
-          'error',
-          ...deps,
-        ].filter((arg) => arg !== null);
-
-    if (verbose) {
-      args.push('--verbose');
-    }
+    const addCommand = getAddCommand({ deps, type, logLevel, exact });
+    const [command, ...args] = addCommand.split(' ');
 
     const child = spawn(command, args, { stdio: 'inherit' });
 

--- a/packages/sku/lib/packageManager.js
+++ b/packages/sku/lib/packageManager.js
@@ -1,7 +1,9 @@
 const { cwd } = require('../lib/cwd');
 const { findRootSync } = require('@manypkg/find-root');
+const { getCommand, INSTALL_PAGE } = require('@antfu/ni');
 
 const { sync: which } = require('which');
+const skuArgs = require('../config/args');
 
 /** @typedef {'yarn' | 'pnpm' | 'npm'} SupportedPackageManager */
 
@@ -15,13 +17,10 @@ const supportedPackageManagers = ['yarn', 'pnpm', 'npm'];
 const detectPackageManagerCommand = (commandName) =>
   which(commandName, { nothrow: true }) ? commandName : null;
 
-const detectPackageManager = () => {
-  return (
-    detectPackageManagerCommand('yarn') ||
-    detectPackageManagerCommand('pnpm') ||
-    'npm'
-  );
-};
+const detectPackageManager = () =>
+  detectPackageManagerCommand('yarn') ||
+  detectPackageManagerCommand('pnpm') ||
+  'npm';
 
 /**
  * Get the package manager and root directory of the project. If the project does not have a
@@ -30,18 +29,25 @@ const detectPackageManager = () => {
  * @returns {{packageManager: SupportedPackageManager, rootDir: string | null}}
  */
 const getPackageManager = () => {
-  try {
-    const { tool, rootDir } = findRootSync(cwd());
+  let _packageManager = skuArgs?.packageManager;
 
-    if (!supportedPackageManagers.includes(tool.type)) {
+  try {
+    const {
+      tool: { type: foundPackageManager },
+      rootDir,
+    } = findRootSync(cwd());
+
+    if (!supportedPackageManagers.includes(foundPackageManager)) {
       throw new Error('Unsupported package manager found');
     }
 
-    return { packageManager: tool.type, rootDir };
-  } catch {
-    const packageManager = detectPackageManager();
+    _packageManager ||= foundPackageManager;
 
-    return { packageManager, rootDir: null };
+    return { packageManager: _packageManager, rootDir };
+  } catch {
+    _packageManager ||= detectPackageManager();
+
+    return { packageManager: _packageManager, rootDir: null };
   }
 };
 
@@ -51,4 +57,96 @@ const isYarn = packageManager === 'yarn';
 const isPnpm = packageManager === 'pnpm';
 const isNpm = packageManager === 'npm';
 
-module.exports = { rootDir, packageManager, isYarn, isPnpm, isNpm };
+/**
+ * @param {string} scriptName
+ */
+const getRunCommand = (scriptName) =>
+  getCommand(packageManager, 'run', [scriptName]);
+
+/**
+ * @param {string[]} args
+ */
+const getExecuteCommand = (args) => getCommand(packageManager, 'execute', args);
+
+/** @type {Record<SupportedPackageManager, string[]>} */
+const regularLoglevelArgsByPackageManager = {
+  // Yarn doesn't have a loglevel flag
+  yarn: [],
+  pnpm: ['--loglevel', 'error'],
+  npm: ['--loglevel', 'error'],
+};
+
+/** @type {Record<SupportedPackageManager, string[]>} */
+const verboseLoglevelArgsByPackageManager = {
+  yarn: ['--verbose'],
+  pnpm: ['--loglevel', 'info'],
+  npm: ['--loglevel', 'verbose'],
+};
+
+/**
+ * @param {'verbose' | 'regular'} logLevel
+ */
+const resolveLogLevelArgs = (logLevel) => {
+  if (logLevel === 'verbose') {
+    return verboseLoglevelArgsByPackageManager[packageManager];
+  }
+
+  return regularLoglevelArgsByPackageManager[packageManager];
+};
+
+/**
+ * @typedef {object} GetAddCommandOptions
+ * @property {'dev' | 'prod'} type
+ * @property {'verbose' | 'regular' | undefined} logLevel
+ * @property {boolean} exact
+ * @property {string[]} deps
+ * @param {GetAddCommandOptions} options
+ */
+const getAddCommand = ({ type, logLevel, deps, exact }) => {
+  const args = [];
+
+  const addingDevDeps = type === 'dev';
+
+  if (addingDevDeps) {
+    const devDepFlag = isYarn ? '--dev' : `--save-dev`;
+    args.push(devDepFlag);
+  }
+
+  if (exact) {
+    const exactFlag = isYarn ? '--exact' : '--save-exact';
+    args.push(exactFlag);
+  }
+
+  if (logLevel) {
+    args.push(...resolveLogLevelArgs(logLevel));
+  }
+
+  args.push(...deps);
+
+  return getCommand(packageManager, 'add', args);
+};
+
+const getInstallCommand = () => getCommand(packageManager, 'install', []);
+
+const getWhyCommand = () => {
+  const whyCommand = isPnpm ? '-r why' : 'why';
+
+  return `${packageManager} ${whyCommand}`;
+};
+
+const getPackageManagerInstallPage = () => INSTALL_PAGE[packageManager];
+
+module.exports = {
+  supportedPackageManagers,
+  rootDir,
+  packageManager,
+  isYarn,
+  isPnpm,
+  isNpm,
+  getRunCommand,
+  getExecuteCommand,
+  getAddCommand,
+  getInstallCommand,
+  getWhyCommand,
+  getPackageManagerInstallPage,
+};

--- a/packages/sku/lib/packageManager.js
+++ b/packages/sku/lib/packageManager.js
@@ -129,7 +129,7 @@ const getAddCommand = ({ type, logLevel, deps, exact }) => {
 const getInstallCommand = () => getCommand(packageManager, 'install', []);
 
 const getWhyCommand = () => {
-  const whyCommand = isPnpm ? '-r why' : 'why';
+  const whyCommand = isPnpm ? 'why -r' : 'why';
 
   return `${packageManager} ${whyCommand}`;
 };

--- a/packages/sku/lib/parseArgs.js
+++ b/packages/sku/lib/parseArgs.js
@@ -37,6 +37,10 @@ const optionDefinitions = [
     type: String,
   },
   {
+    name: 'packageManager',
+    type: String,
+  },
+  {
     name: 'port',
     type: Number,
   },

--- a/packages/sku/lib/runPrettier.js
+++ b/packages/sku/lib/runPrettier.js
@@ -69,7 +69,7 @@ const runPrettier = async ({ write, listDifferent, paths }) => {
             'Error: The file(s) listed above failed the prettier check',
           ),
         );
-        await suggestScript('format');
+        suggestScript('format');
       } else {
         console.error(
           chalk.red('Error: Prettier check exited with exit code', exitCode),

--- a/packages/sku/lib/suggestScript.js
+++ b/packages/sku/lib/suggestScript.js
@@ -1,14 +1,15 @@
-const { getCommand } = require('@antfu/ni');
-const { packageManager } = require('./packageManager');
+const { getRunCommand, getExecuteCommand } = require('./packageManager');
 
 const chalk = require('chalk');
 const { requireFromCwd } = require('./cwd');
 
 /**
  * @param {string} scriptContents
+ * @returns {string | undefined}
  */
 const findPackageScript = (scriptContents) => {
   let pkg;
+
   try {
     pkg = requireFromCwd('./package.json');
   } catch (err) {
@@ -23,17 +24,6 @@ const findPackageScript = (scriptContents) => {
 };
 
 /**
- * @param {boolean} isPackageScript
- */
-const resolvePackageManagerCommand = (isPackageScript) => {
-  if (isPackageScript) {
-    return getCommand(packageManager, 'run');
-  }
-
-  return getCommand(packageManager, 'execute');
-};
-
-/**
  * @typedef {object} Options
  * @property {boolean} sudo
  */
@@ -42,28 +32,24 @@ const resolvePackageManagerCommand = (isPackageScript) => {
  * @param {string} scriptName
  * @param {Options | undefined} options
  */
-const getSuggestedScript = async (scriptName, options = { sudo: false }) => {
+const getSuggestedScript = (scriptName, options = { sudo: false }) => {
   const packageScript = findPackageScript(`sku ${scriptName}`);
 
-  const packageManagerCommand = resolvePackageManagerCommand(
-    Boolean(packageScript),
-  );
-
-  const packageOrSkuScript = packageScript
-    ? packageScript
-    : `sku ${scriptName}`;
+  const command = packageScript
+    ? getRunCommand(packageScript)
+    : getExecuteCommand(['sku', packageScript]);
 
   const sudoPrefix = options.sudo ? 'sudo ' : '';
 
-  return `${sudoPrefix}${packageManagerCommand} ${packageOrSkuScript}`;
+  return `${sudoPrefix}${command}`;
 };
 
 /**
  * @param {string} scriptName
  * @param {Options | undefined} options
  */
-const suggestScript = async (scriptName, options) => {
-  const suggestedScript = await getSuggestedScript(scriptName, options);
+const suggestScript = (scriptName, options) => {
+  const suggestedScript = getSuggestedScript(scriptName, options);
 
   console.log(
     chalk.blue(`To fix this issue, run '${chalk.bold(suggestedScript)}'`),

--- a/packages/sku/lib/suggestScript.js
+++ b/packages/sku/lib/suggestScript.js
@@ -7,7 +7,7 @@ const { requireFromCwd } = require('./cwd');
  * @param {string} scriptContents
  * @returns {string | undefined}
  */
-const findPackageScript = (scriptContents) => {
+const findPackageScriptName = (scriptContents) => {
   let pkg;
 
   try {
@@ -33,11 +33,11 @@ const findPackageScript = (scriptContents) => {
  * @param {Options | undefined} options
  */
 const getSuggestedScript = (scriptName, options = { sudo: false }) => {
-  const packageScript = findPackageScript(`sku ${scriptName}`);
+  const packageScriptName = findPackageScriptName(`sku ${scriptName}`);
 
-  const command = packageScript
-    ? getRunCommand(packageScript)
-    : getExecuteCommand(['sku', packageScript]);
+  const command = packageScriptName
+    ? getRunCommand(packageScriptName)
+    : getExecuteCommand(['sku', scriptName]);
 
   const sudoPrefix = options.sudo ? 'sudo ' : '';
 

--- a/packages/sku/lib/validatePeerDeps.js
+++ b/packages/sku/lib/validatePeerDeps.js
@@ -1,4 +1,4 @@
-const { packageManager, isPnpm } = require('./packageManager');
+const { getWhyCommand } = require('./packageManager');
 
 const { readFile } = require('fs/promises');
 const glob = require('fast-glob');
@@ -56,10 +56,8 @@ module.exports = async () => {
             .join('\n'),
         );
 
-        const whyCommand = isPnpm ? '-r why' : 'why';
-
         messages.push(
-          chalk`Try running "{blue.bold ${packageManager} ${whyCommand}} {bold ${packageName}}" to diagnose the issue`,
+          chalk`Try running "{blue.bold ${getWhyCommand()}} {bold ${packageName}}" to diagnose the issue`,
         );
 
         track.count('duplicate_compile_package', {

--- a/packages/sku/telemetry/provider.js
+++ b/packages/sku/telemetry/provider.js
@@ -1,6 +1,4 @@
-const { packageManager, isYarn } = require('../lib/packageManager');
-const { getCommand } = require('@antfu/ni');
-
+const { getAddCommand } = require('../lib/packageManager');
 const banner = require('../lib/banner');
 
 function noop() {}
@@ -26,11 +24,10 @@ try {
     provider = realProvider;
   }
 } catch (e) {
-  const addDevDepFlag = isYarn ? '--dev' : '--save-dev';
-  const addCommand = getCommand(packageManager, 'add', [
-    addDevDepFlag,
-    '@seek/sku-telemetry',
-  ]);
+  const addCommand = getAddCommand({
+    deps: ['@seek/sku-telemetry'],
+    type: 'dev',
+  });
 
   banner('warning', '@seek/sku-telemetry not installed', [
     'To help us improve sku, please install our private telemetry package that gives us insights on usage, errors and performance.',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,31 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sku
 
+  fixtures/sku-init/new-project:
+    dependencies:
+      braid-design-system:
+        specifier: ^32.0.0
+        version: 32.9.1(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(sku@packages+sku)
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
+    devDependencies:
+      '@types/react':
+        specifier: ^18.2.3
+        version: 18.2.21
+      '@types/react-dom':
+        specifier: ^18.2.3
+        version: 18.2.7
+      '@vanilla-extract/css':
+        specifier: ^1.0.0
+        version: 1.13.0
+      sku:
+        specifier: workspace:^
+        version: link:../../../packages/sku
+
   fixtures/sku-test:
     devDependencies:
       sku:


### PR DESCRIPTION
See changeset. This is a followup to #876 that rounds out sku's pnpm support by enabling `sku init` to use `pnpm`.

This PR also includes a refactor of the `packageManager` lib to be the sole user of `@antfu/ni`, as suggested by Remus in #876.