### PR TITLE
`start` script: Add fallback browser names to supported browser list

### DIFF
--- a/.changeset/nine-penguins-attend.md
+++ b/.changeset/nine-penguins-attend.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Adds "Chrome" and "Edge" as fallback browser names for the reusing existing tabs, improving compatibility with different Chromium browser versions which may use abbreviated browser names.

--- a/.changeset/nine-penguins-attend.md
+++ b/.changeset/nine-penguins-attend.md
@@ -2,4 +2,4 @@
 'sku': patch
 ---
 
-Adds "Chrome" and "Edge" as fallback browser names for the reusing existing tabs, improving compatibility with different Chromium browser versions which may use abbreviated browser names.
+Adds "Chrome" and "Edge" as fallback browser names for reusing existing tabs, improving compatibility with different Chromium browser versions which may use abbreviated browser names.

--- a/packages/sku/lib/openBrowser/index.js
+++ b/packages/sku/lib/openBrowser/index.js
@@ -9,8 +9,10 @@ const isCI = require('../isCI');
 const OSX_CHROME = 'google chrome';
 
 const supportedChromiumBrowsers = [
+  'Chrome',
   'Google Chrome',
   'Google Chrome Canary',
+  'Edge',
   'Microsoft Edge',
   'Brave Browser',
   'Vivaldi',


### PR DESCRIPTION
Fix bug from https://github.com/seek-oss/sku/pull/1036

Looks like certain instances of Chrome use "Google Chrome" and others "Chrome" as their respective names. "Chrome" was not in the supported browser list and was not being picked up correctly.
Adds both names for fallback purposes to ensure the feature works in more versions. Also giving "Edge" the same treatment.

Have tested locally and appears to be working