### PR TITLE
Fix package manager detection in non-monorepos

### DIFF
--- a/.changeset/short-schools-report.md
+++ b/.changeset/short-schools-report.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fix package manager detection in non-monorepos

--- a/packages/sku/config/lintStaged/lintStagedConfig.js
+++ b/packages/sku/config/lintStaged/lintStagedConfig.js
@@ -2,16 +2,18 @@ const { isYarn } = require('../../lib/packageManager');
 const { lintExtensions } = require('../../lib/lint');
 const { getCommand } = require('@antfu/ni');
 
-const steps = {};
+/**
+ * @type {import('lint-staged').Config}
+ */
+const config = {
+  [`**/*.{${lintExtensions},md,less}`]: ['sku format', 'sku lint'],
+};
 
 // Yarn lock integrity check
 if (isYarn) {
-  steps['+(package.json|yarn.lock)'] = [
-    () => getCommand('yarn', 'install', ['--check-files']),
+  config['+(package.json|yarn.lock)'] = [
+    getCommand('yarn', 'install', ['--check-files']),
   ];
 }
 
-// Format & lint
-steps[`**/*.{${lintExtensions},md,less}`] = ['sku format', 'sku lint'];
-
-module.exports = steps;
+module.exports = config;

--- a/packages/sku/lib/preCommit.js
+++ b/packages/sku/lib/preCommit.js
@@ -1,11 +1,12 @@
 const chalk = require('chalk');
+
+const config = require('../config/lintStaged/lintStagedConfig');
 const lintStaged = require('lint-staged');
-const configPath = require.resolve('../config/lintStaged/lintStagedConfig');
 
 module.exports = async () => {
   let success = false;
   try {
-    success = await lintStaged({ configPath });
+    success = await lintStaged({ config });
   } catch (e) {
     console.error(chalk.red(e));
   }


### PR DESCRIPTION
For reasons unknown, `@manypkg/find-root` only returns a tool (package manager) if it detects that you're in a monorepo. If you're not, it returns a `Root` tool, which is absolutely useless.

This was causing `yarn` (via the fallback logic) to be incorrectly detected as the package manager in a `pnpm` repo, causing `sku pre-commit` to run the wrong command (`yarn --check-files`).

I've kept the root directory detection from `@manypkg/find-root`, but leveraged `@antfu/ni`'s  API for detecting the package manager in the case where a non-supported tool is detected. This involves looking for lockfiles, which is what the `detect` API from `@antfu/ni` does, but it's async only, so I've made a synchronous version because package manager detection in sku can't be made async right now.

Finally, I made the `lintStaged` call use config defined as an object rather than resolving to a file because it's simpler IMO. I did this initially as I thought maybe the lint staged config was the issue.