### PR TITLE
Better jest preset

### DIFF
--- a/.changeset/pink-carpets-return.md
+++ b/.changeset/pink-carpets-return.md
@@ -1,0 +1,27 @@
+---
+'sku': patch
+---
+
+Replace `sku/config/jest` entrypoint with `sku/jest-preset`
+
+**BREAKING CHANGE**:
+
+This breaking change will only affect a very small number of projects that have a custom Jest configuration/wish to debug tests in their IDE, and it is intended to be a quick fix/improvement for a feature released in `sku@13.0.0`. Therefore, it's not being released as a major version.
+
+The `sku/config/jest` entrypoint has been removed in favor of a new `sku/jest-preset` entrypoint. The `sku/jest-preset` module is a better way to expose a [jest preset], rather than a relative path, as it works even if `sku` is hoisted to a parent `node_modules` directory.
+
+**MIGRATION GUIDE**:
+
+```diff
+// jest.config.js
+- const { preset } = require('sku/config/jest');
+
+/** @type {import('jest').Config} */
+module.exports = {
+-  preset,
+-  preset: 'sku/config/jest',
++  preset: 'sku',
+};
+```
+
+[jest preset]: https://jestjs.io/docs/configuration#preset-string

--- a/.changeset/pink-carpets-return.md
+++ b/.changeset/pink-carpets-return.md
@@ -4,11 +4,11 @@
 
 Replace `sku/config/jest` entrypoint with `sku/jest-preset`
 
-**BREAKING CHANGE**:
+**BREAKING CHANGE FOR CUSTOM JEST CONFIG**:
 
 This breaking change will only affect a very small number of projects that have a custom Jest configuration/wish to debug tests in their IDE, and it is intended to be a quick fix/improvement for a feature released in `sku@13.0.0`. Therefore, it's not being released as a major version.
 
-The `sku/config/jest` entrypoint has been removed in favor of a new `sku/jest-preset` entrypoint. The `sku/jest-preset` module is a better way to expose a [jest preset], rather than a relative path, as it works even if `sku` is hoisted to a parent `node_modules` directory.
+The `sku/config/jest` entrypoint has been removed in favor of a new `sku/jest-preset` entrypoint. The `sku/jest-preset` module is a better way to expose a [jest preset], rather than a relative path (the previous implementation), as it works even if `sku` is hoisted to a parent `node_modules` directory.
 
 **MIGRATION GUIDE**:
 
@@ -18,7 +18,9 @@ The `sku/config/jest` entrypoint has been removed in favor of a new `sku/jest-pr
 
 /** @type {import('jest').Config} */
 module.exports = {
+   // If you've already migrated to sku v13
 -  preset,
+   // If you're still on sku v12.x
 -  preset: 'sku/config/jest',
 +  preset: 'sku',
 };

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -25,9 +25,9 @@ import { loadableReady } from 'sku/@loadable/component';
 
 [code splitting documentation]: ./docs/code-splitting.md
 
-## `sku/config/jest`
+## `sku/jest-preset`
 
-A jest preset for consuming `sku`'s Jest configuration.
+A [jest preset] for consuming `sku`'s Jest configuration.
 See the [testing documentation] for more information.
 
 Example:
@@ -36,10 +36,11 @@ Example:
 // jest.config.js
 /** @type {import('jest').Config} */
 module.exports = {
-  preset: 'sku/config/jest',
+  preset: 'sku',
 };
 ```
 
+[jest preset]: https://jestjs.io/docs/configuration#preset-string
 [testing documentation]: ./docs/testing.md
 
 ## `sku/config/storybook`

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -31,11 +31,9 @@ import '@testing-library/jest-dom';
 sku's Jest configuration can also be used as a [preset](https://jestjs.io/docs/configuration#preset-string):
 
 ```js
-const { preset } = require('sku/config/jest');
-
 /** @type {import('jest').Config} */
 module.exports = {
-  preset,
+  preset: 'sku',
 };
 ```
 

--- a/fixtures/jest-test/jest.config.js
+++ b/fixtures/jest-test/jest.config.js
@@ -1,6 +1,4 @@
-const { preset } = require('sku/config/jest');
-
 /** @type {import('jest').Config} */
 module.exports = {
-  preset,
+  preset: 'sku',
 };

--- a/packages/sku/CHANGELOG.md
+++ b/packages/sku/CHANGELOG.md
@@ -10,22 +10,20 @@
 
 ### Major Changes
 
-- Export jest preset path ([#984](https://github.com/seek-oss/sku/pull/984))
+- Export jest preset ([#984](https://github.com/seek-oss/sku/pull/984))
 
   **BREAKING CHANGE**:
 
-  The jest preset is now accessible via a relative path rather than pointing to a module. This may affect users that require a jest config for debugging tests in their IDE. See the [testing documentation] for more information.
+  The jest preset is now accessible via the `sku` preset. This may affect users that require a jest config for debugging tests in their IDE. See the [testing documentation] for more information.
 
   **MIGRATION GUIDE**:
 
   ```diff
   // jest.config.js
-  + const { preset } = require('sku/config/jest');
-
   /** @type {import('jest').Config} */
   module.exports = {
   -  preset: 'sku/config/jest',
-  +  preset,
+  +  preset: 'sku',
   };
   ```
 

--- a/packages/sku/config/jest/index.d.ts
+++ b/packages/sku/config/jest/index.d.ts
@@ -1,1 +1,0 @@
-export const preset: string;

--- a/packages/sku/config/jest/index.js
+++ b/packages/sku/config/jest/index.js
@@ -1,8 +1,0 @@
-// @ts-check
-
-// Relative preset paths must start with `./` or jest complains
-const preset = './node_modules/sku/config/jest/jest-preset.js';
-
-module.exports = {
-  preset,
-};

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -7,13 +7,8 @@
     "sku": "./bin/sku.js"
   },
   "exports": {
-    ".": {
-      "types": "./sku-types.d.ts"
-    },
-    "./config/jest": {
-      "default": "./config/jest/index.js",
-      "types": "./config/jest/index.d.ts"
-    },
+    ".": "./sku-types.d.ts",
+    "./jest-preset": "./config/jest/jest-preset.js",
     "./config/storybook": {
       "default": "./config/storybook/index.js",
       "types": "./config/storybook/index.d.ts"

--- a/packages/sku/scripts/test.js
+++ b/packages/sku/scripts/test.js
@@ -11,12 +11,12 @@ const log = debug('sku:jest');
   await runVocabCompile();
 
   // https://jestjs.io/docs/configuration#preset-string
-  const { preset } = require('../config/jest');
-  log(`Using Jest preset at ${preset}`);
+  const jestPreset = 'sku';
+  log(`Using '${jestPreset}' Jest preset`);
 
   const jestArgv = [...argv];
 
-  jestArgv.push('--preset', preset);
+  jestArgv.push('--preset', jestPreset);
 
   if (isCI) {
     jestArgv.push('--ci');


### PR DESCRIPTION
I'm considering this a fast-follow to the jest preset work done in sku 13, and since it's a barely-used feature, I'm not marking it as breaking, even though it is. I've updated the v13 changelog and docs accordingly.

Before the v13 release, I tried adding a `jest-preset` entrypoint to sku's `package.json`, but it didn't work, so I went with a relative path exported as a constant instead. It turns out that, if jest actually surfaced the relevant errors from [`resolve.exports`](https://www.npmjs.com/package/resolve.exports) (the package used by jest to resolve package exports), the fix would've been trivial and a `jest-preset` entrypoint would've worked just fine.

Jest uses [`resolve.exports`](https://www.npmjs.com/package/resolve.exports) to resolve package.json exports. It turns out `resolve.exports` doesn't like this entrypoint, causing it to fail, so preset module resolution fails when trying to resolve a `sku` preset.
```json
 ".": {
      "types": "./sku-types.d.ts"
    },
```

Simplifying it to this allows exports to be resolved, and then `sku` works as a jest preset:
```json
 ".": "./sku-types.d.ts"
```

This change doesn't affect the `sku` entrypoint at all, it still just exports types. The primary benefit of this change is that `jest` can now resolve `sku`'s jest preset even if it's hoisted to higher `node_modules` directory, which is a nice to have in certain monorepo situations. This was not possible using a relative path.

This has been tested in two different internal projects.