### PR TITLE
fix missing eslint config issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,3 +97,11 @@ This repo uses [changesets] for publishing new versions.
 If this is your first time using changesets, please read the documentation available in the changesets repo.
 
 [changesets]: https://github.com/changesets/changesets
+
+## Troubleshooting
+
+When running `lint`, if you encounter an error about a missing ESLint configuration file, you can run the following command to regenerate all sku fixture configuration files:
+
+```sh
+pnpm --filter="@sku-fixtures/*" exec sku configure
+```

--- a/fixtures/sku-webpack-plugin/.gitignore
+++ b/fixtures/sku-webpack-plugin/.gitignore
@@ -1,0 +1,14 @@
+# this fixture doesn't use sku's CLI, and doesn't need these files either
+# these should never be committed 
+.eslintignore
+.prettierignore
+
+# managed by sku
+.eslintcache
+.eslintrc
+.prettierrc
+coverage/
+dist/
+report/
+tsconfig.json
+# end managed by sku


### PR DESCRIPTION
Fixes an issue when running `lint` and getting an error about a missing ESLint configuration file