### PR TITLE
Exclude pnpm-lock.yaml from linting 

### DIFF
--- a/.changeset/shy-singers-judge.md
+++ b/.changeset/shy-singers-judge.md
@@ -2,4 +2,4 @@
 'sku': patch
 ---
 
-Add pnpm-lock.yaml to .prettierignore
+Add `pnpm-lock.yaml` to `.prettierignore` and `.eslintignore`

--- a/.changeset/shy-singers-judge.md
+++ b/.changeset/shy-singers-judge.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Add pnpm-lock.yaml to .prettierignore

--- a/fixtures/assertion-removal/.eslintignore
+++ b/fixtures/assertion-removal/.eslintignore
@@ -4,6 +4,7 @@
 .prettierrc
 coverage/
 dist/
+pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/assertion-removal/.eslintignore
+++ b/fixtures/assertion-removal/.eslintignore
@@ -4,7 +4,6 @@
 .prettierrc
 coverage/
 dist/
-pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/assertion-removal/.eslintignore
+++ b/fixtures/assertion-removal/.eslintignore
@@ -6,4 +6,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/braid-design-system/.eslintignore
+++ b/fixtures/braid-design-system/.eslintignore
@@ -4,6 +4,7 @@
 .prettierrc
 coverage/
 dist/
+pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/braid-design-system/.eslintignore
+++ b/fixtures/braid-design-system/.eslintignore
@@ -4,7 +4,6 @@
 .prettierrc
 coverage/
 dist/
-pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/braid-design-system/.eslintignore
+++ b/fixtures/braid-design-system/.eslintignore
@@ -6,4 +6,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/custom-src-paths/.eslintignore
+++ b/fixtures/custom-src-paths/.eslintignore
@@ -4,6 +4,7 @@
 .prettierrc
 coverage/
 dist/
+pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/custom-src-paths/.eslintignore
+++ b/fixtures/custom-src-paths/.eslintignore
@@ -4,7 +4,6 @@
 .prettierrc
 coverage/
 dist/
-pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/custom-src-paths/.eslintignore
+++ b/fixtures/custom-src-paths/.eslintignore
@@ -6,4 +6,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/jest-test/.eslintignore
+++ b/fixtures/jest-test/.eslintignore
@@ -9,4 +9,5 @@ dist-storybook/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/jest-test/.prettierignore
+++ b/fixtures/jest-test/.prettierignore
@@ -9,4 +9,5 @@ dist-storybook/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/library-build/.eslintignore
+++ b/fixtures/library-build/.eslintignore
@@ -6,4 +6,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/library-build/.prettierignore
+++ b/fixtures/library-build/.prettierignore
@@ -6,4 +6,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/library-file/.eslintignore
+++ b/fixtures/library-file/.eslintignore
@@ -6,4 +6,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/library-file/.prettierignore
+++ b/fixtures/library-file/.prettierignore
@@ -6,4 +6,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/lint-format/.eslintignore
+++ b/fixtures/lint-format/.eslintignore
@@ -4,6 +4,7 @@
 .prettierrc
 coverage/
 dist/
+pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/lint-format/.eslintignore
+++ b/fixtures/lint-format/.eslintignore
@@ -4,7 +4,6 @@
 .prettierrc
 coverage/
 dist/
-pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/lint-format/.eslintignore
+++ b/fixtures/lint-format/.eslintignore
@@ -6,4 +6,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/multiple-routes/.eslintignore
+++ b/fixtures/multiple-routes/.eslintignore
@@ -4,6 +4,7 @@
 .prettierrc
 coverage/
 dist/
+pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/multiple-routes/.eslintignore
+++ b/fixtures/multiple-routes/.eslintignore
@@ -4,7 +4,6 @@
 .prettierrc
 coverage/
 dist/
-pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/multiple-routes/.eslintignore
+++ b/fixtures/multiple-routes/.eslintignore
@@ -6,4 +6,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/public-path/.eslintignore
+++ b/fixtures/public-path/.eslintignore
@@ -6,4 +6,5 @@ coverage/
 dist/static/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/public-path/.prettierignore
+++ b/fixtures/public-path/.prettierignore
@@ -6,4 +6,5 @@ coverage/
 dist/static/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/sku-test/.eslintignore
+++ b/fixtures/sku-test/.eslintignore
@@ -6,4 +6,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/sku-test/.prettierignore
+++ b/fixtures/sku-test/.prettierignore
@@ -6,4 +6,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/sku-with-https/.eslintignore
+++ b/fixtures/sku-with-https/.eslintignore
@@ -4,6 +4,7 @@
 .prettierrc
 coverage/
 dist/
+pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/sku-with-https/.eslintignore
+++ b/fixtures/sku-with-https/.eslintignore
@@ -4,7 +4,6 @@
 .prettierrc
 coverage/
 dist/
-pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/sku-with-https/.eslintignore
+++ b/fixtures/sku-with-https/.eslintignore
@@ -6,4 +6,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/source-maps/.eslintignore
+++ b/fixtures/source-maps/.eslintignore
@@ -6,4 +6,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/source-maps/.prettierignore
+++ b/fixtures/source-maps/.prettierignore
@@ -6,4 +6,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/ssr-hello-world/.eslintignore
+++ b/fixtures/ssr-hello-world/.eslintignore
@@ -6,4 +6,5 @@ coverage/
 dist-build/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/ssr-hello-world/.eslintignore
+++ b/fixtures/ssr-hello-world/.eslintignore
@@ -4,6 +4,7 @@
 .prettierrc
 coverage/
 dist-build/
+pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/ssr-hello-world/.eslintignore
+++ b/fixtures/ssr-hello-world/.eslintignore
@@ -4,7 +4,6 @@
 .prettierrc
 coverage/
 dist-build/
-pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/storybook-config/.eslintignore
+++ b/fixtures/storybook-config/.eslintignore
@@ -8,4 +8,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/storybook-config/.prettierignore
+++ b/fixtures/storybook-config/.prettierignore
@@ -8,4 +8,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/styling/.eslintignore
+++ b/fixtures/styling/.eslintignore
@@ -8,4 +8,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/styling/.eslintignore
+++ b/fixtures/styling/.eslintignore
@@ -6,6 +6,7 @@ storybook-static/
 .prettierrc
 coverage/
 dist/
+pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/styling/.eslintignore
+++ b/fixtures/styling/.eslintignore
@@ -6,7 +6,6 @@ storybook-static/
 .prettierrc
 coverage/
 dist/
-pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/translations/.eslintignore
+++ b/fixtures/translations/.eslintignore
@@ -4,7 +4,8 @@
 .eslintrc
 .prettierrc
 coverage/
-dist/
+dist-ssr/
+pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/translations/.eslintignore
+++ b/fixtures/translations/.eslintignore
@@ -7,4 +7,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/translations/.eslintignore
+++ b/fixtures/translations/.eslintignore
@@ -4,8 +4,7 @@
 .eslintrc
 .prettierrc
 coverage/
-dist-ssr/
-pnpm-lock.yaml
+dist/
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/translations/.gitignore
+++ b/fixtures/translations/.gitignore
@@ -6,7 +6,7 @@
 .eslintrc
 .prettierrc
 coverage/
-dist/
+dist-ssr/
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/translations/.gitignore
+++ b/fixtures/translations/.gitignore
@@ -6,7 +6,7 @@
 .eslintrc
 .prettierrc
 coverage/
-dist-ssr/
+dist/
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/translations/.prettierignore
+++ b/fixtures/translations/.prettierignore
@@ -6,7 +6,7 @@ translations.ts
 .eslintrc
 .prettierrc
 coverage/
-dist/
+dist-ssr/
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/translations/.prettierignore
+++ b/fixtures/translations/.prettierignore
@@ -6,7 +6,8 @@ translations.ts
 .eslintrc
 .prettierrc
 coverage/
-dist-ssr/
+dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/fixtures/typescript-css-modules/.eslintignore
+++ b/fixtures/typescript-css-modules/.eslintignore
@@ -4,6 +4,7 @@
 .prettierrc
 coverage/
 dist/
+pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/typescript-css-modules/.eslintignore
+++ b/fixtures/typescript-css-modules/.eslintignore
@@ -4,7 +4,6 @@
 .prettierrc
 coverage/
 dist/
-pnpm-lock.yaml
 report/
 tsconfig.json
 # end managed by sku

--- a/fixtures/typescript-css-modules/.eslintignore
+++ b/fixtures/typescript-css-modules/.eslintignore
@@ -6,4 +6,5 @@ coverage/
 dist/
 report/
 tsconfig.json
+pnpm-lock.yaml
 # end managed by sku

--- a/packages/sku/lib/configure.js
+++ b/packages/sku/lib/configure.js
@@ -65,7 +65,7 @@ module.exports = async () => {
   await writeFileToCWD(tsConfigFileName, createTSConfig());
   gitIgnorePatterns.push(tsConfigFileName);
 
-  const lintIgnorePatterns = [...gitIgnorePatterns];
+  const lintIgnorePatterns = [...gitIgnorePatterns, 'pnpm-lock.yaml'];
 
   if (languages) {
     const generatedVocabFileGlob = '**/*.vocab/index.ts';
@@ -84,9 +84,7 @@ module.exports = async () => {
   await ensureGitignore({
     filepath: getPathFromCwd('.prettierignore'),
     comment: 'managed by sku',
-    patterns: lintIgnorePatterns
-      .concat('pnpm-lock.yaml')
-      .map(convertToForwardSlashPaths),
+    patterns: lintIgnorePatterns.map(convertToForwardSlashPaths),
   });
 
   // Generate self-signed certificate and ignore

--- a/packages/sku/lib/configure.js
+++ b/packages/sku/lib/configure.js
@@ -77,16 +77,16 @@ module.exports = async () => {
   await ensureGitignore({
     filepath: getPathFromCwd('.eslintignore'),
     comment: 'managed by sku',
-    patterns: lintIgnorePatterns
-      .concat('pnpm-lock.yaml')
-      .map(convertToForwardSlashPaths),
+    patterns: lintIgnorePatterns.map(convertToForwardSlashPaths),
   });
 
   // Write `.prettierignore`
   await ensureGitignore({
     filepath: getPathFromCwd('.prettierignore'),
     comment: 'managed by sku',
-    patterns: lintIgnorePatterns.map(convertToForwardSlashPaths),
+    patterns: lintIgnorePatterns
+      .concat('pnpm-lock.yaml')
+      .map(convertToForwardSlashPaths),
   });
 
   // Generate self-signed certificate and ignore

--- a/packages/sku/lib/configure.js
+++ b/packages/sku/lib/configure.js
@@ -77,7 +77,9 @@ module.exports = async () => {
   await ensureGitignore({
     filepath: getPathFromCwd('.eslintignore'),
     comment: 'managed by sku',
-    patterns: lintIgnorePatterns.map(convertToForwardSlashPaths),
+    patterns: lintIgnorePatterns
+      .concat('pnpm-lock.yaml')
+      .map(convertToForwardSlashPaths),
   });
 
   // Write `.prettierignore`

--- a/tests/__snapshots__/configure.test.ts.snap
+++ b/tests/__snapshots__/configure.test.ts.snap
@@ -19,6 +19,7 @@ exports[`configure custom should generate $ignore 2`] = `
   ".prettierrc",
   "coverage/",
   "foo/bar/",
+  "pnpm-lock.yaml",
   "report/",
   "tsconfig.json",
 ]
@@ -43,6 +44,7 @@ exports[`configure default should generate $ignore 2`] = `
   ".prettierrc",
   "coverage/",
   "dist/",
+  "pnpm-lock.yaml",
   "report/",
   "tsconfig.json",
 ]

--- a/tests/__snapshots__/configure.test.ts.snap
+++ b/tests/__snapshots__/configure.test.ts.snap
@@ -7,6 +7,7 @@ exports[`configure custom should generate $ignore 1`] = `
   ".prettierrc",
   "coverage/",
   "foo/bar/",
+  "pnpm-lock.yaml",
   "report/",
   "tsconfig.json",
 ]
@@ -32,6 +33,7 @@ exports[`configure default should generate $ignore 1`] = `
   ".prettierrc",
   "coverage/",
   "dist/",
+  "pnpm-lock.yaml",
   "report/",
   "tsconfig.json",
 ]


### PR DESCRIPTION
`prettier` causes mayhem with `pnpm-lock.yaml` and this reared its head a bit more by the recent changes not to use an extensions list, I think.