### PR TITLE
Enable `@ts-check` to work (again) and add it to some files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,4 @@ dist/
 dist-build/
 dist-ssr/
 dist-start/
-.eslintcache
 yarn.lock
-tsconfig.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "postinstall": "node ./postinstall.js",
     "prepare": "husky",
-    "lint": "concurrently -c auto --group 'pnpm:lint:*'",
+    "lint": "pnpm run '/^lint:.*/'",
     "lint:eslint": "eslint --cache --cache-location 'node_modules/.cache/eslint/.eslintcache' .",
     "lint:prettier": "prettier --cache --list-different '**/*.{js,ts,tsx,md,less,css}'",
     "lint:tsc": "tsc",
@@ -47,7 +47,6 @@
     "@tsconfig/node-lts": "^18.12.3",
     "@types/jest": "^29.0.0",
     "@types/node": "^18.16.19",
-    "concurrently": "^8.2.1",
     "debug": "^4.3.1",
     "dedent": "^1.5.1",
     "eslint": "^8.41.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "postinstall": "node ./postinstall.js",
     "prepare": "husky",
     "lint": "concurrently -c auto --group 'pnpm:lint:*'",
-    "lint:eslint": "eslint --cache .",
+    "lint:eslint": "eslint --cache --cache-location 'node_modules/.cache/eslint/.eslintcache' .",
     "lint:prettier": "prettier --cache --list-different '**/*.{js,ts,tsx,md,less,css}'",
     "lint:tsc": "tsc",
     "check": "pnpm install --frozen-lockfile && echo 'Ignore paths from lint-staged'",

--- a/packages/sku/lib/allocatePort.js
+++ b/packages/sku/lib/allocatePort.js
@@ -1,9 +1,10 @@
+// @ts-check
 const { yellow, bold } = require('chalk');
 const getPort = require('get-port');
 const debug = require('debug')('sku:allocatePort');
 
 /**
- * @param {{ port?: number, host?: string }}
+ * @param {{ port?: number, host?: string }} options
  */
 const allocatePort = async ({ port, host }) => {
   debug(`Finding available port with request for ${port}`);

--- a/packages/sku/lib/buildFileUtils.js
+++ b/packages/sku/lib/buildFileUtils.js
@@ -1,3 +1,4 @@
+// @ts-check
 const path = require('node:path');
 const fs = require('node:fs/promises');
 const { rimraf } = require('rimraf');

--- a/packages/sku/lib/copyDirContents.js
+++ b/packages/sku/lib/copyDirContents.js
@@ -1,3 +1,4 @@
+// @ts-check
 const path = require('node:path');
 const fs = require('node:fs/promises');
 const exists = require('./exists');

--- a/packages/sku/lib/createServer.js
+++ b/packages/sku/lib/createServer.js
@@ -1,3 +1,4 @@
+// @ts-check
 const http = require('node:http');
 const https = require('node:https');
 

--- a/packages/sku/lib/cwd.js
+++ b/packages/sku/lib/cwd.js
@@ -1,3 +1,4 @@
+// @ts-check
 const path = require('node:path');
 
 let currentCwd = process.cwd();

--- a/packages/sku/lib/env.js
+++ b/packages/sku/lib/env.js
@@ -1,3 +1,4 @@
+// @ts-check
 const args = require('../config/args');
 
 /**

--- a/packages/sku/lib/exists.js
+++ b/packages/sku/lib/exists.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { access } = require('node:fs/promises');
 
 /**

--- a/packages/sku/lib/getSiteForHost.js
+++ b/packages/sku/lib/getSiteForHost.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { sites } = require('../context');
 
 /**

--- a/packages/sku/lib/install.js
+++ b/packages/sku/lib/install.js
@@ -1,9 +1,11 @@
+// @ts-check
 const { getAddCommand } = require('./packageManager');
 
 const spawn = require('cross-spawn');
 
 /**
  * @param {import("../lib/packageManager").GetAddCommandOptions} options
+ * @returns {Promise<void>}
  */
 module.exports = ({ deps, type, logLevel, exact = true }) =>
   new Promise((resolve, reject) => {

--- a/packages/sku/lib/isCI.js
+++ b/packages/sku/lib/isCI.js
@@ -1,1 +1,2 @@
+// @ts-check
 module.exports = Boolean(process.env.CI || process.env.BUILDKITE_BUILD_ID);

--- a/packages/sku/lib/isCompilePackage.js
+++ b/packages/sku/lib/isCompilePackage.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { getPathFromCwd } = require('./cwd');
 
 const isCompilePackage = () => {

--- a/packages/sku/lib/isEmptyDir.js
+++ b/packages/sku/lib/isEmptyDir.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { statSync, readdirSync } = require('node:fs');
 
 /**

--- a/packages/sku/lib/parseArgs.js
+++ b/packages/sku/lib/parseArgs.js
@@ -1,10 +1,11 @@
+// @ts-check
 const minimist = require('minimist');
 
 /**
  * Supports parsing args that look like:
  * [/path/to/node/node, /path/to/sku, scriptName, arg1, arg2]
  *
- * @param {string[]} args - should look like process.argv
+ * @param {string[]} processArgv - should look like process.argv
  */
 module.exports = (processArgv) => {
   /**
@@ -48,6 +49,8 @@ module.exports = (processArgv) => {
       // need to track them ourselves
       unknown: (arg) => {
         unknown.push(arg);
+
+        return true;
       },
     },
   );

--- a/packages/sku/lib/routeMatcher.js
+++ b/packages/sku/lib/routeMatcher.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { match } = require('path-to-regexp');
 
 /**

--- a/packages/sku/lib/runBin.js
+++ b/packages/sku/lib/runBin.js
@@ -1,3 +1,4 @@
+// @ts-check
 const path = require('node:path');
 const spawn = require('cross-spawn');
 
@@ -45,13 +46,13 @@ const spawnPromise = (commandPath, args, options) => {
  */
 
 /**
- * @param {Options}
+ * @param {Options} options
  */
 const runBin = ({ packageName, binName, args, options }) =>
   spawnPromise(resolveBin(packageName, binName), args, options);
 
 /**
- * @param {Options}
+ * @param {Options} options
  */
 const startBin = ({ packageName, binName, args, options }) => {
   const childProcess = spawn(resolveBin(packageName, binName), args, options);

--- a/packages/sku/lib/runTsc.js
+++ b/packages/sku/lib/runTsc.js
@@ -1,3 +1,4 @@
+// @ts-check
 const chalk = require('chalk');
 const { runBin } = require('./runBin');
 const { cwd } = require('./cwd');

--- a/packages/sku/lib/runVocab.js
+++ b/packages/sku/lib/runVocab.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { compile } = require('@vocab/core');
 const { getVocabConfig } = require('../config/vocab/vocab');
 

--- a/packages/sku/lib/storybook.js
+++ b/packages/sku/lib/storybook.js
@@ -1,3 +1,4 @@
+// @ts-check
 const path = require('node:path');
 const fs = require('node:fs/promises');
 const debug = require('debug');

--- a/packages/sku/lib/suggestScript.js
+++ b/packages/sku/lib/suggestScript.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { getRunCommand, getExecuteCommand } = require('./packageManager');
 
 const chalk = require('chalk');

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -130,7 +130,9 @@
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.3",
+    "@types/debug": "^4.1.12",
     "@types/express": "^4.17.11",
+    "@types/minimist": "^1.2.5",
     "@types/react": "^18.2.3",
     "@types/react-dom": "^18.2.3",
     "@types/which": "^3.0.0",

--- a/packages/sku/tsconfig.json
+++ b/packages/sku/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "include": ["@loadable/**/*", "@storybook/**/*", "sku-types.d.ts"]
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       '@types/node':
         specifier: ^18.16.19
         version: 18.19.12
-      concurrently:
-        specifier: ^8.2.1
-        version: 8.2.2
       debug:
         specifier: ^4.3.1
         version: 4.3.4(supports-color@8.1.1)
@@ -798,9 +795,15 @@ importers:
       '@types/cross-spawn':
         specifier: ^6.0.3
         version: 6.0.6
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.12
       '@types/express':
         specifier: ^4.17.11
         version: 4.17.21
+      '@types/minimist':
+        specifier: ^1.2.5
+        version: 1.2.5
       '@types/react':
         specifier: ^18.2.3
         version: 18.2.48
@@ -5090,6 +5093,12 @@ packages:
     dependencies:
       '@types/node': 18.19.12
 
+  /@types/debug@4.1.12:
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+    dependencies:
+      '@types/ms': 0.7.34
+    dev: true
+
   /@types/dedent@0.7.2:
     resolution: {integrity: sha512-kRiitIeUg1mPV9yH4VUJ/1uk2XjyANfeL8/7rH1tsjvHeO9PJLBHJIYsFWmAvmGj5u8rj+1TZx7PZzW2qLw3Lw==}
 
@@ -5229,6 +5238,10 @@ packages:
 
   /@types/minimist@1.2.5:
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
+    dev: true
+
+  /@types/ms@0.7.34:
+    resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
     dev: true
 
   /@types/node-fetch@2.6.11:
@@ -7056,22 +7069,6 @@ packages:
       typedarray: 0.0.6
     dev: false
 
-  /concurrently@8.2.2:
-    resolution: {integrity: sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==}
-    engines: {node: ^14.13.0 || >=16.0.0}
-    hasBin: true
-    dependencies:
-      chalk: 4.1.2
-      date-fns: 2.30.0
-      lodash: 4.17.21
-      rxjs: 7.8.1
-      shell-quote: 1.8.1
-      spawn-command: 0.0.2
-      supports-color: 8.1.1
-      tree-kill: 1.2.2
-      yargs: 17.7.2
-    dev: true
-
   /configstore@5.0.1:
     resolution: {integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==}
     engines: {node: '>=8'}
@@ -7486,13 +7483,6 @@ packages:
 
   /dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
-    dev: true
-
-  /date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
-    dependencies:
-      '@babel/runtime': 7.23.9
     dev: true
 
   /death@1.1.0:
@@ -14108,10 +14098,6 @@ packages:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
     dev: false
-
-  /spawn-command@0.0.2:
-    resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
-    dev: true
 
   /spawnd@9.0.2:
     resolution: {integrity: sha512-nl8DVHEDQ57IcKakzpjanspVChkMpGLuVwMR/eOn9cXE55Qr6luD2Kn06sA0ootRMdgrU4tInN6lA6ohTNvysw==}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "outDir": "node_modules/.cache/typescript",
     "incremental": true
   },
-  "include": ["tests/**/*", "test-utils/**/*"]
+  "exclude": ["node_modules", "fixtures"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     "allowJs": true,
     "jsx": "react-jsx",
     "noEmit": true,
+    // Output incremental build info to node_modules
+    "outDir": "node_modules/.cache/typescript",
     "incremental": true
   },
   "include": ["tests/**/*", "test-utils/**/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "outDir": "node_modules/.cache/typescript",
     "incremental": true
   },
-  "exclude": ["node_modules", "fixtures"]
+  "exclude": ["node_modules", "fixtures", "packages/sku/template"]
 }


### PR DESCRIPTION
`@ts-check` annotations weren't actually doing anything because of how our TSConfigs were configured. I've removed the `sku` package tsconfig and updated the top-level tsconfig to include _most_ files in the repo.

Had some trouble with the `template` directory. `tsc` was passing locally, but failing on CI. Gave up and just excluded it, but it was excluded before this change anyway.

Also:
- Replaced `concurrently` dep with `pnpm run`
- Output cache files to `node_modules` so there's less files in the repo root when developing locally
- Added `@ts-check` to a bunch of files where there was no change needed, minor changes needed or a `@types` dep was needed