### PR TITLE
`start` script: reuse tab if possible in more Chromium browsers

### DIFF
--- a/.changeset/new-eggs-admire.md
+++ b/.changeset/new-eggs-admire.md
@@ -22,5 +22,3 @@ A tab will be reused if:
 * The user has an existing tab open in a supported Chromium browser with the exact same URL.
 
 If any of the above is not true, a new tab will be created in the user's default browser.
-
-The supported Chromium browsers are:

--- a/.changeset/new-eggs-admire.md
+++ b/.changeset/new-eggs-admire.md
@@ -1,0 +1,26 @@
+---
+'sku': minor
+---
+
+Widen support for reusing existing browser tab to more Chromium browsers.
+
+`start` and `start-ssr` scripts would previously only reuse an existing tab in Google Chrome.
+This change adds support for the following Chromium browsers:
+
+- Google Chrome,
+- Google Chrome Canary,
+- Microsoft Edge,
+- Brave Browser,
+- Vivaldi,
+- Chromium,
+- Arc.
+
+A tab will be reused if:
+
+* The OS is macOS,
+* The user's default browser is a supported Chromium browser,
+* The user has an existing tab open in a supported Chromium browser with the exact same URL.
+
+If any of the above is not true, a new tab will be created in the user's default browser.
+
+The supported Chromium browsers are:

--- a/.changeset/three-cows-dream.md
+++ b/.changeset/three-cows-dream.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+dummy to force snapshot publish

--- a/.changeset/three-cows-dream.md
+++ b/.changeset/three-cows-dream.md
@@ -1,5 +1,0 @@
----
-'sku': patch
----
-
-dummy to force snapshot publish

--- a/packages/sku/lib/openBrowser/index.js
+++ b/packages/sku/lib/openBrowser/index.js
@@ -2,32 +2,35 @@
 // https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/openBrowser.js
 
 const execSync = require('node:child_process').execSync;
-const defaultBrowser = require('x-default-browser');
 const open = require('open');
 
 const isCI = require('../isCI');
 
+const OSX_CHROME = 'google chrome';
+
 module.exports = (url) => {
   if (process.env.OPEN_TAB !== 'false' && !isCI) {
-    defaultBrowser((err, res) => {
-      const useChrome = err ? false : res.isChrome;
+    const browser = process.env.BROWSER;
 
-      if (process.platform === 'darwin' && useChrome) {
-        try {
-          // Try our best to reuse existing tab
-          // on OS X Google Chrome with AppleScript
-          execSync('ps cax | grep "Google Chrome"');
-          execSync(`osascript openChrome.applescript "${encodeURI(url)}"`, {
-            cwd: __dirname,
-            stdio: 'ignore',
-          });
-          return;
-        } catch (e) {
-          // Ignore errors.
-        }
+    const shouldTryOpenChromeWithAppleScript =
+      process.platform === 'darwin' &&
+      (typeof browser !== 'string' || browser === OSX_CHROME);
+
+    if (shouldTryOpenChromeWithAppleScript) {
+      try {
+        // Try our best to reuse existing tab
+        // on OS X Google Chrome with AppleScript
+        execSync('ps cax | grep "Google Chrome"');
+        execSync(`osascript openChrome.applescript "${encodeURI(url)}"`, {
+          cwd: __dirname,
+          stdio: 'ignore',
+        });
+        return;
+      } catch (e) {
+        // Ignore errors.
       }
+    }
 
-      open(url, { url: true });
-    });
+    open(url, { url: true });
   }
 };

--- a/packages/sku/lib/openBrowser/index.js
+++ b/packages/sku/lib/openBrowser/index.js
@@ -12,22 +12,39 @@ module.exports = (url) => {
   if (process.env.OPEN_TAB !== 'false' && !isCI) {
     const browser = process.env.BROWSER;
 
-    const shouldTryOpenChromeWithAppleScript =
+    const shouldTryOpenChromiumWithAppleScript =
       process.platform === 'darwin' &&
       (typeof browser !== 'string' || browser === OSX_CHROME);
 
-    if (shouldTryOpenChromeWithAppleScript) {
-      try {
-        // Try our best to reuse existing tab
-        // on OS X Google Chrome with AppleScript
-        execSync('ps cax | grep "Google Chrome"');
-        execSync(`osascript openChrome.applescript "${encodeURI(url)}"`, {
-          cwd: __dirname,
-          stdio: 'ignore',
-        });
-        return;
-      } catch (e) {
-        // Ignore errors.
+    if (shouldTryOpenChromiumWithAppleScript) {
+      // Will use the first open browser found from list
+      const supportedChromiumBrowsers = [
+        'Google Chrome Canary',
+        'Google Chrome',
+        'Microsoft Edge',
+        'Brave Browser',
+        'Vivaldi',
+        'Chromium',
+      ];
+
+      for (const chromiumBrowser of supportedChromiumBrowsers) {
+        try {
+          // Try our best to reuse existing tab
+          // on OS X Google Chrome with AppleScript
+          execSync(`ps cax | grep "${chromiumBrowser}"`);
+          execSync(
+            `osascript openChrome.applescript "${encodeURI(
+              url,
+            )}" "${chromiumBrowser}"`,
+            {
+              cwd: __dirname,
+              stdio: 'ignore',
+            },
+          );
+          return true;
+        } catch (e) {
+          // Ignore errors.
+        }
       }
     }
 

--- a/packages/sku/lib/openBrowser/index.js
+++ b/packages/sku/lib/openBrowser/index.js
@@ -10,8 +10,8 @@ const OSX_CHROME = 'google chrome';
 
 module.exports = async (url) => {
   if (process.env.OPEN_TAB !== 'false' && !isCI) {
-    const getDefaultBrowser = (await import('default-browser')).default;
-    const defaultBrowser = (await getDefaultBrowser()).name;
+    const { default: getDefaultBrowser } = await import('default-browser');
+    const { name: defaultBrowser } = await getDefaultBrowser();
 
     const availableBrowser = process.env.BROWSER;
 
@@ -32,9 +32,7 @@ module.exports = async (url) => {
         'Arc',
       ];
 
-      const uniqueSupportedChromiumBrowsers = Array.from(
-        new Set(supportedChromiumBrowsers),
-      );
+      const uniqueSupportedChromiumBrowsers = new Set(supportedChromiumBrowsers);
 
       for (const chromiumBrowser of uniqueSupportedChromiumBrowsers) {
         try {

--- a/packages/sku/lib/openBrowser/index.js
+++ b/packages/sku/lib/openBrowser/index.js
@@ -8,6 +8,16 @@ const isCI = require('../isCI');
 
 const OSX_CHROME = 'google chrome';
 
+const supportedChromiumBrowsers = [
+  'Google Chrome',
+  'Google Chrome Canary',
+  'Microsoft Edge',
+  'Brave Browser',
+  'Vivaldi',
+  'Chromium',
+  'Arc',
+];
+
 module.exports = async (url) => {
   if (process.env.OPEN_TAB !== 'false' && !isCI) {
     const { default: getDefaultBrowser } = await import('default-browser');
@@ -17,24 +27,18 @@ module.exports = async (url) => {
 
     const shouldTryOpenChromiumWithAppleScript =
       process.platform === 'darwin' &&
-      (typeof availableBrowser !== 'string' || availableBrowser === OSX_CHROME);
+      (typeof availableBrowser !== 'string' ||
+        availableBrowser === OSX_CHROME) &&
+      supportedChromiumBrowsers.includes(defaultBrowser);
 
     if (shouldTryOpenChromiumWithAppleScript) {
       // Will use the first open browser found from list
-      const supportedChromiumBrowsers = [
+      const supportedChromiumBrowsersByPreference = new Set([
         defaultBrowser,
-        'Google Chrome Canary',
-        'Google Chrome',
-        'Microsoft Edge',
-        'Brave Browser',
-        'Vivaldi',
-        'Chromium',
-        'Arc',
-      ];
+        ...supportedChromiumBrowsers,
+      ]);
 
-      const uniqueSupportedChromiumBrowsers = new Set(supportedChromiumBrowsers);
-
-      for (const chromiumBrowser of uniqueSupportedChromiumBrowsers) {
+      for (const chromiumBrowser of supportedChromiumBrowsersByPreference) {
         try {
           // Try our best to reuse existing tab
           // on OS X Google Chrome with AppleScript

--- a/packages/sku/lib/openBrowser/index.js
+++ b/packages/sku/lib/openBrowser/index.js
@@ -1,5 +1,5 @@
 // Inspired by create-react-app
-// https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/openBrowser.js
+// https://github.com/facebook/create-react-app/commit/d2de54b25cc25800df1764058997e3e274bd79ac
 
 const execSync = require('node:child_process').execSync;
 const open = require('open');

--- a/packages/sku/lib/openBrowser/index.js
+++ b/packages/sku/lib/openBrowser/index.js
@@ -8,26 +8,35 @@ const isCI = require('../isCI');
 
 const OSX_CHROME = 'google chrome';
 
-module.exports = (url) => {
+module.exports = async (url) => {
   if (process.env.OPEN_TAB !== 'false' && !isCI) {
-    const browser = process.env.BROWSER;
+    const getDefaultBrowser = (await import('default-browser')).default;
+    const defaultBrowser = (await getDefaultBrowser()).name;
+
+    const availableBrowser = process.env.BROWSER;
 
     const shouldTryOpenChromiumWithAppleScript =
       process.platform === 'darwin' &&
-      (typeof browser !== 'string' || browser === OSX_CHROME);
+      (typeof availableBrowser !== 'string' || availableBrowser === OSX_CHROME);
 
     if (shouldTryOpenChromiumWithAppleScript) {
       // Will use the first open browser found from list
       const supportedChromiumBrowsers = [
+        defaultBrowser,
         'Google Chrome Canary',
         'Google Chrome',
         'Microsoft Edge',
         'Brave Browser',
         'Vivaldi',
         'Chromium',
+        'Arc',
       ];
 
-      for (const chromiumBrowser of supportedChromiumBrowsers) {
+      const uniqueSupportedChromiumBrowsers = Array.from(
+        new Set(supportedChromiumBrowsers),
+      );
+
+      for (const chromiumBrowser of uniqueSupportedChromiumBrowsers) {
         try {
           // Try our best to reuse existing tab
           // on OS X Google Chrome with AppleScript

--- a/packages/sku/lib/openBrowser/openChrome.applescript
+++ b/packages/sku/lib/openBrowser/openChrome.applescript
@@ -6,47 +6,56 @@ https://github.com/facebook/create-react-app/blob/master/packages/react-dev-util
 property targetTab: null
 property targetTabIndex: -1
 property targetWindow: null
+property theProgram: "Google Chrome"
 
 on run argv
   set theURL to item 1 of argv
 
-  tell application "Chrome"
+  -- Allow requested program to be optional,
+  -- default to Google Chrome
+  if (count of argv) > 1 then
+    set theProgram to item 2 of argv
+  end if
 
-    if (count every window) = 0 then
-      make new window
-    end if
+  using terms from application "Google Chrome"
+    tell application theProgram
 
-    -- 1: Looking for tab running debugger
-    -- then, Reload debugging tab if found
-    -- then return
-    set found to my lookupTabWithUrl(theURL)
-    if found then
-      set targetWindow's active tab index to targetTabIndex
-      tell targetTab to reload
-      tell targetWindow to activate
-      set index of targetWindow to 1
-      return
-    end if
+      if (count every window) = 0 then
+        make new window
+      end if
 
-    -- 2: Looking for Empty tab
-    -- In case debugging tab was not found
-    -- We try to find an empty tab instead
-    set found to my lookupTabWithUrl("chrome://newtab/")
-    if found then
-      set targetWindow's active tab index to targetTabIndex
-      set URL of targetTab to theURL
-      tell targetWindow to activate
-      return
-    end if
+      -- 1: Looking for tab running debugger
+      -- then, Reload debugging tab if found
+      -- then return
+      set found to my lookupTabWithUrl(theURL)
+      if found then
+        set targetWindow's active tab index to targetTabIndex
+        tell targetTab to reload
+        tell targetWindow to activate
+        set index of targetWindow to 1
+        return
+      end if
 
-    -- 3: Create new tab
-    -- both debugging and empty tab were not found
-    -- make a new tab with url
-    tell window 1
-      activate
-      make new tab with properties {URL:theURL}
+      -- 2: Looking for Empty tab
+      -- In case debugging tab was not found
+      -- We try to find an empty tab instead
+      set found to my lookupTabWithUrl("chrome://newtab/")
+      if found then
+        set targetWindow's active tab index to targetTabIndex
+        set URL of targetTab to theURL
+        tell targetWindow to activate
+        return
+      end if
+
+      -- 3: Create new tab
+      -- both debugging and empty tab were not found
+      -- make a new tab with url
+      tell window 1
+        activate
+        make new tab with properties {URL:theURL}
+      end tell
     end tell
-  end tell
+  end using terms from
 end run
 
 -- Function:
@@ -54,28 +63,30 @@ end run
 -- if found, store tab, index, and window in properties
 -- (properties were declared on top of file)
 on lookupTabWithUrl(lookupUrl)
-  tell application "Chrome"
-    -- Find a tab with the given url
-    set found to false
-    set theTabIndex to -1
-    repeat with theWindow in every window
-      set theTabIndex to 0
-      repeat with theTab in every tab of theWindow
-        set theTabIndex to theTabIndex + 1
-        if (theTab's URL as string) contains lookupUrl then
-          -- assign tab, tab index, and window to properties
-          set targetTab to theTab
-          set targetTabIndex to theTabIndex
-          set targetWindow to theWindow
-          set found to true
+  using terms from application "Google Chrome"
+    tell application theProgram
+      -- Find a tab with the given url
+      set found to false
+      set theTabIndex to -1
+      repeat with theWindow in every window
+        set theTabIndex to 0
+        repeat with theTab in every tab of theWindow
+          set theTabIndex to theTabIndex + 1
+          if (theTab's URL as string) contains lookupUrl then
+            -- assign tab, tab index, and window to properties
+            set targetTab to theTab
+            set targetTabIndex to theTabIndex
+            set targetWindow to theWindow
+            set found to true
+            exit repeat
+          end if
+        end repeat
+
+        if found then
           exit repeat
         end if
       end repeat
-
-      if found then
-        exit repeat
-      end if
-    end repeat
-  end tell
+    end tell
+  end using terms from
   return found
 end lookupTabWithUrl

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -138,7 +138,7 @@
     "webpack-merge": "^5.8.0",
     "webpack-node-externals": "^3.0.0",
     "wrap-ansi": "^7.0.0",
-    "x-default-browser": "^0.5.0"
+    "default-browser": "^5.2.1"
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,7 +393,7 @@ importers:
         version: 3.0.3(webpack@5.93.0(@swc/core@1.7.11)(esbuild@0.21.5))
       '@storybook/react':
         specifier: ^8.1.5
-        version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
+        version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))(typescript@5.5.4)
       '@storybook/react-webpack5':
         specifier: ^8.1.5
         version: 8.2.9(@swc/core@1.7.11)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
@@ -411,7 +411,7 @@ importers:
         version: link:../../packages/sku
       storybook:
         specifier: ^8.1.5
-        version: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+        version: 8.2.9(@babel/preset-env@7.25.3)
 
   fixtures/styling:
     dependencies:
@@ -433,10 +433,10 @@ importers:
         version: 3.0.3(webpack@5.93.0(@swc/core@1.7.11))
       '@storybook/react':
         specifier: ^8.1.5
-        version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
+        version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))(typescript@5.5.4)
       '@storybook/react-webpack5':
         specifier: ^8.1.5
-        version: 8.2.9(@swc/core@1.7.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
+        version: 8.2.9(@swc/core@1.7.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))(typescript@5.5.4)
       '@types/react':
         specifier: ^18.2.3
         version: 18.3.3
@@ -454,7 +454,7 @@ importers:
         version: link:../../packages/sku
       storybook:
         specifier: ^8.1.5
-        version: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+        version: 8.2.9(@babel/preset-env@7.25.3)
 
   fixtures/translations:
     dependencies:
@@ -658,6 +658,9 @@ importers:
       dedent:
         specifier: ^1.5.1
         version: 1.5.3(babel-plugin-macros@3.1.0)
+      default-browser:
+        specifier: ^5.2.1
+        version: 5.2.1
       didyoumean2:
         specifier: ^6.0.1
         version: 6.0.1
@@ -802,9 +805,6 @@ importers:
       wrap-ansi:
         specifier: ^7.0.0
         version: 7.0.0
-      x-default-browser:
-        specifier: ^0.5.0
-        version: 0.5.2
     devDependencies:
       '@types/cross-spawn':
         specifier: ^6.0.3
@@ -10182,14 +10182,14 @@ snapshots:
       '@storybook/blocks': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))
       '@storybook/csf-plugin': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))
+      '@storybook/react-dom-shim': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))
       '@types/react': 18.3.3
       fs-extra: 11.2.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       rehype-external-links: 3.0.0
       rehype-slug: 6.0.0
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -10223,7 +10223,7 @@ snapshots:
       memoizerific: 1.11.3
       polished: 4.3.1
       react-colorful: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
       telejson: 7.2.0
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
@@ -10233,7 +10233,7 @@ snapshots:
 
   '@storybook/builder-webpack5@8.2.9(@swc/core@1.7.11)(esbuild@0.21.5)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3))
       '@types/node': 18.19.44
       '@types/semver': 7.5.8
       browser-assert: 1.2.1
@@ -10250,7 +10250,7 @@ snapshots:
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
       style-loader: 3.3.4(webpack@5.93.0(@swc/core@1.7.11)(esbuild@0.21.5))
       terser-webpack-plugin: 5.3.10(@swc/core@1.7.11)(esbuild@0.21.5)(webpack@5.93.0(@swc/core@1.7.11)(esbuild@0.21.5))
       ts-dedent: 2.2.0
@@ -10273,7 +10273,7 @@ snapshots:
 
   '@storybook/builder-webpack5@8.2.9(@swc/core@1.7.11)(esbuild@0.23.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3))
       '@types/node': 18.19.44
       '@types/semver': 7.5.8
       browser-assert: 1.2.1
@@ -10290,7 +10290,7 @@ snapshots:
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
       style-loader: 3.3.4(webpack@5.93.0(@swc/core@1.7.11)(esbuild@0.23.1))
       terser-webpack-plugin: 5.3.10(@swc/core@1.7.11)(esbuild@0.23.1)(webpack@5.93.0(@swc/core@1.7.11)(esbuild@0.23.1))
       ts-dedent: 2.2.0
@@ -10311,9 +10311,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/builder-webpack5@8.2.9(@swc/core@1.7.11)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)':
+  '@storybook/builder-webpack5@8.2.9(@swc/core@1.7.11)(storybook@8.2.9(@babel/preset-env@7.25.3))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3))
       '@types/node': 18.19.44
       '@types/semver': 7.5.8
       browser-assert: 1.2.1
@@ -10330,7 +10330,7 @@ snapshots:
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
       style-loader: 3.3.4(webpack@5.93.0(@swc/core@1.7.11))
       terser-webpack-plugin: 5.3.10(@swc/core@1.7.11)(webpack@5.93.0(@swc/core@1.7.11))
       ts-dedent: 2.2.0
@@ -10361,7 +10361,7 @@ snapshots:
       '@types/cross-spawn': 6.0.6
       cross-spawn: 7.0.3
       globby: 14.0.2
-      jscodeshift: 0.15.2(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      jscodeshift: 0.15.2(@babel/preset-env@7.25.3)
       lodash: 4.17.21
       prettier: 3.3.3
       recast: 0.23.9
@@ -10371,14 +10371,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@storybook/components@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))':
+  '@storybook/components@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3))':
     dependencies:
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
 
-  '@storybook/core-webpack@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))':
+  '@storybook/core-webpack@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3))':
     dependencies:
       '@types/node': 18.19.44
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
       ts-dedent: 2.2.0
 
   '@storybook/core@8.2.9':
@@ -10401,7 +10401,7 @@ snapshots:
 
   '@storybook/csf-plugin@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))':
     dependencies:
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
       unplugin: 1.12.2
 
   '@storybook/csf@0.1.11':
@@ -10415,14 +10415,14 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/manager-api@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))':
+  '@storybook/manager-api@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3))':
     dependencies:
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
 
   '@storybook/preset-react-webpack@8.2.9(@swc/core@1.7.11)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3))
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))(typescript@5.5.4)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.4)(webpack@5.93.0(@swc/core@1.7.11)(esbuild@0.21.5))
       '@types/node': 18.19.44
       '@types/semver': 7.5.8
@@ -10434,7 +10434,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.8
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
       tsconfig-paths: 4.2.0
       webpack: 5.93.0(@swc/core@1.7.11)(esbuild@0.21.5)
     optionalDependencies:
@@ -10448,8 +10448,8 @@ snapshots:
 
   '@storybook/preset-react-webpack@8.2.9(@swc/core@1.7.11)(esbuild@0.23.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3))
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))(typescript@5.5.4)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.4)(webpack@5.93.0(@swc/core@1.7.11)(esbuild@0.23.1))
       '@types/node': 18.19.44
       '@types/semver': 7.5.8
@@ -10461,7 +10461,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.8
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
       tsconfig-paths: 4.2.0
       webpack: 5.93.0(@swc/core@1.7.11)(esbuild@0.23.1)
     optionalDependencies:
@@ -10473,10 +10473,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/preset-react-webpack@8.2.9(@swc/core@1.7.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)':
+  '@storybook/preset-react-webpack@8.2.9(@swc/core@1.7.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3))
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))(typescript@5.5.4)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.4)(webpack@5.93.0(@swc/core@1.7.11))
       '@types/node': 18.19.44
       '@types/semver': 7.5.8
@@ -10488,7 +10488,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.8
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
       tsconfig-paths: 4.2.0
       webpack: 5.93.0(@swc/core@1.7.11)
     optionalDependencies:
@@ -10500,9 +10500,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/preview-api@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))':
+  '@storybook/preview-api@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3))':
     dependencies:
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
 
   '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.5.4)(webpack@5.93.0(@swc/core@1.7.11)(esbuild@0.21.5))':
     dependencies:
@@ -10546,21 +10546,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))':
+  '@storybook/react-dom-shim@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
 
   '@storybook/react-webpack5@8.2.9(@swc/core@1.7.11)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)':
     dependencies:
       '@storybook/builder-webpack5': 8.2.9(@swc/core@1.7.11)(esbuild@0.21.5)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
       '@storybook/preset-react-webpack': 8.2.9(@swc/core@1.7.11)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))(typescript@5.5.4)
       '@types/node': 18.19.44
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -10575,11 +10575,11 @@ snapshots:
     dependencies:
       '@storybook/builder-webpack5': 8.2.9(@swc/core@1.7.11)(esbuild@0.23.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
       '@storybook/preset-react-webpack': 8.2.9(@swc/core@1.7.11)(esbuild@0.23.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))(typescript@5.5.4)
       '@types/node': 18.19.44
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -10590,15 +10590,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-webpack5@8.2.9(@swc/core@1.7.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)':
+  '@storybook/react-webpack5@8.2.9(@swc/core@1.7.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))(typescript@5.5.4)':
     dependencies:
-      '@storybook/builder-webpack5': 8.2.9(@swc/core@1.7.11)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
-      '@storybook/preset-react-webpack': 8.2.9(@swc/core@1.7.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/builder-webpack5': 8.2.9(@swc/core@1.7.11)(storybook@8.2.9(@babel/preset-env@7.25.3))(typescript@5.5.4)
+      '@storybook/preset-react-webpack': 8.2.9(@swc/core@1.7.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))(typescript@5.5.4)
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))(typescript@5.5.4)
       '@types/node': 18.19.44
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -10609,14 +10609,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)':
+  '@storybook/react@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))(typescript@5.5.4)':
     dependencies:
-      '@storybook/components': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))
+      '@storybook/components': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3))
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))
-      '@storybook/preview-api': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))
-      '@storybook/react-dom-shim': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))
-      '@storybook/theming': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))
+      '@storybook/manager-api': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3))
+      '@storybook/preview-api': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3))
+      '@storybook/react-dom-shim': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.3))
+      '@storybook/theming': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3))
       '@types/escodegen': 0.0.6
       '@types/estree': 0.0.51
       '@types/node': 18.19.44
@@ -10631,16 +10631,16 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-element-to-jsx-string: 15.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       util-deprecate: 1.0.2
     optionalDependencies:
       typescript: 5.5.4
 
-  '@storybook/theming@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)))':
+  '@storybook/theming@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.3))':
     dependencies:
-      storybook: 8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.3)
 
   '@swc/core-darwin-arm64@1.7.11':
     optional: true
@@ -14837,7 +14837,7 @@ snapshots:
 
   jsbn@1.1.0: {}
 
-  jscodeshift@0.15.2(@babel/preset-env@7.25.3(@babel/core@7.25.2)):
+  jscodeshift@0.15.2(@babel/preset-env@7.25.3):
     dependencies:
       '@babel/core': 7.25.2
       '@babel/parser': 7.25.3
@@ -16851,7 +16851,7 @@ snapshots:
     dependencies:
       internal-slot: 1.0.7
 
-  storybook@8.2.9(@babel/preset-env@7.25.3(@babel/core@7.25.2)):
+  storybook@8.2.9(@babel/preset-env@7.25.3):
     dependencies:
       '@babel/core': 7.25.2
       '@babel/types': 7.25.2
@@ -16871,7 +16871,7 @@ snapshots:
       fs-extra: 11.2.0
       giget: 1.2.3
       globby: 14.0.2
-      jscodeshift: 0.15.2(@babel/preset-env@7.25.3(@babel/core@7.25.2))
+      jscodeshift: 0.15.2(@babel/preset-env@7.25.3)
       leven: 3.1.0
       ora: 5.4.1
       prettier: 3.3.3


### PR DESCRIPTION
`sku` will reuse an existing tab if available in more Chromium browsers.

If the user's default browser is not Chromium based, there will be no change. If it is Chromium based, and the user has multiple supported Chromium browsers installed, the tab will open (or be reused) in:

* The user's default browser, if it is open, or if no browsers are open.
* Another supported browser, if it is open and the default browser is not open.

Using [default-browser](https://www.npmjs.com/package/default-browser) package instead of [x-default-browser](https://www.npmjs.com/package/x-default-browser) as it has support for Microsoft Edge and is more widely used.

NB:

This PR is heavily based on the changes from [this PR](https://github.com/facebook/create-react-app/pull/8367), referenced [here](https://github.com/seek-oss/sku/compare/open-edge-one-tab?expand=1#diff-b07bf4a632a44c85e64c21303e58f117e276133822fc8d1a0769e5fc2542d1daL2).
It is an update to https://github.com/seek-oss/sku/pull/426.