### PR TITLE
Update storybook docs TSConfig example

### DIFF
--- a/docs/docs/storybook.md
+++ b/docs/docs/storybook.md
@@ -59,7 +59,7 @@ export default {
     ...config,
     include: [
       '**/*', // Implicit default value if `include` is not set and `files` is not set
-      '.storybook/*', // 👈 Add this line
+      '.storybook/**/*', // 👈 Add this line
     ],
   }),
 } satisfies SkuConfig;


### PR DESCRIPTION
Realized that `.storybook/*` will only hit top-level files, so files in nested directories will not be included.