### PR TITLE
Minify with SWC

### DIFF
--- a/.changeset/nervous-dogs-give.md
+++ b/.changeset/nervous-dogs-give.md
@@ -1,0 +1,10 @@
+---
+'sku': patch
+---
+
+Minify build output with [SWC]
+
+Minification of production build output is now performed by [SWC]. Previously this was performed by [Terser]. This should result in a noticeable reduction in build times for larger projects, as well as a slight decrease in bundle size.
+
+[swc]: https://swc.rs/docs/configuration/minification
+[terser]: https://terser.org/

--- a/packages/sku/config/webpack/webpack.config.js
+++ b/packages/sku/config/webpack/webpack.config.js
@@ -134,7 +134,17 @@ const makeWebpackConfig = ({
         // The 'TerserPlugin' is actually the default minimizer for webpack
         // We add a custom one to ensure licence comments stay inside the final JS assets
         // Without this a '*.js.LICENSE.txt' file would be created alongside
-        minimizer: [new TerserPlugin({ extractComments: false })],
+        minimizer: [
+          new TerserPlugin({
+            extractComments: false,
+            minify: TerserPlugin.swcMinify,
+            parallel: true,
+            terserOptions: {
+              compress: true,
+              mangle: true,
+            },
+          }),
+        ],
         concatenateModules: isProductionBuild,
         ...(!isLibrary
           ? {

--- a/packages/sku/config/webpack/webpack.config.ssr.js
+++ b/packages/sku/config/webpack/webpack.config.ssr.js
@@ -97,7 +97,17 @@ const makeWebpackConfig = ({
         // The 'TerserPlugin' is actually the default minimizer for webpack
         // We add a custom one to ensure licence comments stay inside the final JS assets
         // Without this a '*.js.LICENSE.txt' file would be created alongside
-        minimizer: [new TerserPlugin({ extractComments: false })],
+        minimizer: [
+          new TerserPlugin({
+            extractComments: false,
+            minify: TerserPlugin.swcMinify,
+            parallel: true,
+            terserOptions: {
+              compress: true,
+              mangle: true,
+            },
+          }),
+        ],
         concatenateModules: isProductionBuild,
         splitChunks: {
           chunks: 'all',

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -47,6 +47,7 @@
     "@storybook/cli": "^7.0.17",
     "@storybook/react": "^7.0.17",
     "@storybook/react-webpack5": "^7.0.17",
+    "@swc/core": "^1.5.25",
     "@types/jest": "^29.0.0",
     "@types/loadable__component": "^5.13.1",
     "@vanilla-extract/jest-transform": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,10 +19,10 @@ importers:
         version: link:test-utils
       '@swc/core':
         specifier: ^1.3.84
-        version: 1.5.24
+        version: 1.5.25
       '@swc/jest':
         specifier: ^0.2.29
-        version: 0.2.36(@swc/core@1.5.24)
+        version: 0.2.36(@swc/core@1.5.25)
       '@tsconfig/node-lts':
         specifier: ^18.12.3
         version: 18.12.5
@@ -306,13 +306,13 @@ importers:
     devDependencies:
       babel-loader:
         specifier: ^9.1.2
-        version: 9.1.3(@babel/core@7.24.6)(webpack@5.91.0(@swc/core@1.5.24))
+        version: 9.1.3(@babel/core@7.24.6)(webpack@5.91.0(@swc/core@1.5.25))
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.6.0(webpack@5.91.0(@swc/core@1.5.24))
+        version: 5.6.0(webpack@5.91.0(@swc/core@1.5.25))
       mini-css-extract-plugin:
         specifier: ^2.6.1
-        version: 2.9.0(webpack@5.91.0(@swc/core@1.5.24))
+        version: 2.9.0(webpack@5.91.0(@swc/core@1.5.25))
       sku:
         specifier: workspace:*
         version: link:../../packages/sku
@@ -443,7 +443,7 @@ importers:
         version: 1.1.11(react@18.3.1)
       '@vocab/webpack':
         specifier: ^1.2.9
-        version: 1.2.9(webpack@5.91.0(@swc/core@1.5.24))
+        version: 1.2.9(webpack@5.91.0(@swc/core@1.5.25))
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -535,13 +535,13 @@ importers:
         version: 5.16.5(@loadable/component@5.16.4(react@18.3.1))(react@18.3.1)
       '@loadable/webpack-plugin':
         specifier: ^5.14.0
-        version: 5.15.2(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+        version: 5.15.2(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       '@manypkg/find-root':
         specifier: ^2.2.0
         version: 2.2.1
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: ^0.5.12
-        version: 0.5.14(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+        version: 0.5.14(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       '@storybook/builder-webpack5':
         specifier: ^7.0.17
         version: 7.6.19(esbuild@0.19.12)(typescript@5.3.3)
@@ -553,7 +553,10 @@ importers:
         version: 7.6.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       '@storybook/react-webpack5':
         specifier: ^7.0.17
-        version: 7.6.19(@babel/core@7.24.6)(@swc/core@1.5.24)(esbuild@0.19.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@2.19.0)(typescript@5.3.3)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)
+        version: 7.6.19(@babel/core@7.24.6)(@swc/core@1.5.25)(esbuild@0.19.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@2.19.0)(typescript@5.3.3)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)
+      '@swc/core':
+        specifier: ^1.5.25
+        version: 1.5.25
       '@types/jest':
         specifier: ^29.0.0
         version: 29.5.12
@@ -565,7 +568,7 @@ importers:
         version: 1.1.5(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(less@4.2.0)(terser@5.31.0)
       '@vanilla-extract/webpack-plugin':
         specifier: ^2.2.0
-        version: 2.3.9(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(less@4.2.0)(terser@5.31.0)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+        version: 2.3.9(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(less@4.2.0)(terser@5.31.0)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       '@vocab/core':
         specifier: ^1.6.2
         version: 1.6.2
@@ -577,7 +580,7 @@ importers:
         version: 1.0.1
       '@vocab/webpack':
         specifier: ^1.2.9
-        version: 1.2.9(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+        version: 1.2.9(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       '@zendesk/babel-plugin-react-displayname':
         specifier: zendesk/babel-plugin-react-displayname#7a837f2
         version: https://codeload.github.com/zendesk/babel-plugin-react-displayname/tar.gz/7a837f2(@babel/core@7.24.6)(@babel/preset-react@7.24.6(@babel/core@7.24.6))
@@ -589,7 +592,7 @@ importers:
         version: 29.7.0(@babel/core@7.24.6)
       babel-loader:
         specifier: ^9.1.2
-        version: 9.1.3(@babel/core@7.24.6)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+        version: 9.1.3(@babel/core@7.24.6)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       babel-plugin-macros:
         specifier: ^3.1.0
         version: 3.1.0
@@ -619,7 +622,7 @@ importers:
         version: 7.0.3
       css-loader:
         specifier: ^6.7.1
-        version: 6.11.0(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+        version: 6.11.0(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       css-modules-typescript-loader:
         specifier: 4.0.1
         version: 4.0.1
@@ -703,13 +706,13 @@ importers:
         version: 4.2.0
       less-loader:
         specifier: ^12.0.0
-        version: 12.2.0(less@4.2.0)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+        version: 12.2.0(less@4.2.0)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       lint-staged:
         specifier: ^11.1.1
         version: 11.2.6
       mini-css-extract-plugin:
         specifier: ^2.6.1
-        version: 2.9.0(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+        version: 2.9.0(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
@@ -733,7 +736,7 @@ importers:
         version: 8.4.38
       postcss-loader:
         specifier: ^8.0.0
-        version: 8.1.1(postcss@8.4.38)(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+        version: 8.1.1(postcss@8.4.38)(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -760,7 +763,7 @@ importers:
         version: 4.0.0
       terser-webpack-plugin:
         specifier: ^5.1.4
-        version: 5.3.10(@swc/core@1.5.24)(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+        version: 5.3.10(@swc/core@1.5.25)(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       tree-kill:
         specifier: ^1.2.1
         version: 1.2.2
@@ -769,13 +772,13 @@ importers:
         version: 5.3.3
       webpack:
         specifier: ^5.52.0
-        version: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+        version: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
       webpack-bundle-analyzer:
         specifier: ^4.6.1
         version: 4.10.2
       webpack-dev-server:
         specifier: ^5.0.2
-        version: 5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+        version: 5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       webpack-merge:
         specifier: ^5.8.0
         version: 5.10.0
@@ -824,7 +827,7 @@ importers:
         version: 1.1.11(react@18.3.1)
       braid-design-system:
         specifier: ^32.0.0
-        version: 32.18.1(@types/react@18.3.3)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sku@12.6.2(@swc/core@1.5.24)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1))
+        version: 32.18.1(@types/react@18.3.3)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sku@12.6.2(@swc/core@1.5.25)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1))
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -950,7 +953,7 @@ importers:
         version: 6.0.1
       webpack:
         specifier: ^5.52.0
-        version: 5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4)
+        version: 5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.0.0
         version: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0)
@@ -3035,68 +3038,68 @@ packages:
   '@storybook/types@7.6.19':
     resolution: {integrity: sha512-DeGYrRPRMGTVfT7o2rEZtRzyLT2yKTI2exgpnxbwPWEFAduZCSfzBrcBXZ/nb5B0pjA9tUNWls1YzGkJGlkhpg==}
 
-  '@swc/core-darwin-arm64@1.5.24':
-    resolution: {integrity: sha512-M7oLOcC0sw+UTyAuL/9uyB9GeO4ZpaBbH76JSH6g1m0/yg7LYJZGRmplhDmwVSDAR5Fq4Sjoi1CksmmGkgihGA==}
+  '@swc/core-darwin-arm64@1.5.25':
+    resolution: {integrity: sha512-YbD0SBgVJS2DM0vwJTU5m7+wOyCjHPBDMf3nCBJQzFZzOLzK11eRW7SzU2jhJHr9HI9sKcNFfN4lIC2Sj+4inA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@swc/core-darwin-x64@1.5.24':
-    resolution: {integrity: sha512-MfcFjGGYognpSBSos2pYUNYJSmqEhuw5ceGr6qAdME7ddbjGXliza4W6FggsM+JnWwpqa31+e7/R+GetW4WkaQ==}
+  '@swc/core-darwin-x64@1.5.25':
+    resolution: {integrity: sha512-OhP4TROT6gQuozn+ah0Y4UidSdgDmxwtQq3lgCUIAxJYErJAQ82/Y0kve2UaNmkSGjOHU+/b4siHPrYTkXOk0Q==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
 
-  '@swc/core-linux-arm-gnueabihf@1.5.24':
-    resolution: {integrity: sha512-amI2pwtcWV3E/m/nf+AQtn1LWDzKLZyjCmWd3ms7QjEueWYrY8cU1Y4Wp7wNNsxIoPOi8zek1Uj2wwFD/pttNQ==}
+  '@swc/core-linux-arm-gnueabihf@1.5.25':
+    resolution: {integrity: sha512-tNmUfrAHxN2gvYPyYNnHx2CYlPO7DGAUuK/bZrqawu++djcg+atAV3eI3XYJgmHId7/sYAlDQ9wjkrOLofFjVg==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
 
-  '@swc/core-linux-arm64-gnu@1.5.24':
-    resolution: {integrity: sha512-sTSvmqMmgT1ynH/nP75Pc51s+iT4crZagHBiDOf5cq+kudUYjda9lWMs7xkXB/TUKFHPCRK0HGunl8bkwiIbuw==}
+  '@swc/core-linux-arm64-gnu@1.5.25':
+    resolution: {integrity: sha512-stzpke+bRaNFM/HrZPRjX0aQZ86S/2DChVCwb8NAV1n5lu9mz1CS750y7WbbtX/KZjk92FsCeRy2qwkvjI0gWw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-arm64-musl@1.5.24':
-    resolution: {integrity: sha512-vd2/hfOBGbrX21FxsFdXCUaffjkHvlZkeE2UMRajdXifwv79jqOHIJg3jXG1F3ZrhCghCzirFts4tAZgcG8XWg==}
+  '@swc/core-linux-arm64-musl@1.5.25':
+    resolution: {integrity: sha512-UckUfDYedish/bj2V1jgQDGgouLhyRpG7jgF3mp8jHir11V2K6JiTyjFoz99eOiclS3+hNdr4QLJ+ifrQMJNZw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-x64-gnu@1.5.24':
-    resolution: {integrity: sha512-Zrdzi7NqzQxm2BvAG5KyOSBEggQ7ayrxh599AqqevJmsUXJ8o2nMiWQOBvgCGp7ye+Biz3pvZn1EnRzAp+TpUg==}
+  '@swc/core-linux-x64-gnu@1.5.25':
+    resolution: {integrity: sha512-LwbJEgNT3lXbvz4WFzVNXNvs8DvxpoXjMZk9K9Hig8tmZQJKHC2qZTGomcyK5EFzfj2HBuBXZnAEW8ZT9PcEaA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-linux-x64-musl@1.5.24':
-    resolution: {integrity: sha512-1F8z9NRi52jdZQCGc5sflwYSctL6omxiVmIFVp8TC9nngjQKc00TtX/JC2Eo2HwvgupkFVl5YQJidAck9YtmJw==}
+  '@swc/core-linux-x64-musl@1.5.25':
+    resolution: {integrity: sha512-rsepMTgml0EkswWkBpg3Wrjj5eqjwTzZN5omAn1klzXSZnClTrfeHvBuoIJYVr1yx+jmBkqySgME2p7+magUAw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-win32-arm64-msvc@1.5.24':
-    resolution: {integrity: sha512-cKpP7KvS6Xr0jFSTBXY53HZX/YfomK5EMQYpCVDOvfsZeYHN20sQSKXfpVLvA/q2igVt1zzy1XJcOhpJcgiKLg==}
+  '@swc/core-win32-arm64-msvc@1.5.25':
+    resolution: {integrity: sha512-DJDsLBsRBV3uQBShRK2x6fqzABp9RLNVxDUpTTvUjc7qywJ8vS/yn+POK/zCyVEqLagf1z/8D5CEQ+RAIJq1NA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
 
-  '@swc/core-win32-ia32-msvc@1.5.24':
-    resolution: {integrity: sha512-IoPWfi0iwqjZuf7gE223+B97/ZwkKbu7qL5KzGP7g3hJrGSKAvv7eC5Y9r2iKKtLKyv5R/T6Ho0kFR/usi7rHw==}
+  '@swc/core-win32-ia32-msvc@1.5.25':
+    resolution: {integrity: sha512-BARL1ulHol53MEKC1ZVWM3A3FP757UUgG5Q8v97za+4a1SaIgbwvAQyHDxMYWi9+ij+OapK8YnWjJcFa17g8dw==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
 
-  '@swc/core-win32-x64-msvc@1.5.24':
-    resolution: {integrity: sha512-zHgF2k1uVJL8KIW+PnVz1To4a3Cz9THbh2z2lbehaF/gKHugH4c3djBozU4das1v35KOqf5jWIEviBLql2wDLQ==}
+  '@swc/core-win32-x64-msvc@1.5.25':
+    resolution: {integrity: sha512-o+MHUWrQI9iR6EusEV8eNU2Ezi3KtlhUR4gfptQN5MbVzlgjTvQbhiKpE1GYOxp+0BLBbKRwITKOcdhxfEJ2Uw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
 
-  '@swc/core@1.5.24':
-    resolution: {integrity: sha512-Eph9zvO4xvqWZGVzTdtdEJ0Vqf0VIML/o/e4Qd2RLOqtfgnlRi7avmMu5C0oqciJ0tk+hqdUKVUZ4JPoPaiGvQ==}
+  '@swc/core@1.5.25':
+    resolution: {integrity: sha512-qdGEIdLVoTjEQ7w72UyyQ0wLFY4XbHfZiidmPHKJQsvSXzdpHXxPdlTCea/mY4AhMqo/M+pvkJSXJAxZnFl7qw==}
     engines: {node: '>=10'}
     peerDependencies:
       '@swc/helpers': '*'
@@ -10875,10 +10878,10 @@ snapshots:
       lodash: 4.17.21
       react: 18.3.1
 
-  '@loadable/webpack-plugin@5.15.2(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))':
+  '@loadable/webpack-plugin@5.15.2(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))':
     dependencies:
       make-dir: 3.1.0
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -10936,7 +10939,7 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.14(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.14(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.37.1
@@ -10946,10 +10949,10 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.2.0
       source-map: 0.7.4
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
     optionalDependencies:
       type-fest: 2.19.0
-      webpack-dev-server: 5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      webpack-dev-server: 5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       webpack-hot-middleware: 2.26.1
 
   '@polka/url@1.0.0-next.25': {}
@@ -11427,33 +11430,33 @@ snapshots:
       '@storybook/node-logger': 7.6.19
       '@storybook/preview': 7.6.19
       '@storybook/preview-api': 7.6.19
-      '@swc/core': 1.5.24
+      '@swc/core': 1.5.25
       '@types/node': 18.19.33
       '@types/semver': 7.5.8
-      babel-loader: 9.1.3(@babel/core@7.24.6)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      babel-loader: 9.1.3(@babel/core@7.24.6)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.3.1
       constants-browserify: 1.0.0
-      css-loader: 6.11.0(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      css-loader: 6.11.0(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       es-module-lexer: 1.5.3
       express: 4.19.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       fs-extra: 11.2.0
-      html-webpack-plugin: 5.6.0(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      html-webpack-plugin: 5.6.0(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       magic-string: 0.30.10
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.2
-      style-loader: 3.3.4(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
-      swc-loader: 0.2.6(@swc/core@1.5.24)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
-      terser-webpack-plugin: 5.3.10(@swc/core@1.5.24)(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      style-loader: 3.3.4(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
+      swc-loader: 0.2.6(@swc/core@1.5.25)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.5.25)(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
-      webpack-dev-middleware: 6.1.3(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
+      webpack-dev-middleware: 6.1.3(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.5.0
     optionalDependencies:
@@ -11722,16 +11725,16 @@ snapshots:
 
   '@storybook/node-logger@7.6.19': {}
 
-  '@storybook/preset-react-webpack@7.6.19(@babel/core@7.24.6)(@swc/core@1.5.24)(esbuild@0.19.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@2.19.0)(typescript@5.3.3)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)':
+  '@storybook/preset-react-webpack@7.6.19(@babel/core@7.24.6)(@swc/core@1.5.25)(esbuild@0.19.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@2.19.0)(typescript@5.3.3)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/preset-flow': 7.24.6(@babel/core@7.24.6)
       '@babel/preset-react': 7.24.6(@babel/core@7.24.6)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.14(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.14(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       '@storybook/core-webpack': 7.6.19
       '@storybook/docs-tools': 7.6.19
       '@storybook/node-logger': 7.6.19
       '@storybook/react': 7.6.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       '@types/node': 18.19.33
       '@types/semver': 7.5.8
       babel-plugin-add-react-displayname: 0.0.5
@@ -11742,7 +11745,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.2
       semver: 7.6.2
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
     optionalDependencies:
       '@babel/core': 7.24.6
       typescript: 5.3.3
@@ -11779,7 +11782,7 @@ snapshots:
 
   '@storybook/preview@7.6.19': {}
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))':
     dependencies:
       debug: 4.3.5(supports-color@8.1.1)
       endent: 2.1.0
@@ -11789,7 +11792,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.3.3)
       tslib: 2.6.2
       typescript: 5.3.3
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
     transitivePeerDependencies:
       - supports-color
 
@@ -11798,10 +11801,10 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/react-webpack5@7.6.19(@babel/core@7.24.6)(@swc/core@1.5.24)(esbuild@0.19.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@2.19.0)(typescript@5.3.3)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)':
+  '@storybook/react-webpack5@7.6.19(@babel/core@7.24.6)(@swc/core@1.5.25)(esbuild@0.19.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@2.19.0)(typescript@5.3.3)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@storybook/builder-webpack5': 7.6.19(esbuild@0.19.12)(typescript@5.3.3)
-      '@storybook/preset-react-webpack': 7.6.19(@babel/core@7.24.6)(@swc/core@1.5.24)(esbuild@0.19.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@2.19.0)(typescript@5.3.3)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)
+      '@storybook/preset-react-webpack': 7.6.19(@babel/core@7.24.6)(@swc/core@1.5.25)(esbuild@0.19.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@2.19.0)(typescript@5.3.3)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)
       '@storybook/react': 7.6.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       '@types/node': 18.19.33
       react: 18.3.1
@@ -11892,58 +11895,58 @@ snapshots:
       '@types/express': 4.17.21
       file-system-cache: 2.3.0
 
-  '@swc/core-darwin-arm64@1.5.24':
+  '@swc/core-darwin-arm64@1.5.25':
     optional: true
 
-  '@swc/core-darwin-x64@1.5.24':
+  '@swc/core-darwin-x64@1.5.25':
     optional: true
 
-  '@swc/core-linux-arm-gnueabihf@1.5.24':
+  '@swc/core-linux-arm-gnueabihf@1.5.25':
     optional: true
 
-  '@swc/core-linux-arm64-gnu@1.5.24':
+  '@swc/core-linux-arm64-gnu@1.5.25':
     optional: true
 
-  '@swc/core-linux-arm64-musl@1.5.24':
+  '@swc/core-linux-arm64-musl@1.5.25':
     optional: true
 
-  '@swc/core-linux-x64-gnu@1.5.24':
+  '@swc/core-linux-x64-gnu@1.5.25':
     optional: true
 
-  '@swc/core-linux-x64-musl@1.5.24':
+  '@swc/core-linux-x64-musl@1.5.25':
     optional: true
 
-  '@swc/core-win32-arm64-msvc@1.5.24':
+  '@swc/core-win32-arm64-msvc@1.5.25':
     optional: true
 
-  '@swc/core-win32-ia32-msvc@1.5.24':
+  '@swc/core-win32-ia32-msvc@1.5.25':
     optional: true
 
-  '@swc/core-win32-x64-msvc@1.5.24':
+  '@swc/core-win32-x64-msvc@1.5.25':
     optional: true
 
-  '@swc/core@1.5.24':
+  '@swc/core@1.5.25':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.7
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.5.24
-      '@swc/core-darwin-x64': 1.5.24
-      '@swc/core-linux-arm-gnueabihf': 1.5.24
-      '@swc/core-linux-arm64-gnu': 1.5.24
-      '@swc/core-linux-arm64-musl': 1.5.24
-      '@swc/core-linux-x64-gnu': 1.5.24
-      '@swc/core-linux-x64-musl': 1.5.24
-      '@swc/core-win32-arm64-msvc': 1.5.24
-      '@swc/core-win32-ia32-msvc': 1.5.24
-      '@swc/core-win32-x64-msvc': 1.5.24
+      '@swc/core-darwin-arm64': 1.5.25
+      '@swc/core-darwin-x64': 1.5.25
+      '@swc/core-linux-arm-gnueabihf': 1.5.25
+      '@swc/core-linux-arm64-gnu': 1.5.25
+      '@swc/core-linux-arm64-musl': 1.5.25
+      '@swc/core-linux-x64-gnu': 1.5.25
+      '@swc/core-linux-x64-musl': 1.5.25
+      '@swc/core-win32-arm64-msvc': 1.5.25
+      '@swc/core-win32-ia32-msvc': 1.5.25
+      '@swc/core-win32-x64-msvc': 1.5.25
 
   '@swc/counter@0.1.3': {}
 
-  '@swc/jest@0.2.36(@swc/core@1.5.24)':
+  '@swc/jest@0.2.36(@swc/core@1.5.25)':
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
-      '@swc/core': 1.5.24
+      '@swc/core': 1.5.25
       '@swc/counter': 0.1.3
       jsonc-parser: 3.2.1
 
@@ -12421,13 +12424,13 @@ snapshots:
     dependencies:
       '@vanilla-extract/css': 1.15.2(babel-plugin-macros@3.1.0)
 
-  '@vanilla-extract/webpack-plugin@2.3.9(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(less@4.2.0)(terser@5.31.0)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))':
+  '@vanilla-extract/webpack-plugin@2.3.9(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(less@4.2.0)(terser@5.31.0)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))':
     dependencies:
       '@vanilla-extract/integration': 7.1.5(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(less@4.2.0)(terser@5.31.0)
       debug: 4.3.5(supports-color@8.1.1)
       loader-utils: 2.0.4
       picocolors: 1.0.1
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -12485,7 +12488,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vocab/webpack@1.2.9(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))':
+  '@vocab/webpack@1.2.9(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))':
     dependencies:
       '@vocab/core': 1.6.2
       cjs-module-lexer: 1.3.1
@@ -12493,11 +12496,11 @@ snapshots:
       es-module-lexer: 1.5.3
       picocolors: 1.0.1
       virtual-resource-loader: 1.0.1
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
     transitivePeerDependencies:
       - supports-color
 
-  '@vocab/webpack@1.2.9(webpack@5.91.0(@swc/core@1.5.24))':
+  '@vocab/webpack@1.2.9(webpack@5.91.0(@swc/core@1.5.25))':
     dependencies:
       '@vocab/core': 1.6.2
       cjs-module-lexer: 1.3.1
@@ -12505,7 +12508,7 @@ snapshots:
       es-module-lexer: 1.5.3
       picocolors: 1.0.1
       virtual-resource-loader: 1.0.1
-      webpack: 5.91.0(@swc/core@1.5.24)
+      webpack: 5.91.0(@swc/core@1.5.25)
     transitivePeerDependencies:
       - supports-color
 
@@ -12585,19 +12588,19 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0))(webpack@5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4))':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0))(webpack@5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4))':
     dependencies:
-      webpack: 5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0))(webpack@5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4))':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0))(webpack@5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4))':
     dependencies:
-      webpack: 5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0))(webpack-dev-server@5.0.4(debug@4.3.5)(webpack-cli@5.1.4)(webpack@5.91.0))(webpack@5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4))':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0))(webpack-dev-server@5.0.4(debug@4.3.5)(webpack-cli@5.1.4)(webpack@5.91.0))(webpack@5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4))':
     dependencies:
-      webpack: 5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0)
     optionalDependencies:
       webpack-dev-server: 5.0.4(debug@4.3.5)(webpack-cli@5.1.4)(webpack@5.91.0)
@@ -12925,19 +12928,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.1.3(@babel/core@7.24.6)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)):
+  babel-loader@9.1.3(@babel/core@7.24.6)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)):
     dependencies:
       '@babel/core': 7.24.6
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
 
-  babel-loader@9.1.3(@babel/core@7.24.6)(webpack@5.91.0(@swc/core@1.5.24)):
+  babel-loader@9.1.3(@babel/core@7.24.6)(webpack@5.91.0(@swc/core@1.5.25)):
     dependencies:
       '@babel/core': 7.24.6
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.91.0(@swc/core@1.5.24)
+      webpack: 5.91.0(@swc/core@1.5.25)
 
   babel-plugin-add-react-displayname@0.0.5: {}
 
@@ -13134,7 +13137,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  braid-design-system@32.18.1(@types/react@18.3.3)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sku@12.6.2(@swc/core@1.5.24)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)):
+  braid-design-system@32.18.1(@types/react@18.3.3)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sku@12.6.2(@swc/core@1.5.25)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@capsizecss/core': 4.1.2
       '@capsizecss/metrics': 3.2.0
@@ -13158,7 +13161,7 @@ snapshots:
       react-is: 18.3.1
       react-popper-tooltip: 4.4.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-remove-scroll: 2.5.10(@types/react@18.3.3)(react@18.3.1)
-      sku: 12.6.2(@swc/core@1.5.24)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)
+      sku: 12.6.2(@swc/core@1.5.25)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)
       utility-types: 3.11.0
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -13603,7 +13606,7 @@ snapshots:
     dependencies:
       postcss: 8.4.38
 
-  css-loader@6.11.0(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)):
+  css-loader@6.11.0(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
@@ -13614,7 +13617,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.2
     optionalDependencies:
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
 
   css-modules-typescript-loader@4.0.1:
     dependencies:
@@ -14938,7 +14941,7 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)):
     dependencies:
       '@babel/code-frame': 7.24.6
       chalk: 4.1.2
@@ -14953,7 +14956,7 @@ snapshots:
       semver: 7.6.2
       tapable: 2.2.1
       typescript: 5.3.3
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
 
   form-data@3.0.1:
     dependencies:
@@ -15336,7 +15339,7 @@ snapshots:
 
   html-tags@3.3.1: {}
 
-  html-webpack-plugin@5.6.0(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)):
+  html-webpack-plugin@5.6.0(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -15344,9 +15347,9 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
 
-  html-webpack-plugin@5.6.0(webpack@5.91.0(@swc/core@1.5.24)):
+  html-webpack-plugin@5.6.0(webpack@5.91.0(@swc/core@1.5.25)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -15354,7 +15357,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.91.0(@swc/core@1.5.24)
+      webpack: 5.91.0(@swc/core@1.5.25)
 
   htmlparser2@3.10.1:
     dependencies:
@@ -16344,11 +16347,11 @@ snapshots:
       dotenv: 16.4.5
       dotenv-expand: 10.0.0
 
-  less-loader@12.2.0(less@4.2.0)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)):
+  less-loader@12.2.0(less@4.2.0)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)):
     dependencies:
       less: 4.2.0
     optionalDependencies:
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
 
   less@4.2.0:
     dependencies:
@@ -16631,17 +16634,17 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.0(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)):
+  mini-css-extract-plugin@2.9.0(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
 
-  mini-css-extract-plugin@2.9.0(webpack@5.91.0(@swc/core@1.5.24)):
+  mini-css-extract-plugin@2.9.0(webpack@5.91.0(@swc/core@1.5.25)):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
-      webpack: 5.91.0(@swc/core@1.5.24)
+      webpack: 5.91.0(@swc/core@1.5.25)
 
   minimalistic-assert@1.0.1: {}
 
@@ -17190,14 +17193,14 @@ snapshots:
     dependencies:
       postcss: 8.4.38
 
-  postcss-loader@8.1.1(postcss@8.4.38)(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)):
+  postcss-loader@8.1.1(postcss@8.4.38)(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.3.3)
       jiti: 1.21.0
       postcss: 8.4.38
       semver: 7.6.2
     optionalDependencies:
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
     transitivePeerDependencies:
       - typescript
 
@@ -18109,7 +18112,7 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  sku@12.6.2(@swc/core@1.5.24)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1):
+  sku@12.6.2(@swc/core@1.5.25)(@types/node@18.19.33)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1):
     dependencies:
       '@antfu/ni': 0.21.12
       '@babel/core': 7.24.6
@@ -18123,25 +18126,25 @@ snapshots:
       '@loadable/babel-plugin': 5.16.1(@babel/core@7.24.6)
       '@loadable/component': 5.16.4(react@18.3.1)
       '@loadable/server': 5.16.5(@loadable/component@5.16.4(react@18.3.1))(react@18.3.1)
-      '@loadable/webpack-plugin': 5.15.2(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      '@loadable/webpack-plugin': 5.15.2(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       '@manypkg/find-root': 2.2.1
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.14(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.14(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       '@storybook/builder-webpack5': 7.6.19(esbuild@0.19.12)(typescript@5.3.3)
       '@storybook/cli': 7.6.19
       '@storybook/react': 7.6.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
-      '@storybook/react-webpack5': 7.6.19(@babel/core@7.24.6)(@swc/core@1.5.24)(esbuild@0.19.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@2.19.0)(typescript@5.3.3)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)
+      '@storybook/react-webpack5': 7.6.19(@babel/core@7.24.6)(@swc/core@1.5.25)(esbuild@0.19.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@2.19.0)(typescript@5.3.3)(webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)))(webpack-hot-middleware@2.26.1)
       '@types/jest': 29.5.12
       '@types/loadable__component': 5.13.9
       '@vanilla-extract/jest-transform': 1.1.5(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(less@4.2.0)(terser@5.31.0)
-      '@vanilla-extract/webpack-plugin': 2.3.9(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(less@4.2.0)(terser@5.31.0)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      '@vanilla-extract/webpack-plugin': 2.3.9(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(less@4.2.0)(terser@5.31.0)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       '@vocab/core': 1.6.2
       '@vocab/phrase': 1.3.3
       '@vocab/pseudo-localize': 1.0.1
-      '@vocab/webpack': 1.2.9(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      '@vocab/webpack': 1.2.9(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       '@zendesk/babel-plugin-react-displayname': https://codeload.github.com/zendesk/babel-plugin-react-displayname/tar.gz/7a837f2(@babel/core@7.24.6)(@babel/preset-react@7.24.6(@babel/core@7.24.6))
       autoprefixer: 10.4.19(postcss@8.4.38)
       babel-jest: 29.7.0(@babel/core@7.24.6)
-      babel-loader: 9.1.3(@babel/core@7.24.6)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      babel-loader: 9.1.3(@babel/core@7.24.6)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       babel-plugin-macros: 3.1.0
       babel-plugin-module-resolver: 5.0.2
       babel-plugin-transform-react-remove-prop-types: 0.4.24
@@ -18151,7 +18154,7 @@ snapshots:
       browserslist-config-seek: 2.1.1
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      css-loader: 6.11.0(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      css-loader: 6.11.0(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       css-modules-typescript-loader: 4.0.1
       cssnano: 6.1.2(postcss@8.4.38)
       death: 1.1.0
@@ -18179,9 +18182,9 @@ snapshots:
       jest-environment-jsdom: 29.7.0
       jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0))
       less: 4.2.0
-      less-loader: 12.2.0(less@4.2.0)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      less-loader: 12.2.0(less@4.2.0)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       lint-staged: 11.2.6
-      mini-css-extract-plugin: 2.9.0(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      mini-css-extract-plugin: 2.9.0(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       minimist: 1.2.8
       nano-memoize: 3.0.16
       node-html-parser: 6.1.13
@@ -18189,7 +18192,7 @@ snapshots:
       path-to-regexp: 6.2.2
       picomatch: 3.0.1
       postcss: 8.4.38
-      postcss-loader: 8.1.1(postcss@8.4.38)(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      postcss-loader: 8.1.1(postcss@8.4.38)(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       prettier: 2.8.8
       pretty-ms: 7.0.1
       react: 18.3.1
@@ -18199,12 +18202,12 @@ snapshots:
       serialize-javascript: 6.0.2
       serve-handler: 6.1.5
       svgo-loader: 4.0.0
-      terser-webpack-plugin: 5.3.10(@swc/core@1.5.24)(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.5.25)(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       tree-kill: 1.2.2
       typescript: 5.3.3
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      webpack-dev-server: 5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       webpack-merge: 5.10.0
       webpack-node-externals: 3.0.0
       which: 4.0.0
@@ -18508,9 +18511,9 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  style-loader@3.3.4(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)):
+  style-loader@3.3.4(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)):
     dependencies:
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
 
   stylehacks@6.1.1(postcss@8.4.38):
     dependencies:
@@ -18548,11 +18551,11 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.0.1
 
-  swc-loader@0.2.6(@swc/core@1.5.24)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)):
+  swc-loader@0.2.6(@swc/core@1.5.25)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)):
     dependencies:
-      '@swc/core': 1.5.24
+      '@swc/core': 1.5.25
       '@swc/counter': 0.1.3
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
 
   symbol-tree@3.2.4: {}
 
@@ -18623,39 +18626,39 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.5.24)(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.5.25)(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.0
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
     optionalDependencies:
-      '@swc/core': 1.5.24
+      '@swc/core': 1.5.25
       esbuild: 0.19.12
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.5.24)(webpack@5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.5.25)(webpack@5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.0
-      webpack: 5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4)
     optionalDependencies:
-      '@swc/core': 1.5.24
+      '@swc/core': 1.5.25
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.5.24)(webpack@5.91.0(@swc/core@1.5.24)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.5.25)(webpack@5.91.0(@swc/core@1.5.25)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.0
-      webpack: 5.91.0(@swc/core@1.5.24)
+      webpack: 5.91.0(@swc/core@1.5.25)
     optionalDependencies:
-      '@swc/core': 1.5.24
+      '@swc/core': 1.5.25
 
   terser@5.31.0:
     dependencies:
@@ -19072,9 +19075,9 @@ snapshots:
   webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0))(webpack@5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4))
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0))(webpack@5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4))
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0))(webpack-dev-server@5.0.4(debug@4.3.5)(webpack-cli@5.1.4)(webpack@5.91.0))(webpack@5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4))
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0))(webpack@5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4))
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0))(webpack@5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4))
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0))(webpack-dev-server@5.0.4(debug@4.3.5)(webpack-cli@5.1.4)(webpack@5.91.0))(webpack@5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4))
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.3
@@ -19083,12 +19086,12 @@ snapshots:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-dev-server: 5.0.4(debug@4.3.5)(webpack-cli@5.1.4)(webpack@5.91.0)
 
-  webpack-dev-middleware@6.1.3(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)):
+  webpack-dev-middleware@6.1.3(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -19096,9 +19099,9 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
 
-  webpack-dev-middleware@7.2.1(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)):
+  webpack-dev-middleware@7.2.1(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.9.2
@@ -19107,9 +19110,9 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
 
-  webpack-dev-middleware@7.2.1(webpack@5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4)):
+  webpack-dev-middleware@7.2.1(webpack@5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.9.2
@@ -19118,7 +19121,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4)
 
   webpack-dev-server@5.0.4(debug@4.3.5)(webpack-cli@5.1.4)(webpack@5.91.0):
     dependencies:
@@ -19150,10 +19153,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.2.1(webpack@5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4))
+      webpack-dev-middleware: 7.2.1(webpack@5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4))
       ws: 8.17.0
     optionalDependencies:
-      webpack: 5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0)
     transitivePeerDependencies:
       - bufferutil
@@ -19161,7 +19164,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)):
+  webpack-dev-server@5.0.4(debug@4.3.5)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -19191,10 +19194,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.2.1(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      webpack-dev-middleware: 7.2.1(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       ws: 8.17.0
     optionalDependencies:
-      webpack: 5.91.0(@swc/core@1.5.24)(esbuild@0.19.12)
+      webpack: 5.91.0(@swc/core@1.5.25)(esbuild@0.19.12)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -19221,7 +19224,7 @@ snapshots:
 
   webpack-virtual-modules@0.5.0: {}
 
-  webpack@5.91.0(@swc/core@1.5.24):
+  webpack@5.91.0(@swc/core@1.5.25):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.5
@@ -19244,7 +19247,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.5.24)(webpack@5.91.0(@swc/core@1.5.24))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.5.25)(webpack@5.91.0(@swc/core@1.5.25))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -19252,7 +19255,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12):
+  webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.5
@@ -19275,7 +19278,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.5.24)(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.19.12))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.5.25)(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.25)(esbuild@0.19.12))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -19283,7 +19286,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4):
+  webpack@5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.5
@@ -19306,7 +19309,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.5.24)(webpack@5.91.0(@swc/core@1.5.24)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.5.25)(webpack@5.91.0(@swc/core@1.5.25)(webpack-cli@5.1.4))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     optionalDependencies:


### PR DESCRIPTION
Our current minifier is [Terser](https://terser.org/). Based on [these benchmarks](https://github.com/privatenumber/minification-benchmarks/blob/bca7286d0b06108252638ebe729afc284859a38c/README.md), and taking into consideration sku's current dependencies, I think there are two viable candidates to replace it.

## [`esbuild`](https://esbuild.github.io/api/#minify)

Pros:

- `sku` already depends on it
- Very fast

Cons:

- Slightly worse gzip size relative to both terser and SWC

## [SWC](https://swc.rs/docs/configuration/minification)

Pro:

- Fast
- Pretty much the smallest gzip size relative to all other minifiers

Cons:

- Not as fast as `esbulid`, but on large bundles it’s at most worse by a second or two. On small bundles the difference is negligible (a few 100ms).
- `sku` doesn’t directly depend on it. However, we depend on it via a transitive storybook dependency, so depending on it directly won’t affect our install size.

## Decision

Though not the fastest option, when combined with its superior gzip size, SWC is the clear winner.

## Benchmarks

Bundle size differences are negligible, so not really worth talking about. In terms of `sku build` time, I've measured roughly a 15-20s decrease in large-ish bundles (gzipped size of ~1mb).
