### PR TITLE
Upgrade to TypeScript 5.3, emit incremental build info for faster subsequent type checking

### DIFF
--- a/.changeset/late-seahorses-worry.md
+++ b/.changeset/late-seahorses-worry.md
@@ -1,0 +1,9 @@
+---
+'sku': minor
+---
+
+Update TypeScript to 5.3
+
+This release includes breaking changes. See the [TypeScript 5.3 announcement] for more information.
+
+[TypeScript 5.3 announcement]: https://devblogs.microsoft.com/typescript/announcing-typescript-5-3/

--- a/.changeset/real-vans-care.md
+++ b/.changeset/real-vans-care.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Emit incremental TypeScript build info for faster subsequent type checking

--- a/packages/sku/config/typescript/tsconfig.js
+++ b/packages/sku/config/typescript/tsconfig.js
@@ -4,10 +4,14 @@ const { rootResolution, tsconfigDecorator } = require('../../context');
 module.exports = () => {
   const config = {
     compilerOptions: {
-      // This flag allows tsc to be invoked directly by VS Code (via Cmd+Shift+B),
-      // otherwise it would emit a bunch of useless JS/JSX files in your project.
-      // We emit compiled JavaScript into `dist` via webpack + Babel, not tsc.
+      // Don't compile anything, only perform type checking
       noEmit: true,
+
+      // Emit build information for faster subsequent type checking
+      incremental: true,
+      // Emit build information to `node_modules` to avoid bloating the project root
+      // and ignore files
+      outDir: 'node_modules',
 
       // Fixes https://github.com/cypress-io/cypress/issues/1087
       skipLibCheck: true,

--- a/packages/sku/lib/configure.js
+++ b/packages/sku/lib/configure.js
@@ -32,27 +32,23 @@ const writeFileToCWD = async (fileName, content, { banner = true } = {}) => {
 };
 
 module.exports = async () => {
-  // Ignore webpack bundle report output
-  const gitIgnorePatterns = [
-    addSep(bundleReportFolder),
-    addSep(coverageFolder),
-    storybookMainConfigPath,
-  ];
-  const lintIgnorePatterns = [
-    addSep(bundleReportFolder),
-    addSep(coverageFolder),
-    '*.less.d.ts',
-    storybookMainConfigPath,
-  ];
-
-  // Ignore webpack target directories
-  const targetDirectory = addSep(paths.target.replace(addSep(cwd()), ''));
+  // Ignore target directories
+  const webpackTargetDirectory = addSep(
+    paths.target.replace(addSep(cwd()), ''),
+  );
   const storybookTargetDirectory = addSep(
     paths.storybookTarget.replace(addSep(cwd()), ''),
   );
 
-  gitIgnorePatterns.push(targetDirectory, storybookTargetDirectory);
-  lintIgnorePatterns.push(targetDirectory, storybookTargetDirectory);
+  const gitIgnorePatterns = [
+    // Ignore webpack bundle report output
+    addSep(bundleReportFolder),
+    addSep(coverageFolder),
+    webpackTargetDirectory,
+    storybookTargetDirectory,
+    storybookMainConfigPath,
+  ];
+  const lintIgnorePatterns = [...gitIgnorePatterns, '*.less.d.ts'];
 
   // Generate ESLint configuration
   const eslintConfigFilename = '.eslintrc';

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -118,7 +118,7 @@
     "svgo-loader": "^4.0.0",
     "terser-webpack-plugin": "^5.1.4",
     "tree-kill": "^1.2.1",
-    "typescript": "~5.2.0",
+    "typescript": "~5.3.0",
     "validate-npm-package-name": "^5.0.0",
     "webpack": "^5.52.0",
     "webpack-bundle-analyzer": "^4.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 8.56.0
       eslint-config-seek:
         specifier: ^12.0.1
-        version: 12.1.1(eslint@8.56.0)(jest@29.7.0)(typescript@5.2.2)
+        version: 12.1.1(eslint@8.56.0)(jest@29.7.0)(typescript@5.3.3)
       eslint-plugin-jsdoc:
         specifier: ^48.0.0
         version: 48.0.4(eslint@8.56.0)
@@ -67,7 +67,7 @@ importers:
         version: 29.7.0
       jest-puppeteer:
         specifier: ^9.0.1
-        version: 9.0.2(debug@4.3.4)(puppeteer@21.10.0)(typescript@5.2.2)
+        version: 9.0.2(debug@4.3.4)(puppeteer@21.10.0)(typescript@5.3.3)
       jest-watch-typeahead:
         specifier: ^2.2.0
         version: 2.2.2(jest@29.7.0)
@@ -79,7 +79,7 @@ importers:
         version: 2.8.8
       puppeteer:
         specifier: ^21.6.0
-        version: 21.10.0(typescript@5.2.2)
+        version: 21.10.0(typescript@5.3.3)
       renovate-config-seek:
         specifier: ^0.4.0
         version: 0.4.0
@@ -88,7 +88,7 @@ importers:
         version: 5.0.5
       typescript:
         specifier: '*'
-        version: 5.2.2
+        version: 5.3.3
 
   docs:
     devDependencies:
@@ -288,6 +288,31 @@ importers:
       sku:
         specifier: workspace:*
         version: link:../../packages/sku
+
+  fixtures/sku-init/new-project:
+    dependencies:
+      braid-design-system:
+        specifier: ^32.0.0
+        version: 32.15.1(@types/react@18.2.48)(react-dom@18.2.0)(react@18.2.0)(sku@packages+sku)
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
+    devDependencies:
+      '@types/react':
+        specifier: ^18.2.3
+        version: 18.2.48
+      '@types/react-dom':
+        specifier: ^18.2.3
+        version: 18.2.18
+      '@vanilla-extract/css':
+        specifier: ^1.0.0
+        version: 1.14.1
+      sku:
+        specifier: workspace:^
+        version: link:../../../packages/sku
 
   fixtures/sku-test:
     devDependencies:
@@ -544,16 +569,16 @@ importers:
         version: 0.5.11(react-refresh@0.14.0)(webpack-dev-server@5.0.2)(webpack@5.90.0)
       '@storybook/builder-webpack5':
         specifier: ^7.0.17
-        version: 7.6.12(esbuild@0.19.12)(typescript@5.2.2)
+        version: 7.6.12(esbuild@0.19.12)(typescript@5.3.3)
       '@storybook/cli':
         specifier: ^7.0.17
         version: 7.6.12
       '@storybook/react':
         specifier: ^7.0.17
-        version: 7.6.12(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+        version: 7.6.12(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
       '@storybook/react-webpack5':
         specifier: ^7.0.17
-        version: 7.6.12(@babel/core@7.23.9)(@swc/core@1.3.107)(esbuild@0.19.12)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack-dev-server@5.0.2)
+        version: 7.6.12(@babel/core@7.23.9)(@swc/core@1.3.107)(esbuild@0.19.12)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)(webpack-dev-server@5.0.2)
       '@types/jest':
         specifier: ^29.0.0
         version: 29.5.11
@@ -667,7 +692,7 @@ importers:
         version: 8.56.0
       eslint-config-seek:
         specifier: ^12.0.1
-        version: 12.1.1(eslint@8.56.0)(jest@29.7.0)(typescript@5.2.2)
+        version: 12.1.1(eslint@8.56.0)(jest@29.7.0)(typescript@5.3.3)
       exception-formatter:
         specifier: ^2.1.2
         version: 2.1.2
@@ -733,7 +758,7 @@ importers:
         version: 8.4.33
       postcss-loader:
         specifier: ^8.0.0
-        version: 8.1.0(postcss@8.4.33)(typescript@5.2.2)(webpack@5.90.0)
+        version: 8.1.0(postcss@8.4.33)(typescript@5.3.3)(webpack@5.90.0)
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -768,8 +793,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.2
       typescript:
-        specifier: ~5.2.0
-        version: 5.2.2
+        specifier: ~5.3.0
+        version: 5.3.3
       validate-npm-package-name:
         specifier: ^5.0.0
         version: 5.0.0
@@ -4291,7 +4316,7 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/builder-webpack5@7.6.12(esbuild@0.19.12)(typescript@5.2.2):
+  /@storybook/builder-webpack5@7.6.12(esbuild@0.19.12)(typescript@5.3.3):
     resolution: {integrity: sha512-6y5hfMV2rqKbloGZ8CicCH1UQd6sdiFdHf6/5Wo4tBoaGYzQjPM/cV1fizsO/01GG0yGJg7J6BohTiCCbNdGCA==}
     peerDependencies:
       typescript: '*'
@@ -4319,7 +4344,7 @@ packages:
       css-loader: 6.10.0(webpack@5.90.0)
       es-module-lexer: 1.4.1
       express: 4.18.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.2.2)(webpack@5.90.0)
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.3.3)(webpack@5.90.0)
       fs-extra: 11.2.0
       html-webpack-plugin: 5.6.0(webpack@5.90.0)
       magic-string: 0.30.6
@@ -4330,7 +4355,7 @@ packages:
       swc-loader: 0.2.3(@swc/core@1.3.107)(webpack@5.90.0)
       terser-webpack-plugin: 5.3.10(@swc/core@1.3.107)(esbuild@0.19.12)(webpack@5.90.0)
       ts-dedent: 2.2.0
-      typescript: 5.2.2
+      typescript: 5.3.3
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
@@ -4635,7 +4660,7 @@ packages:
   /@storybook/node-logger@7.6.12:
     resolution: {integrity: sha512-iS44/EjfF6hLecKzICmcpQoB9bmVi4tXx5gVXnbI5ZyziBibRQcg/U191Njl7wY2ScN/RCQOr8lh5k57rI3Prg==}
 
-  /@storybook/preset-react-webpack@7.6.12(@babel/core@7.23.9)(@swc/core@1.3.107)(esbuild@0.19.12)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack-dev-server@5.0.2):
+  /@storybook/preset-react-webpack@7.6.12(@babel/core@7.23.9)(@swc/core@1.3.107)(esbuild@0.19.12)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)(webpack-dev-server@5.0.2):
     resolution: {integrity: sha512-j6gyC2KVyjO0zIvGtGqL4NoQKbTgMAoUYjF6w1UigoiU53rjxkrq2NMt+BnMxXnYwD+iXMoxyUIex01NBUpNnA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -4656,8 +4681,8 @@ packages:
       '@storybook/core-webpack': 7.6.12
       '@storybook/docs-tools': 7.6.12
       '@storybook/node-logger': 7.6.12
-      '@storybook/react': 7.6.12(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.2.2)(webpack@5.90.0)
+      '@storybook/react': 7.6.12(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.90.0)
       '@types/node': 18.19.12
       '@types/semver': 7.5.6
       babel-plugin-add-react-displayname: 0.0.5
@@ -4668,7 +4693,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       react-refresh: 0.14.0
       semver: 7.5.4
-      typescript: 5.2.2
+      typescript: 5.3.3
       webpack: 5.90.0(@swc/core@1.3.107)(esbuild@0.19.12)
     transitivePeerDependencies:
       - '@swc/core'
@@ -4707,7 +4732,7 @@ packages:
     resolution: {integrity: sha512-7vbeqQY3X+FCt/ccgCuBmj4rkbQebLHGEBAt8elcX0E2pr7SGW57lWhnasU3jeMaz7tNrkcs0gfl4hyVRWUHDg==}
     dev: false
 
-  /@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.2.2)(webpack@5.90.0):
+  /@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.90.0):
     resolution: {integrity: sha512-KUqXC3oa9JuQ0kZJLBhVdS4lOneKTOopnNBK4tUAgoxWQ3u/IjzdueZjFr7gyBrXMoU6duutk3RQR9u8ZpYJ4Q==}
     peerDependencies:
       typescript: '>= 4.x'
@@ -4718,9 +4743,9 @@ packages:
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
       micromatch: 4.0.5
-      react-docgen-typescript: 2.2.2(typescript@5.2.2)
+      react-docgen-typescript: 2.2.2(typescript@5.3.3)
       tslib: 2.6.2
-      typescript: 5.2.2
+      typescript: 5.3.3
       webpack: 5.90.0(@swc/core@1.3.107)(esbuild@0.19.12)
     transitivePeerDependencies:
       - supports-color
@@ -4736,7 +4761,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@storybook/react-webpack5@7.6.12(@babel/core@7.23.9)(@swc/core@1.3.107)(esbuild@0.19.12)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack-dev-server@5.0.2):
+  /@storybook/react-webpack5@7.6.12(@babel/core@7.23.9)(@swc/core@1.3.107)(esbuild@0.19.12)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)(webpack-dev-server@5.0.2):
     resolution: {integrity: sha512-MyIqGF8QrL6v5iCLDG3zQ1Yh8faUJcwt155BOjKWCjXXpWkCklCucuSHkhN79FkWMO6xMwjAlV2AuYBL8wraeg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -4751,13 +4776,13 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.23.9
-      '@storybook/builder-webpack5': 7.6.12(esbuild@0.19.12)(typescript@5.2.2)
-      '@storybook/preset-react-webpack': 7.6.12(@babel/core@7.23.9)(@swc/core@1.3.107)(esbuild@0.19.12)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack-dev-server@5.0.2)
-      '@storybook/react': 7.6.12(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+      '@storybook/builder-webpack5': 7.6.12(esbuild@0.19.12)(typescript@5.3.3)
+      '@storybook/preset-react-webpack': 7.6.12(@babel/core@7.23.9)(@swc/core@1.3.107)(esbuild@0.19.12)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)(webpack-dev-server@5.0.2)
+      '@storybook/react': 7.6.12(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
       '@types/node': 18.19.12
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      typescript: 5.2.2
+      typescript: 5.3.3
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -4775,7 +4800,7 @@ packages:
       - webpack-plugin-serve
     dev: false
 
-  /@storybook/react@7.6.12(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
+  /@storybook/react@7.6.12(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3):
     resolution: {integrity: sha512-ITDRGi79Qg+z1kGYv+yyJESz/5AsJVdBTMO7tr1qV7gmHElkASt6UR8SBSqKgePOnYgy3k/1PLfbzOs6G4OgYQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -4808,7 +4833,7 @@ packages:
       react-element-to-jsx-string: 15.0.0(react-dom@18.2.0)(react@18.2.0)
       ts-dedent: 2.2.0
       type-fest: 2.19.0
-      typescript: 5.2.2
+      typescript: 5.3.3
       util-deprecate: 1.0.2
     transitivePeerDependencies:
       - encoding
@@ -5358,7 +5383,7 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin@6.20.0(@typescript-eslint/parser@6.20.0)(eslint@8.56.0)(typescript@5.2.2):
+  /@typescript-eslint/eslint-plugin@6.20.0(@typescript-eslint/parser@6.20.0)(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-fTwGQUnjhoYHeSF6m5pWNkzmDDdsKELYrOBxhjMrofPqCkoC2k3B2wvGHFxa1CTIqkEn88nlW1HVMztjo2K8Hg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -5370,10 +5395,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/scope-manager': 6.20.0
-      '@typescript-eslint/type-utils': 6.20.0(eslint@8.56.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.20.0(eslint@8.56.0)(typescript@5.2.2)
+      '@typescript-eslint/type-utils': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.20.0
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.56.0
@@ -5381,12 +5406,12 @@ packages:
       ignore: 5.3.0
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.0.3(typescript@5.3.3)
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.2.2):
+  /@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-bYerPDF/H5v6V76MdMYhjwmwgMA+jlPVqjSDq2cRqMi8bP5sR3Z+RLOiOMad3nsnmDVmn2gAFCyNgh/dIrfP/w==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -5398,11 +5423,11 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.20.0
       '@typescript-eslint/types': 6.20.0
-      '@typescript-eslint/typescript-estree': 6.20.0(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.20.0(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.20.0
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.56.0
-      typescript: 5.2.2
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5420,7 +5445,7 @@ packages:
       '@typescript-eslint/types': 6.20.0
       '@typescript-eslint/visitor-keys': 6.20.0
 
-  /@typescript-eslint/type-utils@6.20.0(eslint@8.56.0)(typescript@5.2.2):
+  /@typescript-eslint/type-utils@6.20.0(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-qnSobiJQb1F5JjN0YDRPHruQTrX7ICsmltXhkV536mp4idGAYrIyr47zF/JmkJtEcAVnIz4gUYJ7gOZa6SmN4g==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -5430,12 +5455,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.20.0(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.20.0(eslint@8.56.0)(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.20.0(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.56.0
-      ts-api-utils: 1.0.3(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.0.3(typescript@5.3.3)
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5447,7 +5472,7 @@ packages:
     resolution: {integrity: sha512-MM9mfZMAhiN4cOEcUOEx+0HmuaW3WBfukBZPCfwSqFnQy0grXYtngKCqpQN339X3RrwtzspWJrpbrupKYUSBXQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.2.2):
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.3.3):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5462,12 +5487,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
+      tsutils: 3.21.0(typescript@5.3.3)
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree@6.20.0(typescript@5.2.2):
+  /@typescript-eslint/typescript-estree@6.20.0(typescript@5.3.3):
     resolution: {integrity: sha512-RnRya9q5m6YYSpBN7IzKu9FmLcYtErkDkc8/dKv81I9QiLLtVBHrjz+Ev/crAqgMNW2FCsoZF4g2QUylMnJz+g==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -5483,12 +5508,12 @@ packages:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.0.3(typescript@5.3.3)
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.56.0)(typescript@5.2.2):
+  /@typescript-eslint/utils@5.62.0(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5499,7 +5524,7 @@ packages:
       '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.3.3)
       eslint: 8.56.0
       eslint-scope: 5.1.1
       semver: 7.5.4
@@ -5507,7 +5532,7 @@ packages:
       - supports-color
       - typescript
 
-  /@typescript-eslint/utils@6.20.0(eslint@8.56.0)(typescript@5.2.2):
+  /@typescript-eslint/utils@6.20.0(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-/EKuw+kRu2vAqCoDwDCBtDRU6CTKbUmwwI7SH7AashZ+W+7o8eiyy6V2cdOqN49KsTcASWsC5QeghYuRDTyOOg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -5518,7 +5543,7 @@ packages:
       '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 6.20.0
       '@typescript-eslint/types': 6.20.0
-      '@typescript-eslint/typescript-estree': 6.20.0(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.20.0(typescript@5.3.3)
       eslint: 8.56.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -7190,7 +7215,7 @@ packages:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  /cosmiconfig@8.3.6(typescript@5.2.2):
+  /cosmiconfig@8.3.6(typescript@5.3.3):
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -7203,10 +7228,10 @@ packages:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
-      typescript: 5.2.2
+      typescript: 5.3.3
     dev: true
 
-  /cosmiconfig@9.0.0(typescript@5.2.2):
+  /cosmiconfig@9.0.0(typescript@5.3.3):
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -7219,7 +7244,7 @@ packages:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
-      typescript: 5.2.2
+      typescript: 5.3.3
 
   /cp-file@7.0.0:
     resolution: {integrity: sha512-0Cbj7gyvFVApzpK/uhCtQ/9kE9UnYpxMzaq5nQQC/Dh4iaj5fxp7iEFIullrYwzj8nf0qnsI1Qsx34hAeAebvw==}
@@ -8401,7 +8426,7 @@ packages:
     dependencies:
       eslint: 8.56.0
 
-  /eslint-config-seek@12.1.1(eslint@8.56.0)(jest@29.7.0)(typescript@5.2.2):
+  /eslint-config-seek@12.1.1(eslint@8.56.0)(jest@29.7.0)(typescript@5.3.3):
     resolution: {integrity: sha512-DOFCXYI0GuJSWeFNM2h0VAcOjImA9dlkd7FzM6FjOFBCcjn3zTz4Qm1KZzeQ1WbxuOfxoEenzIXH76QcdoiRUw==}
     peerDependencies:
       eslint: '>=7'
@@ -8411,18 +8436,18 @@ packages:
       '@babel/eslint-parser': 7.23.10(@babel/core@7.23.9)(eslint@8.56.0)
       '@babel/preset-react': 7.23.3(@babel/core@7.23.9)
       '@finsit/eslint-plugin-cypress': 3.1.1(eslint@8.56.0)
-      '@typescript-eslint/eslint-plugin': 6.20.0(@typescript-eslint/parser@6.20.0)(eslint@8.56.0)(typescript@5.2.2)
-      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.2.2)
+      '@typescript-eslint/eslint-plugin': 6.20.0(@typescript-eslint/parser@6.20.0)(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
       eslint-config-prettier: 8.10.0(eslint@8.56.0)
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.20.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.20.0)(eslint@8.56.0)(jest@29.7.0)(typescript@5.2.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.20.0)(eslint@8.56.0)(jest@29.7.0)(typescript@5.3.3)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
       eslint-plugin-rulesdir: 0.2.2
       find-root: 1.1.0
-      typescript: 5.2.2
+      typescript: 5.3.3
     transitivePeerDependencies:
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
@@ -8482,7 +8507,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
       debug: 3.2.7
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
@@ -8500,7 +8525,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -8524,7 +8549,7 @@ packages:
       - eslint-import-resolver-webpack
       - supports-color
 
-  /eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@6.20.0)(eslint@8.56.0)(jest@29.7.0)(typescript@5.2.2):
+  /eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@6.20.0)(eslint@8.56.0)(jest@29.7.0)(typescript@5.3.3):
     resolution: {integrity: sha512-+YsJFVH6R+tOiO3gCJon5oqn4KWc+mDq2leudk8mrp8RFubLOo9CVyi3cib4L7XMpxExmkmBZQTPDYVBzgpgOA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -8537,8 +8562,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.20.0(@typescript-eslint/parser@6.20.0)(eslint@8.56.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.2.2)
+      '@typescript-eslint/eslint-plugin': 6.20.0(@typescript-eslint/parser@6.20.0)(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
       jest: 29.7.0(@types/node@18.19.12)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
@@ -9196,7 +9221,7 @@ packages:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  /fork-ts-checker-webpack-plugin@8.0.0(typescript@5.2.2)(webpack@5.90.0):
+  /fork-ts-checker-webpack-plugin@8.0.0(typescript@5.3.3)(webpack@5.90.0):
     resolution: {integrity: sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==}
     engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
     peerDependencies:
@@ -9215,7 +9240,7 @@ packages:
       schema-utils: 3.3.0
       semver: 7.5.4
       tapable: 2.2.1
-      typescript: 5.2.2
+      typescript: 5.3.3
       webpack: 5.90.0(@swc/core@1.3.107)(esbuild@0.19.12)
     dev: false
 
@@ -10695,12 +10720,12 @@ packages:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  /jest-environment-puppeteer@9.0.2(debug@4.3.4)(typescript@5.2.2):
+  /jest-environment-puppeteer@9.0.2(debug@4.3.4)(typescript@5.3.3):
     resolution: {integrity: sha512-t7+W4LUiPoOz+xpKREgnu6IElMuRthOWTkrThDZqVKPmLhwbK3yx7OCiX8xT1Pw/Cv5WnSoNhwtN7czdCC3fQg==}
     engines: {node: '>=16'}
     dependencies:
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.2.2)
+      cosmiconfig: 8.3.6(typescript@5.3.3)
       deepmerge: 4.3.1
       jest-dev-server: 9.0.2(debug@4.3.4)
       jest-environment-node: 29.7.0
@@ -10781,15 +10806,15 @@ packages:
     dependencies:
       jest-resolve: 29.7.0
 
-  /jest-puppeteer@9.0.2(debug@4.3.4)(puppeteer@21.10.0)(typescript@5.2.2):
+  /jest-puppeteer@9.0.2(debug@4.3.4)(puppeteer@21.10.0)(typescript@5.3.3):
     resolution: {integrity: sha512-ZB0K/tH+0e7foRRn+VpKIufvkW1by8l7ifh62VOdOh5ijEf7yt8W2/PcBNNwP0RLm46AytiBkrIEenvWhxcBRQ==}
     engines: {node: '>=16'}
     peerDependencies:
       puppeteer: '>=19'
     dependencies:
       expect-puppeteer: 9.0.2
-      jest-environment-puppeteer: 9.0.2(debug@4.3.4)(typescript@5.2.2)
-      puppeteer: 21.10.0(typescript@5.2.2)
+      jest-environment-puppeteer: 9.0.2(debug@4.3.4)(typescript@5.3.3)
+      puppeteer: 21.10.0(typescript@5.3.3)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -12607,7 +12632,7 @@ packages:
       postcss: 8.4.33
     dev: false
 
-  /postcss-loader@8.1.0(postcss@8.4.33)(typescript@5.2.2)(webpack@5.90.0):
+  /postcss-loader@8.1.0(postcss@8.4.33)(typescript@5.3.3)(webpack@5.90.0):
     resolution: {integrity: sha512-AbperNcX3rlob7Ay7A/HQcrofug1caABBkopoFeOQMspZBqcqj6giYn1Bwey/0uiOPAcR+NQD0I2HC7rXzk91w==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
@@ -12620,7 +12645,7 @@ packages:
       webpack:
         optional: true
     dependencies:
-      cosmiconfig: 9.0.0(typescript@5.2.2)
+      cosmiconfig: 9.0.0(typescript@5.3.3)
       jiti: 1.21.0
       postcss: 8.4.33
       semver: 7.5.4
@@ -13103,14 +13128,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /puppeteer@21.10.0(typescript@5.2.2):
+  /puppeteer@21.10.0(typescript@5.3.3):
     resolution: {integrity: sha512-Y1yQjcLE00hHTDAmv3M3A6hhW0Ytjdp6xr6nyjl7FZ7E7hzp/6Rsw80FbaTJzJHFCplBNi082wrgynbmD7RlYw==}
     engines: {node: '>=16.13.2'}
     hasBin: true
     requiresBuild: true
     dependencies:
       '@puppeteer/browsers': 1.9.1
-      cosmiconfig: 9.0.0(typescript@5.2.2)
+      cosmiconfig: 9.0.0(typescript@5.3.3)
       puppeteer-core: 21.10.0
     transitivePeerDependencies:
       - bufferutil
@@ -13204,12 +13229,12 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /react-docgen-typescript@2.2.2(typescript@5.2.2):
+  /react-docgen-typescript@2.2.2(typescript@5.3.3):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 5.2.2
+      typescript: 5.3.3
     dev: false
 
   /react-docgen@7.0.3:
@@ -14764,13 +14789,13 @@ packages:
       escape-string-regexp: 1.0.5
     dev: true
 
-  /ts-api-utils@1.0.3(typescript@5.2.2):
+  /ts-api-utils@1.0.3(typescript@5.3.3):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.2.2
+      typescript: 5.3.3
 
   /ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
@@ -14790,14 +14815,14 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsutils@3.21.0(typescript@5.2.2):
+  /tsutils@3.21.0(typescript@5.3.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.2.2
+      typescript: 5.3.3
 
   /tty-table@4.2.3:
     resolution: {integrity: sha512-Fs15mu0vGzCrj8fmJNP7Ynxt5J7praPXqFN0leZeZBXJwkMxv9cb2D454k1ltrtUSJbZ4yH4e0CynsHLxmUfFA==}
@@ -14920,8 +14945,8 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: false
 
-  /typescript@5.2.2:
-    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+  /typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
     hasBin: true
 


### PR DESCRIPTION
- TS 5.3 (to keep us aligned with [skuba](https://github.com/seek-oss/skuba/pull/1324))
- Enable incremental builds for faster type checking (after the first time)
- Small refactor of `configure` script