### PR TITLE
Add docs for sku's API/entrypoints

### DIFF
--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -6,3 +6,4 @@
   - [v9.0.0](./migration-guides/v9.0.0.md)
   - [v10.0.0](./migration-guides/v10.0.0.md)
   - [v11.0.0](./migration-guides/v11.0.0.md)
+  - [v12.0.0](./migration-guides/v12.0.0.md)

--- a/docs/docs/_sidebar.md
+++ b/docs/docs/_sidebar.md
@@ -1,6 +1,7 @@
 - [Getting started](./docs/getting-started.md)
 - [Configuration](./docs/configuration.md)
 - [CLI](./docs/cli.md)
+- [API](./docs/api.md)
 - [FAQ](./docs/faq)
 - [Debugging](./docs/debugging.md)
 - **Project types**

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -14,7 +14,7 @@ import type { SkuConfig, Render } from 'sku';
 
 ## `sku/@loadable/component`
 
-A re-export of the `@loadble/component` package, which `sku` provides as a dependency.
+A re-export of the `@loadable/component` package, which `sku` provides as a dependency.
 
 Example:
 

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -63,7 +63,7 @@ import storybookConfig from 'sku/config/storybook';
 ## `sku/webpack-plugin`
 
 A plugin that provides `sku` functionality to custom webpack builds.
-See [custom builds] for more information.
+See the [custom builds documentation] for more information.
 
 Example:
 
@@ -71,4 +71,4 @@ Example:
 import SkuWebpackPlugin from 'sku/webpack-plugin';
 ```
 
-[custom builds]: ./docs/custom-builds.md
+[custom builds documentation]: ./docs/custom-builds.md

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -1,0 +1,74 @@
+# API
+
+`sku` provides a number of entrypoints that export configuration, utilities and types for use alongside your application.
+
+## `sku`
+
+Exports `sku` configuration and application entrypoint types.
+
+Example:
+
+```ts
+import type { SkuConfig, Render } from 'sku';
+```
+
+## `sku/@loadable/component`
+
+A re-export of the `@loadble/component` package, which `sku` provides as a dependency.
+
+Example:
+
+```ts
+import { loadableReady } from 'sku/@loadable/component';
+```
+
+## `sku/@storybook/react`
+
+A re-export of the `@storybook/react` package, which `sku` provides as a dependency.
+
+Example:
+
+```ts
+import type { StoryObj } from 'sku/@storybook/react';
+```
+
+## `sku/config/jest`
+
+A jest preset for consuming `sku`'s Jest configuration.
+See the [testing documentation] for more information.
+
+Example:
+
+```js
+// jest.config.js
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'sku/config/jest',
+};
+```
+
+## `sku/config/storybook`
+
+Exports storybook config compatible with `sku`.
+`sku` creates your Storybook configuration for you, so you don't need to use this directly.
+
+Example:
+
+```ts
+import storybookConfig from 'sku/config/storybook';
+```
+
+[testing documentation]: ./docs/testing.md
+
+## `sku/webpack-plugin`
+
+A plugin that provides `sku` functionality to custom webpack builds.
+See [custom builds] for more information.
+
+Example:
+
+```ts
+import SkuWebpackPlugin from 'sku/webpack-plugin';
+```
+
+[custom builds]: ./docs/custom-builds.md

--- a/docs/index.html
+++ b/docs/index.html
@@ -106,6 +106,7 @@
     </script>
     <script src="//unpkg.com/docsify@4.13.0/lib/docsify.min.js"></script>
     <script src="//unpkg.com/docsify@4.13.0/lib/plugins/search.min.js"></script>
+    <script src="//unpkg.com/docsify-copy-code@3"></script>
     <script src="//unpkg.com/docsify-themeable@0.9.0/dist/js/docsify-themeable.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-diff.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-json.min.js"></script>


### PR DESCRIPTION
- Added docs for all sku entrypoints. Currently, consumers can import from any subpath within `sku`, so I've only documented the ones we officially support. In the next major version, these will be explicitly defined in `package.json#exports`, preventing imports from arbitrary subpaths.
- Added the v12 migration guide link to the navbar
- Added a docsify plugin that adds a copy code button to code blocks

Copy code button demo:
![output](https://github.com/seek-oss/sku/assets/5663042/905bd9e5-0bad-4f4e-8895-2c6cc37427c6)

