### PR TITLE
Fixes a bug that caused React 19 applications to fail during `sku build`

### DIFF
--- a/.changeset/great-gifts-hope.md
+++ b/.changeset/great-gifts-hope.md
@@ -1,0 +1,7 @@
+---
+'sku': patch
+---
+
+Fixes a bug that caused React 19 applications to fail during `sku build`
+
+Note: remaining on React 18 is recommended until `sku` officially supports React 19. Updating your application to React 19 may require overriding dependency versions by configuring your package manager. Additionally, there may be other incompatibilities that haven't been found yet.

--- a/packages/sku/config/babel/babelConfig.js
+++ b/packages/sku/config/babel/babelConfig.js
@@ -45,7 +45,6 @@ module.exports = ({
 
   if (isProductionBuild) {
     plugins.push(
-      require.resolve('@babel/plugin-transform-react-inline-elements'),
       require.resolve('babel-plugin-transform-react-remove-prop-types'),
       require.resolve('@babel/plugin-transform-react-constant-elements'),
     );

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -52,7 +52,6 @@
   "dependencies": {
     "@babel/core": "^7.21.8",
     "@babel/plugin-transform-react-constant-elements": "^7.21.3",
-    "@babel/plugin-transform-react-inline-elements": "^7.21.0",
     "@babel/plugin-transform-runtime": "^7.21.4",
     "@babel/preset-env": "^7.21.5",
     "@babel/preset-react": "^7.18.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -566,9 +566,6 @@ importers:
       '@babel/plugin-transform-react-constant-elements':
         specifier: ^7.21.3
         version: 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-react-inline-elements':
-        specifier: ^7.21.0
-        version: 7.25.7(@babel/core@7.25.8)
       '@babel/plugin-transform-runtime':
         specifier: ^7.21.4
         version: 7.25.7(@babel/core@7.25.8)
@@ -1061,10 +1058,6 @@ packages:
     resolution: {integrity: sha512-12xfNeKNH7jubQNm7PAkzlLwEmCs1tfuX3UjIw6vP6QXi+leKh6+LyC/+Ed4EIQermwd58wsyh070yjDHFlNGg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-builder-react-jsx@7.25.7':
-    resolution: {integrity: sha512-fqUfgY1k8uhv8T9boCLTF5fVVJFkHZ9qE3C62UQeVRxSgVtLvWpCfutxGdC+RNOjWTjJu7x7xFEJZiQQeP+gIw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-compilation-targets@7.25.7':
     resolution: {integrity: sha512-DniTEax0sv6isaw6qSQSfV4gVRNtw2rte8HHM45t9ZR0xILaufBRNkpMifCRiAPyvL4ACD6v0gfCwCmtOQaV4A==}
     engines: {node: '>=6.9.0'}
@@ -1541,12 +1534,6 @@ packages:
 
   '@babel/plugin-transform-react-display-name@7.25.7':
     resolution: {integrity: sha512-r0QY7NVU8OnrwE+w2IWiRom0wwsTbjx4+xH2RTd7AVdof3uurXOF+/mXHQDRk+2jIvWgSaCHKMgggfvM4dyUGA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-inline-elements@7.25.7':
-    resolution: {integrity: sha512-X92N1hWgUkZCvFJPFepIhd3XfiEmdkIC5IEckJ1sUpP7xlWwetHRfJtHtcuS5/7pKGgCAEB6ensiIY2QTP6MqA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -8527,11 +8514,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-builder-react-jsx@7.25.7':
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.25.7
-      '@babel/types': 7.26.0
-
   '@babel/helper-compilation-targets@7.25.7':
     dependencies:
       '@babel/compat-data': 7.25.8
@@ -9068,12 +9050,6 @@ snapshots:
   '@babel/plugin-transform-react-display-name@7.25.7(@babel/core@7.25.8)':
     dependencies:
       '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.25.7
-
-  '@babel/plugin-transform-react-inline-elements@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-builder-react-jsx': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-transform-react-jsx-development@7.25.7(@babel/core@7.25.8)':


### PR DESCRIPTION
TL;DR: Babel's JSX runtime is incompatible with React 19. We've been using Babel's JSX runtime since before [React had one](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html). React's runtime effectively makes the Babel one obsolete, so [the plugin that injects it](https://babeljs.io/docs/babel-plugin-transform-react-inline-elements) has been removed in favour of letting `@babel/preset-react` inject React's runtime.

> [!CAUTION]
> This PR _does not_ explicitly implement support for React 19 or any of its features (e.g. RSC, the React compiler).
> While your application may work with React 19, it is not recommended to upgrade just yet.

## Problem

Applications that attempt to run a `sku build` with React 19 as a dependency will run into the following error during the static render:

```
Objects are not valid as a React child (found: object with keys {$$typeof, type, key, ref, props, _owner}). If you meant to render a collection of children, use an array instead.
```

This error occurs regardless of what is being rendered. My minimal reproduction involved rendering a single `<div />`.

## Investigation

There were a number of stepping stones that lead me to find the cause of this problem. The first notable observation was that this error occurred during `sku build`, not during `sku start`. So something about the production environment and/or the lack of a dev server was the cause.

After some googling, I also found https://github.com/facebook/react/issues/31832, which suggested that the issue was related to [the JSX runtime](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) somehow. Additionally, replacing the JSX `<div />` with a `createElement('div')` in the static render resulted in a successful build. However, serving the production app with `sku serve` would result in [Minified React error #525](https://react.dev/errors/525):

```
A React Element from an older version of React was rendered. This is not supported. It can happen if:
- Multiple copies of the "react" package is used.
- A library pre-bundled an old copy of "react" or "react/jsx-runtime".
- A compiler tries to "inline" JSX instead of using the runtime.
```

This adds to the theory that the JSX runtime is somehow to blame.

After this I wanted to inspect the actual code being used for the static render, so I looked at the `dist/render.js` file, but there weren't any notable differences in the code between react 18 and react 19.

Using [RSDoctor](https://rsdoctor.dev/) to see the transform being applied by `babel-loader`, I noticed that the JSX runtime being injected into our code was actually babel's JSX runtime from `@babel/runtime/helpers/jsx` rather than the React one from `react/jsx-runtime`. This was being injected by `@babel/plugin-transform-react-inline-elements` which notably only runs in production. Removing this plugin and instead relying on the react JSX runtime (injected by `@babel/preset-react`) fixed the error.

## Cause

It's not immediately apparent why swapping from babel's JSX runtime to React's would fix the issue. Comparing the result of the JSX runtime on a simple `<div />` makes the issue more apparent:

```js
// React 18
{
  '$$typeof': Symbol(react.element),
  type: 'div',
  key: null,
  ref: null,
  props: {},
  _owner: null
}

// React 19
{
  '$$typeof': Symbol(react.transitional.element),
  type: 'div',
  key: null,
  ref: null,
  props: {}
}
```

With a bit of digging, we can see that [the symbol used to identify React elements was intentionally changed in React 19](https://github.com/facebook/react/commit/3b551c82844bcfde51f0febb8e42c1a0d777df2c) to help make runtime mismatch errors more apparent. In reality the error we were seeing wasn't very helpful at all 😢.

## Fix

The JSX runtime provided by [`@babel/plugin-transform-react-inline-elements`
](https://babeljs.io/docs/babel-plugin-transform-react-inline-elements) evidently doesn't support React 19. Removing it results in babel injecting React's runtime (via `@babel/preset-react`) which supports React 19, and fixes the build error.

We've likely just kept the babel runtime around because we were using it since [well before React provided it's own JSX runtime](https://github.com/seek-oss/sku/blame/f9965a1f35df57869eca3d5e339ea2e994536ccd/packages/sku/config/babel/babelConfig.js#L48). However, it's effectively obsolete thesedays, so I have no qualms with removing it.

> [!NOTE]
> While I wanted to update a single fixture to use React 19 in order to reproduce the bug, due to various dependencies still not support React 19, dependency overrides would've been required to get this working.
> I'd prefer to avoid overriding `react` dependencies, at least until we officially support React 19, so for that reason I chose to just implement the fix.