### PR TITLE
Convert `postinstall` to mjs

### DIFF
--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -26,7 +26,7 @@
     "node": ">=20.15"
   },
   "scripts": {
-    "postinstall": "node ./scripts/postinstall.js"
+    "postinstall": "node ./scripts/postinstall.mjs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Part of the incremental ESM migration. See [the feature branch diff](https://github.com/seek-oss/sku/compare/v14...v14-mjs-refactor) for history.

Converted the package json import to a read file. We can use top-level await too which is nice. Also swapped to our internal async `exists` utility.