### PR TITLE
Remove `empty-dir` dependency and add our own implementation

### DIFF
--- a/.changeset/early-hats-live.md
+++ b/.changeset/early-hats-live.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Remove `empty-dir` dependency

--- a/packages/sku/lib/isEmptyDir.js
+++ b/packages/sku/lib/isEmptyDir.js
@@ -1,0 +1,20 @@
+const { statSync, readdirSync } = require('node:fs');
+
+/**
+ * Returns whether the given directory is empty, throwing if the path is not a directory
+ * @typedef {import('fs').PathLike} PathLike
+ * @param {PathLike} path A path to a directory
+ */
+const isEmptyDir = (path) => {
+  const isDirectory = statSync(path).isDirectory();
+
+  if (!isDirectory) {
+    throw new Error(`${path} is not a directory`);
+  }
+
+  const files = readdirSync(path);
+
+  return files.length === 0;
+};
+
+module.exports = { isEmptyDir };

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -77,7 +77,6 @@
     "dedent": "^1.5.1",
     "didyoumean2": "^6.0.1",
     "ejs": "^3.1.8",
-    "empty-dir": "^3.0.0",
     "ensure-gitignore": "^1.1.2",
     "env-ci": "^7.0.0",
     "esbuild": "^0.19.7",

--- a/packages/sku/scripts/init.js
+++ b/packages/sku/scripts/init.js
@@ -10,7 +10,7 @@ const {
 const chalk = require('chalk');
 const fs = require('node:fs/promises');
 const { posix: path } = require('node:path');
-const emptyDir = require('empty-dir');
+const { isEmptyDir } = require('../lib/isEmptyDir');
 const validatePackageName = require('validate-npm-package-name');
 const dedent = require('dedent');
 const { setCwd } = require('../lib/cwd');
@@ -125,7 +125,7 @@ const getTemplateFileDestinationFromRoot =
 
   await fs.mkdir(projectName, { recursive: true });
 
-  if (!emptyDir.sync(root)) {
+  if (!isEmptyDir(root)) {
     console.log(`The directory ${chalk.green(projectName)} is not empty.`);
     process.exit(1);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -644,9 +644,6 @@ importers:
       ejs:
         specifier: ^3.1.8
         version: 3.1.9
-      empty-dir:
-        specifier: ^3.0.0
-        version: 3.0.0
       ensure-gitignore:
         specifier: ^1.1.2
         version: 1.2.0
@@ -8045,11 +8042,6 @@ packages:
   /emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
-    dev: false
-
-  /empty-dir@3.0.0:
-    resolution: {integrity: sha512-BVrc23tc2khY2AiAAaNsAlhSHBPdDU/gAMAYzA8QwBqqLpZ3PGedNNeatONxk4nYGuY852VlgSDrQxmjKHP/yw==}
-    engines: {node: '>=10.13.0'}
     dev: false
 
   /encodeurl@1.0.2:


### PR DESCRIPTION
This dep has some features we don't use such as filtering files and a promise API, and it's simple enough to just re-implement ourselves.