### PR TITLE
sku v13: Simplify package manager detection

### DIFF
--- a/.changeset/shy-books-trade.md
+++ b/.changeset/shy-books-trade.md
@@ -1,0 +1,16 @@
+---
+'sku': major
+---
+
+Simplify package manager detection
+
+By default, the package manager used to run a sku command will be used by sku for installing dependencies (during `sku init`) or suggesting commands.
+This can be overridden via the `--packageManager` flag:
+
+```sh
+$ npx sku init --packageManager pnpm my-app
+$ cd my-app
+$ pnpm start
+```
+
+If a package manager cannot be detected, _and_ the `--packageManager` flag is not used, sku will now default to using `npm`.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -5,15 +5,14 @@ Create a new project and start a local development environment:
 ```bash
 $ npx sku init my-app
 $ cd my-app
-$ yarn start
+$ npm start
 ```
 
-By default, a new project's dependencies will be installed with the first supported package manager detected on your system.
-Package managers are detected in the following order: `yarn` -> `pnpm` -> `npm`.
+By default, a new project's dependencies will be installed using the package manager it was run with.
 This can be overridden via the `--packageManager` flag:
 
 ```bash
-$ pnpm dlx sku init --packageManager pnpm my-app
+$ npx sku init --packageManager pnpm my-app
 $ cd my-app
 $ pnpm start
 ```

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -123,7 +123,6 @@
     "webpack-dev-server": "^5.0.2",
     "webpack-merge": "^5.8.0",
     "webpack-node-externals": "^3.0.0",
-    "which": "^4.0.0",
     "wrap-ansi": "^7.0.0",
     "x-default-browser": "^0.5.0"
   },
@@ -135,7 +134,6 @@
     "@types/picomatch": "^2.3.3",
     "@types/react": "^18.2.3",
     "@types/react-dom": "^18.2.3",
-    "@types/which": "^3.0.0",
     "@vanilla-extract/css": "^1.0.0",
     "@vocab/react": "^1.0.1",
     "braid-design-system": "^32.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -782,9 +782,6 @@ importers:
       webpack-node-externals:
         specifier: ^3.0.0
         version: 3.0.0
-      which:
-        specifier: ^4.0.0
-        version: 4.0.0
       wrap-ansi:
         specifier: ^7.0.0
         version: 7.0.0
@@ -813,9 +810,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.3
         version: 18.3.0
-      '@types/which':
-        specifier: ^3.0.0
-        version: 3.0.3
       '@vanilla-extract/css':
         specifier: ^1.0.0
         version: 1.15.2(babel-plugin-macros@3.1.0)
@@ -3341,9 +3335,6 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
-
-  '@types/which@3.0.3':
-    resolution: {integrity: sha512-2C1+XoY0huExTbs8MQv1DuS5FS86+SEjdM9F/+GS61gg5Hqbtj8ZiDSx8MfWcyei907fIPbfPGCOrNUTnVHY1g==}
 
   '@types/ws@8.5.10':
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
@@ -12165,8 +12156,6 @@ snapshots:
   '@types/stack-utils@2.0.3': {}
 
   '@types/tough-cookie@4.0.5': {}
-
-  '@types/which@3.0.3': {}
 
   '@types/ws@8.5.10':
     dependencies:


### PR DESCRIPTION
Package managers set a `npm_config_user_agent` envar. We can do a simple `includes` check to get the package manager from it, greatly simplifying our package manager detection.