### PR TITLE
Convert `context` directory to mjs

### DIFF
--- a/packages/sku/context/configPath.mjs
+++ b/packages/sku/context/configPath.mjs
@@ -2,18 +2,13 @@
 /** @type {string | undefined} */
 let configPath;
 
-const getConfigPath = () => {
+export const getConfigPath = () => {
   return configPath;
 };
 
 /**
  * @param {string | undefined} path
  */
-const setConfigPath = (path) => {
+export const setConfigPath = (path) => {
   configPath = path;
-};
-
-module.exports = {
-  getConfigPath,
-  setConfigPath,
 };

--- a/packages/sku/context/configSchema.mjs
+++ b/packages/sku/context/configSchema.mjs
@@ -1,4 +1,4 @@
-const Validator = require('fastest-validator');
+import Validator from 'fastest-validator';
 
 const validator = new Validator();
 
@@ -48,7 +48,7 @@ const routes = {
   ],
 };
 
-module.exports = validator.compile({
+export default validator.compile({
   clientEntry: {
     type: 'string',
   },

--- a/packages/sku/context/defaultClientEntry.js
+++ b/packages/sku/context/defaultClientEntry.js
@@ -1,1 +1,0 @@
-module.exports = 'main';

--- a/packages/sku/context/defaultClientEntry.mjs
+++ b/packages/sku/context/defaultClientEntry.mjs
@@ -1,0 +1,1 @@
+export default 'main';

--- a/packages/sku/context/defaultCompilePackages.mjs
+++ b/packages/sku/context/defaultCompilePackages.mjs
@@ -1,11 +1,13 @@
-const { posix: path } = require('node:path');
-const chalk = require('chalk');
-const { fdir: Fdir } = require('fdir');
+import { posix as path } from 'node:path';
+import { red } from 'chalk';
+import { fdir as Fdir } from 'fdir';
 
-const toPosixPath = require('../lib/toPosixPath');
+import toPosixPath from '../lib/toPosixPath';
 
-const { rootDir, isPnpm } = require('../lib/packageManager');
-const debug = require('debug')('sku:compilePackages');
+import { rootDir, isPnpm } from '../lib/packageManager';
+import _debug from 'debug';
+
+const debug = _debug('sku:compilePackages');
 
 /** @type {string[]} */
 let detectedCompilePackages = [];
@@ -62,7 +64,7 @@ if (rootDir) {
       .map(({ packageName }) => packageName);
   } catch (e) {
     console.log(
-      chalk.red`Warning: Failed to detect compile packages. Contact #sku-support.`,
+      red`Warning: Failed to detect compile packages. Contact #sku-support.`,
     );
     console.error(e);
   }
@@ -70,7 +72,7 @@ if (rootDir) {
 
 debug(detectedCompilePackages);
 
-module.exports = [
+export default [
   'sku',
   'braid-design-system',
   ...new Set(detectedCompilePackages),

--- a/packages/sku/context/defaultSkuConfig.mjs
+++ b/packages/sku/context/defaultSkuConfig.mjs
@@ -1,11 +1,11 @@
-const supportedBrowsers = require('browserslist-config-seek');
-const path = require('node:path');
-const isCompilePackage = require('../lib/isCompilePackage');
+import browserslistConfigSeek from 'browserslist-config-seek';
+import { join } from 'node:path';
+import isCompilePackage from '../lib/isCompilePackage';
 
 const defaultDecorator = (a) => a;
 
-/** @type {import("../").SkuConfig} */
-module.exports = {
+/** @type {import("../sku-types").SkuConfig} */
+export default {
   clientEntry: 'src/client.js',
   renderEntry: 'src/render.js',
   serverEntry: 'src/server.js',
@@ -14,7 +14,7 @@ module.exports = {
   sites: [],
   environments: [],
   transformOutputPath: ({ environment = '', site = '', route = '' }) =>
-    path.join(environment, site, route),
+    join(environment, site, route),
   srcPaths: ['./src'],
   compilePackages: [],
   hosts: ['localhost'],
@@ -35,7 +35,7 @@ module.exports = {
   dangerouslySetESLintConfig: defaultDecorator,
   dangerouslySetTSConfig: defaultDecorator,
   eslintIgnore: [],
-  supportedBrowsers,
+  supportedBrowsers: browserslistConfigSeek,
   cspEnabled: false,
   cspExtraScriptSrcHosts: [],
   httpsDevServer: false,

--- a/packages/sku/context/index.mjs
+++ b/packages/sku/context/index.mjs
@@ -1,18 +1,19 @@
-const fs = require('node:fs');
-const path = require('node:path');
-const chalk = require('chalk');
-const { register } = require('esbuild-register/dist/node');
-const { getPathFromCwd } = require('../lib/cwd');
-const defaultSkuConfig = require('./defaultSkuConfig');
-const defaultClientEntry = require('./defaultClientEntry');
-const validateConfig = require('./validateConfig');
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { red, bold } from 'chalk';
+import { register } from 'esbuild-register/dist/node';
+import { getPathFromCwd } from '../lib/cwd';
+import defaultSkuConfig from './defaultSkuConfig';
+import defaultClientEntry from './defaultClientEntry';
+import validateConfig from './validateConfig';
 
-const defaultCompilePackages = require('./defaultCompilePackages');
-const isCompilePackage = require('../lib/isCompilePackage');
-const targets = require('../config/targets.json');
-const { getConfigPath } = require('./configPath.js');
+import defaultCompilePackages from './defaultCompilePackages';
+import isCompilePackage from '../lib/isCompilePackage';
+import { esbuildNodeTarget } from '../config/targets.json' with { type: 'json' };
+import { getConfigPath } from './configPath.js';
+import { createRequire } from 'node:module';
 
-/** @typedef {import("../").SkuConfig} SkuConfig */
+/** @typedef {import("../sku-types.d.ts").SkuConfig} SkuConfig */
 
 /** @returns {{ appSkuConfig: SkuConfig, appSkuConfigPath: string | null }} */
 const getSkuConfig = () => {
@@ -24,9 +25,9 @@ const getSkuConfig = () => {
 
   if (customSkuConfig) {
     appSkuConfigPath = getPathFromCwd(customSkuConfig);
-  } else if (fs.existsSync(tsPath)) {
+  } else if (existsSync(tsPath)) {
     appSkuConfigPath = tsPath;
-  } else if (fs.existsSync(jsPath)) {
+  } else if (existsSync(jsPath)) {
     appSkuConfigPath = jsPath;
   } else {
     return {
@@ -35,8 +36,9 @@ const getSkuConfig = () => {
     };
   }
 
+  const require = createRequire(import.meta.url);
   // Target sku's minimum supported node version
-  const { unregister } = register({ target: targets.esbuildNodeTarget });
+  const { unregister } = register({ target: esbuildNodeTarget });
 
   const newConfig = require(appSkuConfigPath);
 
@@ -60,8 +62,8 @@ validateConfig(skuConfig);
 
 if (isCompilePackage && skuConfig.rootResolution) {
   console.log(
-    chalk.red(
-      `Error: "${chalk.bold(
+    red(
+      `Error: "${bold(
         'rootResolution',
       )}" is not safe for compile packages as consuming apps can't resolve them.`,
     ),
@@ -75,12 +77,12 @@ const isStartScript = firstArg === 'start' || firstArg === 'start-ssr';
 const isBuildScript = firstArg === 'build' || firstArg === 'build-ssr';
 
 /**
- * @typedef {import('../').SkuRouteObject} SkuRouteObject
+ * @typedef {import('../sku-types.d.ts').SkuRouteObject} SkuRouteObject
  * @typedef {SkuRouteObject & { siteIndex?: number }} NormalizedSkuRoute
  */
 
 /**
- * @param {import('../').SkuRoute} route
+ * @param {import('../sku-types.d.ts').SkuRoute} route
  * @returns {NormalizedSkuRoute}
  */
 const normalizeRoute = (route) =>
@@ -109,8 +111,7 @@ const normalizedLanguages = skuConfig.languages
     )
   : null;
 
-const startTransformPath = ({ site = '', route = '' }) =>
-  path.join(site, route);
+const startTransformPath = ({ site = '', route = '' }) => join(site, route);
 
 const transformOutputPath = isStartScript
   ? startTransformPath
@@ -145,7 +146,7 @@ const devServerMiddleware =
   getPathFromCwd(skuConfig.devServerMiddleware);
 
 const useDevServerMiddleware = devServerMiddleware
-  ? fs.existsSync(devServerMiddleware)
+  ? existsSync(devServerMiddleware)
   : false;
 
 if (devServerMiddleware && !useDevServerMiddleware) {
@@ -173,7 +174,7 @@ const paths = {
   setupTests: getSetupTests(skuConfig.setupTests),
 };
 
-module.exports = {
+export default {
   paths,
   locales: skuConfig.locales,
   hosts: skuConfig.hosts,

--- a/packages/sku/context/index.mjs
+++ b/packages/sku/context/index.mjs
@@ -145,9 +145,8 @@ const devServerMiddleware =
   skuConfig.devServerMiddleware &&
   getPathFromCwd(skuConfig.devServerMiddleware);
 
-const useDevServerMiddleware = devServerMiddleware
-  ? existsSync(devServerMiddleware)
-  : false;
+const useDevServerMiddleware = Boolean(devServerMiddleware) ||
+  existsSync(devServerMiddleware);
 
 if (devServerMiddleware && !useDevServerMiddleware) {
   throw new Error(

--- a/packages/sku/context/packageManager.mjs
+++ b/packages/sku/context/packageManager.mjs
@@ -2,18 +2,13 @@
 /** @type {string | undefined} */
 let packageManager;
 
-const getPackageManager = () => {
+export const getPackageManager = () => {
   return packageManager;
 };
 
 /**
  * @param {string | undefined} pm
  */
-const setPackageManager = (pm) => {
+export const setPackageManager = (pm) => {
   packageManager = pm;
-};
-
-module.exports = {
-  getPackageManager,
-  setPackageManager,
 };

--- a/packages/sku/context/validateConfig.mjs
+++ b/packages/sku/context/validateConfig.mjs
@@ -1,10 +1,10 @@
-const browserslist = require('browserslist');
-const { yellow, red, bold, underline, white } = require('chalk');
-const didYouMean = require('didyoumean2').default;
+import browserslist from 'browserslist';
+import { yellow, red, bold, underline, white } from 'chalk';
+import didYouMean from 'didyoumean2';
 
-const configSchema = require('./configSchema');
-const defaultSkuConfig = require('./defaultSkuConfig');
-const defaultClientEntry = require('./defaultClientEntry');
+import configSchema from './configSchema.mjs';
+import defaultSkuConfig from './defaultSkuConfig';
+import defaultClientEntry from './defaultClientEntry';
 
 const availableConfigKeys = Object.keys(defaultSkuConfig);
 
@@ -16,7 +16,7 @@ const exitWithErrors = async (errors) => {
   process.exit(1);
 };
 
-module.exports = (skuConfig) => {
+export default (skuConfig) => {
   const errors = [];
 
   // Validate extra keys


### PR DESCRIPTION
Part of the incremental ESM migration. See [the feature branch diff](https://github.com/seek-oss/sku/compare/v14...v14-mjs-refactor) for history.

Note that file extensions in dependent files have intentionally not been updated. They will be addressed in the future.