### PR TITLE
Run `.cjs` and `.mjs` files through preset env

### DIFF
--- a/.changeset/famous-crabs-complain.md
+++ b/.changeset/famous-crabs-complain.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fixes a bug where `.cjs` and `.mjs` files were not being transpiled for browser targets

--- a/packages/sku/config/webpack/utils/index.js
+++ b/packages/sku/config/webpack/utils/index.js
@@ -1,12 +1,18 @@
 const loaders = require('./loaders');
 const { resolvePackage } = require('./resolvePackage');
-const { js, ts } = require('eslint-config-seek/extensions');
+
+// TODO: Figure out a better way to share this config. This is currently copy-pasted from
+// `eslint-config-seek`
+const extensions = {
+  js: ['js', 'cjs', 'mjs', 'jsx'],
+  ts: ['ts', 'cts', 'mts', 'tsx'],
+};
 
 module.exports = {
   ...loaders,
   resolvePackage,
-  TYPESCRIPT: new RegExp(`\.(${ts.join('|')})$`),
-  JAVASCRIPT: new RegExp(`\.(${js.join('|')})$`),
+  TYPESCRIPT: new RegExp(`\.(${extensions.ts.join('|')})$`),
+  JAVASCRIPT: new RegExp(`\.(${extensions.js.join('|')})$`),
   LESS: /\.less$/,
   IMAGE: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
   SVG: /\.svg$/,

--- a/packages/sku/config/webpack/utils/index.js
+++ b/packages/sku/config/webpack/utils/index.js
@@ -1,11 +1,12 @@
 const loaders = require('./loaders');
 const { resolvePackage } = require('./resolvePackage');
+const { js, ts } = require('eslint-config-seek/extensions');
 
 module.exports = {
   ...loaders,
   resolvePackage,
-  TYPESCRIPT: /\.(ts|tsx)$/,
-  JAVASCRIPT: /\.(js|cjs|mjs)$/,
+  TYPESCRIPT: new RegExp(`\.(${ts.join('|')})$`),
+  JAVASCRIPT: new RegExp(`\.(${js.join('|')})$`),
   LESS: /\.less$/,
   IMAGE: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
   SVG: /\.svg$/,

--- a/packages/sku/config/webpack/utils/index.js
+++ b/packages/sku/config/webpack/utils/index.js
@@ -5,7 +5,7 @@ module.exports = {
   ...loaders,
   resolvePackage,
   TYPESCRIPT: /\.(ts|tsx)$/,
-  JAVASCRIPT: /\.js$/,
+  JAVASCRIPT: /\.(js|cjs|mjs)$/,
   LESS: /\.less$/,
   IMAGE: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
   SVG: /\.svg$/,

--- a/tests/__snapshots__/braid-design-system.test.js.snap
+++ b/tests/__snapshots__/braid-design-system.test.js.snap
@@ -4985,7 +4985,6 @@ html:not(.vtjip3z) .ht7o11m {
 ,
   "2.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "externals.json": "[
-  "assert",
   "crypto",
   "fs",
   "node:crypto",

--- a/tests/__snapshots__/sku-webpack-plugin.test.js.snap
+++ b/tests/__snapshots__/sku-webpack-plugin.test.js.snap
@@ -5026,14 +5026,7 @@ html._3ylw6xz ._2h419fj {
 }
 ,
   "main.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "main.js.LICENSE.txt": /*!
- * The buffer module from node.js, for the browser.
- *
- * @author   Feross Aboukhadijeh <feross@feross.org> <http://feross.org>
- * @license  MIT
- */
-
-/**
+  "main.js.LICENSE.txt": /**
  * @license React
  * react-dom.production.min.js
  *


### PR DESCRIPTION
This will affect packages like Braid and our internal component libraries as they're compiled with crackle, but also any 3rd party dependencies that are shipping `.cjs`/`.mjs` source files.

For now we're depending on the extension lists provided by `eslint-config-seek`, but this may change in the future.