### PR TITLE
fix error when determining default browser in `start` script

### DIFF
--- a/.changeset/three-bugs-sip.md
+++ b/.changeset/three-bugs-sip.md
@@ -4,5 +4,5 @@
 
 Improve error handling and messaging when opening the user's browser during the `start`, `start-ssr` and `serve` scripts
 
-This fixes a macOS error when the user's terminal application's Finder automation permissions were disabled, which caused an error when trying to detect the user's default browser.
-This change provides instructions to resolve the system permission issue and prevents script failure.
+This fixes a macOS error where `sku` would crash when failing to detect the user's default browser. 
+Instead, the user will be shown a warning message with instructions to enable the system permission required to fix the issue.

--- a/.changeset/three-bugs-sip.md
+++ b/.changeset/three-bugs-sip.md
@@ -2,7 +2,7 @@
 'sku': patch
 ---
 
-Improve error handling and messaging in `start` script.
+Improve error handling and messaging when opening the user's browser during the `start`, `start-ssr` and `serve` scripts
 
 This fixes a macOS error when the user's terminal application's Finder automation permissions were disabled, which caused an error when trying to detect the user's default browser.
 This change provides instructions to resolve the system permission issue and prevents script failure.

--- a/.changeset/three-bugs-sip.md
+++ b/.changeset/three-bugs-sip.md
@@ -1,0 +1,8 @@
+---
+'sku': patch
+---
+
+Improve error handling and messaging in `start` script.
+
+This fixes a macOS error when the user's terminal application's Finder automation permissions were disabled, which caused an error when trying to detect the user's default browser.
+This change provides instructions to resolve the system permission issue and prevents script failure.

--- a/packages/sku/lib/openBrowser/index.js
+++ b/packages/sku/lib/openBrowser/index.js
@@ -1,6 +1,7 @@
 // Inspired by create-react-app
 // https://github.com/facebook/create-react-app/commit/d2de54b25cc25800df1764058997e3e274bd79ac
 
+const { yellow, italic } = require('chalk');
 const execSync = require('node:child_process').execSync;
 const open = require('open');
 
@@ -23,7 +24,20 @@ const supportedChromiumBrowsers = [
 module.exports = async (url) => {
   if (process.env.OPEN_TAB !== 'false' && !isCI) {
     const { default: getDefaultBrowser } = await import('default-browser');
-    const { name: defaultBrowser } = await getDefaultBrowser();
+    let defaultBrowser;
+    try {
+      const { name } = await getDefaultBrowser();
+      defaultBrowser = name;
+    } catch (e) {
+      console.log(yellow.bold('Failed to detect default browser.'));
+      console.log(
+        yellow(
+          `For a better ${italic('start')} experience on macOS, go to ${italic(
+            'System Preferences > Privacy & Security > Automation > Terminal/Application',
+          )} and enable Finder permissions.`,
+        ),
+      );
+    }
 
     const availableBrowser = process.env.BROWSER;
 


### PR DESCRIPTION
Improve error handling and messaging in `start` script.

This fixes a macOS error when the user's terminal application's Finder automation permissions were disabled, which caused an error when trying to detect the user's default browser.
This change provides instructions to resolve the system permission issue and prevents script failure.