### PR TITLE
Functionalize global args

### DIFF
--- a/packages/sku/context/configPath.js
+++ b/packages/sku/context/configPath.js
@@ -1,0 +1,19 @@
+// @ts-check
+/** @type {string | undefined} */
+let configPath;
+
+const getConfigPath = () => {
+  return configPath;
+};
+
+/**
+ * @param {string | undefined} path
+ */
+const setConfigPath = (path) => {
+  configPath = path;
+};
+
+module.exports = {
+  getConfigPath,
+  setConfigPath,
+};

--- a/packages/sku/context/index.js
+++ b/packages/sku/context/index.js
@@ -10,7 +10,7 @@ const validateConfig = require('./validateConfig');
 const defaultCompilePackages = require('./defaultCompilePackages');
 const isCompilePackage = require('../lib/isCompilePackage');
 const targets = require('../config/targets.json');
-const program = require('../lib/program');
+const { getConfigPath } = require('./configPath.js');
 
 /** @typedef {import("../").SkuConfig} SkuConfig */
 
@@ -20,9 +20,7 @@ const getSkuConfig = () => {
   const tsPath = getPathFromCwd('sku.config.ts');
   const jsPath = getPathFromCwd('sku.config.js');
 
-  const config = program.opts()?.config;
-
-  const customSkuConfig = config || process.env.SKU_CONFIG;
+  const customSkuConfig = getConfigPath() || process.env.SKU_CONFIG;
 
   if (customSkuConfig) {
     appSkuConfigPath = getPathFromCwd(customSkuConfig);

--- a/packages/sku/lib/program/commands/serve/serve.action.js
+++ b/packages/sku/lib/program/commands/serve/serve.action.js
@@ -18,7 +18,7 @@ const { checkHosts, getAppHosts } = require('../../../hosts');
 const allocatePort = require('../../../allocatePort');
 const openBrowser = require('../../../openBrowser');
 const getSiteForHost = require('../../../getSiteForHost');
-const resolveEnvironment = require('../../../resolveEnvironment');
+const { resolveEnvironment } = require('../../../resolveEnvironment');
 const track = require('../../../../telemetry');
 const createServer = require('../../../createServer');
 const {
@@ -30,7 +30,11 @@ const {
   validatePeerDeps,
 } = require('../../../utils/configure');
 
-const serveAction = async ({ site: preferredSite, port: preferredPort }) => {
+const serveAction = async ({
+  site: preferredSite,
+  port: preferredPort,
+  environment: environmentOption,
+}) => {
   await configureProject();
   validatePeerDeps();
   track.count('serve');
@@ -80,7 +84,7 @@ const serveAction = async ({ site: preferredSite, port: preferredPort }) => {
 
   console.log(blue(`sku serve`));
 
-  const environment = resolveEnvironment();
+  const environment = resolveEnvironment({ environment: environmentOption });
 
   const app = express();
 

--- a/packages/sku/lib/program/commands/serve/serve.command.js
+++ b/packages/sku/lib/program/commands/serve/serve.command.js
@@ -10,9 +10,11 @@ serve
   )
   .addOption(siteOption)
   .addOption(portOption)
-  .action(({ site, port }) => {
+  .action(({ site, port }, command) => {
+    const environment = command.parent.opts()?.environment;
+
     const serveAction = require('./serve.action');
-    serveAction({ site, port });
+    serveAction({ site, port, environment });
   });
 
 module.exports = serve;

--- a/packages/sku/lib/program/commands/start/start.action.js
+++ b/packages/sku/lib/program/commands/start/start.action.js
@@ -9,7 +9,7 @@ const { checkHosts, getAppHosts } = require('../../../hosts');
 const allocatePort = require('../../../allocatePort');
 const openBrowser = require('../../../openBrowser');
 const getSiteForHost = require('../../../getSiteForHost');
-const resolveEnvironment = require('../../../resolveEnvironment');
+const { resolveEnvironment } = require('../../../resolveEnvironment');
 const routeMatcher = require('../../../routeMatcher');
 const {
   port,
@@ -39,14 +39,17 @@ const localhost = '0.0.0.0';
 
 const hot = process.env.SKU_HOT !== 'false';
 
-const startAction = async ({ stats: statsOption }) => {
+const startAction = async ({
+  stats: statsOption,
+  environment: environmentOption,
+}) => {
   await configureProject();
   validatePeerDeps();
   console.log(blue(`sku start`));
 
   await watchVocabCompile();
 
-  const environment = resolveEnvironment();
+  const environment = resolveEnvironment({ environment: environmentOption });
 
   console.log();
 

--- a/packages/sku/lib/program/commands/start/start.command.js
+++ b/packages/sku/lib/program/commands/start/start.command.js
@@ -8,9 +8,11 @@ start
     'Start the sku development server for a statically-rendered application.',
   )
   .addOption(statsOption)
-  .action(({ stats }) => {
+  .action(({ stats }, command) => {
+    const environment = command.parent.opts()?.environment;
+
     const startAction = require('./start.action');
-    startAction({ stats });
+    startAction({ stats, environment });
   });
 
 module.exports = start;

--- a/packages/sku/lib/program/index.js
+++ b/packages/sku/lib/program/index.js
@@ -4,6 +4,8 @@ const debugOption = require('./options/debug/debug.option');
 const configOption = require('./options/config/config.option');
 const environmentOption = require('./options/environment/environment.option');
 const { name, description, version } = require('../../package.json');
+const { initDebug } = require('../utils/debug');
+const { setConfigPath } = require('../../context/configPath.js');
 
 const program = new Command();
 
@@ -14,7 +16,15 @@ program
   .allowUnknownOption(true)
   .addOption(environmentOption)
   .addOption(configOption)
-  .addOption(debugOption);
+  .addOption(debugOption)
+  .on('option:debug', () => {
+    if (program.opts()?.debug) {
+      initDebug();
+    }
+  })
+  .on('option:config', () => {
+    setConfigPath(program.opts()?.config);
+  });
 
 for (const command of commands) {
   program.addCommand(command);

--- a/packages/sku/lib/resolveEnvironment.js
+++ b/packages/sku/lib/resolveEnvironment.js
@@ -1,12 +1,12 @@
 // @ts-check
 const { environments } = require('../context');
 const { bold, red } = require('chalk');
-const program = require('./program');
 
-module.exports = () => {
-  const environment = program.opts()?.environment
-    ? program.opts()?.environment
-    : environments?.[0] || '';
+/**
+ * @param {{environment?: string}} options
+ */
+const resolveEnvironment = ({ environment: environmentOption }) => {
+  const environment = environmentOption || environments?.[0] || '';
 
   if (environment) {
     if (!environments?.includes(environment)) {
@@ -19,3 +19,5 @@ module.exports = () => {
 
   return environment;
 };
+
+module.exports = { resolveEnvironment };

--- a/packages/sku/lib/utils/debug.js
+++ b/packages/sku/lib/utils/debug.js
@@ -1,15 +1,16 @@
-const program = require('../program');
+// @ts-check
 const debug = require('debug');
 
 const log = debug('sku:bin');
 
-if (program.opts()?.debug) {
+const initDebug = () => {
   // Enable all sku:* `debug` logs
   // @see https://www.npmjs.com/package/debug
   process.env.DEBUG = `sku:*${`,${process.env.DEBUG}` || ''}`;
   debug.enable(process.env.DEBUG);
-}
+};
 
 module.exports = {
   log,
+  initDebug,
 };


### PR DESCRIPTION
Replaces direct usage of `program` to get global args by either passing the args into the action handler from the command handler, or in the case of the sku config path, still setting it globally, but ✨elsewhere✨.