### PR TITLE
Only remove output directory files, not the directory

### DIFF
--- a/.changeset/dirty-hounds-try.md
+++ b/.changeset/dirty-hounds-try.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+When cleaning the build output directory, only delete files within the directory, rather than the entire directory

--- a/packages/sku/lib/buildFileUtils.js
+++ b/packages/sku/lib/buildFileUtils.js
@@ -8,7 +8,18 @@ const exists = require('./exists');
 const copyDirContents = require('./copyDirContents');
 
 const cleanTargetDirectory = async () => {
-  fs.rm(paths.target, { recursive: true, force: true });
+  const files = await new Fdir()
+    .withBasePath()
+    .withMaxDepth(1)
+    .withDirs()
+    // This glob pattern is used to exclude the target directory itself
+    .glob(`${paths.target}/*`)
+    .crawl(paths.target)
+    .withPromise();
+
+  for (const file of files) {
+    await fs.rm(file, { recursive: true, force: true });
+  }
 };
 
 const copyPublicFiles = async () => {


### PR DESCRIPTION
When this function used `rimraf`, a glob was being used, so the old behaviour was to only remove files within the directory. During #961, this was modified to just delete the output directory entirely.

Turns out it was probably like that for a reason. For example, if you're mounting a directory from a host, e.g. you're in docker, you probably don't have permission delete the mounted directory from within the container.