### PR TITLE
Update `didyoumean2` dep to fix `npx sku init`

### DIFF
--- a/.changeset/pretty-meals-tie.md
+++ b/.changeset/pretty-meals-tie.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Update `didyoumean2` dependency to fix issue when running `npx sku init`

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -89,7 +89,7 @@
     "debug": "^4.3.1",
     "dedent": "^1.5.1",
     "default-browser": "^5.2.1",
-    "didyoumean2": "^6.0.1",
+    "didyoumean2": "^7.0.2",
     "ensure-gitignore": "^1.1.2",
     "env-ci": "^7.0.0",
     "esbuild": ">0.19.7 <1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -656,8 +656,8 @@ importers:
         specifier: ^5.2.1
         version: 5.2.1
       didyoumean2:
-        specifier: ^6.0.1
-        version: 6.0.1
+        specifier: ^7.0.2
+        version: 7.0.2
       ensure-gitignore:
         specifier: ^1.1.2
         version: 1.2.0
@@ -4029,6 +4029,10 @@ packages:
   didyoumean2@6.0.1:
     resolution: {integrity: sha512-PSy0zQwMg5O+LjT5Mz7vnKC8I7DfWLPF6M7oepqW7WP5mn2CY3hz46xZOa1GJY+KVfyXhdmz6+tdgXwrHlZc5g==}
     engines: {node: ^16.14.0 || >=18.12.0}
+
+  didyoumean2@7.0.2:
+    resolution: {integrity: sha512-zK9I8vmMjmhwhFv52Trd4we5cr++mvhPp2HWswZK/+8vmozMNR7WelZqtCNV+4OHspgKfMvHexBp9wxgCGs56w==}
+    engines: {node: ^18.12.0 || >=20.9.0}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -12000,6 +12004,12 @@ snapshots:
   devtools-protocol@0.0.1312386: {}
 
   didyoumean2@6.0.1:
+    dependencies:
+      '@babel/runtime': 7.25.6
+      fastest-levenshtein: 1.0.16
+      lodash.deburr: 4.1.0
+
+  didyoumean2@7.0.2:
     dependencies:
       '@babel/runtime': 7.25.6
       fastest-levenshtein: 1.0.16


### PR DESCRIPTION
Running `npx sku init my-app` fails on `node@18.20.1/npm@10.5.0` with no error message. Adding `--loglevel=verbose` surfaced this log line:

```
npm info run didyoumean2@6.0.1 postinstall { code: 127, signal: null }
```

This lead me to believe that the cause of the failure was probably the issue that Karl raised a while ago https://github.com/foray1010/didyoumean2/issues/1531. Figured the fix would eventually come through via renovate, but that hasn't happened for some reason, so I'm updating it manually.