### PR TITLE
Add support for WebP and AVIF image formats

### DIFF
--- a/.changeset/eighty-masks-hang.md
+++ b/.changeset/eighty-masks-hang.md
@@ -3,4 +3,4 @@
 ---
 Add WebP and AVIF image format support to sku
 
-Added support for `webp` and `avif` image formats in, and updated documentation to include these formats in the list of supported image types.
+Support for `webp` and `avif` image formats has been added. Note that browser support for these formats may vary. To ensure compatibility across browsers, consumers are advised to use the `<picture>` element with fallback formats. 

--- a/.changeset/eighty-masks-hang.md
+++ b/.changeset/eighty-masks-hang.md
@@ -1,0 +1,6 @@
+---
+'sku': minor
+---
+Add WebP and AVIF image format support to sku
+
+Added support for `webp` and `avif` image formats in, and updated documentation to include these formats in the list of supported image types.

--- a/docs/docs/extra-features.md
+++ b/docs/docs/extra-features.md
@@ -3,7 +3,16 @@
 ## Images
 
 The following images types are supported in sku:
-`bmp`, `gif`, `jpeg`, `png` and `svg`.
+`bmp`, `gif`, `jpeg`, `png`, `svg`, `webp` and `avif`.
+
+> Browser support for `webp` and `avif` varies. To ensure compatability across browsers, consider providing fallback image formats using the [`picture`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture) element.
+>
+> ```html
+> <picture>
+>   <source srcset="image.webp" type="image/webp" />
+>   <img src="image.png" />
+> </picture>
+> ```
 
 If you want to use a currently unsupported format feel free to submit a PR or contact #sku-support.
 

--- a/docs/docs/extra-features.md
+++ b/docs/docs/extra-features.md
@@ -5,14 +5,15 @@
 The following images types are supported in sku:
 `bmp`, `gif`, `jpeg`, `png`, `svg`, `webp` and `avif`.
 
-> Browser support for `webp` and `avif` varies. To ensure compatability across browsers, consider providing fallback image formats using the [`picture`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture) element.
->
-> ```html
-> <picture>
->   <source srcset="image.webp" type="image/webp" />
->   <img src="image.png" />
-> </picture>
-> ```
+?> Browser support for `webp` and `avif` varies. To ensure compatability across browsers, consider providing fallback image formats using the [`picture`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture) element.
+
+```html
+<picture>
+  <source srcset="image.avif" type="image/avif" />
+  <source srcset="image.webp" type="image/webp" />
+  <img src="image.png" />
+</picture>
+```
 
 If you want to use a currently unsupported format feel free to submit a PR or contact #sku-support.
 

--- a/packages/sku/config/webpack/utils/index.js
+++ b/packages/sku/config/webpack/utils/index.js
@@ -13,6 +13,6 @@ module.exports = {
   resolvePackage,
   TYPESCRIPT: new RegExp(`\.(${extensions.ts.join('|')})$`),
   JAVASCRIPT: new RegExp(`\.(${extensions.js.join('|')})$`),
-  IMAGE: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
+  IMAGE: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/, /\.webp$/, /\.avif$/],
   SVG: /\.svg$/,
 };


### PR DESCRIPTION
- Added support for webp and avif image formats.
- Updated documentation to reflect the supported image types: bmp, gif, jpeg, png, svg, webp, and avif.
- Added a note on browser support for webp and avif formats, including a fallback strategy using the `<picture>` element.