### PR TITLE
Disable `babel-loader` cache compression

### DIFF
--- a/.changeset/cuddly-cooks-grin.md
+++ b/.changeset/cuddly-cooks-grin.md
@@ -1,0 +1,7 @@
+---
+'sku': patch
+---
+
+Disable `babel-loader` cache compression
+
+`sku` applications tend to transpile many modules and upload all cache files as a single compressed file. This makes compressing each individual cache file superfluous, so this feature has been disabled.

--- a/packages/sku/config/babel/babelConfig.js
+++ b/packages/sku/config/babel/babelConfig.js
@@ -101,6 +101,7 @@ module.exports = ({
     ...(!isJest
       ? {
           cacheDirectory: true,
+          cacheCompression: false,
         }
       : {}),
     presets,

--- a/packages/sku/config/webpack/webpack.config.js
+++ b/packages/sku/config/webpack/webpack.config.js
@@ -177,6 +177,7 @@ const makeWebpackConfig = ({
                       options: {
                         babelrc: false,
                         cacheDirectory: true,
+                        cacheCompression: false,
                         presets: [
                           [
                             require.resolve('@babel/preset-env'),

--- a/packages/sku/config/webpack/webpack.config.ssr.js
+++ b/packages/sku/config/webpack/webpack.config.ssr.js
@@ -140,6 +140,7 @@ const makeWebpackConfig = ({
                       options: {
                         babelrc: false,
                         cacheDirectory: true,
+                        cacheCompression: false,
                         presets: [
                           [
                             require.resolve('@babel/preset-env'),


### PR DESCRIPTION
`sku` applications tend to transpile many modules and upload all cache files as a single compressed file. This makes compressing each individual cache file superfluous, so this feature has been disabled.