### PR TITLE
Fix tests in CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -82,4 +82,4 @@ jobs:
           restore-keys: jest-${{ runner.os }}-
 
       - name: Test
-        run: pnpm run test && pnpm run test:sku-init
+        run: aa-exec --profile=chrome pnpm run test && aa-exec --profile=chrome pnpm run test:sku-init


### PR DESCRIPTION
CI currently [fails](https://github.com/seek-oss/sku/actions/runs/12781542320/job/35629617908#step:14:13) on `master` because `puppeteer` refuses to run due to a sanboxing issue.

This started happening suddenly, and without any changes to sku `master` over the last few weeks, because [Ubuntu 24.04 started to be rolled out](https://github.com/actions/runner-images/issues/10636) to `ubuntu-latest` agents (previously it was Ubuntu 22.10). Due to stricter sandboxing in Ubuntu 23.10, Chrome binaries that aren't installed at an expected path will not run. See [here](https://github.com/puppeteer/puppeteer/blob/d98c877ead8cf2f32fe793260d2b2c2f618964f9/docs/troubleshooting.md#issues-with-apparmor-on-ubuntu) for more info and some workarounds.

Upon digging further into various repo issues related to this, such as:
- https://github.com/puppeteer/puppeteer/issues/12818
- https://github.com/puppeteer/puppeteer/pull/13196
- https://github.com/sumup-oss/circuit-ui/pull/2862

I've decided to implement the workaround described [here](https://github.com/mermaid-js/mermaid-cli/issues/730#issuecomment-2408615110). This utilizes [`aa-exec`](https://manpages.ubuntu.com/manpages/trusty/man8/aa-exec.8.html) to explicitly set the `chrome` policy on our `pnpm` process, allowing it to successfully spin up the version of Chrome installed by puppeteer.