### PR TITLE
Upgrade to cache action v4

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,14 +47,14 @@ jobs:
 
       - name: Cache Puppeteer
         id: puppeteer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.set-puppeteer-cache.outputs.PUPPETEER_CACHE_DIR }}
           key: puppeteer-${{ runner.os }}-${{ hashFiles('./pnpm-lock.yaml') }}
 
       - name: Cache babel-loader
         id: babel-loader-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: 'fixtures/*/node_modules/.cache/babel-loader'
           key: babel-loader-${{ runner.os }}-${{ hashFiles('./pnpm-lock.yaml') }}
@@ -76,7 +76,7 @@ jobs:
         run: echo "JEST_CACHE_DIR=$(pnpm jest --showConfig | jq '.configs[0].cacheDirectory' | tr -d '"')" >> $GITHUB_OUTPUT
 
       - name: Cache Jest cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.set-jest-cache.outputs.JEST_CACHE_DIR }}
           key: jest-${{ runner.os }}-${{ hashFiles('./pnpm-lock.yaml') }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           path: ${{ steps.set-jest-cache.outputs.JEST_CACHE_DIR }}
           key: jest-${{ runner.os }}-${{ hashFiles('./pnpm-lock.yaml') }}
+          restore-keys: jest-${{ runner.os }}-
 
       - name: Test
         run: pnpm run test && pnpm run test:sku-init


### PR DESCRIPTION
Once again, to fix [warnings](https://github.com/seek-oss/sku/actions/runs/9377058972).

Also added a `restore-key` to the jest cache, as an old cache is still better than no cache (for jest).