### PR TITLE
Replace `@antfu/ni` and remove `@manypkg/find-root`

### DIFF
--- a/.changeset/healthy-pets-share.md
+++ b/.changeset/healthy-pets-share.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Replace `@manypkg/find-root` dependency with `find-up`

--- a/.changeset/slow-crabs-visit.md
+++ b/.changeset/slow-crabs-visit.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Replace `@antfu/ni` dependency with `package-manager-detector`

--- a/packages/sku/config/lintStaged/lintStagedConfig.js
+++ b/packages/sku/config/lintStaged/lintStagedConfig.js
@@ -1,6 +1,6 @@
 const { isYarn } = require('../../lib/packageManager');
 const { lintExtensions } = require('../../lib/lint');
-const { getCommand } = require('@antfu/ni');
+const { getCommand } = require('../../lib/packageManager');
 
 /**
  * @type {import('lint-staged').Config}

--- a/packages/sku/lib/packageManager.js
+++ b/packages/sku/lib/packageManager.js
@@ -164,6 +164,7 @@ module.exports = {
   isYarn,
   isPnpm,
   isNpm,
+  getCommand,
   getRunCommand,
   getExecuteCommand,
   getAddCommand,

--- a/packages/sku/lib/parseArgs.js
+++ b/packages/sku/lib/parseArgs.js
@@ -1,4 +1,7 @@
+// @ts-check
+
 const minimist = require('minimist');
+
 /**
  * Supports parsing args that look like:
  * [/path/to/node/node, /path/to/sku, scriptName, arg1, arg2]

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -58,7 +58,6 @@
     "@loadable/component": "^5.14.1",
     "@loadable/server": "^5.14.0",
     "@loadable/webpack-plugin": "^5.14.0",
-    "@manypkg/find-root": "^2.2.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
     "@swc/core": "^1.6.13",
     "@types/express": "^4.17.11",

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -46,7 +46,6 @@
     }
   },
   "dependencies": {
-    "@antfu/ni": "^0.21.8",
     "@babel/core": "^7.21.8",
     "@babel/plugin-transform-react-constant-elements": "^7.21.3",
     "@babel/plugin-transform-react-inline-elements": "^7.21.0",
@@ -61,8 +60,8 @@
     "@loadable/webpack-plugin": "^5.14.0",
     "@manypkg/find-root": "^2.2.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
-    "@types/express": "^4.17.11",
     "@swc/core": "^1.6.13",
+    "@types/express": "^4.17.11",
     "@types/jest": "^29.0.0",
     "@types/loadable__component": "^5.13.1",
     "@types/loadable__server": "^5.12.10",
@@ -117,6 +116,7 @@
     "nano-memoize": "^3.0.16",
     "node-html-parser": "^6.1.1",
     "open": "^7.3.1",
+    "package-manager-detector": "^0.2.0",
     "path-to-regexp": "^6.2.0",
     "picomatch": "^3.0.1",
     "postcss": "^8.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,16 +387,16 @@ importers:
     devDependencies:
       '@storybook/addon-docs':
         specifier: ^8.2.8
-        version: 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
+        version: 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.3
-        version: 3.0.3(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.21.5))
+        version: 3.0.3(webpack@5.94.0(@swc/core@1.7.18))
       '@storybook/react':
         specifier: ^8.1.5
         version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@storybook/react-webpack5':
         specifier: ^8.1.5
-        version: 8.2.9(@swc/core@1.7.18)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+        version: 8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@types/react':
         specifier: ^18.2.3
         version: 18.3.4
@@ -430,13 +430,13 @@ importers:
         version: link:../../test-utils
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.3
-        version: 3.0.3(webpack@5.94.0(@swc/core@1.7.18))
+        version: 3.0.3(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.21.5))
       '@storybook/react':
         specifier: ^8.1.5
         version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@storybook/react-webpack5':
         specifier: ^8.1.5
-        version: 8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
+        version: 8.2.9(@swc/core@1.7.18)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
       '@types/react':
         specifier: ^18.2.3
         version: 18.3.4
@@ -559,9 +559,6 @@ importers:
       '@loadable/webpack-plugin':
         specifier: ^5.14.0
         version: 5.15.2(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.23.1))
-      '@manypkg/find-root':
-        specifier: ^2.2.0
-        version: 2.2.3
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: ^0.5.15
         version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4(debug@4.3.6)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.23.1)))(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.23.1))
@@ -7001,6 +6998,7 @@ packages:
 
   react-focus-lock@2.13.0:
     resolution: {integrity: sha512-w7aIcTwZwNzUp2fYQDMICy+khFwVmKmOrLF8kNsPS+dz4Oi/oxoVJ2wCMVvX6rWGriM/+mYaTyp1MRmkcs2amw==}
+    deprecated: incorrect typescript definition
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -10156,12 +10154,12 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@storybook/addon-docs@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
+  '@storybook/addon-docs@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))':
     dependencies:
       '@babel/core': 7.25.2
       '@mdx-js/react': 3.0.1(@types/react@18.3.4)(react@18.3.1)
-      '@storybook/blocks': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
-      '@storybook/csf-plugin': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
+      '@storybook/blocks': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))
+      '@storybook/csf-plugin': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))
       '@types/react': 18.3.4
@@ -10191,7 +10189,7 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/blocks@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
+  '@storybook/blocks@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))':
     dependencies:
       '@storybook/csf': 0.1.11
       '@storybook/global': 5.0.0
@@ -10380,7 +10378,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@storybook/csf-plugin@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
+  '@storybook/csf-plugin@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))':
     dependencies:
       storybook: 8.2.9(@babel/preset-env@7.25.4)
       unplugin: 1.12.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,7 +393,7 @@ importers:
         version: 3.0.3(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.21.5))
       '@storybook/react':
         specifier: ^8.1.5
-        version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+        version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@storybook/react-webpack5':
         specifier: ^8.1.5
         version: 8.2.9(@swc/core@1.7.18)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
@@ -411,7 +411,7 @@ importers:
         version: link:../../packages/sku
       storybook:
         specifier: ^8.1.5
-        version: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+        version: 8.2.9(@babel/preset-env@7.25.4)
 
   fixtures/styling:
     dependencies:
@@ -433,10 +433,10 @@ importers:
         version: 3.0.3(webpack@5.94.0(@swc/core@1.7.18))
       '@storybook/react':
         specifier: ^8.1.5
-        version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+        version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@storybook/react-webpack5':
         specifier: ^8.1.5
-        version: 8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+        version: 8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@types/react':
         specifier: ^18.2.3
         version: 18.3.4
@@ -454,7 +454,7 @@ importers:
         version: link:../../packages/sku
       storybook:
         specifier: ^8.1.5
-        version: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+        version: 8.2.9(@babel/preset-env@7.25.4)
 
   fixtures/translations:
     dependencies:
@@ -523,9 +523,6 @@ importers:
 
   packages/sku:
     dependencies:
-      '@antfu/ni':
-        specifier: ^0.21.8
-        version: 0.21.12
       '@babel/core':
         specifier: ^7.21.8
         version: 7.25.2
@@ -742,6 +739,9 @@ importers:
       open:
         specifier: ^7.3.1
         version: 7.4.2
+      package-manager-detector:
+        specifier: ^0.2.0
+        version: 0.2.0
       path-to-regexp:
         specifier: ^6.2.0
         version: 6.2.2
@@ -6452,6 +6452,9 @@ packages:
     resolution: {integrity: sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==}
     engines: {node: '>=8'}
 
+  package-manager-detector@0.2.0:
+    resolution: {integrity: sha512-E385OSk9qDcXhcM9LNSe4sdhx8a9mAPrZ4sMLW+tmxl5ZuGtPUcdFu+MPP2jbgiWAZ6Pfe5soGFMd+0Db5Vrog==}
+
   param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
 
@@ -10160,14 +10163,14 @@ snapshots:
       '@storybook/blocks': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
       '@storybook/csf-plugin': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
+      '@storybook/react-dom-shim': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))
       '@types/react': 18.3.4
       fs-extra: 11.2.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       rehype-external-links: 3.0.0
       rehype-slug: 6.0.0
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -10201,7 +10204,7 @@ snapshots:
       memoizerific: 1.11.3
       polished: 4.3.1
       react-colorful: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       telejson: 7.2.0
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
@@ -10211,7 +10214,7 @@ snapshots:
 
   '@storybook/builder-webpack5@8.2.9(@swc/core@1.7.18)(esbuild@0.21.5)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
       '@types/node': 18.19.45
       '@types/semver': 7.5.8
       browser-assert: 1.2.1
@@ -10228,7 +10231,7 @@ snapshots:
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.21.5))
       terser-webpack-plugin: 5.3.10(@swc/core@1.7.18)(esbuild@0.21.5)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.21.5))
       ts-dedent: 2.2.0
@@ -10251,7 +10254,7 @@ snapshots:
 
   '@storybook/builder-webpack5@8.2.9(@swc/core@1.7.18)(esbuild@0.23.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
       '@types/node': 18.19.45
       '@types/semver': 7.5.8
       browser-assert: 1.2.1
@@ -10268,7 +10271,7 @@ snapshots:
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.23.1))
       terser-webpack-plugin: 5.3.10(@swc/core@1.7.18)(esbuild@0.23.1)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.23.1))
       ts-dedent: 2.2.0
@@ -10289,9 +10292,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/builder-webpack5@8.2.9(@swc/core@1.7.18)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
+  '@storybook/builder-webpack5@8.2.9(@swc/core@1.7.18)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
       '@types/node': 18.19.45
       '@types/semver': 7.5.8
       browser-assert: 1.2.1
@@ -10308,7 +10311,7 @@ snapshots:
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.7.18))
       terser-webpack-plugin: 5.3.10(@swc/core@1.7.18)(webpack@5.94.0(@swc/core@1.7.18))
       ts-dedent: 2.2.0
@@ -10339,7 +10342,7 @@ snapshots:
       '@types/cross-spawn': 6.0.6
       cross-spawn: 7.0.3
       globby: 14.0.2
-      jscodeshift: 0.15.2(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      jscodeshift: 0.15.2(@babel/preset-env@7.25.4)
       lodash: 4.17.21
       prettier: 3.3.3
       recast: 0.23.9
@@ -10349,14 +10352,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@storybook/components@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
+  '@storybook/components@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))':
     dependencies:
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
 
-  '@storybook/core-webpack@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
+  '@storybook/core-webpack@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))':
     dependencies:
       '@types/node': 18.19.45
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       ts-dedent: 2.2.0
 
   '@storybook/core@8.2.9':
@@ -10379,7 +10382,7 @@ snapshots:
 
   '@storybook/csf-plugin@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
     dependencies:
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       unplugin: 1.12.2
 
   '@storybook/csf@0.1.11':
@@ -10393,14 +10396,14 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/manager-api@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
+  '@storybook/manager-api@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))':
     dependencies:
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
 
   '@storybook/preset-react-webpack@8.2.9(@swc/core@1.7.18)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.4)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.21.5))
       '@types/node': 18.19.45
       '@types/semver': 7.5.8
@@ -10412,7 +10415,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.8
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       tsconfig-paths: 4.2.0
       webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.21.5)
     optionalDependencies:
@@ -10426,8 +10429,8 @@ snapshots:
 
   '@storybook/preset-react-webpack@8.2.9(@swc/core@1.7.18)(esbuild@0.23.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.4)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.23.1))
       '@types/node': 18.19.45
       '@types/semver': 7.5.8
@@ -10439,7 +10442,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.8
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       tsconfig-paths: 4.2.0
       webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.23.1)
     optionalDependencies:
@@ -10451,10 +10454,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/preset-react-webpack@8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
+  '@storybook/preset-react-webpack@8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/core-webpack': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.4)(webpack@5.94.0(@swc/core@1.7.18))
       '@types/node': 18.19.45
       '@types/semver': 7.5.8
@@ -10466,7 +10469,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.8
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       tsconfig-paths: 4.2.0
       webpack: 5.94.0(@swc/core@1.7.18)
     optionalDependencies:
@@ -10478,9 +10481,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/preview-api@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
+  '@storybook/preview-api@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))':
     dependencies:
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
 
   '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.5.4)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.21.5))':
     dependencies:
@@ -10524,21 +10527,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
+  '@storybook/react-dom-shim@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
 
   '@storybook/react-webpack5@8.2.9(@swc/core@1.7.18)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
     dependencies:
       '@storybook/builder-webpack5': 8.2.9(@swc/core@1.7.18)(esbuild@0.21.5)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
       '@storybook/preset-react-webpack': 8.2.9(@swc/core@1.7.18)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@types/node': 18.19.45
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -10553,11 +10556,11 @@ snapshots:
     dependencies:
       '@storybook/builder-webpack5': 8.2.9(@swc/core@1.7.18)(esbuild@0.23.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
       '@storybook/preset-react-webpack': 8.2.9(@swc/core@1.7.18)(esbuild@0.23.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@types/node': 18.19.45
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -10568,15 +10571,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-webpack5@8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
+  '@storybook/react-webpack5@8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)':
     dependencies:
-      '@storybook/builder-webpack5': 8.2.9(@swc/core@1.7.18)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
-      '@storybook/preset-react-webpack': 8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
-      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)
+      '@storybook/builder-webpack5': 8.2.9(@swc/core@1.7.18)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
+      '@storybook/preset-react-webpack': 8.2.9(@swc/core@1.7.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
+      '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)
       '@types/node': 18.19.45
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -10587,14 +10590,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(typescript@5.5.4)':
+  '@storybook/react@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))(typescript@5.5.4)':
     dependencies:
-      '@storybook/components': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
+      '@storybook/components': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
-      '@storybook/preview-api': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
-      '@storybook/react-dom-shim': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
-      '@storybook/theming': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
+      '@storybook/manager-api': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
+      '@storybook/preview-api': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
+      '@storybook/react-dom-shim': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4))
+      '@storybook/theming': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))
       '@types/escodegen': 0.0.6
       '@types/estree': 0.0.51
       '@types/node': 18.19.45
@@ -10609,16 +10612,16 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-element-to-jsx-string: 15.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       semver: 7.6.3
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       util-deprecate: 1.0.2
     optionalDependencies:
       typescript: 5.5.4
 
-  '@storybook/theming@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))':
+  '@storybook/theming@8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4))':
     dependencies:
-      storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      storybook: 8.2.9(@babel/preset-env@7.25.4)
 
   '@swc/core-darwin-arm64@1.7.18':
     optional: true
@@ -14796,7 +14799,7 @@ snapshots:
 
   jsbn@1.1.0: {}
 
-  jscodeshift@0.15.2(@babel/preset-env@7.25.4(@babel/core@7.25.2)):
+  jscodeshift@0.15.2(@babel/preset-env@7.25.4):
     dependencies:
       '@babel/core': 7.25.2
       '@babel/parser': 7.25.4
@@ -15512,6 +15515,8 @@ snapshots:
       registry-auth-token: 4.2.2
       registry-url: 5.1.0
       semver: 6.3.1
+
+  package-manager-detector@0.2.0: {}
 
   param-case@3.0.4:
     dependencies:
@@ -16810,7 +16815,7 @@ snapshots:
     dependencies:
       internal-slot: 1.0.7
 
-  storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)):
+  storybook@8.2.9(@babel/preset-env@7.25.4):
     dependencies:
       '@babel/core': 7.25.2
       '@babel/types': 7.25.4
@@ -16830,7 +16835,7 @@ snapshots:
       fs-extra: 11.2.0
       giget: 1.2.3
       globby: 14.0.2
-      jscodeshift: 0.15.2(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      jscodeshift: 0.15.2(@babel/preset-env@7.25.4)
       leven: 3.1.0
       ora: 5.4.1
       prettier: 3.3.3


### PR DESCRIPTION
`@antfu/ni` is both a CLI and a library, but we don't use the CLI in sku. [`package-manager-detector`](https://github.com/antfu-collective/package-manager-detector) (also an antfu package) is basically just the package manager detection/command constructor part of `@antfu/ni`, which is all we need.

I've also removed `@manypkg/find-root`, which IMO has a bad API anyway, with just using `find-up` (an existing sku dep) to find the closest lockfile. This is pretty much the same method `@manypkg/find-root` and `package-manager-detector` use internally anyway.

The reason we don't use `package-manager-detector` to detect the package manager is because it only provides an async function to do so, which we can't use in our `packageManager` module as it relies on the global scope.