### PR TITLE
Fix default compile package detection in PNPM repos

### DIFF
--- a/.changeset/tiny-forks-kneel.md
+++ b/.changeset/tiny-forks-kneel.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fix default compile package detection in PNPM repos

--- a/fixtures/braid-design-system/package.json
+++ b/fixtures/braid-design-system/package.json
@@ -12,6 +12,5 @@
     "@types/react-dom": "^18.2.3",
     "@vanilla-extract/css": "^1.0.0",
     "sku": "workspace:*"
-  },
-  "skuSkipValidatePeerDeps": true
+  }
 }


### PR DESCRIPTION
Using `withSymlinks` always resolves to an absolute path. However, in combination with `withRelativePaths`, `fdir` _thinks_ it's dealing with a relative path, but it's actually absolute, so it ends up removing part of the start of the path, resulting in an error.

In hindsight, it's much simpler to just use absolute paths everywhere, rather than joining paths ourselves.

Not exactly sure how this slipped through when I was testing the `fdir` refactor, but I don't think the effort required to setup a unit test for this functionality is worth it.