### PR TITLE
docs: Add `Debugging` page and document sku logs and `--stats` argument

### DIFF
--- a/docs/docs/_sidebar.md
+++ b/docs/docs/_sidebar.md
@@ -1,6 +1,7 @@
 - [Getting started](./docs/getting-started.md)
 - [Configuration](./docs/configuration.md)
 - [FAQ](./docs/faq)
+- [Debugging](./docs/debugging.md)
 - **Project types**
 - [Static rendering](./docs/static-rendering.md)
 - [Server rendering](./docs/server-rendering.md)

--- a/docs/docs/debugging.md
+++ b/docs/docs/debugging.md
@@ -22,11 +22,11 @@ For more detailed information about webpack warnings/errors, the `--stats` CLI a
 yarn sku start --stats=detailed
 ```
 
-The default values are as follows:
+The default value of the `--stats` argument is as follows:
 
-| sku command       | webpack stats value |
-| ----------------- | ------------------- |
-| `start/start-ssr` | `summary`           |
-| `build/build-ssr` | `errors-only`       |
+| sku command       | webpack stats preset |
+| ----------------- | -------------------- |
+| `start/start-ssr` | `summary`            |
+| `build/build-ssr` | `errors-only`        |
 
 [webpack stats preset]: https://webpack.js.org/configuration/stats/#stats-presets

--- a/docs/docs/debugging.md
+++ b/docs/docs/debugging.md
@@ -1,0 +1,32 @@
+# Debugging
+
+Below are some strategies for debugging issues in your sku app.
+
+## Enable sku Logs
+
+By default, sku's [debug] logs are disabled.
+These logs can offer insights into sku's config resolution, package resolution, dev server routing, and more.
+They can be enabled by setting the `DEBUG` environment variable:
+
+```sh
+DEBUG="sku*" yarn sku start
+```
+
+[debug]: https://www.npmjs.com/package/debug
+
+## Webpack Stats
+
+For more detailed information about webpack warnings/errors, the `--stats` CLI argument can be used to override the default [webpack stats preset]:
+
+```sh
+yarn sku start --stats=detailed
+```
+
+The default values are as follows:
+
+| sku command       | webpack stats value |
+| ----------------- | ------------------- |
+| `start/start-ssr` | `summary`           |
+| `build/build-ssr` | `errors-only`       |
+
+[webpack stats preset]: https://webpack.js.org/configuration/stats/#stats-presets


### PR DESCRIPTION
Figured it was worth adding some debugging docs after Remus discovered that we don't document [the `--stats` argument added in sku 11](https://github.com/seek-oss/sku/releases/tag/v11.0.0#:~:text=Add%20%2D%2Dstats%20argument), which I had no idea even existed.