### PR TITLE
Use Relative path for sku Config

### DIFF
--- a/.changeset/stale-olives-hammer.md
+++ b/.changeset/stale-olives-hammer.md
@@ -8,4 +8,4 @@ sku generates ignore files (e.g. `.eslintignore`) for the project.
 When ran as part of `sku init`, the current working directory (CWD) would sometimes be incorrect.
 It should now give the same result as `sku configure`.
 
-This change includes a refactor on how the Webpack Target Directory is set in ignore files.
+This change includes a refactor to how the webpack target directory is set in ignore files.

--- a/.changeset/stale-olives-hammer.md
+++ b/.changeset/stale-olives-hammer.md
@@ -1,0 +1,11 @@
+---
+'sku': patch
+---
+
+Fix incorrect path in ignore files when running `sku init`
+
+sku generates ignore files (e.g. `.eslintignore`) for the project.
+The current working directory (CWD) used would sometimes be incorrect when first ran as part of `sku init`.
+It should now give the same result as `sku configure`.
+
+This change includes a refactor on how the Webpack Target Directory is set in ignore files.

--- a/.changeset/stale-olives-hammer.md
+++ b/.changeset/stale-olives-hammer.md
@@ -5,7 +5,7 @@
 Fix incorrect path in ignore files when running `sku init`
 
 sku generates ignore files (e.g. `.eslintignore`) for the project.
-The current working directory (CWD) used would sometimes be incorrect when first ran as part of `sku init`.
+When ran as part of `sku init`, the current working directory (CWD) would sometimes be incorrect.
 It should now give the same result as `sku configure`.
 
 This change includes a refactor on how the Webpack Target Directory is set in ignore files.

--- a/fixtures/sku-init/__snapshots__/sku-init.test.js.snap
+++ b/fixtures/sku-init/__snapshots__/sku-init.test.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sku init should create .eslintignore 1`] = `
+"# managed by sku
+.eslintcache
+.eslintrc
+.prettierrc
+coverage/
+dist/
+pnpm-lock.yaml
+report/
+tsconfig.json
+# end managed by sku
+"
+`;
+
+exports[`sku init should create .gitignore 1`] = `
+"node_modules
+npm-debug.log
+
+# managed by sku
+.eslintcache
+.eslintrc
+.prettierrc
+coverage/
+dist/
+report/
+tsconfig.json
+# end managed by sku
+"
+`;
+
+exports[`sku init should create .prettierignore 1`] = `
+"# managed by sku
+.eslintcache
+.eslintrc
+.prettierrc
+coverage/
+dist/
+pnpm-lock.yaml
+report/
+tsconfig.json
+# end managed by sku
+"
+`;
+
+exports[`sku init should create package.json 1`] = `
+{
+  "dependencies": {
+    "braid-design-system": "VERSION_IGNORED",
+    "react": "VERSION_IGNORED",
+    "react-dom": "VERSION_IGNORED",
+  },
+  "devDependencies": {
+    "@types/react": "VERSION_IGNORED",
+    "@types/react-dom": "VERSION_IGNORED",
+    "@vanilla-extract/css": "VERSION_IGNORED",
+    "sku": "VERSION_IGNORED",
+  },
+  "name": "new-project",
+  "private": true,
+  "scripts": {
+    "build": "sku build",
+    "format": "sku format",
+    "lint": "sku lint",
+    "serve": "sku serve",
+    "start": "sku start",
+    "test": "sku test",
+  },
+  "version": "0.1.0",
+}
+`;
+
+exports[`sku init should create sku.config.ts 1`] = `
+"import type { SkuConfig } from 'sku';
+
+const skuConfig: SkuConfig = {
+  clientEntry: 'src/client.tsx',
+  renderEntry: 'src/render.tsx',
+  environments: ['development', 'production'],
+  publicPath: '/path/to/public/assets/', // <-- Required for sku build output
+};
+
+export default skuConfig;
+"
+`;

--- a/packages/sku/lib/configure.js
+++ b/packages/sku/lib/configure.js
@@ -4,7 +4,7 @@ const { writeFile, rm } = require('node:fs/promises');
 const path = require('node:path');
 
 const ensureGitignore = require('ensure-gitignore');
-const { cwd, getPathFromCwd } = require('./cwd');
+const { getPathFromCwd } = require('./cwd');
 
 const { paths, httpsDevServer, languages } = require('../context');
 const {
@@ -32,9 +32,7 @@ const writeFileToCWD = async (fileName, content, { banner = true } = {}) => {
 
 module.exports = async () => {
   // Ignore target directories
-  const webpackTargetDirectory = addSep(
-    paths.target.replace(addSep(cwd()), ''),
-  );
+  const webpackTargetDirectory = addSep(paths.relativeTarget);
 
   const gitIgnorePatterns = [
     // Ignore webpack bundle report output


### PR DESCRIPTION
Fixes a situation when an incorrect path would be used for ignore files.

Previously you might get a list with whatever the users current directory was, minus the app name, with 'dist' on the end:

**.gitignore**
```
.eslintcache
.eslintrc
.prettierrc
/users/current/dir/dist/
coverage/
report/
tsconfig.json
```

Now this value will just be `dist/`, as it would be if running `sku configure`.

More information in changeset.

---

Changed `sku-init` test to also check generated files so we can potentially catch this in the future, and make changes to init steps with more confidence.

I needed to special-case package.json as we don't want to update the snapshot when there are new dependency versions.

Whilst jest does support [Property Matchers](https://jestjs.io/docs/snapshot-testing#property-matchers), I chose to implement this by just replacing the version as it's easier to still test WHICH dependencies were installed (regardless of the version), and IMO it's a cleaner snapshot.