### PR TITLE
Update tsconfig comment and changeset

### DIFF
--- a/.changeset/odd-mugs-enjoy.md
+++ b/.changeset/odd-mugs-enjoy.md
@@ -17,6 +17,6 @@ import { b, type c, type d } from "bcd";
 import { type xyz } from "xyz";
 ```
 
-This change is not expected to have an affect on bundled application code or library code. However, it may surface some TypeScript errors in `compilePackage` dependencies that do not adhere to the correct type-only import syntax. These errors should be fixed in the dependency's codebase.
+This change is not expected to have an effect on bundled application code or library code. However, it may surface some TypeScript errors in `compilePackage` dependencies that do not adhere to the correct type-only import syntax. These errors should be fixed in the dependency's codebase.
 
 [`verbatimModuleSyntax`]: https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax

--- a/.changeset/odd-mugs-enjoy.md
+++ b/.changeset/odd-mugs-enjoy.md
@@ -2,7 +2,7 @@
 'sku': major
 ---
 
-Remove type-only imports during transpilation
+Remove type-only imports during transpilation and enforce correct type-only import syntax with `verbatimModuleSyntax: true`
 
 This change enables babel to mimic the behaviour of TypeScript's [`verbatimModuleSyntax`] compiler option. The following code demonstrates the result of this change when transpiling TypeScript to JavaScript:
 
@@ -17,6 +17,6 @@ import { b, type c, type d } from "bcd";
 import { type xyz } from "xyz";
 ```
 
-Since bundled code should not contain `import` statements, this change should not affect the output of most app code. Additionally, since our ESLint config ensures that `import { type xyz }` is transformed into `import type { xyz }`, this change is unlikely to affect library code either.
+This change is not expected to have an affect on bundled application code or library code. However, it may surface some TypeScript errors in `compilePackage` dependencies that do not adhere to the correct type-only import syntax. These errors should be fixed in the dependency's codebase.
 
 [`verbatimModuleSyntax`]: https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax

--- a/packages/sku/config/typescript/tsconfig.js
+++ b/packages/sku/config/typescript/tsconfig.js
@@ -29,8 +29,8 @@ module.exports = () => {
       isolatedModules: true,
       resolveJsonModule: true,
 
-      // Not strictly required since we don't use tsc to compile, but aligns with the
-      // babel-preset-typescript `onlyRemoveTypeImports` option
+      // Simplifies import elision, and enforces correct usage of type-only imports.
+      // Aligns with `babel-preset-typescript`'s `onlyRemoveTypeImports` option.
       verbatimModuleSyntax: true,
 
       // misc


### PR DESCRIPTION
It turns out that `verbatimModuleSyntax: true` enables `tsc` to emit errors when type-only imports are missing. This is only really an issue if a sku app is depending on a `compilePackage` that ships raw `.ts` files that do not adhere to our ESLint rules that enforce correct type import syntax. Only 1 such case (an internal package) has been identified internally, and will be fixed very soon.

This PR updates the changeset and comment relevant to the `verbatimModuleSyntax: true` change from #983 to be a bit clearer about what the option does and to mention that TypeScript errors _may_ occur. However, I'm confident that most consumers won't actually run into these errors at all, unless they depend on the package mentioned above.