### PR TITLE
Replace `validate-npm-package-name` with a regexp

### DIFF
--- a/.changeset/sharp-llamas-chew.md
+++ b/.changeset/sharp-llamas-chew.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Replace `validate-npm-package-name` dependency with a regexp

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -118,7 +118,6 @@
     "terser-webpack-plugin": "^5.1.4",
     "tree-kill": "^1.2.1",
     "typescript": "~5.3.0",
-    "validate-npm-package-name": "^5.0.0",
     "webpack": "^5.52.0",
     "webpack-bundle-analyzer": "^4.6.1",
     "webpack-dev-server": "^5.0.2",

--- a/packages/sku/scripts/init.js
+++ b/packages/sku/scripts/init.js
@@ -11,7 +11,6 @@ const chalk = require('chalk');
 const fs = require('node:fs/promises');
 const { posix: path } = require('node:path');
 const { isEmptyDir } = require('../lib/isEmptyDir');
-const validatePackageName = require('validate-npm-package-name');
 const dedent = require('dedent');
 const { setCwd } = require('../lib/cwd');
 const prettierWrite = require('../lib/runPrettier').write;
@@ -47,6 +46,11 @@ const getTemplateFileDestinationFromRoot =
 
     return path.join(projectRoot, filePathRelativeToTemplate);
   };
+
+// Copied from `package-name-regex@4.0.0`
+// See https://github.com/dword-design/package-name-regex/blob/acae7d482b1d03379003899df4d484238625364d/src/index.js#L1-L2
+const packageNameRegex =
+  /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
 
 (async () => {
   const projectName = args.argv[0];
@@ -89,20 +93,15 @@ const getTemplateFileDestinationFromRoot =
     'braid-design-system',
   ].sort();
 
-  const {
-    validForNewPackages,
-    errors = [],
-    warnings = [],
-  } = validatePackageName(appName);
+  const isValidPackageName = packageNameRegex.test(appName);
 
-  if (!validForNewPackages) {
+  if (!isValidPackageName) {
     console.error(dedent`
-    Could not create a project called ${chalk.red(`"${appName}"`)} \
-    because of npm naming restrictions:
+    Could not create a project called ${chalk.red(
+      `"${appName}"`,
+    )} because of npm naming restrictions. \
+    Please see https://docs.npmjs.com/cli/configuring-npm/package-json for package name rules.
   `);
-
-    const results = [...errors, ...warnings];
-    results.forEach((result) => console.error(chalk.red(`  *  ${result}`)));
 
     process.exit(1);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -764,9 +764,6 @@ importers:
       typescript:
         specifier: ~5.3.0
         version: 5.3.3
-      validate-npm-package-name:
-        specifier: ^5.0.0
-        version: 5.0.0
       webpack:
         specifier: ^5.52.0
         version: 5.91.0(@swc/core@1.4.11)(esbuild@0.19.12)
@@ -2579,7 +2576,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/aix-ppc64@0.20.2:
@@ -2605,7 +2601,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-arm64@0.20.2:
@@ -2631,7 +2626,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-arm@0.20.2:
@@ -2657,7 +2651,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-x64@0.20.2:
@@ -2683,7 +2676,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/darwin-arm64@0.20.2:
@@ -2709,7 +2701,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/darwin-x64@0.20.2:
@@ -2735,7 +2726,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/freebsd-arm64@0.20.2:
@@ -2761,7 +2751,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/freebsd-x64@0.20.2:
@@ -2787,7 +2776,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-arm64@0.20.2:
@@ -2813,7 +2801,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-arm@0.20.2:
@@ -2839,7 +2826,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-ia32@0.20.2:
@@ -2865,7 +2851,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-loong64@0.20.2:
@@ -2891,7 +2876,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-mips64el@0.20.2:
@@ -2917,7 +2901,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-ppc64@0.20.2:
@@ -2943,7 +2926,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-riscv64@0.20.2:
@@ -2969,7 +2951,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-s390x@0.20.2:
@@ -2995,7 +2976,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-x64@0.20.2:
@@ -3021,7 +3001,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/netbsd-x64@0.20.2:
@@ -3047,7 +3026,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/openbsd-x64@0.20.2:
@@ -3073,7 +3051,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/sunos-x64@0.20.2:
@@ -3099,7 +3076,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-arm64@0.20.2:
@@ -3125,7 +3101,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-ia32@0.20.2:
@@ -3151,7 +3126,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-x64@0.20.2:
@@ -6949,12 +6923,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /builtins@5.0.1:
-    resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
-    dependencies:
-      semver: 7.6.0
-    dev: false
-
   /bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -8660,7 +8628,6 @@ packages:
       '@esbuild/win32-arm64': 0.19.12
       '@esbuild/win32-ia32': 0.19.12
       '@esbuild/win32-x64': 0.19.12
-    dev: false
 
   /esbuild@0.20.2:
     resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
@@ -15013,7 +14980,6 @@ packages:
       serialize-javascript: 6.0.2
       terser: 5.30.0
       webpack: 5.91.0(@swc/core@1.4.11)(esbuild@0.19.12)
-    dev: false
 
   /terser-webpack-plugin@5.3.10(@swc/core@1.4.11)(webpack@5.91.0):
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
@@ -15546,13 +15512,6 @@ packages:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  /validate-npm-package-name@5.0.0:
-    resolution: {integrity: sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dependencies:
-      builtins: 5.0.1
-    dev: false
-
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -15762,7 +15721,7 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.91.0(@swc/core@1.4.11)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.4.11)(esbuild@0.19.12)
 
   /webpack-dev-server@5.0.4(debug@4.3.4)(webpack-cli@5.1.4)(webpack@5.91.0):
     resolution: {integrity: sha512-dljXhUgx3HqKP2d8J/fUMvhxGhzjeNVarDLcbO/EWMSgRizDkxHQDZQaLFL5VJY9tRBj2Gz+rvCEYYvhbqPHNA==}
@@ -15937,7 +15896,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: false
 
   /webpack@5.91.0(@swc/core@1.4.11)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==}


### PR DESCRIPTION
IMO [the extra edge case handling and explicit errors/warnings](https://www.npmjs.com/package/validate-npm-package-name?activeTab=readme) aren't really worth [the dependencies](https://npmgraph.js.org/?q=validate-npm-package-name%405.0.0#color=outdated). Simpler is better.