### PR TITLE
Add support for removing functions named `invariant` and assertions from `tiny-invariant`

### DIFF
--- a/.changeset/seven-apes-tap.md
+++ b/.changeset/seven-apes-tap.md
@@ -1,0 +1,18 @@
+---
+'sku': minor
+---
+
+Add support for removing assertion functions named `invariant` and assertions from the `tiny-invariant` library
+
+**EXAMPLE USAGE**:
+
+```tsx
+import React from 'react';
+import invariant from 'tiny-invariant';
+
+export const Rating = ({ rating }: { rating: number }) => {
+  invariant(rating >= 0 && rating <= 5, 'Rating must be between 0 and 5');
+
+  return <div>...</div>;
+};
+```

--- a/.changeset/seven-apes-tap.md
+++ b/.changeset/seven-apes-tap.md
@@ -2,7 +2,7 @@
 'sku': minor
 ---
 
-Add support for removing assertion functions named `invariant` and assertions from the `tiny-invariant` library
+Add support for removing assertion functions named `invariant` and assertions from the `tiny-invariant` library, a lightweight altnerative to `assert`
 
 **EXAMPLE USAGE**:
 

--- a/.changeset/seven-apes-tap.md
+++ b/.changeset/seven-apes-tap.md
@@ -2,7 +2,7 @@
 'sku': minor
 ---
 
-Add support for removing assertion functions named `invariant` and assertions from the `tiny-invariant` library, a lightweight altnerative to `assert`
+Add support for removing assertion functions named `invariant` and assertions from the `tiny-invariant` library, a lightweight alternative to `assert`
 
 **EXAMPLE USAGE**:
 

--- a/docs/docs/extra-features.md
+++ b/docs/docs/extra-features.md
@@ -109,8 +109,8 @@ export const Rating = ({ rating }) => <div>...</div>;
 
 ### Supported Assertion Function Names
 
-- `assert`
 - `invariant`
+- `assert`
 
 ### Supported Assertion Libraries
 
@@ -119,6 +119,7 @@ export const Rating = ({ rating }) => <div>...</div>;
 - `node:assert` ([Node.js built-in])
 
 Any combination of function name and library name is supported.
+[`tiny-invariant`] is recommended over [`assert`][browser port] due to its simplicity and size.
 
 [`tiny-invariant`]: https://www.npmjs.com/package/tiny-invariant
 [Node.js built-in]: https://nodejs.org/api/assert.html

--- a/docs/docs/extra-features.md
+++ b/docs/docs/extra-features.md
@@ -84,7 +84,7 @@ For more details on configuring hooks, please see husky's [documentation](https:
 By default, sku will remove assertions in your production builds with [`babel-plugin-unassert`].
 This allows you to perform more expensive checks during development without worrying about the perfomance impacts on users.
 
-For example, let's assume you wrote the following code:
+For example, given the following code:
 
 ```tsx
 import React from 'react';
@@ -97,7 +97,7 @@ export const Rating = ({ rating }: { rating: number }) => {
 };
 ```
 
-In production, the code above would be logically equivalent to this:
+In production, sku would transform the code above into code roughly equivalent to:
 
 ```js
 import React from 'react';

--- a/docs/docs/extra-features.md
+++ b/docs/docs/extra-features.md
@@ -81,7 +81,7 @@ For more details on configuring hooks, please see husky's [documentation](https:
 
 ## Assertion removal
 
-If you use [Node's `assert` library](https://nodejs.org/api/assert.html) or its [browser port](https://www.npmjs.com/package/assert), your assertions will be automatically removed in production via [`babel-plugin-unassert`](https://github.com/unassert-js/babel-plugin-unassert).
+By default, sku will remove assertions in your production builds with [`babel-plugin-unassert`].
 This allows you to perform more expensive checks during development without worrying about the perfomance impacts on users.
 
 For example, let's assume you wrote the following code:
@@ -104,6 +104,25 @@ import React from 'react';
 
 export const Rating = ({ rating }) => <div>...</div>;
 ```
+
+[`babel-plugin-unassert`]: https://github.com/unassert-js/babel-plugin-unassert
+
+### Supported Assertion Function Names
+
+- `assert`
+- `invariant`
+
+### Supported Assertion Libraries
+
+- [`tiny-invariant`]
+- `assert` ([Node.js built-in] or [browser port])
+- `node:assert` ([Node.js built-in])
+
+Any combination of function name and library name is supported.
+
+[`tiny-invariant`]: https://www.npmjs.com/package/tiny-invariant
+[Node.js built-in]: https://nodejs.org/api/assert.html
+[browser port]: https://www.npmjs.com/package/assert
 
 ## DevServer Middleware
 

--- a/docs/docs/extra-features.md
+++ b/docs/docs/extra-features.md
@@ -114,7 +114,7 @@ export const Rating = ({ rating }) => <div>...</div>;
 
 ### Supported Assertion Libraries
 
-- [`tiny-invariant`]
+- [`tiny-invariant`] (Recommended)
 - `assert` ([Node.js built-in] or [browser port])
 - `node:assert` ([Node.js built-in])
 

--- a/fixtures/assertion-removal/package.json
+++ b/fixtures/assertion-removal/package.json
@@ -11,7 +11,8 @@
     "@types/react-dom": "^18.2.3",
     "assert": "^2.0.0",
     "dedent": "^1.5.1",
-    "sku": "workspace:*"
+    "sku": "workspace:*",
+    "tiny-invariant": "^1.3.3"
   },
   "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/assertion-removal/src/App.tsx
+++ b/fixtures/assertion-removal/src/App.tsx
@@ -1,7 +1,9 @@
 import assert from 'assert';
+import invariant from 'tiny-invariant';
 
 export default () => {
   assert(false, 'Should be true');
+  invariant(false, 'Should be true');
 
   return <div>It rendered without throwing an assertion error</div>;
 };

--- a/packages/sku/config/babel/babelConfig.js
+++ b/packages/sku/config/babel/babelConfig.js
@@ -55,7 +55,13 @@ module.exports = ({
     }
 
     if (removeAssertionsInProduction) {
-      plugins.push(require.resolve('babel-plugin-unassert'));
+      plugins.push([
+        require.resolve('babel-plugin-unassert'),
+        {
+          variables: ['assert', 'invariant'],
+          modules: ['assert', 'node:assert', 'tiny-invariant'],
+        },
+      ]);
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       sku:
         specifier: workspace:*
         version: link:../../packages/sku
+      tiny-invariant:
+        specifier: ^1.3.3
+        version: 1.3.3
 
   fixtures/braid-design-system:
     dependencies:
@@ -821,7 +824,7 @@ importers:
         version: 1.1.11(react@18.3.1)
       braid-design-system:
         specifier: ^32.0.0
-        version: 32.17.0(@types/react@18.3.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sku@12.5.0(@swc/core@1.5.5)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1))
+        version: 32.17.0(@types/react@18.3.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sku@12.5.1(@swc/core@1.5.5)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1))
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -2426,32 +2429,6 @@ packages:
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
-
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.11':
-    resolution: {integrity: sha512-7j/6vdTym0+qZ6u4XbSAxrWBGYSdCfTzySkj7WAFgDLmSyWlOrWvpyzxlFh5jtw9dn0oL/jtW+06XfFiisN3JQ==}
-    engines: {node: '>= 10.13'}
-    peerDependencies:
-      '@types/webpack': 4.x || 5.x
-      react-refresh: '>=0.10.0 <1.0.0'
-      sockjs-client: ^1.4.0
-      type-fest: '>=0.17.0 <5.0.0'
-      webpack: '>=4.43.0 <6.0.0'
-      webpack-dev-server: 3.x || 4.x
-      webpack-hot-middleware: 2.x
-      webpack-plugin-serve: 0.x || 1.x
-    peerDependenciesMeta:
-      '@types/webpack':
-        optional: true
-      sockjs-client:
-        optional: true
-      type-fest:
-        optional: true
-      webpack-dev-server:
-        optional: true
-      webpack-hot-middleware:
-        optional: true
-      webpack-plugin-serve:
-        optional: true
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.13':
     resolution: {integrity: sha512-odZVYXly+JwzYri9rKqqUAk0cY6zLpv4dxoKinhoJNShV36Gpxf+CyDIILJ4tYsJ1ZxIWs233Y39iVnynvDA/g==}
@@ -4536,10 +4513,6 @@ packages:
     resolution: {integrity: sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA==}
     engines: {node: '>=0.8'}
 
-  d@1.0.2:
-    resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
-    engines: {node: '>=0.12'}
-
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
@@ -4976,20 +4949,6 @@ packages:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
 
-  es5-ext@0.10.64:
-    resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
-    engines: {node: '>=0.10'}
-
-  es6-iterator@2.0.3:
-    resolution: {integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==}
-
-  es6-symbol@3.1.4:
-    resolution: {integrity: sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==}
-    engines: {node: '>=0.12'}
-
-  es6-weak-map@2.0.3:
-    resolution: {integrity: sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==}
-
   esbuild-plugin-alias@0.2.1:
     resolution: {integrity: sha512-jyfL/pwPqaFXyKnj8lP8iLk6Z0m099uXR45aSN8Av1XD4vhvQutxxPzgA2bTcAwQpa1zCXDcWOlhFgyP3GKqhQ==}
 
@@ -5156,10 +5115,6 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
 
-  esniff@2.0.1:
-    resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
-    engines: {node: '>=0.10'}
-
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5196,9 +5151,6 @@ packages:
   eval@0.1.8:
     resolution: {integrity: sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==}
     engines: {node: '>= 0.8'}
-
-  event-emitter@0.3.5:
-    resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
@@ -5238,9 +5190,6 @@ packages:
   express@4.19.2:
     resolution: {integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==}
     engines: {node: '>= 0.10.0'}
-
-  ext@1.7.0:
-    resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -6115,9 +6064,6 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
-  is-promise@2.2.2:
-    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
-
   is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
@@ -6707,9 +6653,6 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
-  lru-queue@0.1.0:
-    resolution: {integrity: sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==}
-
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -6777,9 +6720,6 @@ packages:
   memfs@4.9.2:
     resolution: {integrity: sha512-f16coDZlTG1jskq3mxarwB+fGRrd0uXWt+o1WIhRfOwbXQZqUDsTVxQBFK9JjRQHblg8eAG2JSbprDXKjc7ijQ==}
     engines: {node: '>= 4.0.0'}
-
-  memoizee@0.4.15:
-    resolution: {integrity: sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==}
 
   memoizerific@1.11.3:
     resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
@@ -6974,9 +6914,6 @@ packages:
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
-
-  next-tick@1.1.0:
-    resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
@@ -8262,8 +8199,8 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  sku@12.5.0:
-    resolution: {integrity: sha512-EYc3OcRe5YhTXQwP4Lx8Tm8M2BuQkroUCDI0nyvYPYJ9vZfeXTCFywieVQbKAB3W7Zd92DRA5lAwe0tW9a0nVg==}
+  sku@12.5.1:
+    resolution: {integrity: sha512-SyULkGtBoIolhGcuRZsZFUlOpcLrXfqKQQP9Ji8vhHK0t9moLY6QNU5TtXVXAUcyna47tyyVu5Vek7b4QEMiyQ==}
     engines: {node: '>=18.12'}
     hasBin: true
     peerDependencies:
@@ -8638,9 +8575,6 @@ packages:
   thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
 
-  timers-ext@0.1.7:
-    resolution: {integrity: sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==}
-
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -8779,9 +8713,6 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
-
-  type@2.7.2:
-    resolution: {integrity: sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==}
 
   typed-array-buffer@1.0.2:
     resolution: {integrity: sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==}
@@ -8950,10 +8881,6 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
-
-  validate-npm-package-name@5.0.1:
-    resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -10969,24 +10896,6 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.1.1': {}
-
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4(debug@4.3.4)(webpack@5.91.0(@swc/core@1.5.5)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)(webpack@5.91.0(@swc/core@1.5.5)(esbuild@0.19.12))':
-    dependencies:
-      ansi-html-community: 0.0.8
-      common-path-prefix: 3.0.0
-      core-js-pure: 3.37.0
-      error-stack-parser: 2.1.4
-      find-up: 5.0.0
-      html-entities: 2.5.2
-      loader-utils: 2.0.4
-      react-refresh: 0.14.2
-      schema-utils: 3.3.0
-      source-map: 0.7.4
-      webpack: 5.91.0(@swc/core@1.5.5)(esbuild@0.19.12)
-    optionalDependencies:
-      type-fest: 2.19.0
-      webpack-dev-server: 5.0.4(debug@4.3.4)(webpack@5.91.0(@swc/core@1.5.5)(esbuild@0.19.12))
-      webpack-hot-middleware: 2.26.1
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.13(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4(debug@4.3.4)(webpack@5.91.0(@swc/core@1.5.5)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)(webpack@5.91.0(@swc/core@1.5.5)(esbuild@0.19.12))':
     dependencies:
@@ -13157,7 +13066,7 @@ snapshots:
     dependencies:
       fill-range: 7.0.1
 
-  braid-design-system@32.17.0(@types/react@18.3.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sku@12.5.0(@swc/core@1.5.5)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)):
+  braid-design-system@32.17.0(@types/react@18.3.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sku@12.5.1(@swc/core@1.5.5)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@capsizecss/core': 4.1.2
       '@capsizecss/metrics': 2.2.0
@@ -13184,7 +13093,7 @@ snapshots:
       react-is: 18.3.1
       react-popper-tooltip: 4.4.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-remove-scroll: 2.5.10(@types/react@18.3.2)(react@18.3.1)
-      sku: 12.5.0(@swc/core@1.5.5)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)
+      sku: 12.5.1(@swc/core@1.5.5)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)
       utility-types: 3.11.0
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -13769,11 +13678,6 @@ snapshots:
       find-pkg: 0.1.2
       fs-exists-sync: 0.1.0
 
-  d@1.0.2:
-    dependencies:
-      es5-ext: 0.10.64
-      type: 2.7.2
-
   data-uri-to-buffer@6.0.2: {}
 
   data-urls@3.0.2:
@@ -14303,31 +14207,6 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
-  es5-ext@0.10.64:
-    dependencies:
-      es6-iterator: 2.0.3
-      es6-symbol: 3.1.4
-      esniff: 2.0.1
-      next-tick: 1.1.0
-
-  es6-iterator@2.0.3:
-    dependencies:
-      d: 1.0.2
-      es5-ext: 0.10.64
-      es6-symbol: 3.1.4
-
-  es6-symbol@3.1.4:
-    dependencies:
-      d: 1.0.2
-      ext: 1.7.0
-
-  es6-weak-map@2.0.3:
-    dependencies:
-      d: 1.0.2
-      es5-ext: 0.10.64
-      es6-iterator: 2.0.3
-      es6-symbol: 3.1.4
-
   esbuild-plugin-alias@0.2.1: {}
 
   esbuild-register@3.5.0(esbuild@0.18.20):
@@ -14666,13 +14545,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  esniff@2.0.1:
-    dependencies:
-      d: 1.0.2
-      es5-ext: 0.10.64
-      event-emitter: 0.3.5
-      type: 2.7.2
-
   espree@9.6.1:
     dependencies:
       acorn: 8.11.3
@@ -14701,11 +14573,6 @@ snapshots:
     dependencies:
       '@types/node': 18.19.33
       require-like: 0.1.2
-
-  event-emitter@0.3.5:
-    dependencies:
-      d: 1.0.2
-      es5-ext: 0.10.64
 
   eventemitter3@4.0.7: {}
 
@@ -14790,10 +14657,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  ext@1.7.0:
-    dependencies:
-      type: 2.7.2
 
   extendable-error@0.1.7: {}
 
@@ -15745,8 +15608,6 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
-  is-promise@2.2.2: {}
-
   is-regex@1.1.4:
     dependencies:
       call-bind: 1.0.7
@@ -16593,10 +16454,6 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
-  lru-queue@0.1.0:
-    dependencies:
-      es5-ext: 0.10.64
-
   lz-string@1.5.0: {}
 
   magic-string@0.30.10:
@@ -16654,17 +16511,6 @@ snapshots:
       '@jsonjoy.com/util': 1.1.3(tslib@2.6.2)
       sonic-forest: 1.0.3(tslib@2.6.2)
       tslib: 2.6.2
-
-  memoizee@0.4.15:
-    dependencies:
-      d: 1.0.2
-      es5-ext: 0.10.64
-      es6-weak-map: 2.0.3
-      event-emitter: 0.3.5
-      is-promise: 2.2.2
-      lru-queue: 0.1.0
-      next-tick: 1.1.0
-      timers-ext: 0.1.7
 
   memoizerific@1.11.3:
     dependencies:
@@ -16831,8 +16677,6 @@ snapshots:
   nested-error-stacks@2.1.1: {}
 
   netmask@2.0.2: {}
-
-  next-tick@1.1.0: {}
 
   no-case@3.0.4:
     dependencies:
@@ -18199,7 +18043,7 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  sku@12.5.0(@swc/core@1.5.5)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1):
+  sku@12.5.1(@swc/core@1.5.5)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1):
     dependencies:
       '@antfu/ni': 0.21.12
       '@babel/core': 7.24.5
@@ -18215,7 +18059,7 @@ snapshots:
       '@loadable/server': 5.16.5(@loadable/component@5.16.4(react@18.3.1))(react@18.3.1)
       '@loadable/webpack-plugin': 5.15.2(webpack@5.91.0(@swc/core@1.5.5)(esbuild@0.19.12))
       '@manypkg/find-root': 2.2.1
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4(debug@4.3.4)(webpack@5.91.0(@swc/core@1.5.5)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)(webpack@5.91.0(@swc/core@1.5.5)(esbuild@0.19.12))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.13(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4(debug@4.3.4)(webpack@5.91.0(@swc/core@1.5.5)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)(webpack@5.91.0(@swc/core@1.5.5)(esbuild@0.19.12))
       '@storybook/builder-webpack5': 7.6.19(esbuild@0.19.12)(typescript@5.3.3)
       '@storybook/cli': 7.6.19
       '@storybook/react': 7.6.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
@@ -18258,8 +18102,8 @@ snapshots:
       eslint-config-seek: 12.1.1(eslint@8.57.0)(jest@29.7.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0))(typescript@5.3.3)
       exception-formatter: 2.1.2
       express: 4.19.2
-      fast-glob: 3.3.2
       fastest-validator: 1.18.0
+      fdir: 6.1.1(picomatch@3.0.1)
       find-up: 5.0.0
       get-port: 5.1.1
       hostile: 1.4.0
@@ -18271,19 +18115,19 @@ snapshots:
       less: 4.2.0
       less-loader: 12.2.0(less@4.2.0)(webpack@5.91.0(@swc/core@1.5.5)(esbuild@0.19.12))
       lint-staged: 11.2.6
-      memoizee: 0.4.15
       mini-css-extract-plugin: 2.9.0(webpack@5.91.0(@swc/core@1.5.5)(esbuild@0.19.12))
       minimist: 1.2.8
+      nano-memoize: 3.0.16
       node-html-parser: 6.1.13
       open: 7.4.2
       path-to-regexp: 6.2.2
+      picomatch: 3.0.1
       postcss: 8.4.38
       postcss-loader: 8.1.1(postcss@8.4.38)(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.5)(esbuild@0.19.12))
       prettier: 2.8.8
       pretty-ms: 7.0.1
       react: 18.3.1
       react-refresh: 0.14.2
-      rimraf: 5.0.7
       selfsigned: 2.4.1
       semver: 7.6.2
       serialize-javascript: 6.0.2
@@ -18292,7 +18136,6 @@ snapshots:
       terser-webpack-plugin: 5.3.10(@swc/core@1.5.5)(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.5)(esbuild@0.19.12))
       tree-kill: 1.2.2
       typescript: 5.3.3
-      validate-npm-package-name: 5.0.1
       webpack: 5.91.0(@swc/core@1.5.5)(esbuild@0.19.12)
       webpack-bundle-analyzer: 4.10.2
       webpack-dev-server: 5.0.4(debug@4.3.4)(webpack@5.91.0(@swc/core@1.5.5)(esbuild@0.19.12))
@@ -18773,11 +18616,6 @@ snapshots:
 
   thunky@1.1.0: {}
 
-  timers-ext@0.1.7:
-    dependencies:
-      es5-ext: 0.10.64
-      next-tick: 1.1.0
-
   tiny-invariant@1.3.3: {}
 
   tinydate@1.3.0: {}
@@ -18885,8 +18723,6 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
-
-  type@2.7.2: {}
 
   typed-array-buffer@1.0.2:
     dependencies:
@@ -19068,8 +18904,6 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
-
-  validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
 

--- a/tests/assertion-removal.test.ts
+++ b/tests/assertion-removal.test.ts
@@ -33,7 +33,7 @@ describe('assertion-removal', () => {
       await process.kill();
     });
 
-    it('should not contain "assert" in production', async () => {
+    it('should not contain "assert" or "invariant" in production', async () => {
       const page = await browser.newPage();
       const response = await page.goto(url, { waitUntil: 'networkidle0' });
       const sourceHtml = await response?.text();
@@ -62,7 +62,7 @@ describe('assertion-removal', () => {
       closeAssetServer();
     });
 
-    it('should not contain "assert" in production', async function () {
+    it('should not contain "assert" or "invariant" in production', async function () {
       const page = await browser.newPage();
       const response = await page.goto(backendUrl, {
         waitUntil: 'networkidle0',
@@ -82,7 +82,7 @@ describe('assertion-removal', () => {
       exitCode = child.exitCode;
     });
 
-    it('should keep "assert" in tests', async () => {
+    it('should keep "assert" and "invariant" in tests', async () => {
       // App.test.tsx expects the code to throw, which means that the sku test script passes
       expect(exitCode).toEqual(0);
     });


### PR DESCRIPTION
## Support `invariant` function and `tiny-invariant` library

[`tiny-invariant`](https://www.npmjs.com/package/tiny-invariant) is a small, 0 dependency assertion library. The standard way of importing its assertion function is to name it `invariant`, which is why I added it to the `variables` config for `babel-plugin-unassert`.

> [!NOTE]
> Technically this changes removes support for removing assertions from [`power-assert`](https://www.npmjs.com/package/power-assert), because we're now overriding [the default config](https://github.com/unassert-js/babel-plugin-unassert?tab=readme-ov-file#options). There is no internal usage of `power-assert` that I'm aware of, so not marking this change as breaking.

## Why should we support `tiny-invariant`?

For dev-time assertions in the browser, usually we'd reach for the [`assert`](https://www.npmjs.com/package/assert) library. This is what Braid uses. However, it has [**an unnecessarily large dependency graph**](https://npmgraph.js.org/?q=assert#zoom=w) for an assertion library.

Hopefully we can eventually replace `assert` with `tiny-invariant` within Braid. Part of that involves supporting an alternative assertion library in sku. Not sure when the change in Braid will happen, as it depends on consumers using a version of sku that supports `tiny-invariant` (i.e. whatever version this change is released in).

## Tradeoffs between `assert` and `tiny-invariant`

`assert` supports checking non-primitive values, has more useful error messages, and offers various assertion functions. `tiny-invariant` just asserts on a user-provided condition, throwing an error if it fails. That's it. This is likely suitable for most use cases, and will probably work just fine in Braid and most front-end apps/libraries.

## Meme

<details>
<summary>Show</summary>

![drug eyes polyfills meme](https://github.com/seek-oss/sku/assets/5663042/90194631-73c2-459c-b28a-55719d5c5fab)

</details>