### PR TITLE
Uplift dangerously set docs

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -30,7 +30,7 @@ Config files can use either TypeScript or JavaScript.
 
 ## clientEntry
 
-type `string`
+Type: `string`
 
 Default: `./src/client.js`
 
@@ -40,7 +40,7 @@ Each `route` can also specify a client entry, if none is specified the `clientEn
 
 ## compilePackages
 
-type `Array<string>`
+Type: `Array<string>`
 
 Default: `[]`
 
@@ -48,7 +48,7 @@ An array of `node_modules` to be compiled as if they were part of your source co
 
 ## cspEnabled
 
-type `boolean`
+Type: `boolean`
 
 **Unavailable for libraries**
 
@@ -58,7 +58,7 @@ Enable content security policy feature. See [`Content Security Policy`](./docs/c
 
 ## cspExtraScriptSrcHosts
 
-type `Array<string>`
+Type: `Array<string>`
 
 Default: `[]`
 
@@ -66,7 +66,7 @@ Extra external hosts to allow in your `script-src` [content security policy](htt
 
 ## dangerouslySetESLintConfig
 
-type `function`
+Type: `function`
 
 This function provides a way to modify sku's ESLint configuration.
 It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
@@ -95,7 +95,7 @@ export default {
 
 ## dangerouslySetJestConfig
 
-type `function`
+Type: `function`
 
 This function provides a way to modify sku's Jest configuration.
 It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
@@ -120,7 +120,7 @@ export default {
 
 ## dangerouslySetTSConfig
 
-type `function`
+Type: `function`
 
 This function provides a way to modify sku's TypeScript configuration.
 It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
@@ -144,7 +144,7 @@ export default {
 
 ## dangerouslySetWebpackConfig
 
-type `function`
+Type: `function`
 
 This function provides a way to modify sku's Webpack configuration.
 It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
@@ -170,7 +170,7 @@ export default {
 
 ## devServerMiddleware
 
-type `string`
+Type: `string`
 
 Path to a file in your project that exports a function that can receive the Express server.
 
@@ -188,7 +188,7 @@ module.exports = app => {
 
 ## displayNamesProd
 
-type `boolean`
+Type: `boolean`
 
 Default: `false`
 
@@ -206,7 +206,7 @@ export default {
 
 **Only for static apps**
 
-type `Array<string>`
+Type: `Array<string>`
 
 Default: `[]`
 
@@ -214,7 +214,7 @@ An array of environments the app supports. Apps should have one environment for 
 
 ## externalizeNodeModules
 
-type `boolean`
+Type: `boolean`
 
 Default: `false`
 
@@ -222,7 +222,7 @@ By default, sku compiles all node_modules in builds that target node. Setting th
 
 ## hosts
 
-type `Array<string>`
+Type: `Array<string>`
 
 Default: `['localhost']`
 
@@ -230,7 +230,7 @@ An array of custom hosts the app can be served off when running `sku start`. You
 
 ## httpsDevServer
 
-type `boolean`
+Type: `boolean`
 
 Default: `false`
 
@@ -238,7 +238,7 @@ Whether or not to use `https` for the local development server with a self-signe
 
 ## initialPath
 
-type `string`
+Type: `string`
 
 Default: `routes[0].route`
 
@@ -246,7 +246,7 @@ The browser URL to open when running `sku start` or `sku start-ssr`. It will def
 
 ## languages
 
-type `Array<string | { name: string, extends: string }>`
+Type: `Array<string | { name: string, extends: string }>`
 
 The languages your application supports.
 
@@ -254,7 +254,7 @@ See [Multi-language support](./docs/multi-language.md) for details.
 
 ## libraryEntry
 
-type `string`
+Type: `string`
 
 **Only for libraries**
 
@@ -270,7 +270,7 @@ export default () => {
 
 ## libraryName
 
-type `string`
+Type: `string`
 
 **Only for libraries**
 
@@ -278,7 +278,7 @@ The global name of the library. Will be added to the `window` object under `wind
 
 ## libraryFile
 
-type `string`
+Type: `string`
 
 **Only for libraries**
 
@@ -289,7 +289,7 @@ If `libraryFile` is not specified then `libraryName` will be used instead.
 
 ## polyfills
 
-type `Array<string>`
+Type: `Array<string>`
 
 Default: `[]`
 
@@ -297,7 +297,7 @@ An array of polyfills to be included into all client entry points.
 
 ## port
 
-type `number`
+Type: `number`
 
 Default: `8080`
 
@@ -305,7 +305,7 @@ The port the app is hosted on when running `sku start`.
 
 ## public
 
-type `string`
+Type: `string`
 
 Default: `public`
 
@@ -315,7 +315,7 @@ A folder of public assets to be copied into the `target` directory after `sku bu
 
 ## publicPath
 
-type `string`
+Type: `string`
 
 Default: `/`
 
@@ -323,7 +323,7 @@ The URL all the static assets of the app are accessible under.
 
 ## renderEntry
 
-type `string`
+Type: `string`
 
 **Only for static apps and libraries**
 
@@ -333,7 +333,7 @@ The render entry file to the app. This file should export the required functions
 
 ## rootResolution
 
-type `boolean`
+Type: `boolean`
 
 Default: `true`
 
@@ -345,7 +345,7 @@ You can set this option in `sku.config.js`, or adding `"skuCompilePackage": true
 
 ## routes
 
-type `Array<string | {route: string, name: string, entry: string, languages: Array<string>}>`
+Type: `Array<string | {route: string, name: string, entry: string, languages: Array<string>}>`
 
 **Only for static apps**
 
@@ -365,7 +365,7 @@ export default {
 
 ## serverEntry
 
-type `string`
+Type: `string`
 
 **Only for SSR apps**
 
@@ -375,7 +375,7 @@ The entry file for the server.
 
 ## serverPort
 
-type `number`
+Type: `number`
 
 **Only for SSR apps**
 
@@ -385,7 +385,7 @@ The port the server is hosted on when running `sku start-ssr`.
 
 ## setupTests
 
-type `string`
+Type: `string`
 
 Point to a JS file that will run before your tests to setup the testing environment.
 
@@ -393,7 +393,7 @@ Point to a JS file that will run before your tests to setup the testing environm
 
 **Only for static apps**
 
-type `Array<string | { name: string, host: string, languages: Array<string>, routes: Array<string> }>`
+Type: `Array<string | { name: string, host: string, languages: Array<string>, routes: Array<string> }>`
 
 Default: `[]`
 
@@ -405,7 +405,7 @@ Can be used to limit the languages rendered for a specific site. Any listed lang
 
 ## skipPackageCompatibilityCompilation
 
-type `Array<string>`
+Type: `Array<string>`
 
 Default: `[]`
 
@@ -423,7 +423,7 @@ const config = {
 
 ## sourceMapsProd
 
-type `boolean`
+Type: `boolean`
 
 Default: `true`
 
@@ -455,7 +455,7 @@ If your application does not utilize production source maps, e.g. you have no tr
 
 ## srcPaths
 
-type `Array<string>`
+Type: `Array<string>`
 
 Default: `['./src']`
 
@@ -463,7 +463,7 @@ An array of directories holding your app's source code. By default, sku expects 
 
 ## supportedBrowsers
 
-type `browserslist-query`
+Type: `browserslist-query`
 
 Default: [browserslist-config-seek](https://github.com/seek-oss/browserslist-config-seek)
 
@@ -471,7 +471,7 @@ The [`browserslist`](https://github.com/browserslist/browserslist) query describ
 
 ## target
 
-type `string`
+Type: `string`
 
 Default: `dist`
 
@@ -479,7 +479,7 @@ The directory to build your assets into when running `sku build` or `sku build-s
 
 ## transformOutputPath
 
-type `function`
+Type: `function`
 
 **Only for static apps**
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -100,7 +100,7 @@ Type: `function`
 This function provides a way to modify sku's Jest configuration.
 It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
 
-Make sure {@link setupTests} definitely doesn’t cover your needs before using.
+Make sure [`setupTests`] definitely doesn’t cover your needs before using.
 
 Before customizing your Jest configuration, please reach out in [`#sku-support`] to discuss your requirements and potential alternative solutions.
 
@@ -117,6 +117,8 @@ export default {
   }),
 } satisfies SkuConfig;
 ```
+
+[`setupTests`]: #setupTests
 
 ## dangerouslySetTSConfig
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -68,7 +68,19 @@ Extra external hosts to allow in your `script-src` [content security policy](htt
 
 type `function`
 
-Similar to `dangerouslySetWebpackConfig`, but for [ESLint](https://eslint.org/) config.
+This function provides a way to modify sku's ESLint configuration.
+It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
+
+Before customizing your ESLint configuration, please reach out in [`#sku-support`] to discuss your requirements and potential alternative solutions.
+
+ESLint rules help to maintain code quality and consistency.
+Some rules even prevent potential bugs in your code, e.g. React rules.
+Rather than disabling a rule purely because it causes frequent errors, consider whether these errors may be a symptom of a larger problem in your codebase.
+
+If you believe other consumers would benefit from the addition/removal/modificaton of a rule, consider contributing the change to [`eslint-config-seek`](https://github.com/seek-oss/eslint-config-seek).
+
+> Sku provides no guarantees that its ESLint configuration will remain compatible with any customizations made within this function.
+> It is the responsibility of the user to ensure that their customizations are compatible with sku.
 
 Example:
 
@@ -85,9 +97,15 @@ export default {
 
 type `function`
 
-Similar to `dangerouslySetWebpackConfig`, but for [Jest](https://jestjs.io/docs/en/configuration) config. Make sure [`setupTests`](#setuptests) definitely doesn't cover your needs before using.
+This function provides a way to modify sku's Jest configuration.
+It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
 
-Please speak with the `sku-support` group before using.
+Make sure {@link setupTests} definitely doesn’t cover your needs before using.
+
+Before customizing your Jest configuration, please reach out in [`#sku-support`] to discuss your requirements and potential alternative solutions.
+
+> Sku provides no guarantees that its Jest configuration will remain compatible with any customizations made within this function.
+> It is the responsibility of the user to ensure that their customizations are compatible with sku.
 
 Example:
 
@@ -104,7 +122,13 @@ export default {
 
 type `function`
 
-Similar to `dangerouslySetWebpackConfig`, but for [TypeScript (`tsconfig.json`)](https://www.typescriptlang.org/tsconfig).
+This function provides a way to modify sku's TypeScript configuration.
+It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
+
+Before customizing your TypeScript configuration, please reach out in [`#sku-support`]() to discuss your requirements and potential alternative solutions.
+
+> Sku provides no guarantees that its TypeScript configuration will remain compatible with any customizations made within this function.
+> It is the responsibility of the user to ensure that their customizations are compatible with sku.
 
 Example:
 
@@ -122,11 +146,16 @@ export default {
 
 type `function`
 
-This function provides a way to override the webpack config after sku has created it. As sku creates two webpack configs (`client` & `server|render`) this function will actually run twice, if you only need to modify one, then you can check `config.name`.
+This function provides a way to modify sku's Webpack configuration.
+It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
 
-Ideally, this setting is not needed and only used for experimenting/debugging. If you require webpack features not currently supported by sku please speak to the `sku-support` group.
+Before customizing your Webpack configuration, please reach out in [`#sku-support`] to discuss your requirements and potential alternative solutions.
 
-Reliance on this setting will cause issues when upgrading sku as any custom settings may break at any time. You've been warned!
+As sku creates two webpack configs (`client` & `server|render`), this function will actually run twice.
+If you only need to modify one of these configs, then you can check `config.name`.
+
+> Sku provides no guarantees that its Webpack configuration will remain compatible with any customizations made within this function.
+> It is the responsibility of the user to ensure that their customizations are compatible with sku.
 
 Example:
 
@@ -456,4 +485,6 @@ type `function`
 
 Default: `({ environment = '', site = '', route = '' }) => path.join(environment, site, route)`
 
-This function returns the output path within [`target`](#target) for each rendered page. Generally, this value should be sufficient. If you think you need to modify this setting, please reach out to the `sku-support` group first to discuss.
+This function returns the output path within [`target`](#target) for each rendered page. Generally, this value should be sufficient. If you think you need to modify this setting, please reach out in [`#sku-support`] first to discuss.
+
+[`#sku-support`]: https://seek.enterprise.slack.com/archives/CDL5VP5NU

--- a/packages/sku/sku-types.d.ts
+++ b/packages/sku/sku-types.d.ts
@@ -130,36 +130,65 @@ export interface SkuConfig {
   cspExtraScriptSrcHosts?: string[];
 
   /**
-   * Similar to {@link dangerouslySetWebpackConfig}, but for ESLint config.
+   * This function provides a way to modify sku's ESLint configuration.
+   * It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
+   *
+   * Before customizing your ESLint configuration, please reach out in [#sku-support](https://seek.enterprise.slack.com/archives/CDL5VP5NU) to discuss your requirements and potential alternative solutions.
+   *
+   * ESLint rules help to maintain code quality and consistency.
+   * Some rules even prevent potential bugs in your code, e.g. React rules.
+   * Rather than disabling a rule purely because it causes frequent errors, consider whether these errors may be a symptom of a larger problem in your codebase.
+   *
+   * If you believe other consumers would benefit from the addition/removal/modificaton of a rule, consider contributing the change to [`eslint-config-seek`](https://github.com/seek-oss/eslint-config-seek).
+   *
+   * Sku provides no guarantees that its ESLint configuration will remain compatible with any customizations made within this function.
+   * It is the responsibility of the user to ensure that their customizations are compatible with sku.
    *
    * @link https://seek-oss.github.io/sku/#/./docs/configuration?id=dangerouslyseteslintconfig
    */
-  dangerouslySetESLintConfig?: (existingESLintConfig: any) => any;
+  dangerouslySetESLintConfig?: (skuESLintConfig: any) => any;
 
   /**
-   * Similar to {@link dangerouslySetWebpackConfig}, but for Jest config. Make sure {@link setupTests} definitely doesn’t cover your needs before using.
-   * Please speak with the `sku-support` group before using.
+   * This function provides a way to modify sku's Jest configuration.
+   * It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
+   *
+   * Before customizing your Jest configuration, please reach out in [#sku-support](https://seek.enterprise.slack.com/archives/CDL5VP5NU) to discuss your requirements and potential alternative solutions.
+   *
+   * Sku provides no guarantees that its Jest configuration will remain compatible with any customizations made within this function.
+   * It is the responsibility of the user to ensure that their customizations are compatible with sku.
    *
    * @link https://seek-oss.github.io/sku/#/./docs/configuration?id=dangerouslysetjestconfig
    */
-  dangerouslySetJestConfig?: (existingJestConfig: any) => any;
+  dangerouslySetJestConfig?: (skuJestConfig: any) => any;
 
   /**
-   * Similar to {@link dangerouslySetWebpackConfig}, but for TypeScript (`tsconfig.json`).
+   * This function provides a way to modify sku's TypeScript configuration.
+   * It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
+   *
+   * Before customizing your TypeScript configuration, please reach out in [#sku-support](https://seek.enterprise.slack.com/archives/CDL5VP5NU) to discuss your requirements and potential alternative solutions.
+   *
+   * Sku provides no guarantees that its TypeScript configuration will remain compatible with any customizations made within this function.
+   * It is the responsibility of the user to ensure that their customizations are compatible with sku.
    *
    * @link https://seek-oss.github.io/sku/#/./docs/configuration?id=dangerouslysettsconfig
    */
-  dangerouslySetTSConfig?: (existingTSConfig: any) => any;
+  dangerouslySetTSConfig?: (skuTSConfig: any) => any;
 
   /**
-   * This function provides a way to override the webpack config after sku has created it.
-   * Ideally, this setting is not needed and only used for experimenting/debugging. If you require webpack features not currently supported by sku please speak to the `sku-support` group.
+   * This function provides a way to modify sku's Webpack configuration.
+   * It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
    *
-   * Reliance on this setting will cause issues when upgrading sku as any custom settings may break at anytime. You’ve been warned!
+   * Before customizing your Webpack configuration, please reach out in [#sku-support](https://seek.enterprise.slack.com/archives/CDL5VP5NU) to discuss your requirements and potential alternative solutions.
+   *
+   * As sku creates two webpack configs (`client` & `server|render`), this function will actually run twice.
+   * If you only need to modify one of these configs, then you can check `config.name` within.
+   *
+   * Sku provides no guarantees that its Webpack configuration will remain compatible with any customizations made within this function.
+   * It is the responsibility of the user to ensure that their customizations are compatible with sku.
    *
    * @link https://seek-oss.github.io/sku/#/./docs/configuration?id=dangerouslysetwebpackconfig
    */
-  dangerouslySetWebpackConfig?: (existingWebpackConfig: any) => any;
+  dangerouslySetWebpackConfig?: (skuWebpackConfig: any) => any;
 
   /**
    * Path to a file in your project that exports a function that can receive the Express server.


### PR DESCRIPTION
Given recent discussion around the `dangerouslySet` APIs, I figured it was time their docs got a bit of an uplift:

- Rather than each option's docs just pointing to `dangerouslySetWebpackConfig`, I've instead opted to duplicate the same sections about `sku` providing no guarantees on future compatibility with changes made via these functions, as well as the CTA to reach out in #sku-support.
- I've added unique sections to each where required, e.g. mentioning the multiple webpack configs for `dangerouslySetWebpackConfig`, or encouraging changes to `eslint-config-seek` in `dangerouslySetEslintConfig`
- I renamed the config parameters in the types to align with the argument names used in the docs examples, and because I think `existing` doesn't work that well here. E.g. `existingJestConfig` -> `skuJestConfig`.
- Formatted the word `type` to `Type:` to align with how `Default:` is formatted