### PR TITLE
Use HTTPS URL for `zendesk/babel-plugin-react-displayname` dependency

### DIFF
--- a/.changeset/famous-spiders-thank.md
+++ b/.changeset/famous-spiders-thank.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Use HTTPS URL for `zendesk/babel-plugin-react-displayname` dependency to hopefully prevent it from being cloned via SSH

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -72,7 +72,7 @@
     "@vocab/phrase": "^2.0.1",
     "@vocab/pseudo-localize": "^1.0.1",
     "@vocab/webpack": "^1.2.9",
-    "@zendesk/babel-plugin-react-displayname": "zendesk/babel-plugin-react-displayname#7a837f2",
+    "@zendesk/babel-plugin-react-displayname": "https://github.com/zendesk/babel-plugin-react-displayname.git#7a837f2",
     "autoprefixer": "^10.3.1",
     "babel-jest": "^29.0.0",
     "babel-loader": "^9.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,7 +393,7 @@ importers:
         version: 3.0.3(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.21.5))
       '@storybook/react':
         specifier: ^8.1.5
-        version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+        version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@storybook/react-webpack5':
         specifier: ^8.1.5
         version: 8.2.9(@swc/core@1.7.18)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
@@ -411,7 +411,7 @@ importers:
         version: link:../../packages/sku
       storybook:
         specifier: ^8.1.5
-        version: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+        version: 8.2.9(@babel/preset-env@7.25.4)
 
   fixtures/styling:
     dependencies:
@@ -433,10 +433,10 @@ importers:
         version: 3.0.3(webpack@5.94.0(@swc/core@1.7.18))
       '@storybook/react':
         specifier: ^8.1.5
-        version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+        version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@storybook/react-webpack5':
         specifier: ^8.1.5
-        version: 8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+        version: 8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@types/react':
         specifier: ^18.2.3
         version: 18.3.4
@@ -454,7 +454,7 @@ importers:
         version: link:../../packages/sku
       storybook:
         specifier: ^8.1.5
-        version: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+        version: 8.2.9(@babel/preset-env@7.25.4)
 
   fixtures/translations:
     dependencies:
@@ -605,7 +605,7 @@ importers:
         specifier: ^1.2.9
         version: 1.2.9(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.23.1))
       '@zendesk/babel-plugin-react-displayname':
-        specifier: zendesk/babel-plugin-react-displayname#7a837f2
+        specifier: https://github.com/zendesk/babel-plugin-react-displayname.git#7a837f2
         version: https://codeload.github.com/zendesk/babel-plugin-react-displayname/tar.gz/7a837f2(@babel/core@7.25.2)(@babel/preset-react@7.24.7(@babel/core@7.25.2))
       autoprefixer:
         specifier: ^10.3.1
@@ -10160,14 +10160,14 @@ snapshots:
       '@storybook/blocks': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
       '@storybook/csf-plugin': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
+      '@storybook/react-dom-shim': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))
       '@types/react': 18.3.4
       fs-extra: 11.2.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       rehype-external-links: 3.0.0
       rehype-slug: 6.0.0
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -10201,7 +10201,7 @@ snapshots:
       memoizerific: 1.11.3
       polished: 4.3.1
       react-colorful: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       telejson: 7.2.0
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
@@ -10211,7 +10211,7 @@ snapshots:
 
   '@storybook/builder-webpack5@8.2.9(@swc/core@1.7.18)(esbuild@0.21.5)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
       '@types/node': 18.19.45
       '@types/semver': 7.5.8
       browser-assert: 1.2.1
@@ -10228,7 +10228,7 @@ snapshots:
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.21.5))
       terser-webpack-plugin: 5.3.10(@swc/core@1.7.18)(esbuild@0.21.5)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.21.5))
       ts-dedent: 2.2.0
@@ -10251,7 +10251,7 @@ snapshots:
 
   '@storybook/builder-webpack5@8.2.9(@swc/core@1.7.18)(esbuild@0.23.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
       '@types/node': 18.19.45
       '@types/semver': 7.5.8
       browser-assert: 1.2.1
@@ -10268,7 +10268,7 @@ snapshots:
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.23.1))
       terser-webpack-plugin: 5.3.10(@swc/core@1.7.18)(esbuild@0.23.1)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.23.1))
       ts-dedent: 2.2.0
@@ -10289,9 +10289,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/builder-webpack5@8.2.9(@swc/core@1.7.18)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
+  '@storybook/builder-webpack5@8.2.9(@swc/core@1.7.18)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
       '@types/node': 18.19.45
       '@types/semver': 7.5.8
       browser-assert: 1.2.1
@@ -10308,7 +10308,7 @@ snapshots:
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.7.18))
       terser-webpack-plugin: 5.3.10(@swc/core@1.7.18)(webpack@5.94.0(@swc/core@1.7.18))
       ts-dedent: 2.2.0
@@ -10339,7 +10339,7 @@ snapshots:
       '@types/cross-spawn': 6.0.6
       cross-spawn: 7.0.3
       globby: 14.0.2
-      jscodeshift: 0.15.2(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      jscodeshift: 0.15.2(@babel/preset-env@7.25.4)
       lodash: 4.17.21
       prettier: 3.3.3
       recast: 0.23.9
@@ -10349,14 +10349,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@storybook/components@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
+  '@storybook/components@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))':
     dependencies:
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
 
-  '@storybook/core-webpack@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
+  '@storybook/core-webpack@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))':
     dependencies:
       '@types/node': 18.19.45
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       ts-dedent: 2.2.0
 
   '@storybook/core@8.2.9':
@@ -10379,7 +10379,7 @@ snapshots:
 
   '@storybook/csf-plugin@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
     dependencies:
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       unplugin: 1.12.2
 
   '@storybook/csf@0.1.11':
@@ -10393,14 +10393,14 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/manager-api@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
+  '@storybook/manager-api@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))':
     dependencies:
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
 
   '@storybook/preset-react-webpack@8.2.9(@swc/core@1.7.18)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.4)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.21.5))
       '@types/node': 18.19.45
       '@types/semver': 7.5.8
@@ -10412,7 +10412,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.8
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       tsconfig-paths: 4.2.0
       webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.21.5)
     optionalDependencies:
@@ -10426,8 +10426,8 @@ snapshots:
 
   '@storybook/preset-react-webpack@8.2.9(@swc/core@1.7.18)(esbuild@0.23.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.4)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.23.1))
       '@types/node': 18.19.45
       '@types/semver': 7.5.8
@@ -10439,7 +10439,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.8
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       tsconfig-paths: 4.2.0
       webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.23.1)
     optionalDependencies:
@@ -10451,10 +10451,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/preset-react-webpack@8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
+  '@storybook/preset-react-webpack@8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.4)(webpack@5.94.0(@swc/core@1.7.18))
       '@types/node': 18.19.45
       '@types/semver': 7.5.8
@@ -10466,7 +10466,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.8
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       tsconfig-paths: 4.2.0
       webpack: 5.94.0(@swc/core@1.7.18)
     optionalDependencies:
@@ -10478,9 +10478,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/preview-api@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
+  '@storybook/preview-api@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))':
     dependencies:
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
 
   '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.5.4)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.21.5))':
     dependencies:
@@ -10524,21 +10524,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
+  '@storybook/react-dom-shim@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
 
   '@storybook/react-webpack5@8.2.9(@swc/core@1.7.18)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
     dependencies:
       '@storybook/builder-webpack5': 8.2.9(@swc/core@1.7.18)(esbuild@0.21.5)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
       '@storybook/preset-react-webpack': 8.2.9(@swc/core@1.7.18)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@types/node': 18.19.45
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -10553,11 +10553,11 @@ snapshots:
     dependencies:
       '@storybook/builder-webpack5': 8.2.9(@swc/core@1.7.18)(esbuild@0.23.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
       '@storybook/preset-react-webpack': 8.2.9(@swc/core@1.7.18)(esbuild@0.23.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@types/node': 18.19.45
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -10568,15 +10568,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-webpack5@8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
+  '@storybook/react-webpack5@8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)':
     dependencies:
-      '@storybook/builder-webpack5': 8.2.9(@swc/core@1.7.18)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
-      '@storybook/preset-react-webpack': 8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/builder-webpack5': 8.2.9(@swc/core@1.7.18)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
+      '@storybook/preset-react-webpack': 8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@types/node': 18.19.45
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -10587,14 +10587,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
+  '@storybook/react@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)':
     dependencies:
-      '@storybook/components': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
+      '@storybook/components': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
-      '@storybook/preview-api': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
-      '@storybook/react-dom-shim': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
-      '@storybook/theming': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
+      '@storybook/manager-api': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
+      '@storybook/preview-api': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
+      '@storybook/react-dom-shim': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))
+      '@storybook/theming': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
       '@types/escodegen': 0.0.6
       '@types/estree': 0.0.51
       '@types/node': 18.19.45
@@ -10609,16 +10609,16 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-element-to-jsx-string: 15.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       util-deprecate: 1.0.2
     optionalDependencies:
       typescript: 5.5.4
 
-  '@storybook/theming@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
+  '@storybook/theming@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))':
     dependencies:
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
 
   '@swc/core-darwin-arm64@1.7.18':
     optional: true
@@ -14796,7 +14796,7 @@ snapshots:
 
   jsbn@1.1.0: {}
 
-  jscodeshift@0.15.2(@babel/preset-env@7.25.4(@babel/core@7.25.2)):
+  jscodeshift@0.15.2(@babel/preset-env@7.25.4):
     dependencies:
       '@babel/core': 7.25.2
       '@babel/parser': 7.25.4
@@ -16810,7 +16810,7 @@ snapshots:
     dependencies:
       internal-slot: 1.0.7
 
-  storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)):
+  storybook@8.2.9(@babel/preset-env@7.25.4):
     dependencies:
       '@babel/core': 7.25.2
       '@babel/types': 7.25.4
@@ -16830,7 +16830,7 @@ snapshots:
       fs-extra: 11.2.0
       giget: 1.2.3
       globby: 14.0.2
-      jscodeshift: 0.15.2(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      jscodeshift: 0.15.2(@babel/preset-env@7.25.4)
       leven: 3.1.0
       ora: 5.4.1
       prettier: 3.3.3


### PR DESCRIPTION
It has been observed internally that PNPM will sometimes replace the artifact URL for a github dependency with an SSH URL.

The only relevant PNPM issue I could find was https://github.com/pnpm/pnpm/issues/4527. I'm not sure if this fix on `sku`'s end will actually prevent it from happening again because the resolution of the dependency is in PNPM's hands, but it's worth a shot.