### PR TITLE
Ignore .pnpm-store files when running Jest tests

### DIFF
--- a/.changeset/cuddly-owls-change.md
+++ b/.changeset/cuddly-owls-change.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Ignore .pnpm-store files when running Jest tests

--- a/packages/sku/config/jest/jest-preset.js
+++ b/packages/sku/config/jest/jest-preset.js
@@ -20,7 +20,7 @@ module.exports = jestDecorator({
     '**/?(*.)+(spec|test).(js|ts|tsx)',
   ],
   testPathIgnorePatterns: [
-    `<rootDir>${slash}(${paths.target}|node_modules)${slash}`,
+    `<rootDir>${slash}(${paths.target}|node_modules|.pnpm_store)${slash}`,
   ],
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
   moduleNameMapper: {


### PR DESCRIPTION
`@zendesk/babel-plugin-react-displayname` is a GitHub dependency, so if .pnpm-store is in the current directory, Jest will attempt to run tests from its source code. 