### PR TITLE
Async import `node-emoji`

### DIFF
--- a/.changeset/stupid-news-chew.md
+++ b/.changeset/stupid-news-chew.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Asynchronously import `node-emoji` to fix ESM require issue

--- a/packages/sku/config/webpack/plugins/sku-webpack-plugin/validateOptions.js
+++ b/packages/sku/config/webpack/plugins/sku-webpack-plugin/validateOptions.js
@@ -2,11 +2,12 @@ const Validator = require('fastest-validator');
 const browserslist = require('browserslist');
 const { yellow, red, bold, underline, white } = require('chalk');
 const didYouMean = require('didyoumean2').default;
-const { emojify } = require('node-emoji');
 
 const validator = new Validator();
 
-const exitWithErrors = (errors) => {
+const exitWithErrors = async (errors) => {
+  const { emojify } = await import('node-emoji');
+
   console.log(bold(underline(red('SkuWebpackPlugin: Invalid options'))));
   errors.forEach((error) => {
     console.log(yellow(emojify(error)));

--- a/packages/sku/context/validateConfig.js
+++ b/packages/sku/context/validateConfig.js
@@ -1,7 +1,6 @@
 const browserslist = require('browserslist');
 const { yellow, red, bold, underline, white } = require('chalk');
 const didYouMean = require('didyoumean2').default;
-const { emojify } = require('node-emoji');
 
 const configSchema = require('./configSchema');
 const defaultSkuConfig = require('./defaultSkuConfig');
@@ -9,7 +8,9 @@ const defaultClientEntry = require('./defaultClientEntry');
 
 const availableConfigKeys = Object.keys(defaultSkuConfig);
 
-const exitWithErrors = (errors) => {
+const exitWithErrors = async (errors) => {
+  const { emojify } = await import('node-emoji');
+
   console.log(bold(underline(red('Errors in sku config:'))));
   errors.forEach((error) => {
     console.log(yellow(emojify(error)));


### PR DESCRIPTION
Because https://github.com/omnidan/node-emoji/issues/151. Getting a temporary fix out as this issue will affect anyone that relocks.