### PR TITLE
Remove `--quiet` flag from `sku storybook`

### DIFF
--- a/.changeset/tidy-lamps-obey.md
+++ b/.changeset/tidy-lamps-obey.md
@@ -1,0 +1,16 @@
+---
+'sku': patch
+---
+
+Stop passing `--quiet` flag to the Storybook CLI when running `sku storybook`
+
+This flag was added to suppress verbose CLI output, but as of [Storybook CLI v7.1.0][release notes] this also hides the dev server info which includes the URL to access the Storybook UI.
+
+The flag has now been removed to provide a better default experience when using the Storybook CLI.
+Users can still pass `--quiet` to suppress verbose output if desired:
+
+```sh
+pnpm run sku storybook --quiet
+```
+
+[release notes]: https://github.com/storybookjs/storybook/releases/tag/v7.1.0-alpha.38

--- a/packages/sku/scripts/storybook.js
+++ b/packages/sku/scripts/storybook.js
@@ -6,7 +6,6 @@ const { watchVocabCompile } = require('../lib/runVocab');
 const { setUpStorybookConfigDirectory } = require('../lib/storybook');
 
 // Unshift args to allow pushing --ci as an arg during storybook-config tests
-argv.unshift('--quiet');
 argv.unshift('--port', storybookPort);
 argv.unshift('dev');
 


### PR DESCRIPTION
See changeset.

We still pass this flag to the Storybook CLI when running `sku build-storybook`, but I think that's fine to keep doing as it avoids some verbose output on CI (errors are still logged).