### PR TITLE
Fix `sku test --watch`  not putting `jest` in watch mode

### DIFF
--- a/.changeset/curvy-adults-build.md
+++ b/.changeset/curvy-adults-build.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fixes a bug causing `sku test --watch` to not put `jest` in watch mode

--- a/packages/sku/scripts/test.js
+++ b/packages/sku/scripts/test.js
@@ -17,15 +17,17 @@ process.env.IS_REACT_ACT_ENVIRONMENT = true;
   const jestPreset = require.resolve('../config/jest/jest-preset');
   log(`Using Jest preset at ${jestPreset}`);
 
-  argv.push('--preset', path.dirname(jestPreset));
+  const jestArgv = [...argv];
+
+  jestArgv.push('--preset', path.dirname(jestPreset));
 
   if (isCI) {
-    argv.push('--ci');
+    jestArgv.push('--ci');
   }
 
   if (watch) {
-    argv.push('--watch');
+    jestArgv.push('--watch');
   }
 
-  jest.run(argv);
+  jest.run(jestArgv);
 })();

--- a/packages/sku/scripts/test.js
+++ b/packages/sku/scripts/test.js
@@ -3,7 +3,7 @@ const debug = require('debug');
 const jest = require('jest');
 
 const isCI = require('../lib/isCI');
-const { argv } = require('../config/args');
+const { argv, watch } = require('../config/args');
 const { runVocabCompile } = require('../lib/runVocab');
 
 const log = debug('sku:jest');
@@ -23,5 +23,5 @@ process.env.IS_REACT_ACT_ENVIRONMENT = true;
     argv.push('--ci');
   }
 
-  jest.run(argv);
+  jest.run([...argv, ...(watch ? ['--watch'] : [])]);
 })();

--- a/packages/sku/scripts/test.js
+++ b/packages/sku/scripts/test.js
@@ -23,5 +23,9 @@ process.env.IS_REACT_ACT_ENVIRONMENT = true;
     argv.push('--ci');
   }
 
-  jest.run([...argv, ...(watch ? ['--watch'] : [])]);
+  if (watch) {
+    argv.push('--watch');
+  }
+
+  jest.run(argv);
 })();


### PR DESCRIPTION
Since #989, the `--watch` flag is being explicitly parsed by `minimist`, which means it's no longer part of `argv`. This results in it not getting passed through to `jest`, which means `sku test --watch` doesn't run `jest` in watch mode.

I opted to conditionally add `--watch` back to the `argv` we pass to `jest`, but I think a more robust solution would be to move to a more structured CLI argument parser, like `yargs`, which would (hopefully) allow us to scope certain flags to certain commands.