### PR TITLE
Update `browserslist-config-seek` to version 3.1.0, and pin version

### DIFF
--- a/.changeset/nice-brooms-whisper.md
+++ b/.changeset/nice-brooms-whisper.md
@@ -2,4 +2,4 @@
 'sku': minor
 ---
 
-Update `browserslist-config-seek` to version 3.1.0.
+Update and pin `browserslist-config-seek` to version `3.1.0`

--- a/.changeset/nice-brooms-whisper.md
+++ b/.changeset/nice-brooms-whisper.md
@@ -1,0 +1,5 @@
+---
+'sku': minor
+---
+
+Update `browserslist-config-seek` to version 3.1.0.

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -84,7 +84,7 @@
     "babel-plugin-transform-remove-imports": "^1.7.0",
     "babel-plugin-unassert": "^3.1.0",
     "browserslist": "^4.16.1",
-    "browserslist-config-seek": "^3.0.0",
+    "browserslist-config-seek": "3.1.0",
     "chalk": "^4.1.0",
     "cross-spawn": "^7.0.3",
     "css-loader": "^6.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -663,8 +663,8 @@ importers:
         specifier: ^4.16.1
         version: 4.24.0
       browserslist-config-seek:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: 3.1.0
+        version: 3.1.0
       chalk:
         specifier: ^4.1.0
         version: 4.1.2
@@ -869,7 +869,7 @@ importers:
         version: 1.1.11(react@18.3.1)
       braid-design-system:
         specifier: ^32.0.0
-        version: 32.24.1(@types/react@18.3.11)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sku@13.2.0(@storybook/react-webpack5@8.3.6(@swc/core@1.7.36)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.6)(typescript@5.5.4))(@types/node@18.19.57)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.36.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1))
+        version: 32.24.1(@types/react@18.3.11)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sku@13.2.1(@storybook/react-webpack5@8.3.6(@swc/core@1.7.36)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.6)(typescript@5.5.4))(@types/node@18.19.57)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.36.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1))
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -3606,8 +3606,8 @@ packages:
   browser-assert@1.2.1:
     resolution: {integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==}
 
-  browserslist-config-seek@3.0.0:
-    resolution: {integrity: sha512-7S3c4+Nk69bT3M7gjADvCGEGvoxQqBqCl0LtIelkpTtQVMe53/aa/bamLCytzLwJrdDQfpFD3lAjCoXs9dGIoQ==}
+  browserslist-config-seek@3.1.0:
+    resolution: {integrity: sha512-UTP8ReaA1d5Yn+MtljwD75B/Fuzwdw9TnRRTACAKRcLWeOTnAlnQSTExv/12rcOFDk6aZGZn3WLPUtrbSkjAaQ==}
 
   browserslist@4.24.0:
     resolution: {integrity: sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==}
@@ -7355,8 +7355,8 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  sku@13.2.0:
-    resolution: {integrity: sha512-ipU8ITbd8+z+uNhQ99B0X6RTU873i5tiOll5O9rmGNtH/pzRzixYeIaM8x5Ej4IHr2AgvavVdMKmAJ3cnGbI4Q==}
+  sku@13.2.1:
+    resolution: {integrity: sha512-XkntJgFtDKW2NsgQ6sK/WBmkFeM3/FHGat/Rbtc1H2ftN/5LTzFTB3i4+PDaZrqjT+AP3DgKRRXHYNOYVNuIiQ==}
     engines: {node: '>=18.20'}
     hasBin: true
     peerDependencies:
@@ -11649,7 +11649,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  braid-design-system@32.24.1(@types/react@18.3.11)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sku@13.2.0(@storybook/react-webpack5@8.3.6(@swc/core@1.7.36)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.6)(typescript@5.5.4))(@types/node@18.19.57)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.36.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)):
+  braid-design-system@32.24.1(@types/react@18.3.11)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sku@13.2.1(@storybook/react-webpack5@8.3.6(@swc/core@1.7.36)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.6)(typescript@5.5.4))(@types/node@18.19.57)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.36.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@capsizecss/core': 4.1.2
       '@capsizecss/metrics': 3.3.0
@@ -11673,7 +11673,7 @@ snapshots:
       react-is: 18.3.1
       react-popper-tooltip: 4.4.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-remove-scroll: 2.6.0(@types/react@18.3.11)(react@18.3.1)
-      sku: 13.2.0(@storybook/react-webpack5@8.3.6(@swc/core@1.7.36)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.6)(typescript@5.5.4))(@types/node@18.19.57)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.36.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)
+      sku: 13.2.1(@storybook/react-webpack5@8.3.6(@swc/core@1.7.36)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.6)(typescript@5.5.4))(@types/node@18.19.57)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.36.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)
       utility-types: 3.11.0
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -11713,7 +11713,7 @@ snapshots:
 
   browser-assert@1.2.1: {}
 
-  browserslist-config-seek@3.0.0: {}
+  browserslist-config-seek@3.1.0: {}
 
   browserslist@4.24.0:
     dependencies:
@@ -16170,7 +16170,7 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  sku@13.2.0(@storybook/react-webpack5@8.3.6(@swc/core@1.7.36)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.6)(typescript@5.5.4))(@types/node@18.19.57)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.36.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1):
+  sku@13.2.1(@storybook/react-webpack5@8.3.6(@swc/core@1.7.36)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.6)(typescript@5.5.4))(@types/node@18.19.57)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.36.0)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1):
     dependencies:
       '@babel/core': 7.25.8
       '@babel/plugin-transform-react-constant-elements': 7.25.7(@babel/core@7.25.8)
@@ -16207,7 +16207,7 @@ snapshots:
       babel-plugin-transform-remove-imports: 1.8.0(@babel/core@7.25.8)
       babel-plugin-unassert: 3.2.0
       browserslist: 4.24.0
-      browserslist-config-seek: 3.0.0
+      browserslist-config-seek: 3.1.0
       chalk: 4.1.2
       cross-spawn: 7.0.3
       css-loader: 6.11.0(webpack@5.95.0(@swc/core@1.7.36)(esbuild@0.24.0))

--- a/tests/__snapshots__/braid-design-system.test.js.snap
+++ b/tests/__snapshots__/braid-design-system.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`braid-design-system build should generate the expected files 1`] = `
 {
-  "2-2a8ae0382a913fa08d4b.css": ._1jca2x30 {
+  "2-8f64d7e9279548b0b720.css": ._1jca2x30 {
   border: 0;
   box-sizing: border-box;
   font-size: 100%;
@@ -37,7 +37,6 @@ exports[`braid-design-system build should generate the expected files 1`] = `
 }
 ._1jca2x36 {
   -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
 }
 ._1jca2x37 {
@@ -84,7 +83,6 @@ exports[`braid-design-system build should generate the expected files 1`] = `
 }
 ._9pmoe04 {
   -webkit-user-select: none;
-  -moz-user-select: none;
   user-select: none;
 }
 ._9pmoe05 {
@@ -2619,9 +2617,9 @@ html._9pmoe0z .r1my9ze {
     0 20px 20px -12px rgba(28, 35, 48, 0.2);
 }
 
-/*# sourceMappingURL=2-2a8ae0382a913fa08d4b.css.map*/
+/*# sourceMappingURL=2-8f64d7e9279548b0b720.css.map*/
 ,
-  "2-2a8ae0382a913fa08d4b.css.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "2-8f64d7e9279548b0b720.css.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "externals.json": "[
   "crypto",
   "fs",
@@ -2641,7 +2639,7 @@ html._9pmoe0z .r1my9ze {
         <meta charset="UTF-8">
         <title>My Awesome Project</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link data-chunk="main" rel="stylesheet" href="/2-2a8ae0382a913fa08d4b.css">
+        <link data-chunk="main" rel="stylesheet" href="/2-8f64d7e9279548b0b720.css">
 <link data-chunk="main" rel="preload" as="script" href="/runtime.js">
 <link data-chunk="main" rel="preload" as="script" href="/main.js">
         <script>
@@ -2671,7 +2669,7 @@ html._9pmoe0z .r1my9ze {
         <meta charset="UTF-8">
         <title>My Awesome Project</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link data-chunk="main" rel="stylesheet" href="/2-2a8ae0382a913fa08d4b.css">
+        <link data-chunk="main" rel="stylesheet" href="/2-8f64d7e9279548b0b720.css">
 <link data-chunk="main" rel="preload" as="script" href="/runtime.js">
 <link data-chunk="main" rel="preload" as="script" href="/main.js">
         <script>
@@ -2699,7 +2697,7 @@ SCRIPTS: [
   "/main.js",
 ]
 CSS: [
-  "/2-2a8ae0382a913fa08d4b.css",
+  "/2-8f64d7e9279548b0b720.css",
 ]
 SOURCE HTML: <!DOCTYPE html>
 <html>
@@ -2928,7 +2926,7 @@ SCRIPTS: [
   "/main.js",
 ]
 CSS: [
-  "/2-2a8ae0382a913fa08d4b.css",
+  "/2-8f64d7e9279548b0b720.css",
 ]
 SOURCE HTML: <!DOCTYPE html>
 <html>

--- a/tests/__snapshots__/sku-webpack-plugin.test.js.snap
+++ b/tests/__snapshots__/sku-webpack-plugin.test.js.snap
@@ -92,7 +92,6 @@ exports[`sku-webpack-plugin build should generate the expected files 1`] = `
 }
 ._1m61nqo6 {
   -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
 }
 ._1m61nqo7 {
@@ -139,7 +138,6 @@ exports[`sku-webpack-plugin build should generate the expected files 1`] = `
 }
 ._1dc46084 {
   -webkit-user-select: none;
-  -moz-user-select: none;
   user-select: none;
 }
 ._1dc46085 {


### PR DESCRIPTION
Making this change manually to pin the dependency to the specific version. This means we can tie browser policy updates to sku versions in the future.