### PR TITLE
Convert `test-utils` to ESM, enable type checking for some files

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 9.15.0(jiti@1.21.6)
       eslint-config-seek:
         specifier: ^14.2.0
-        version: 14.2.0(@typescript-eslint/eslint-plugin@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(eslint@9.15.0(jiti@1.21.6)))(eslint@9.15.0(jiti@1.21.6))(jest@29.7.0(@types/node@18.19.57)(babel-plugin-macros@3.1.0))(typescript@5.6.3)
+        version: 14.2.0(@typescript-eslint/eslint-plugin@8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6)))(eslint@9.15.0(jiti@1.21.6))(jest@29.7.0(@types/node@18.19.57)(babel-plugin-macros@3.1.0))(typescript@5.6.3)
       eslint-plugin-jsdoc:
         specifier: ^50.2.2
         version: 50.5.0(eslint@9.15.0(jiti@1.21.6))
@@ -610,7 +610,7 @@ importers:
         version: 5.15.2(webpack@5.95.0(@swc/core@1.7.36)(esbuild@0.24.0))
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: ^0.5.15
-        version: 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.1.0(debug@4.3.7)(webpack@5.95.0(@swc/core@1.7.36)(esbuild@0.24.0)))(webpack-hot-middleware@2.26.1)(webpack@5.95.0(@swc/core@1.7.36)(esbuild@0.24.0))
+        version: 0.5.15(@types/webpack@4.41.40)(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.1.0(debug@4.3.7)(webpack@5.95.0(@swc/core@1.7.36)(esbuild@0.24.0)))(webpack-hot-middleware@2.26.1)(webpack@5.95.0(@swc/core@1.7.36)(esbuild@0.24.0))
       '@storybook/react-webpack5':
         specifier: ^7.0.0 || ^8.0.0
         version: 8.3.6(@swc/core@1.7.36)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.6)(typescript@5.6.3)
@@ -915,9 +915,24 @@ importers:
 
   test-utils:
     dependencies:
+      '@types/css':
+        specifier: ^0.0.38
+        version: 0.0.38
+      '@types/diffable-html':
+        specifier: ^5.0.2
+        version: 5.0.2
+      '@types/git-diff':
+        specifier: ^2.0.7
+        version: 2.0.7
+      '@types/hostile':
+        specifier: ^1.3.5
+        version: 1.3.5
       '@types/wait-on':
         specifier: ^5.3.4
         version: 5.3.4
+      '@types/webpack-stats-plugin':
+        specifier: ^0.3.5
+        version: 0.3.5
       css:
         specifier: ^3.0.0
         version: 3.0.0
@@ -934,8 +949,8 @@ importers:
         specifier: ^0.1.17
         version: 0.1.17
       prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^3.4.1
+        version: 3.4.1
       serve-handler:
         specifier: ^6.1.3
         version: 6.1.6
@@ -2884,8 +2899,14 @@ packages:
   '@types/cross-spawn@6.0.6':
     resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
+  '@types/css@0.0.38':
+    resolution: {integrity: sha512-FsAy4pBnrJb8qdKmIyDy582o4Xt8pHwpCwYRmIvXw4dslA7C4436oOM+8XNnMEsV/LSculbFNaZsBZmycDjARw==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/diffable-html@5.0.2':
+    resolution: {integrity: sha512-VS6yWnAFw8Dm1BhrTwt84V5VWbdysOOF32vbCtQJMtJxzpLGAIZ5P+1NfRX0elYluZ70vwPkm9msdrHBB2ijFQ==}
 
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
@@ -2917,11 +2938,17 @@ packages:
   '@types/fined@1.1.5':
     resolution: {integrity: sha512-2N93vadEGDFhASTIRbizbl4bNqpMOId5zZfj6hHqYZfEzEfO9onnU4Im8xvzo8uudySDveDHBOOSlTWf38ErfQ==}
 
+  '@types/git-diff@2.0.7':
+    resolution: {integrity: sha512-hipFAUcmf3c+45+Y8+J/xk7gT+0HBuT3O8OTtrnoP6R9gI0r2xESZNdYiA0pj7kQyPCwmkgbnxmfwQ9Ld2lZLQ==}
+
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/hostile@1.3.5':
+    resolution: {integrity: sha512-NvElcxcjEEBZdJ2Xfl8GEFx+c79PTCk5q1mlkCBv8ED+I6n3EfCQzQ4x1IbiOM2nFHMqBOe/MTZwLMtn30WYaQ==}
 
   '@types/html-minifier-terser@6.1.0':
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
@@ -3043,14 +3070,23 @@ packages:
   '@types/sockjs@0.3.36':
     resolution: {integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==}
 
+  '@types/source-list-map@0.1.6':
+    resolution: {integrity: sha512-5JcVt1u5HDmlXkwOD2nslZVllBBc7HDuOICfiZah2Z0is8M8g+ddAEawbmd3VjedfDHBzxCaXLs07QEmb7y54g==}
+
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/tapable@1.0.12':
+    resolution: {integrity: sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==}
 
   '@types/through@0.0.33':
     resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/uglify-js@3.17.5':
+    resolution: {integrity: sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -3060,6 +3096,15 @@ packages:
 
   '@types/webpack-bundle-analyzer@4.7.0':
     resolution: {integrity: sha512-c5i2ThslSNSG8W891BRvOd/RoCjI2zwph8maD22b1adtSns20j+0azDDMCK06DiVrzTgnwiDl5Ntmu1YRJw8Sg==}
+
+  '@types/webpack-sources@3.2.3':
+    resolution: {integrity: sha512-4nZOdMwSPHZ4pTEZzSp0AsTM4K7Qmu40UKW4tJDiOVs20UzYF9l+qUe4s0ftfN0pin06n+5cWWDJXH+sbhAiDw==}
+
+  '@types/webpack-stats-plugin@0.3.5':
+    resolution: {integrity: sha512-Iozu/j/9VwN4x6MYSax2G+zMaXMpFhX0pLL/i1d4HkRg50uYuFw/W0jQho1nyF6IxwUJLZajg60Wt92B7yTLWw==}
+
+  '@types/webpack@4.41.40':
+    resolution: {integrity: sha512-u6kMFSBM9HcoTpUXnL6mt2HSzftqb3JgYV6oxIgL2dl6sX6aCa5k6SOkzv5DuZjBTPUE/dJltKtwwuqrkZHpfw==}
 
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
@@ -10370,7 +10415,7 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.1.0(debug@4.3.7)(webpack@5.95.0(@swc/core@1.7.36)(esbuild@0.24.0)))(webpack-hot-middleware@2.26.1)(webpack@5.95.0(@swc/core@1.7.36)(esbuild@0.24.0))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(@types/webpack@4.41.40)(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.1.0(debug@4.3.7)(webpack@5.95.0(@swc/core@1.7.36)(esbuild@0.24.0)))(webpack-hot-middleware@2.26.1)(webpack@5.95.0(@swc/core@1.7.36)(esbuild@0.24.0))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.38.1
@@ -10382,6 +10427,7 @@ snapshots:
       source-map: 0.7.4
       webpack: 5.95.0(@swc/core@1.7.36)(esbuild@0.24.0)
     optionalDependencies:
+      '@types/webpack': 4.41.40
       type-fest: 2.19.0
       webpack-dev-server: 5.1.0(debug@4.3.7)(webpack@5.95.0(@swc/core@1.7.36)(esbuild@0.24.0))
       webpack-hot-middleware: 2.26.1
@@ -11073,9 +11119,13 @@ snapshots:
     dependencies:
       '@types/node': 18.19.57
 
+  '@types/css@0.0.38': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 0.7.34
+
+  '@types/diffable-html@5.0.2': {}
 
   '@types/doctrine@0.0.9': {}
 
@@ -11115,6 +11165,8 @@ snapshots:
 
   '@types/fined@1.1.5': {}
 
+  '@types/git-diff@2.0.7': {}
+
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 18.19.57
@@ -11122,6 +11174,8 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/hostile@1.3.5': {}
 
   '@types/html-minifier-terser@6.1.0': {}
 
@@ -11253,13 +11307,21 @@ snapshots:
     dependencies:
       '@types/node': 18.19.57
 
+  '@types/source-list-map@0.1.6': {}
+
   '@types/stack-utils@2.0.3': {}
+
+  '@types/tapable@1.0.12': {}
 
   '@types/through@0.0.33':
     dependencies:
       '@types/node': 18.19.57
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/uglify-js@3.17.5':
+    dependencies:
+      source-map: 0.6.1
 
   '@types/unist@3.0.3': {}
 
@@ -11277,6 +11339,25 @@ snapshots:
       - esbuild
       - uglify-js
       - webpack-cli
+
+  '@types/webpack-sources@3.2.3':
+    dependencies:
+      '@types/node': 18.19.57
+      '@types/source-list-map': 0.1.6
+      source-map: 0.7.4
+
+  '@types/webpack-stats-plugin@0.3.5':
+    dependencies:
+      '@types/webpack': 4.41.40
+
+  '@types/webpack@4.41.40':
+    dependencies:
+      '@types/node': 18.19.57
+      '@types/tapable': 1.0.12
+      '@types/uglify-js': 3.17.5
+      '@types/webpack-sources': 3.2.3
+      anymatch: 3.1.3
+      source-map: 0.6.1
 
   '@types/wrap-ansi@3.0.0': {}
 
@@ -13321,29 +13402,7 @@ snapshots:
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import-x@4.2.1(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6)))(eslint@9.15.0(jiti@1.21.6))
       eslint-plugin-cypress: 3.6.0(eslint@9.15.0(jiti@1.21.6))
       eslint-plugin-import-x: 4.2.1(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
-      eslint-plugin-jest: 28.8.3(@typescript-eslint/eslint-plugin@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6))(jest@29.7.0(@types/node@18.19.57)(babel-plugin-macros@3.1.0))(typescript@5.6.3)
-      eslint-plugin-react: 7.37.2(eslint@9.15.0(jiti@1.21.6))
-      eslint-plugin-react-hooks: 5.0.0(eslint@9.15.0(jiti@1.21.6))
-      globals: 15.12.0
-      typescript: 5.6.3
-      typescript-eslint: 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
-    transitivePeerDependencies:
-      - '@typescript-eslint/eslint-plugin'
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import
-      - jest
-      - supports-color
-
-  eslint-config-seek@14.2.0(@typescript-eslint/eslint-plugin@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(eslint@9.15.0(jiti@1.21.6)))(eslint@9.15.0(jiti@1.21.6))(jest@29.7.0(@types/node@18.19.57)(babel-plugin-macros@3.1.0))(typescript@5.6.3):
-    dependencies:
-      eslint: 9.15.0(jiti@1.21.6)
-      eslint-config-prettier: 9.1.0(eslint@9.15.0(jiti@1.21.6))
-      eslint-import-resolver-typescript: 3.6.3(eslint-plugin-import-x@4.2.1(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(eslint@9.15.0(jiti@1.21.6)))(eslint@9.15.0(jiti@1.21.6))
-      eslint-plugin-cypress: 3.6.0(eslint@9.15.0(jiti@1.21.6))
-      eslint-plugin-import-x: 4.2.1(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
-      eslint-plugin-jest: 28.8.3(@typescript-eslint/eslint-plugin@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6))(jest@29.7.0(@types/node@18.19.57)(babel-plugin-macros@3.1.0))(typescript@5.6.3)
+      eslint-plugin-jest: 28.8.3(@typescript-eslint/eslint-plugin@8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6))(jest@29.7.0(@types/node@18.19.57)(babel-plugin-macros@3.1.0))(typescript@5.6.3)
       eslint-plugin-react: 7.37.2(eslint@9.15.0(jiti@1.21.6))
       eslint-plugin-react-hooks: 5.0.0(eslint@9.15.0(jiti@1.21.6))
       globals: 15.12.0
@@ -13386,26 +13445,6 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(eslint-plugin-import-x@4.2.1(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(eslint@9.15.0(jiti@1.21.6)))(eslint@9.15.0(jiti@1.21.6)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.3.7(supports-color@8.1.1)
-      enhanced-resolve: 5.17.1
-      eslint: 9.15.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(eslint-import-resolver-typescript@3.6.3(eslint-plugin-import-x@4.2.1(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(eslint@9.15.0(jiti@1.21.6)))(eslint@9.15.0(jiti@1.21.6)))(eslint@9.15.0(jiti@1.21.6))
-      fast-glob: 3.3.2
-      get-tsconfig: 4.8.1
-      is-bun-module: 1.2.1
-      is-glob: 4.0.3
-    optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6))
-      eslint-plugin-import-x: 4.2.1(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
-      - supports-color
-
   eslint-module-utils@2.12.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.15.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
@@ -13424,15 +13463,6 @@ snapshots:
       '@typescript-eslint/parser': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
       eslint: 9.15.0(jiti@1.21.6)
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import-x@4.2.1(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6)))(eslint@9.15.0(jiti@1.21.6))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.0(eslint-import-resolver-typescript@3.6.3(eslint-plugin-import-x@4.2.1(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(eslint@9.15.0(jiti@1.21.6)))(eslint@9.15.0(jiti@1.21.6)))(eslint@9.15.0(jiti@1.21.6)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      eslint: 9.15.0(jiti@1.21.6)
-      eslint-import-resolver-typescript: 3.6.3(eslint-plugin-import-x@4.2.1(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(eslint@9.15.0(jiti@1.21.6)))(eslint@9.15.0(jiti@1.21.6))
     transitivePeerDependencies:
       - supports-color
 
@@ -13488,7 +13518,7 @@ snapshots:
       - supports-color
     optional: true
 
-  eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6))(jest@29.7.0(@types/node@18.19.57)(babel-plugin-macros@3.1.0))(typescript@5.6.3):
+  eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6))(jest@29.7.0(@types/node@18.19.57)(babel-plugin-macros@3.1.0))(typescript@5.6.3):
     dependencies:
       '@typescript-eslint/utils': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
       eslint: 9.15.0(jiti@1.21.6)

--- a/test-utils/ListExternalsWebpackPlugin.js
+++ b/test-utils/ListExternalsWebpackPlugin.js
@@ -1,8 +1,8 @@
-const { StatsWriterPlugin } = require('webpack-stats-plugin');
+import { StatsWriterPlugin } from 'webpack-stats-plugin';
 
 const externalRegex = /^external node-commonjs "/;
 
-class ListExternalsWebpackPlugin {
+export class ListExternalsWebpackPlugin {
   constructor({ filename = 'externals.json' } = {}) {
     return new StatsWriterPlugin({
       filename,
@@ -23,5 +23,3 @@ class ListExternalsWebpackPlugin {
     });
   }
 }
-
-module.exports = { ListExternalsWebpackPlugin };

--- a/test-utils/appSnapshot.js
+++ b/test-utils/appSnapshot.js
@@ -1,11 +1,17 @@
-const getAppSnapshot = async (url, warningFilter = () => true) => {
+// @ts-check
+/**
+ * @param {string} url
+ */
+export const getAppSnapshot = async (url, warningFilter = () => true) => {
+  /** @type {string[]} */
   const warnings = [];
+  /** @type {string[]} */
   const errors = [];
 
   const appPage = await browser.newPage();
 
   appPage.on('console', (msg) => {
-    if (msg.type() === 'warning') {
+    if (msg.type() === 'warn') {
       warnings.filter(warningFilter).push(msg.text());
     }
 
@@ -13,7 +19,7 @@ const getAppSnapshot = async (url, warningFilter = () => true) => {
       let isFaviconError = false;
       msg.stackTrace().forEach((frame) => {
         // Ignore 404s for favicons
-        if (frame.url.endsWith('favicon.ico')) {
+        if (frame?.url?.endsWith('favicon.ico')) {
           isFaviconError = true;
           return;
         }
@@ -30,15 +36,11 @@ const getAppSnapshot = async (url, warningFilter = () => true) => {
   });
 
   const response = await appPage.goto(url, { waitUntil: 'load' });
-  const sourceHtml = await response.text();
+  const sourceHtml = await response?.text();
   const clientRenderContent = await appPage.content();
 
   expect(warnings).toEqual([]);
   expect(errors).toEqual([]);
 
   return { sourceHtml, clientRenderContent };
-};
-
-module.exports = {
-  getAppSnapshot,
 };

--- a/test-utils/appSnapshotSerializer.js
+++ b/test-utils/appSnapshotSerializer.js
@@ -1,13 +1,18 @@
-const diff = require('git-diff');
-const { formatHtml } = require('./formatHtml');
+// @ts-check
+import diff from 'git-diff';
+import { formatHtml } from './formatHtml.js';
 
 const appSnapshotSerializer = {
+  /**
+   * @param {{sourceHtml: string, clientRenderContent: string}} html
+   * @param {(s: unknown) => string} serializer
+   */
   print: ({ sourceHtml, clientRenderContent }, serializer) => {
     const formattedSourceHtml = formatHtml(sourceHtml);
     const formattedClientHtml = formatHtml(clientRenderContent);
 
     const htmlDiff = diff(formattedSourceHtml, formattedClientHtml, {
-      colors: false,
+      color: false,
       noHeaders: true,
     });
 
@@ -19,10 +24,11 @@ const appSnapshotSerializer = {
     return snapshotItems.join('\n');
   },
 
+  /** @param {unknown} val */
   test: (val) =>
     val &&
     val.hasOwnProperty('clientRenderContent') &&
     val.hasOwnProperty('sourceHtml'),
 };
 
-module.exports = appSnapshotSerializer;
+export default appSnapshotSerializer;

--- a/test-utils/assetServer.js
+++ b/test-utils/assetServer.js
@@ -1,9 +1,9 @@
-const handler = require('serve-handler');
-const http = require('node:http');
+import handler from 'serve-handler';
+import { createServer } from 'node:http';
 
-const startAssetServer = async (port, targetDirectory, rewrites = []) =>
+export const startAssetServer = async (port, targetDirectory, rewrites = []) =>
   new Promise((resolve) => {
-    const server = http.createServer((request, response) => {
+    const server = createServer((request, response) => {
       return handler(request, response, {
         public: targetDirectory,
         // So we can test storybook iframe pages when serving a built storybook
@@ -27,5 +27,3 @@ const startAssetServer = async (port, targetDirectory, rewrites = []) =>
       resolve(() => server.close());
     });
   });
-
-module.exports = { startAssetServer };

--- a/test-utils/cssSnapshotSerializer.js
+++ b/test-utils/cssSnapshotSerializer.js
@@ -1,11 +1,14 @@
-const prettier = require('prettier');
-const css = require('css');
+// @ts-check
+import { format } from 'prettier';
+import { parse } from 'css';
 
 const cssSnapshotSerializer = {
-  print: (value) => prettier.format(value, { parser: 'css' }),
+  /** @param {string} value */
+  print: (value) => format(value, { parser: 'css' }),
+  /** @param {string} value */
   test: (value) => {
     try {
-      css.parse(value);
+      parse(value);
     } catch {
       return false;
     }
@@ -13,4 +16,4 @@ const cssSnapshotSerializer = {
   },
 };
 
-module.exports = cssSnapshotSerializer;
+export default cssSnapshotSerializer;

--- a/test-utils/dirContentsToObject.js
+++ b/test-utils/dirContentsToObject.js
@@ -1,6 +1,8 @@
-const { promisify } = require('node:util');
-const readFilesAsync = promisify(require('node-dir').readFiles);
-const { relative } = require('node:path');
+import { promisify } from 'node:util';
+import { readFiles } from 'node-dir';
+import { relative } from 'node:path';
+
+const readFilesAsync = promisify(readFiles);
 
 // Ignore contents of files where the content changes
 // regularly or is non-deterministic.
@@ -10,7 +12,7 @@ const ignoredFilePattern = new RegExp(
   'i',
 );
 
-const dirContentsToObject = async (dirname, includeExtensions) => {
+export const dirContentsToObject = async (dirname, includeExtensions) => {
   const files = {};
 
   const handleFile = (err, content, filePath, next) => {
@@ -37,4 +39,3 @@ const dirContentsToObject = async (dirname, includeExtensions) => {
 
   return files;
 };
-module.exports = { dirContentsToObject };

--- a/test-utils/formatHtml.js
+++ b/test-utils/formatHtml.js
@@ -1,5 +1,5 @@
-const diffableHtml = require('diffable-html');
+// @ts-check
+import diffableHtml from 'diffable-html';
 
-const formatHtml = (html) => diffableHtml(html).trim();
-
-module.exports = { formatHtml };
+/** @param {string} html */
+export const formatHtml = (html) => diffableHtml(html).trim();

--- a/test-utils/htmlSnapshotSerializer.js
+++ b/test-utils/htmlSnapshotSerializer.js
@@ -1,8 +1,15 @@
-const { formatHtml } = require('./formatHtml');
+// @ts-check
+import { formatHtml } from './formatHtml.js';
 
 const htmlSnapshotSerializer = {
+  /**
+   * @param {string} html
+   * @param {(s: unknown) => string} serializer
+   */
   print: (html, serializer) => {
+    /** @type {unknown[]} */
     const scripts = [];
+    /** @type {unknown[]} */
     const styles = [];
 
     const extractedHtml = formatHtml(html).replace(
@@ -28,9 +35,10 @@ const htmlSnapshotSerializer = {
       `SOURCE HTML: ${formatHtml(extractedHtml)}`,
     ].join('\n');
   },
+  /** @param {string} value */
   test: (value) => {
     return typeof value === 'string' && value.startsWith('<!DOCTYPE html>');
   },
 };
 
-module.exports = htmlSnapshotSerializer;
+export default htmlSnapshotSerializer;

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -1,21 +1,9 @@
-const { ListExternalsWebpackPlugin } = require('./ListExternalsWebpackPlugin');
-const appSnapshot = require('./appSnapshot');
-const { startAssetServer } = require('./assetServer');
-const { dirContentsToObject } = require('./dirContentsToObject');
-const { run, runSkuScriptInDir } = require('./process');
-const { makeStableHashes } = require('./skuConfig');
-const { getStoryPage, getTextContentFromFrameOrPage } = require('./storybook');
-const { waitForUrls } = require('./waitForUrls');
-
-module.exports = {
-  ListExternalsWebpackPlugin,
-  ...appSnapshot,
-  startAssetServer,
-  dirContentsToObject,
-  getStoryPage,
-  getTextContentFromFrameOrPage,
-  makeStableHashes,
-  run,
-  runSkuScriptInDir,
-  waitForUrls,
-};
+// @ts-check
+export { ListExternalsWebpackPlugin } from './ListExternalsWebpackPlugin.js';
+export { getAppSnapshot } from './appSnapshot.js';
+export { startAssetServer } from './assetServer.js';
+export { dirContentsToObject } from './dirContentsToObject.js';
+export { run, runSkuScriptInDir } from './process.js';
+export { makeStableHashes } from './skuConfig.js';
+export { getStoryPage, getTextContentFromFrameOrPage } from './storybook.js';
+export { waitForUrls } from './waitForUrls.js';

--- a/test-utils/package.json
+++ b/test-utils/package.json
@@ -1,14 +1,20 @@
 {
   "name": "@sku-private/test-utils",
   "private": true,
+  "type": "module",
   "dependencies": {
+    "@types/css": "^0.0.38",
+    "@types/diffable-html": "^5.0.2",
+    "@types/git-diff": "^2.0.7",
+    "@types/hostile": "^1.3.5",
     "@types/wait-on": "^5.3.4",
+    "@types/webpack-stats-plugin": "^0.3.5",
     "css": "^3.0.0",
     "diffable-html": "^5.0.0",
     "git-diff": "^2.0.6",
     "hostile": "^1.3.3",
     "node-dir": "^0.1.17",
-    "prettier": "^2.8.8",
+    "prettier": "^3.4.1",
     "serve-handler": "^6.1.3",
     "wait-on": "^8.0.1",
     "webpack-stats-plugin": "^1.0.3"

--- a/test-utils/process.ts
+++ b/test-utils/process.ts
@@ -1,4 +1,4 @@
-import { promisify } from "node:util";
+import { promisify } from 'node:util';
 // spawn can't be promisified so we use execFile, which just wraps spawn and can be promisifyied
 // https://github.com/nodejs/node/blob/2f369ccacfb60c034de806f24164524910301825/lib/child_process.js#L326
 import {
@@ -6,16 +6,18 @@ import {
   type SpawnOptions,
   type ChildProcess,
   type ExecFileOptions,
-} from "node:child_process";
-import gracefulSpawn from "../packages/sku/lib/gracefulSpawn.js";
+} from 'node:child_process';
+import gracefulSpawn from '../packages/sku/lib/gracefulSpawn.js';
+import { createRequire } from 'node:module';
 
 const execFile = promisify(_execFile);
-const skuBin = require.resolve("../packages/sku/bin/sku.js");
+const require = createRequire(import.meta.url);
+const skuBin = require.resolve('../packages/sku/bin/sku.js');
 
 export const run = async (
   file: string,
   args: string[] = [],
-  options: ExecFileOptions = {}
+  options: ExecFileOptions = {},
 ) => {
   try {
     const promise = execFile(file, args, {
@@ -45,35 +47,35 @@ export const run = async (
   }
 };
 
-type DevServerSkuScripts = "serve" | "start" | "start-ssr" | "storybook";
+type DevServerSkuScripts = 'serve' | 'start' | 'start-ssr' | 'storybook';
 type SkuScript =
   | DevServerSkuScripts
-  | "build"
-  | "build-ssr"
-  | "build-storybook"
-  | "configure"
-  | "format"
-  | "init"
-  | "lint"
-  | "test";
+  | 'build'
+  | 'build-ssr'
+  | 'build-storybook'
+  | 'configure'
+  | 'format'
+  | 'init'
+  | 'lint'
+  | 'test';
 
 export async function runSkuScriptInDir(
   script: DevServerSkuScripts,
   cwd: string,
   args?: string[],
-  options?: SpawnOptions
+  options?: SpawnOptions,
 ): Promise<ReturnType<typeof gracefulSpawn>>;
 export async function runSkuScriptInDir(
   script: Exclude<SkuScript, DevServerSkuScripts>,
   cwd: string,
   args?: string[],
-  options?: SpawnOptions
+  options?: SpawnOptions,
 ): Promise<{ stdout: string; stderr: string; child: ChildProcess }>;
 export async function runSkuScriptInDir(
   script: SkuScript,
   cwd: string,
   args?: string[],
-  options?: SpawnOptions
+  options?: SpawnOptions,
 ): Promise<
   ChildProcess | { stdout: string; stderr: string; child: ChildProcess }
 > {
@@ -92,7 +94,7 @@ export async function runSkuScriptInDir(
   // When starting a dev server, return a hook to the running process
   if (/^(start|serve)/.test(script)) {
     return gracefulSpawn(skuBin, [script, ...(args || [])], {
-      stdio: "inherit",
+      stdio: 'inherit',
       ...processOptions,
     });
   }

--- a/test-utils/setupTestHosts.js
+++ b/test-utils/setupTestHosts.js
@@ -1,7 +1,8 @@
-const { promisify } = require('node:util');
-const hostile = require('hostile');
+// @ts-check
+import { promisify } from 'node:util';
+import { set } from 'hostile';
 
-const setSystemHost = promisify(hostile.set);
+const setSystemHost = promisify(set);
 
 const hosts = ['dev.seek.com.au', 'dev.jobstreet.com'];
 

--- a/test-utils/skuConfig.js
+++ b/test-utils/skuConfig.js
@@ -1,4 +1,4 @@
-const makeStableHashes = (config) => {
+export const makeStableHashes = (config) => {
   // Addresses an issue where module IDs were different between local dev and CI
   config.optimization.chunkIds = 'natural';
   config.optimization.moduleIds = 'natural';
@@ -12,8 +12,4 @@ const makeStableHashes = (config) => {
   }
 
   return config;
-};
-
-module.exports = {
-  makeStableHashes,
 };

--- a/test-utils/waitForUrls.js
+++ b/test-utils/waitForUrls.js
@@ -1,6 +1,6 @@
-const waitOn = require('wait-on');
+import waitOn from 'wait-on';
 
-const waitForUrls = async (...urls) => {
+export const waitForUrls = async (...urls) => {
   const timeout = 200000;
 
   try {
@@ -27,5 +27,3 @@ const waitForUrls = async (...urls) => {
     throw error;
   }
 };
-
-module.exports = { waitForUrls };


### PR DESCRIPTION
`test-utils` need to be ESM as they reference sku files. Added `// @ts-check` comments to some files that were easy to add type annotations to. This also required some `@types` dependencies to be installed.