### PR TITLE
Update `parseArgs` tests

### DIFF
--- a/packages/sku/lib/parseArgs.test.js
+++ b/packages/sku/lib/parseArgs.test.js
@@ -1,20 +1,24 @@
 const parseArgs = require('./parseArgs');
 
-describe('arg parsing', () => {
-  test('sku exec', () => {
-    const { script, argv, env } = parseArgs([
+describe('parseArgs', () => {
+  test('sku script with short and long flag', () => {
+    const { script, argv, env, config } = parseArgs([
       '/path/to/node',
       '/path/to/bin/sku',
       'lint',
       '-e',
       'test',
+      '--config',
+      'custom.sku.config.ts',
     ]);
+
     expect(script).toEqual('lint');
     expect(argv).toEqual([]);
     expect(env).toEqual('test');
+    expect(config).toEqual('custom.sku.config.ts');
   });
 
-  test('sku exec with args', () => {
+  test('sku script with flag and argument', () => {
     const { script, argv, env } = parseArgs([
       '/path/to/node',
       '/path/to/bin/sku',
@@ -23,8 +27,25 @@ describe('arg parsing', () => {
       '-e',
       'test',
     ]);
+
     expect(script).toEqual('lint');
     expect(argv).toEqual(['src/components/**']);
+    expect(env).toEqual('test');
+  });
+
+  test('sku script with argument, known flag and unknown flag', () => {
+    const { script, argv, env } = parseArgs([
+      '/path/to/node',
+      '/path/to/bin/sku',
+      'test',
+      '-e',
+      'test',
+      'testFilter',
+      '--someJestFlag',
+    ]);
+
+    expect(script).toEqual('test');
+    expect(argv).toEqual(['testFilter', '--someJestFlag']);
     expect(env).toEqual('test');
   });
 


### PR DESCRIPTION
- More descriptive test names
- Add some whitespace
- Add a test for unknown arguments/flags being present in `argv` for forwarding to other processes such as `jest` and `storybook`