### PR TITLE
Remove `node-emoji` dependency

### DIFF
--- a/.changeset/eight-shoes-check.md
+++ b/.changeset/eight-shoes-check.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Remove `node-emoji` dependency

--- a/packages/sku/config/webpack/plugins/sku-webpack-plugin/validateOptions.js
+++ b/packages/sku/config/webpack/plugins/sku-webpack-plugin/validateOptions.js
@@ -6,11 +6,9 @@ const didYouMean = require('didyoumean2').default;
 const validator = new Validator();
 
 const exitWithErrors = async (errors) => {
-  const { emojify } = await import('node-emoji');
-
   console.log(bold(underline(red('SkuWebpackPlugin: Invalid options'))));
   errors.forEach((error) => {
-    console.log(yellow(emojify(error)));
+    console.log(yellow(error));
   });
   process.exit(1);
 };
@@ -85,7 +83,7 @@ module.exports = (options) => {
       const suggestedMessage = suggestedKey
         ? ` Did you mean '${bold(suggestedKey)}'?`
         : '';
-      errors.push(`:question: ${unknownMessage}${suggestedMessage}`);
+      errors.push(`❓ ${unknownMessage}${suggestedMessage}`);
     });
 
   // Validate schema types
@@ -93,8 +91,8 @@ module.exports = (options) => {
   if (schemaCheckResult !== true) {
     schemaCheckResult.forEach(({ message, field }) => {
       const errorMessage = message
-        ? `:no_entry_sign: ${message.replace(field, `${bold(field)}`)}`
-        : `:no_entry_sign: '${bold(field)}' is invalid`;
+        ? `🚫 ${message.replace(field, `${bold(field)}`)}`
+        : `🚫 '${bold(field)}' is invalid`;
 
       errors.push(errorMessage);
     });
@@ -106,7 +104,7 @@ module.exports = (options) => {
       browserslist(options.browserslist);
     } catch (e) {
       errors.push(
-        `:no_entry_sign: '${bold(
+        `🚫 '${bold(
           'browserslist',
         )}' must be a valid browserslist query. ${white(e.message)}`,
       );

--- a/packages/sku/context/validateConfig.js
+++ b/packages/sku/context/validateConfig.js
@@ -9,11 +9,9 @@ const defaultClientEntry = require('./defaultClientEntry');
 const availableConfigKeys = Object.keys(defaultSkuConfig);
 
 const exitWithErrors = async (errors) => {
-  const { emojify } = await import('node-emoji');
-
   console.log(bold(underline(red('Errors in sku config:'))));
   errors.forEach((error) => {
-    console.log(yellow(emojify(error)));
+    console.log(yellow(error));
   });
   process.exit(1);
 };
@@ -30,7 +28,7 @@ module.exports = (skuConfig) => {
       const suggestedMessage = suggestedKey
         ? ` Did you mean '${bold(suggestedKey)}'?`
         : '';
-      errors.push(`:question: ${unknownMessage}${suggestedMessage}`);
+      errors.push(`❓ ${unknownMessage}${suggestedMessage}`);
     });
 
   // Validate schema types
@@ -38,8 +36,8 @@ module.exports = (skuConfig) => {
   if (schemaCheckResult !== true) {
     schemaCheckResult.forEach(({ message, field }) => {
       const errorMessage = message
-        ? `:no_entry_sign: ${message.replace(field, `${bold(field)}`)}`
-        : `:no_entry_sign: '${bold(field)}' is invalid`;
+        ? `🚫 ${message.replace(field, `${bold(field)}`)}`
+        : `🚫 '${bold(field)}' is invalid`;
 
       errors.push(errorMessage);
     });
@@ -48,9 +46,7 @@ module.exports = (skuConfig) => {
   // Validate library entry has corresponding libraryName
   if (skuConfig.libraryEntry && !skuConfig.libraryName) {
     errors.push(
-      `:no_entry_sign: '${bold(
-        'libraryEntry',
-      )}' must have a corresponding '${bold(
+      `🚫 '${bold('libraryEntry')}' must have a corresponding '${bold(
         'libraryName',
       )}' option. More details: ${underline(
         'https://github.com/seek-oss/sku#building-a-library',
@@ -62,7 +58,7 @@ module.exports = (skuConfig) => {
   skuConfig.routes.forEach(({ name }) => {
     if (name === defaultClientEntry) {
       errors.push(
-        `:no_entry_sign: Invalid route name: '${bold(
+        `🚫 Invalid route name: '${bold(
           defaultClientEntry,
         )}', please use a different route name`,
       );
@@ -74,7 +70,7 @@ module.exports = (skuConfig) => {
     browserslist(skuConfig.supportedBrowsers);
   } catch (e) {
     errors.push(
-      `:no_entry_sign: '${bold(
+      `🚫 '${bold(
         'supportedBrowsers',
       )}' must be a valid browserslist query. ${white(e.message)}`,
     );

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -102,7 +102,6 @@
     "lint-staged": "^11.1.1",
     "memoizee": "^0.4.15",
     "mini-css-extract-plugin": "^2.6.1",
-    "node-emoji": "^2.1.0",
     "node-html-parser": "^6.1.1",
     "open": "^7.3.1",
     "path-to-regexp": "^6.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -722,9 +722,6 @@ importers:
       mini-css-extract-plugin:
         specifier: ^2.6.1
         version: 2.7.6(webpack@5.89.0)
-      node-emoji:
-        specifier: ^2.1.0
-        version: 2.1.0
       node-html-parser:
         specifier: ^6.1.1
         version: 6.1.11
@@ -4391,11 +4388,6 @@ packages:
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
     engines: {node: '>=6'}
     dev: true
-
-  /@sindresorhus/is@3.1.2:
-    resolution: {integrity: sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==}
-    engines: {node: '>=10'}
-    dev: false
 
   /@sinonjs/commons@3.0.0:
     resolution: {integrity: sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==}
@@ -8247,10 +8239,6 @@ packages:
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
-  /emojilib@2.4.0:
-    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
-    dev: false
-
   /emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
@@ -12078,15 +12066,6 @@ packages:
       minimatch: 3.1.2
     dev: false
 
-  /node-emoji@2.1.0:
-    resolution: {integrity: sha512-tcsBm9C6FmPN5Wo7OjFi9lgMyJjvkAeirmjR/ax8Ttfqy4N8PoFic26uqFTIgayHPNI5FH4ltUvfh9kHzwcK9A==}
-    dependencies:
-      '@sindresorhus/is': 3.1.2
-      char-regex: 1.0.2
-      emojilib: 2.4.0
-      skin-tone: 2.0.0
-    dev: false
-
   /node-fetch-native@1.4.1:
     resolution: {integrity: sha512-NsXBU0UgBxo2rQLOeWNZqS3fvflWePMECr8CoSWoSTqCqGbVVsvl9vZu1HfQicYN0g5piV9Gh8RTEvo/uP752w==}
     dev: false
@@ -14192,13 +14171,6 @@ packages:
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  /skin-tone@2.0.0:
-    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
-    engines: {node: '>=8'}
-    dependencies:
-      unicode-emoji-modifier-base: 1.0.0
-    dev: false
-
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -15061,11 +15033,6 @@ packages:
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
-    engines: {node: '>=4'}
-    dev: false
-
-  /unicode-emoji-modifier-base@1.0.0:
-    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
     engines: {node: '>=4'}
     dev: false
 


### PR DESCRIPTION
[Issues](https://github.com/seek-oss/sku/pull/900) aside, I don't think there's enough value in having this dependency given that we only use a small subset of its API and we can just use the emoji characters directly.