### PR TITLE
Revert #1039

### DIFF
--- a/.changeset/ninety-glasses-run.md
+++ b/.changeset/ninety-glasses-run.md
@@ -1,0 +1,7 @@
+---
+'sku': patch
+---
+
+Reverts #1039
+
+This change was causing a dependency to be cloned via `git` which may not be available in all CI envrionments.

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -70,7 +70,7 @@
     "@vocab/phrase": "^2.0.1",
     "@vocab/pseudo-localize": "^1.0.1",
     "@vocab/webpack": "^1.2.9",
-    "@zendesk/babel-plugin-react-displayname": "https://github.com/zendesk/babel-plugin-react-displayname.git#7a837f2",
+    "@zendesk/babel-plugin-react-displayname": "https://codeload.github.com/zendesk/babel-plugin-react-displayname/tar.gz/7a837f2",
     "autoprefixer": "^10.3.1",
     "babel-jest": "^29.0.0",
     "babel-loader": "^9.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -599,7 +599,7 @@ importers:
         specifier: ^1.2.9
         version: 1.2.9(webpack@5.94.0(@swc/core@1.7.26)(esbuild@0.23.1))
       '@zendesk/babel-plugin-react-displayname':
-        specifier: https://github.com/zendesk/babel-plugin-react-displayname.git#7a837f2
+        specifier: https://codeload.github.com/zendesk/babel-plugin-react-displayname/tar.gz/7a837f2
         version: https://codeload.github.com/zendesk/babel-plugin-react-displayname/tar.gz/7a837f2(@babel/core@7.25.2)(@babel/preset-react@7.24.7(@babel/core@7.25.2))
       autoprefixer:
         specifier: ^10.3.1


### PR DESCRIPTION
#1039 was causing the `zendesk/babel-plugin-react-displayname` dependency to be cloned via `git` which may not be available in all CI envrionments.

We could alternatively depend on the actual source code tar `https://codeload.github.com/zendesk/babel-plugin-react-displayname/tar.gz/7a837f2` but that seems risky and unnecessary. The issue that #1039 attempted to fix seems to be ephemeral anyway.