### PR TITLE
Disable peer dep validation in fixtures

### DIFF
--- a/fixtures/assertion-removal/package.json
+++ b/fixtures/assertion-removal/package.json
@@ -12,5 +12,6 @@
     "assert": "^2.0.0",
     "dedent": "^0.7.0",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/braid-design-system/package.json
+++ b/fixtures/braid-design-system/package.json
@@ -12,5 +12,6 @@
     "@types/react-dom": "^18.2.3",
     "@vanilla-extract/css": "^1.0.0",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/configure/package.json
+++ b/fixtures/configure/package.json
@@ -8,5 +8,6 @@
   "devDependencies": {
     "@types/react": "^18.2.3",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/custom-src-paths/package.json
+++ b/fixtures/custom-src-paths/package.json
@@ -10,5 +10,6 @@
     "@sku-private/test-utils": "workspace:*",
     "dedent": "^0.7.0",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/jest-test/package.json
+++ b/fixtures/jest-test/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "devDependencies": {
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/library-build/package.json
+++ b/fixtures/library-build/package.json
@@ -5,5 +5,6 @@
     "@sku-private/test-utils": "workspace:*",
     "dedent": "^0.7.0",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/library-file/package.json
+++ b/fixtures/library-file/package.json
@@ -5,5 +5,6 @@
     "@sku-private/test-utils": "workspace:*",
     "dedent": "^0.7.0",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/lint-format/package.json
+++ b/fixtures/lint-format/package.json
@@ -6,5 +6,6 @@
   },
   "scripts": {
     "format": "sku format"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/multiple-routes/package.json
+++ b/fixtures/multiple-routes/package.json
@@ -11,5 +11,6 @@
     "@testing-library/react": "^14.0.0",
     "dedent": "^0.7.0",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/public-path/package.json
+++ b/fixtures/public-path/package.json
@@ -9,5 +9,6 @@
     "@sku-private/test-utils": "workspace:*",
     "dedent": "^0.7.0",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/react-css-modules/package.json
+++ b/fixtures/react-css-modules/package.json
@@ -9,5 +9,6 @@
     "@sku-private/test-utils": "workspace:*",
     "dedent": "^0.7.0",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/sku-test/package.json
+++ b/fixtures/sku-test/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "devDependencies": {
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/sku-webpack-plugin/package.json
+++ b/fixtures/sku-webpack-plugin/package.json
@@ -11,5 +11,6 @@
     "mini-css-extract-plugin": "^2.6.1",
     "html-webpack-plugin": "^5.3.2",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/sku-with-https/package.json
+++ b/fixtures/sku-with-https/package.json
@@ -9,5 +9,6 @@
     "@sku-private/test-utils": "workspace:*",
     "dedent": "^0.7.0",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/source-maps/package.json
+++ b/fixtures/source-maps/package.json
@@ -9,5 +9,6 @@
     "@sku-private/test-utils": "workspace:*",
     "dedent": "^0.7.0",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/ssr-hello-world/package.json
+++ b/fixtures/ssr-hello-world/package.json
@@ -10,4 +10,6 @@
     "@sku-private/test-utils": "workspace:*",
     "sku": "workspace:*"
   }
+,
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/storybook-config/package.json
+++ b/fixtures/storybook-config/package.json
@@ -12,5 +12,6 @@
     "@types/react-dom": "^18.2.3",
     "@vanilla-extract/css": "^1.0.0",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/styling/package.json
+++ b/fixtures/styling/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "dependencies": {
     "@sku-fixtures/package-with-styles": "./fake/node_modules/package-with-styles",
-    "@vanilla-extract/css": "^1.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -11,7 +10,9 @@
     "@sku-private/test-utils": "workspace:*",
     "@types/react": "^18.2.3",
     "@types/react-dom": "^18.2.3",
+    "@vanilla-extract/css": "^1.0.0",
     "dedent": "^0.7.0",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/translations/package.json
+++ b/fixtures/translations/package.json
@@ -15,5 +15,6 @@
     "@types/react-dom": "^18.2.3",
     "dedent": "^0.7.0",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/typescript-css-modules/package.json
+++ b/fixtures/typescript-css-modules/package.json
@@ -11,5 +11,6 @@
     "@types/react-dom": "^18.2.3",
     "dedent": "^0.7.0",
     "sku": "workspace:*"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,9 +410,6 @@ importers:
       '@sku-fixtures/package-with-styles':
         specifier: ./fake/node_modules/package-with-styles
         version: link:fake/node_modules/package-with-styles
-      '@vanilla-extract/css':
-        specifier: ^1.0.0
-        version: 1.13.0
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -429,6 +426,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.3
         version: 18.2.7
+      '@vanilla-extract/css':
+        specifier: ^1.0.0
+        version: 1.13.0
       dedent:
         specifier: ^0.7.0
         version: 0.7.0

--- a/test-utils/package.json
+++ b/test-utils/package.json
@@ -12,5 +12,6 @@
     "sku": "workspace:*",
     "wait-on": "^7.0.0",
     "webpack-stats-plugin": "^1.0.3"
-  }
+  },
+  "skuSkipValidatePeerDeps": true
 }


### PR DESCRIPTION
Getting tired of all the noise the peer dep validation causes in CI, and _especially_ locally. Dependencies in fixtures tend to be updated all at once anyway, and PNPM's node module structure also helps mitigate issues caused by multiple versions of the same package, so I'm not too concerned that this will cause issues in the future.

Also, turns out that running a bunch of globs over `node_modules` concurrently is slow, so this has the added side-effect of making local testing significantly faster. I'm consistently getting test runs <2 minutes, relative to master where I typically get 3+ minutes (on an M1 pro macbook).

This has had a negligible effect on CI test speed, probably because it can only run 2 test suites at once, so at most 2 globs were running at once.