### PR TITLE
Remove fallback config from `babel-loader` cache docs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -58,7 +58,6 @@ jobs:
         with:
           path: 'fixtures/*/node_modules/.cache/babel-loader'
           key: babel-loader-${{ runner.os }}-${{ hashFiles('./pnpm-lock.yaml') }}
-          restore-keys: babel-loader-${{ runner.os }}-
 
       - name: Install Puppeteer
         if: steps.puppeteer-cache.outputs.cache-hit != 'true'

--- a/docs/docs/extra-features.md
+++ b/docs/docs/extra-features.md
@@ -98,14 +98,11 @@ steps:
       BUILDKITE_PLUGIN_S3_CACHE_BUCKET: my-buildkite-cache-bucket
       BUILDKITE_PLUGIN_S3_CACHE_PREFIX: my-app-babel-loader-cache
     plugins:
-      # v1.1.0 allows saving the cache at multiple levels
       - cache#v1.1.0:
           path: ./node_modules/.cache/babel-loader
-          restore: pipeline
+          restore: file
           save:
             - file
-            # Pipeline-level cache is used as a stale fallback if the manifest doesn't match
-            - pipeline
           manifest: pnpm-lock.yaml
           backend: s3
           compression: tgz
@@ -127,7 +124,6 @@ To utilize the `babel-loader` cache in GitHub actions, you can use the [cache ac
   with:
     path: 'node_modules/.cache/babel-loader'
     key: babel-loader-${{ runner.os }}-${{ hashFiles('./pnpm-lock.yaml') }}
-    restore-keys: babel-loader-${{ runner.os }}-
 ```
 
 [cache action]: https://github.com/actions/cache


### PR DESCRIPTION
This PR removes the config from the docs that enables a stale fallback to be utilized for the `babel-loader` cache. Stale fallbacks are no longer recommended.

There are a few issues with these stale fallbacks:
- The buildkite cache plugin uses [the buildkite organization slug as a cache key](https://github.com/buildkite-plugins/cache-buildkite-plugin/blob/d0177d1afda90a6f0beff16f1a4e1ebf6d4391bc/lib/shared.bash#L50) for `pipeline`-level caches. It also doesn't upload less specific cache levels if more specific levels update. This means that the `pipeline`-level cache will only ever be saved once (the very first time it runs), and never updated (unless it's deleted). This makes the fallback get more stale as time goes on.
- `babel-loader` does not clean up stale cache files, it only populates the cache with new files if necessary. This means that stale cache files accumulate over time as the cache is used across many builds. For example, sku's babel-loader cache files were about 45mb until I deleted them all, after which the cache file dropped down to ~2.5mb (which has already increased to [7+mb](https://github.com/seek-oss/sku/actions/caches?query=key%3Ababel-loader+))

For these reasons, I no longer thing we should recommend configuring a stale fallback cache. Even if there was an option to update the `pipeline` cache when the `file` cache is updated, it still wouldn't prevent stale cache files from accumulating.

The main benefit of this is that stored caches shouldn't increase in size over time as they will no longer store stale cache files. This will result in smaller downloads and uploads, relative to the current state.

The main downside of doing this is that commits that bust the cache (contain a lockfile change) will no longer hit a cache, making the sku build slower for that CI build.

I think the benefits outweigh the downsides here. Not having an ever-increasing cache size is better than having a few slower builds here and there. Builds merged into master will always hit a fresh cache, which is good. LMK if you have any other thoughts on the matter.
