### PR TITLE
sku v13: Drop `react` 16 peer dep, make `@types/react` a peer dep

### DIFF
--- a/.changeset/mighty-teachers-grow.md
+++ b/.changeset/mighty-teachers-grow.md
@@ -1,0 +1,9 @@
+---
+'sku': major
+---
+
+Add peer dependency on `@types/react@^17.0.0 || ^18.0.0`
+
+**BREAKING CHANGE**
+
+`sku` now has a peer dependency on `@types/react@^17.0.0 || ^18.0.0`. Most, if not all consumers of `sku` should already have `@types/react` installed, but if not, you will need to install it.

--- a/.changeset/slow-ads-complain.md
+++ b/.changeset/slow-ads-complain.md
@@ -1,0 +1,9 @@
+---
+'sku': major
+---
+
+Drop support for `react` versions below `17.0.0`
+
+**BREAKING CHANGE**
+
+`sku` no longer supports react versions below `17.0.0`. Please upgrade your react version to `17.0.0` or higher.

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -38,7 +38,8 @@
   },
   "homepage": "https://github.com/seek-oss/sku#readme",
   "peerDependencies": {
-    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "@types/react": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@antfu/ni": "^0.21.8",
@@ -65,7 +66,6 @@
     "@types/jest": "^29.0.0",
     "@types/loadable__component": "^5.13.1",
     "@types/loadable__server": "^5.12.10",
-    "@types/react": "^18.2.3",
     "@vanilla-extract/jest-transform": "^1.1.0",
     "@vanilla-extract/webpack-plugin": "^2.2.0",
     "@vocab/core": "^1.6.2",
@@ -145,6 +145,7 @@
     "@types/debug": "^4.1.12",
     "@types/minimist": "^1.2.5",
     "@types/picomatch": "^2.3.3",
+    "@types/react": "^18.2.3",
     "@types/react-dom": "^18.2.3",
     "@vanilla-extract/css": "^1.0.0",
     "@vocab/react": "^1.1.11",

--- a/packages/sku/sku-types.d.ts
+++ b/packages/sku/sku-types.d.ts
@@ -1,4 +1,4 @@
-import type { ComponentType, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import type { Express, RequestHandler } from 'express';
 import type { ChunkExtractor } from '@loadable/server';
 
@@ -40,7 +40,7 @@ interface SharedRenderProps {
 }
 
 interface RenderAppProps extends SharedRenderProps {
-  SkuProvider: ComponentType<{ children: ReactNode }>;
+  SkuProvider: ({ children }: { children: ReactNode }) => JSX.Element;
   _addChunk: (chunkName: string) => void;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,9 +562,6 @@ importers:
       '@types/loadable__server':
         specifier: ^5.12.10
         version: 5.12.11
-      '@types/react':
-        specifier: ^18.2.3
-        version: 18.3.3
       '@vanilla-extract/jest-transform':
         specifier: ^1.1.0
         version: 1.1.5(@types/node@18.19.34)(babel-plugin-macros@3.1.0)(less@4.2.0)(terser@5.31.1)
@@ -797,6 +794,9 @@ importers:
       '@types/picomatch':
         specifier: ^2.3.3
         version: 2.3.3
+      '@types/react':
+        specifier: ^18.2.3
+        version: 18.3.3
       '@types/react-dom':
         specifier: ^18.2.3
         version: 18.3.0


### PR DESCRIPTION
- `@types/react` should've been made a peer dep in #981. We actually should've already had a peer dep on it because before that PR `sku`'s types already depended on `@types/react`. It needs to be a peer dep because we support multiple major versions of `react` still, so consumers need to BYO the appropriate version.
- Dropped support for `react` < 17. Braid hasn't supported `react@16` since v32, and consumers have practically all moved to v17 or v18 by now.
- Also made our `SkuProvider` type consistent across server and render entries. Didn't use a type alias because then users just see the type `SkuProvider` instead of the react component type.