### PR TITLE
Throw an error when `sku translations` is run without `languages` configured, suggest `vocab` CLI if a vocab config file is detected

### DIFF
--- a/.changeset/hot-fans-wash.md
+++ b/.changeset/hot-fans-wash.md
@@ -1,0 +1,8 @@
+---
+'sku': patch
+---
+
+`sku translations`: Throw an error when `languages` has not been configured
+
+Previously, if `languages` was not configured, the `sku translations` command would log a message and continue to run the command, which would eventually error due to the lack of a vocab config (generated from the `languages` config).
+We now throw an error sooner to make it clear that the `languages` configuration is required to run any `sku translations` commands.

--- a/.changeset/sixty-bats-enjoy.md
+++ b/.changeset/sixty-bats-enjoy.md
@@ -1,0 +1,5 @@
+---
+'sku': minor
+---
+
+`sku translations`: Suggest using the `vocab` CLI when `languages` is not configured and a vocab config file is detected

--- a/.changeset/sour-terms-repeat.md
+++ b/.changeset/sour-terms-repeat.md
@@ -1,0 +1,5 @@
+---
+'sku': minor
+---
+
+`sku translations`: When `languages` is configured in sku config _and_ a vocab config file is found, a warning will be shown telling the user that the vocab config file will be ignored

--- a/packages/sku/scripts/translations.js
+++ b/packages/sku/scripts/translations.js
@@ -40,13 +40,19 @@ const log = (message) => console.log(chalk.cyan(message));
 (async () => {
   const translationSubCommand = commandArguments[0];
 
-  const vocabConfig = getVocabConfig();
+  const vocabConfigFromSkuConfig = getVocabConfig();
+  const resolvedVocabConfig = await resolveConfig();
 
-  if (!vocabConfig) {
+  if (vocabConfigFromSkuConfig && resolvedVocabConfig) {
+    console.log(
+      `Ignoring vocab config file in ${resolvedVocabConfig.projectRoot}. Sku only supports multi-language applications by configuring the "languages" property in your sku config.`,
+    );
+  }
+
+  if (!vocabConfigFromSkuConfig) {
     let errorMessage =
       'No "languages" configured. Please configure "languages" in your sku config before running translation commands.';
 
-    const resolvedVocabConfig = await resolveConfig();
     if (resolvedVocabConfig) {
       errorMessage += `\nIt looks like you have a vocab config file in ${resolvedVocabConfig.projectRoot}. Perhaps you intended to run "vocab ${translationSubCommand}" instead?`;
     }
@@ -70,7 +76,7 @@ const log = (message) => console.log(chalk.cyan(message));
         log('Watching for changes to translations');
       }
 
-      await compile({ watch }, vocabConfig);
+      await compile({ watch }, vocabConfigFromSkuConfig);
 
       if (!watch) {
         log('Successfully compiled translations');
@@ -79,7 +85,7 @@ const log = (message) => console.log(chalk.cyan(message));
 
     if (translationSubCommand === 'validate') {
       log('Validating translations...');
-      await validate(vocabConfig);
+      await validate(vocabConfigFromSkuConfig);
       log('Successfully validated translations');
     }
 
@@ -87,7 +93,7 @@ const log = (message) => console.log(chalk.cyan(message));
       const branch = await ensureBranch();
 
       log('Pushing translations to Phrase...');
-      await push({ branch, deleteUnusedKeys }, vocabConfig);
+      await push({ branch, deleteUnusedKeys }, vocabConfigFromSkuConfig);
       log('Successfully pushed translations to Phrase');
     }
 
@@ -95,7 +101,7 @@ const log = (message) => console.log(chalk.cyan(message));
       const branch = await ensureBranch();
 
       log('Pulling translations from Phrase...');
-      await pull({ branch }, vocabConfig);
+      await pull({ branch }, vocabConfigFromSkuConfig);
       log('Successfully pulled translations from Phrase');
     }
   } catch (e) {

--- a/packages/sku/scripts/translations.js
+++ b/packages/sku/scripts/translations.js
@@ -43,8 +43,8 @@ const log = (message) => console.log(chalk.cyan(message));
   const vocabConfig = getVocabConfig();
 
   if (!vocabConfig) {
-    console.log(
-      'No languages configured. Please set languages in  before running translation commands',
+    throw new Error(
+      'No "languages" configured. Please configure "languages" in your sku config before running translation commands',
     );
   }
 

--- a/packages/sku/scripts/translations.js
+++ b/packages/sku/scripts/translations.js
@@ -4,7 +4,7 @@ const {
   watch,
   'delete-unused-keys': deleteUnusedKeys,
 } = require('../config/args');
-const { compile, validate } = require('@vocab/core');
+const { compile, validate, resolveConfig } = require('@vocab/core');
 const { push, pull } = require('@vocab/phrase');
 const { getVocabConfig } = require('../config/vocab/vocab');
 
@@ -43,9 +43,15 @@ const log = (message) => console.log(chalk.cyan(message));
   const vocabConfig = getVocabConfig();
 
   if (!vocabConfig) {
-    throw new Error(
-      'No "languages" configured. Please configure "languages" in your sku config before running translation commands',
-    );
+    let errorMessage =
+      'No "languages" configured. Please configure "languages" in your sku config before running translation commands.';
+
+    const resolvedVocabConfig = await resolveConfig();
+    if (resolvedVocabConfig) {
+      errorMessage += `\nIt looks like you have a vocab config file in ${resolvedVocabConfig.projectRoot}. Perhaps you intended to run "vocab ${translationSubCommand}" instead?`;
+    }
+
+    throw new Error(errorMessage);
   }
 
   if (!translationSubCommands.includes(translationSubCommand)) {


### PR DESCRIPTION
If you haven't configured `languages` in your sku config and run a `sku translations` command, you get a particularly unhelpful error:

```
TypeError: Cannot destructure property 'projectRoot' of 'config' as it is null.
```

All Vocab APIs used by the `sku translations` commands require a Vocab config, so we should error at the point we don't have a Vocab config instead of during the Vocab API calls.

I discovered this issue when I accidentally ran `sku translations compile` in an internal repo that uses the `vocab` CLI directly. So I added a message to the error suggesting to run the `vocab` CLI directly if a vocab config file is resolved.

Also added a warning about ignoring vocab config when both `languages` is configured and a vocab config is found. This adds a bit of overhead to `sku translations` commands it will always attempt to resolve a vocab config file, but the impact is likely negligible.