### PR TITLE
Update puppeteer, refactor certain storybook tests to target iframe URL directly

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,11 +47,7 @@ module.exports = {
         jest: true,
       },
       globals: {
-        page: true,
         browser: true,
-        context: true,
-        puppeteerConfig: true,
-        jestPuppeteer: true,
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
     "husky": "^9.0.0",
     "jest": "^29.0.0",
     "jest-environment-jsdom": "^29.0.0",
-    "jest-puppeteer": "^9.0.1",
+    "jest-puppeteer": "^10.0.1",
     "jest-watch-typeahead": "^2.2.0",
     "lint-staged": "^11.1.1",
     "prettier": "^2.8.8",
-    "puppeteer": "^21.6.0",
+    "puppeteer": "^22.10.0",
     "renovate-config-seek": "^0.4.0",
     "typescript": "*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^29.0.0
         version: 29.7.0
       jest-puppeteer:
-        specifier: ^9.0.1
-        version: 9.0.2(debug@4.3.4)(puppeteer@21.11.0(typescript@5.3.3))(typescript@5.3.3)
+        specifier: ^10.0.1
+        version: 10.0.1(debug@4.3.4)(puppeteer@22.10.0(typescript@5.3.3))(typescript@5.3.3)
       jest-watch-typeahead:
         specifier: ^2.2.0
         version: 2.2.2(jest@29.7.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0))
@@ -75,8 +75,8 @@ importers:
         specifier: ^2.8.8
         version: 2.8.8
       puppeteer:
-        specifier: ^21.6.0
-        version: 21.11.0(typescript@5.3.3)
+        specifier: ^22.10.0
+        version: 22.10.0(typescript@5.3.3)
       renovate-config-seek:
         specifier: ^0.4.0
         version: 0.4.0
@@ -2462,9 +2462,9 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
-  '@puppeteer/browsers@1.9.1':
-    resolution: {integrity: sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==}
-    engines: {node: '>=16.3.0'}
+  '@puppeteer/browsers@2.2.3':
+    resolution: {integrity: sha512-bJ0UBsk0ESOs6RFcLXOt99a3yTDcOKlzfjad+rhFwdaG1Lu/Wzq58GHYCDTlZ9z6mldf4g+NTb+TXEfe0PpnsQ==}
+    engines: {node: '>=18'}
     hasBin: true
 
   '@radix-ui/number@1.0.1':
@@ -3939,6 +3939,18 @@ packages:
   bare-events@2.2.2:
     resolution: {integrity: sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==}
 
+  bare-fs@2.3.0:
+    resolution: {integrity: sha512-TNFqa1B4N99pds2a5NYHR15o0ZpdNKbAeKTE/+G6ED/UeOavv8RY3dr/Fu99HW3zU3pXpo2kDNO8Sjsm2esfOw==}
+
+  bare-os@2.3.0:
+    resolution: {integrity: sha512-oPb8oMM1xZbhRQBngTgpcQ5gXw6kjOaRsSWsIeNyRxGed2w/ARyP7ScBYpWR1qfX2E5rS3gBw6OWcSQo+s+kUg==}
+
+  bare-path@2.1.3:
+    resolution: {integrity: sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==}
+
+  bare-stream@1.0.0:
+    resolution: {integrity: sha512-KhNUoDL40iP4gFaLSsoGE479t0jHijfYdIcxRn/XtezA2BaUD0NRf/JGRpsMq6dMNM+SrCrB0YSSo/5wBY4rOQ==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -4142,8 +4154,8 @@ packages:
     resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
     engines: {node: '>=6.0'}
 
-  chromium-bidi@0.5.8:
-    resolution: {integrity: sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==}
+  chromium-bidi@0.5.19:
+    resolution: {integrity: sha512-UA6zL77b7RYCjJkZBsZ0wlvCTD+jTjllZ8f6wdO4buevXgTZYjV+XLB9CiEa2OuuTGGTLnI7eN9I60YxuALGQg==}
     peerDependencies:
       devtools-protocol: '*'
 
@@ -4396,9 +4408,6 @@ packages:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
-
-  cross-fetch@4.0.0:
-    resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
 
   cross-spawn@5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
@@ -4711,8 +4720,8 @@ packages:
     engines: {node: '>= 4.0.0'}
     hasBin: true
 
-  devtools-protocol@0.0.1232444:
-    resolution: {integrity: sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==}
+  devtools-protocol@0.0.1286932:
+    resolution: {integrity: sha512-wu58HMQll9voDjR4NlPyoDEw1syfzaBNHymMMZ/QOXiHRNluOnDgu9hp1yHOKYoMlxCh4lSSiugLITe6Fvu1eA==}
 
   didyoumean2@6.0.1:
     resolution: {integrity: sha512-PSy0zQwMg5O+LjT5Mz7vnKC8I7DfWLPF6M7oepqW7WP5mn2CY3hz46xZOa1GJY+KVfyXhdmz6+tdgXwrHlZc5g==}
@@ -5179,8 +5188,8 @@ packages:
     resolution: {integrity: sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q==}
     engines: {node: '>=0.10.0'}
 
-  expect-puppeteer@9.0.2:
-    resolution: {integrity: sha512-nv3RD8MOStXOf4bLpr1wiqxPMLL7MwXvtMeZBtGvg5bubAHiHcYBcvDTJwkUjdOWz3scjOnOOl5z6KZakMobCw==}
+  expect-puppeteer@10.0.0:
+    resolution: {integrity: sha512-E7sE6nVdEbrnpDOBMmcLgyqLJKt876AlBg1A+gsu5R8cWx+SLafreOgJAgzXg5Qko7Tk0cW5oZdRbHQLU738dg==}
     engines: {node: '>=16'}
 
   expect@29.7.0:
@@ -6240,8 +6249,8 @@ packages:
       ts-node:
         optional: true
 
-  jest-dev-server@9.0.2:
-    resolution: {integrity: sha512-Zc/JB0IlNNrpXkhBw+h86cGrde/Mey52KvF+FER2eyrtYJTHObOwW7Iarxm3rPyTKby5+3Y2QZtl8pRz/5GCxg==}
+  jest-dev-server@10.0.0:
+    resolution: {integrity: sha512-FtyBBDxrAIfTX3hyKSOwj5KU6Z7fFLew5pQYOFpwyf+qpPpULL8aYxtsFkbkAwcs+Mb7qhcNbVLeiWsLOd7CKw==}
     engines: {node: '>=16'}
 
   jest-diff@29.7.0:
@@ -6269,8 +6278,8 @@ packages:
     resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  jest-environment-puppeteer@9.0.2:
-    resolution: {integrity: sha512-t7+W4LUiPoOz+xpKREgnu6IElMuRthOWTkrThDZqVKPmLhwbK3yx7OCiX8xT1Pw/Cv5WnSoNhwtN7czdCC3fQg==}
+  jest-environment-puppeteer@10.0.1:
+    resolution: {integrity: sha512-FxMzVRyqieQqSy5CPWiwdK5t9dkRHid5eoRTVa8RtYeXLlpW6lU0dAmxEfPkdnDVCiPUhC2APeKOXq0J72bgag==}
     engines: {node: '>=16'}
 
   jest-get-type@29.6.3:
@@ -6306,8 +6315,8 @@ packages:
       jest-resolve:
         optional: true
 
-  jest-puppeteer@9.0.2:
-    resolution: {integrity: sha512-ZB0K/tH+0e7foRRn+VpKIufvkW1by8l7ifh62VOdOh5ijEf7yt8W2/PcBNNwP0RLm46AytiBkrIEenvWhxcBRQ==}
+  jest-puppeteer@10.0.1:
+    resolution: {integrity: sha512-FzC35XbqeuQEt1smXh1EOqhJaRkWqJkyWDMfGkcZ8C59QHXeJ7F/iOmiNqYi6l/OsycUuOPCk+IkjfGfS9YbrQ==}
     engines: {node: '>=16'}
     peerDependencies:
       puppeteer: '>=19'
@@ -6650,6 +6659,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
 
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
@@ -7619,8 +7632,8 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-agent@6.3.1:
-    resolution: {integrity: sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==}
+  proxy-agent@6.4.0:
+    resolution: {integrity: sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==}
     engines: {node: '>= 14'}
 
   proxy-from-env@1.1.0:
@@ -7659,14 +7672,13 @@ packages:
     resolution: {integrity: sha512-n13AWriBMPYxnpbb6bnaY5YoY6rGj8vPLrz6CZF3o0qJNEwlcfJVxBzYZ0NJsQ21UbdJoijPCDrM++SUVEz7+w==}
     engines: {node: '>=8.16.0'}
 
-  puppeteer-core@21.11.0:
-    resolution: {integrity: sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==}
-    engines: {node: '>=16.13.2'}
+  puppeteer-core@22.10.0:
+    resolution: {integrity: sha512-I54J4Vy4I07UHsgB1QSmuFoF7KNQjJWcvFBPhtY+ezMdBfwgGDr8dzYrJa11aPgP9kxIUHjhktcMmmfJkOAtTw==}
+    engines: {node: '>=18'}
 
-  puppeteer@21.11.0:
-    resolution: {integrity: sha512-9jTHuYe22TD3sNxy0nEIzC7ZrlRnDgeX3xPkbS7PnbdwYjl2o/z/YuCrRBwezdKpbTDTJ4VqIggzNyeRcKq3cg==}
-    engines: {node: '>=16.13.2'}
-    deprecated: < 22.5.0 is no longer supported
+  puppeteer@22.10.0:
+    resolution: {integrity: sha512-ZOkZd6a6t0BdKcWb0wAYHWQqCfdlN1PPnXOmg/XNrbo6gJhYWFX4qCNb6ahSn8TpAqBqLCoD4Q010F7GwOM7mA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   pure-rand@6.1.0:
@@ -8115,6 +8127,11 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.6.0:
+    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.6.2:
     resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
     engines: {node: '>=10'}
@@ -8280,8 +8297,8 @@ packages:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
 
-  spawnd@9.0.2:
-    resolution: {integrity: sha512-nl8DVHEDQ57IcKakzpjanspVChkMpGLuVwMR/eOn9cXE55Qr6luD2Kn06sA0ootRMdgrU4tInN6lA6ohTNvysw==}
+  spawnd@10.0.0:
+    resolution: {integrity: sha512-6GKcakMTryb5b1SWCvdubCDHEsR2k+5VZUD5G19umZRarkvj1RyCGyizcqhjewI7cqZo8fTVD8HpnDZbVOLMtg==}
     engines: {node: '>=16'}
 
   spawndamnit@2.0.0:
@@ -8505,8 +8522,8 @@ packages:
   tar-fs@2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
 
-  tar-fs@3.0.4:
-    resolution: {integrity: sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==}
+  tar-fs@3.0.5:
+    resolution: {integrity: sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
@@ -9165,18 +9182,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.16.0:
-    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.17.0:
     resolution: {integrity: sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==}
     engines: {node: '>=10.0.0'}
@@ -9257,6 +9262,9 @@ packages:
   yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+
+  zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
 
 snapshots:
 
@@ -10920,13 +10928,14 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
-  '@puppeteer/browsers@1.9.1':
+  '@puppeteer/browsers@2.2.3':
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       extract-zip: 2.0.1
       progress: 2.0.3
-      proxy-agent: 6.3.1
-      tar-fs: 3.0.4
+      proxy-agent: 6.4.0
+      semver: 7.6.0
+      tar-fs: 3.0.5
       unbzip2-stream: 1.4.3
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -12986,6 +12995,26 @@ snapshots:
   bare-events@2.2.2:
     optional: true
 
+  bare-fs@2.3.0:
+    dependencies:
+      bare-events: 2.2.2
+      bare-path: 2.1.3
+      bare-stream: 1.0.0
+    optional: true
+
+  bare-os@2.3.0:
+    optional: true
+
+  bare-path@2.1.3:
+    dependencies:
+      bare-os: 2.3.0
+    optional: true
+
+  bare-stream@1.0.0:
+    dependencies:
+      streamx: 2.16.1
+    optional: true
+
   base64-js@1.5.1: {}
 
   basic-ftp@5.0.5: {}
@@ -13277,11 +13306,12 @@ snapshots:
 
   chrome-trace-event@1.0.3: {}
 
-  chromium-bidi@0.5.8(devtools-protocol@0.0.1232444):
+  chromium-bidi@0.5.19(devtools-protocol@0.0.1286932):
     dependencies:
-      devtools-protocol: 0.0.1232444
+      devtools-protocol: 0.0.1286932
       mitt: 3.0.1
       urlpattern-polyfill: 10.0.0
+      zod: 3.22.4
 
   ci-info@2.0.0: {}
 
@@ -13524,12 +13554,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
-
-  cross-fetch@4.0.0:
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
 
   cross-spawn@5.1.0:
     dependencies:
@@ -13870,7 +13894,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  devtools-protocol@0.0.1232444: {}
+  devtools-protocol@0.0.1286932: {}
 
   didyoumean2@6.0.1:
     dependencies:
@@ -14614,7 +14638,7 @@ snapshots:
     dependencies:
       os-homedir: 1.0.2
 
-  expect-puppeteer@9.0.2: {}
+  expect-puppeteer@10.0.0: {}
 
   expect@29.7.0:
     dependencies:
@@ -15833,13 +15857,13 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-dev-server@9.0.2(debug@4.3.4):
+  jest-dev-server@10.0.0(debug@4.3.4):
     dependencies:
       chalk: 4.1.2
       cwd: 0.10.0
       find-process: 1.4.7
       prompts: 2.4.2
-      spawnd: 9.0.2
+      spawnd: 10.0.0
       tree-kill: 1.2.2
       wait-on: 7.2.0(debug@4.3.4)
     transitivePeerDependencies:
@@ -15889,12 +15913,12 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-environment-puppeteer@9.0.2(debug@4.3.4)(typescript@5.3.3):
+  jest-environment-puppeteer@10.0.1(debug@4.3.4)(typescript@5.3.3):
     dependencies:
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.3.3)
       deepmerge: 4.3.1
-      jest-dev-server: 9.0.2(debug@4.3.4)
+      jest-dev-server: 10.0.0(debug@4.3.4)
       jest-environment-node: 29.7.0
     transitivePeerDependencies:
       - debug
@@ -15953,11 +15977,11 @@ snapshots:
     optionalDependencies:
       jest-resolve: 29.7.0
 
-  jest-puppeteer@9.0.2(debug@4.3.4)(puppeteer@21.11.0(typescript@5.3.3))(typescript@5.3.3):
+  jest-puppeteer@10.0.1(debug@4.3.4)(puppeteer@22.10.0(typescript@5.3.3))(typescript@5.3.3):
     dependencies:
-      expect-puppeteer: 9.0.2
-      jest-environment-puppeteer: 9.0.2(debug@4.3.4)(typescript@5.3.3)
-      puppeteer: 21.11.0(typescript@5.3.3)
+      expect-puppeteer: 10.0.0
+      jest-environment-puppeteer: 10.0.1(debug@4.3.4)(typescript@5.3.3)
+      puppeteer: 22.10.0(typescript@5.3.3)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -16453,6 +16477,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
 
   lru-cache@7.18.3: {}
 
@@ -17344,7 +17372,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-agent@6.3.1:
+  proxy-agent@6.4.0:
     dependencies:
       agent-base: 7.1.1
       debug: 4.3.4(supports-color@8.1.1)
@@ -17407,28 +17435,26 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  puppeteer-core@21.11.0:
+  puppeteer-core@22.10.0:
     dependencies:
-      '@puppeteer/browsers': 1.9.1
-      chromium-bidi: 0.5.8(devtools-protocol@0.0.1232444)
-      cross-fetch: 4.0.0
+      '@puppeteer/browsers': 2.2.3
+      chromium-bidi: 0.5.19(devtools-protocol@0.0.1286932)
       debug: 4.3.4(supports-color@8.1.1)
-      devtools-protocol: 0.0.1232444
-      ws: 8.16.0
+      devtools-protocol: 0.0.1286932
+      ws: 8.17.0
     transitivePeerDependencies:
       - bufferutil
-      - encoding
       - supports-color
       - utf-8-validate
 
-  puppeteer@21.11.0(typescript@5.3.3):
+  puppeteer@22.10.0(typescript@5.3.3):
     dependencies:
-      '@puppeteer/browsers': 1.9.1
+      '@puppeteer/browsers': 2.2.3
       cosmiconfig: 9.0.0(typescript@5.3.3)
-      puppeteer-core: 21.11.0
+      devtools-protocol: 0.0.1286932
+      puppeteer-core: 22.10.0
     transitivePeerDependencies:
       - bufferutil
-      - encoding
       - supports-color
       - typescript
       - utf-8-validate
@@ -17922,6 +17948,10 @@ snapshots:
 
   semver@6.3.1: {}
 
+  semver@7.6.0:
+    dependencies:
+      lru-cache: 6.0.0
+
   semver@7.6.2: {}
 
   send@0.18.0:
@@ -18248,7 +18278,7 @@ snapshots:
 
   source-map@0.7.4: {}
 
-  spawnd@9.0.2:
+  spawnd@10.0.0:
     dependencies:
       signal-exit: 4.1.0
       tree-kill: 1.2.2
@@ -18507,11 +18537,13 @@ snapshots:
       pump: 3.0.0
       tar-stream: 2.2.0
 
-  tar-fs@3.0.4:
+  tar-fs@3.0.5:
     dependencies:
-      mkdirp-classic: 0.5.3
       pump: 3.0.0
       tar-stream: 3.1.7
+    optionalDependencies:
+      bare-fs: 2.3.0
+      bare-path: 2.1.3
 
   tar-stream@2.2.0:
     dependencies:
@@ -19380,8 +19412,6 @@ snapshots:
 
   ws@7.5.9: {}
 
-  ws@8.16.0: {}
-
   ws@8.17.0: {}
 
   x-default-browser@0.5.2:
@@ -19453,3 +19483,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.0.0: {}
+
+  zod@3.22.4: {}

--- a/test-utils/appSnapshot.js
+++ b/test-utils/appSnapshot.js
@@ -2,21 +2,36 @@ const getAppSnapshot = async (url, warningFilter = () => true) => {
   const warnings = [];
   const errors = [];
 
-  const page = await browser.newPage();
+  const appPage = await browser.newPage();
 
-  page.on('console', (msg) => {
+  appPage.on('console', (msg) => {
     if (msg.type() === 'warning') {
       warnings.filter(warningFilter).push(msg.text());
     }
 
     if (msg.type() === 'error') {
+      let isFaviconError = false;
+      msg.stackTrace().forEach((frame) => {
+        // Ignore 404s for favicons
+        if (frame.url.endsWith('favicon.ico')) {
+          isFaviconError = true;
+          return;
+        }
+
+        errors.push(`${frame.url}:${frame.lineNumber}:${frame.columnNumber}`);
+      });
+
+      if (isFaviconError) {
+        return;
+      }
+
       errors.push(msg.text());
     }
   });
 
-  const response = await page.goto(url, { waitUntil: 'load' });
+  const response = await appPage.goto(url, { waitUntil: 'load' });
   const sourceHtml = await response.text();
-  const clientRenderContent = await page.content();
+  const clientRenderContent = await appPage.content();
 
   expect(warnings).toEqual([]);
   expect(errors).toEqual([]);

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -5,8 +5,9 @@ const { dirContentsToObject } = require('./dirContentsToObject');
 const { run, runSkuScriptInDir } = require('./process');
 const { makeStableHashes } = require('./skuConfig');
 const {
-  getStorybookFrame,
-  getTextContentFromStorybookFrame,
+  getStoryFrame,
+  getStoryPage,
+  getTextContentFromFrameOrPage,
 } = require('./storybook');
 const { waitForUrls } = require('./waitForUrls');
 
@@ -15,8 +16,9 @@ module.exports = {
   ...appSnapshot,
   startAssetServer,
   dirContentsToObject,
-  getStorybookFrame,
-  getTextContentFromStorybookFrame,
+  getStoryFrame,
+  getStoryPage,
+  getTextContentFromFrameOrPage,
   makeStableHashes,
   run,
   runSkuScriptInDir,

--- a/test-utils/storybook.js
+++ b/test-utils/storybook.js
@@ -2,47 +2,64 @@
 /// <reference lib="dom" />
 
 /**
+ * Returns the page for the given story iframe URL
+ *
+ * @param {string} storybookUrl A URL pointing to a storybook
+ */
+export const getStoryPage = async (storyIframeUrl) => {
+  const storyPage = await browser.newPage();
+  storyPage.setDefaultNavigationTimeout(10_000);
+
+  await storyPage.goto(storyIframeUrl, { waitUntil: ['load'] });
+
+  return storyPage;
+};
+
+/**
  * Returns the iframe of the first story at the provided storybook URL
  *
  * @param {string} storybookUrl A URL pointing to a storybook
  */
-const getStorybookFrame = async (storybookUrl) => {
-  const page = await browser.newPage();
-  page.setDefaultNavigationTimeout(100_000);
-  await page.goto(storybookUrl, { waitUntil: 'load' });
+export const getStoryFrame = async (storybookUrl) => {
+  const storybookPage = await browser.newPage();
+  storybookPage.setDefaultNavigationTimeout(10_000);
 
-  const firstStoryButton = await page.waitForSelector(
+  await storybookPage.goto(storybookUrl, { waitUntil: ['load'] });
+
+  const firstStoryButton = await storybookPage.waitForSelector(
     '#storybook-explorer-menu button',
-    { timeout: 100_000 },
+    { timeout: 10_000 },
   );
 
   // Ensure default story is activated
   await firstStoryButton.click();
 
-  const iframeElement = await page.waitForSelector('#storybook-preview-iframe');
+  const iframeElement = await storybookPage.waitForSelector(
+    '#storybook-preview-iframe',
+  );
 
-  const storybookFrame = await iframeElement.contentFrame();
+  const storyFrame = await iframeElement.contentFrame();
 
-  if (!storybookFrame) {
-    console.log('Unable to find storybookFrame', storybookFrame);
+  if (!storyFrame) {
+    console.log('Unable to find storybookFrame', storyFrame);
     throw new Error('Unable to find iframe by id');
   }
 
-  return storybookFrame;
+  return storyFrame;
 };
 
 /**
  * Runs the provided element selector on the provided frame and returns the text content and font size of the selected element
  *
- * @param {import('puppeteer').Frame} storybookFrame The iframe of a single storybook story
+ * @param {import('puppeteer').Page | import('puppeteer').Frame} frameOrPage The iframe or page of a storybook story
  * @param {string} elementSelector An element selector for targetting a specific element within the story frame
  */
-const getTextContentFromStorybookFrame = async (
-  storybookFrame,
+export const getTextContentFromFrameOrPage = async (
+  frameOrPage,
   elementSelector,
 ) => {
-  const element = await storybookFrame.waitForSelector(elementSelector, {
-    timeout: 100_000,
+  const element = await frameOrPage.waitForSelector(elementSelector, {
+    timeout: 10_000,
   });
 
   return element.evaluate((e) => ({
@@ -50,5 +67,3 @@ const getTextContentFromStorybookFrame = async (
     fontSize: window.getComputedStyle(e).getPropertyValue('font-size'),
   }));
 };
-
-module.exports = { getStorybookFrame, getTextContentFromStorybookFrame };

--- a/tests/assertion-removal.test.ts
+++ b/tests/assertion-removal.test.ts
@@ -34,8 +34,8 @@ describe('assertion-removal', () => {
     });
 
     it('should not contain "assert" or "invariant" in production', async () => {
-      const page = await browser.newPage();
-      const response = await page.goto(url, { waitUntil: 'networkidle0' });
+      const appPage = await browser.newPage();
+      const response = await appPage.goto(url, { waitUntil: 'networkidle0' });
       const sourceHtml = await response?.text();
       expect(sourceHtml).toContain(
         'It rendered without throwing an assertion error',
@@ -63,8 +63,8 @@ describe('assertion-removal', () => {
     });
 
     it('should not contain "assert" or "invariant" in production', async function () {
-      const page = await browser.newPage();
-      const response = await page.goto(backendUrl, {
+      const appPage = await browser.newPage();
+      const response = await appPage.goto(backendUrl, {
         waitUntil: 'networkidle0',
       });
       const sourceHtml = await response?.text();

--- a/tests/storybook-config.test.js
+++ b/tests/storybook-config.test.js
@@ -3,8 +3,9 @@ const {
   runSkuScriptInDir,
   waitForUrls,
   startAssetServer,
-  getStorybookFrame,
-  getTextContentFromStorybookFrame,
+  getStoryFrame,
+  getTextContentFromFrameOrPage,
+  getStoryPage,
 } = require('@sku-private/test-utils');
 const fetch = require('node-fetch');
 
@@ -14,16 +15,22 @@ const appDir = path.dirname(
 );
 const storybookDistDir = path.resolve(appDir, 'dist-storybook');
 
+const { default: skuConfig } = require(`${appDir}/sku.storybook.config.ts`);
+
 // NOTE: Puppeteer renders in a small enough window that it may trigger a breakpoint that alters the
 // font size of an element
 describe('storybook-config', () => {
   describe('storybook', () => {
-    const storybookUrl = 'http://localhost:8089';
-    const middlewareUrl = `${storybookUrl}/test-middleware`;
+    const storybookBaseUrl = `http://localhost:${skuConfig.storybookPort}`;
+    const middlewareUrl = `${storybookBaseUrl}/test-middleware`;
+
+    const storyIframePath =
+      '/iframe.html?viewMode=story&id=testcomponent--default';
+    const storyIframeUrl = `${storybookBaseUrl}${storyIframePath}`;
 
     let server;
-    /** @type {import("puppeteer").Frame} */
-    let storybookFrame;
+    /** @type {import("puppeteer").Page} */
+    let storyPage;
 
     beforeAll(async () => {
       server = await runSkuScriptInDir('storybook', appDir, [
@@ -32,8 +39,8 @@ describe('storybook-config', () => {
         '--config',
         skuConfigFileName,
       ]);
-      await waitForUrls(storybookUrl, middlewareUrl);
-      storybookFrame = await getStorybookFrame(storybookUrl);
+      await waitForUrls(storyIframeUrl, middlewareUrl);
+      storyPage = await getStoryPage(storyIframeUrl);
     }, 200000);
 
     afterAll(async () => {
@@ -48,8 +55,8 @@ describe('storybook-config', () => {
     });
 
     it('should render decorators defined in the storybook preview file', async () => {
-      const { text, fontSize } = await getTextContentFromStorybookFrame(
-        storybookFrame,
+      const { text, fontSize } = await getTextContentFromFrameOrPage(
+        storyPage,
         '[data-automation-decorator]',
       );
 
@@ -58,8 +65,8 @@ describe('storybook-config', () => {
     });
 
     it('should render a component inside a story', async () => {
-      const { text, fontSize } = await getTextContentFromStorybookFrame(
-        storybookFrame,
+      const { text, fontSize } = await getTextContentFromFrameOrPage(
+        storyPage,
         '[data-automation-text]',
       );
 
@@ -68,8 +75,8 @@ describe('storybook-config', () => {
     });
 
     it('should render vanilla styles', async () => {
-      const { text, fontSize } = await getTextContentFromStorybookFrame(
-        storybookFrame,
+      const { text, fontSize } = await getTextContentFromFrameOrPage(
+        storyPage,
         '[data-automation-vanilla]',
       );
 
@@ -78,8 +85,8 @@ describe('storybook-config', () => {
     });
 
     it('should render less styles', async () => {
-      const { text, fontSize } = await getTextContentFromStorybookFrame(
-        storybookFrame,
+      const { text, fontSize } = await getTextContentFromFrameOrPage(
+        storyPage,
         '[data-automation-less]',
       );
 
@@ -94,7 +101,7 @@ describe('storybook-config', () => {
 
     let closeStorybookServer;
     /** @type {import("puppeteer").Frame} */
-    let storybookFrame;
+    let storyFrame;
 
     beforeAll(async () => {
       await runSkuScriptInDir('build-storybook', appDir, [
@@ -106,7 +113,7 @@ describe('storybook-config', () => {
         storybookDistDir,
       );
       await waitForUrls(assetServerUrl);
-      storybookFrame = await getStorybookFrame(assetServerUrl);
+      storyFrame = await getStoryFrame(assetServerUrl);
     }, 200000);
 
     afterAll(() => {
@@ -114,8 +121,8 @@ describe('storybook-config', () => {
     });
 
     it('should render decorators defined in the storybook preview file', async () => {
-      const { text, fontSize } = await getTextContentFromStorybookFrame(
-        storybookFrame,
+      const { text, fontSize } = await getTextContentFromFrameOrPage(
+        storyFrame,
         '[data-automation-decorator]',
       );
 
@@ -124,8 +131,8 @@ describe('storybook-config', () => {
     });
 
     it('should render a component inside a story', async () => {
-      const { text, fontSize } = await getTextContentFromStorybookFrame(
-        storybookFrame,
+      const { text, fontSize } = await getTextContentFromFrameOrPage(
+        storyFrame,
         '[data-automation-text]',
       );
 
@@ -134,8 +141,8 @@ describe('storybook-config', () => {
     });
 
     it('should render vanilla styles', async () => {
-      const { text, fontSize } = await getTextContentFromStorybookFrame(
-        storybookFrame,
+      const { text, fontSize } = await getTextContentFromFrameOrPage(
+        storyFrame,
         '[data-automation-vanilla]',
       );
 
@@ -144,8 +151,8 @@ describe('storybook-config', () => {
     });
 
     it('should render less styles', async () => {
-      const { text, fontSize } = await getTextContentFromStorybookFrame(
-        storybookFrame,
+      const { text, fontSize } = await getTextContentFromFrameOrPage(
+        storyFrame,
         '[data-automation-less]',
       );
 


### PR DESCRIPTION
Finally managed to update `jest-puppeteer` and `puppeteer`. This update forces (I think) us to use [Chrome's new headless mode](https://developer.chrome.com/docs/chromium/new-headless). 

In the past, this update has resulted in 404s when taking app snapshots (most tests do this). These 404s have stopped me from completing this upgrade a few times in the past. Turns out they were just favicon 404s 🤦. I guess the old headless mode never surfaced them.

One other way I tried to fix the issue was removing usage of the global `page`. `jest-puppeteer` provides this, but sometimes we were creating local variables called `page`, which was confusing. I thought this could be the cause of the 404s, but it wasn't. However, I still think it's a good idea stop using the global `page`, hence the ESLint config changes.

Additionally, I've backported some refactors I'm doing in a separate branch that upgrades storybook to v8. This was also causing some test failures, which I fixed by navigating directly to the story iframe, instead of clicking around in the storybook UI to load the correct story. This only works when using the storybook dev server. Navigating directly to the story iframes doesn't work when serving a built storybook directly, for some reason.