### PR TITLE
Update browserslist changeset

### DIFF
--- a/.changeset/nice-brooms-whisper.md
+++ b/.changeset/nice-brooms-whisper.md
@@ -2,4 +2,15 @@
 'sku': minor
 ---
 
-Update and pin `browserslist-config-seek` to version `3.1.0`
+Update and pin `browserslist-config-seek` to version `3.2.0`
+
+`sku` applications and libraries now default to supporting the following browser versions:
+
+| Browser          | Oldest supported version |
+| ---------------- | ------------------------ |
+| Chrome           | 84                       |
+| Edge             | 84                       |
+| Safari           | 14.1                     |
+| Firefox          | 86                       |
+| Samsung Internet | 14                       |
+


### PR DESCRIPTION
Updating the `browserslist-config-seek` version in the changeset from #1078 as we updated to `3.2.0` in #1085. Also added a browser version table to maintain consistency with the last release that changed the browserlist config ([v13.0.0](https://github.com/seek-oss/sku/releases/tag/sku%4013.0.0)).