### PR TITLE
Remove `storybook` and `build-storybook` CLI command docs

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -110,26 +110,6 @@ sku format
 
 [linting/formatting documentation]: ./docs/linting.md
 
-### `storybook`
-
-Start a local Storybook server.
-See the [Storybook documentation] for more information.
-
-```sh
-sku storybook
-```
-
-### `build-storybook`
-
-Build a static version of your Storybook.
-See the [Storybook documentation] for more information.
-
-```sh
-sku build-storybook
-```
-
-[Storybook documentation]: ./docs/storybook.md
-
 ### `pre-commit`
 
 Run the `sku` pre-commit hook.


### PR DESCRIPTION
These commands were [removed in v13](https://github.com/seek-oss/sku/blob/4be885314ee817d18943e63678fb054e1196f671/packages/sku/CHANGELOG.md#update-packagejson-scripts).