### PR TITLE
turning filemock into cjs for jest resolver

### DIFF
--- a/packages/sku/src/config/jest/fileMock.cjs
+++ b/packages/sku/src/config/jest/fileMock.cjs
@@ -1,0 +1,1 @@
+module.exports = 'MOCK_FILE';

--- a/packages/sku/src/config/jest/fileMock.js
+++ b/packages/sku/src/config/jest/fileMock.js
@@ -1,1 +1,0 @@
-export default 'MOCK_FILE';

--- a/packages/sku/src/config/jest/jest-preset.js
+++ b/packages/sku/src/config/jest/jest-preset.js
@@ -26,7 +26,7 @@ export default jestDecorator({
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|svg)$':
-      fileURLToPath(import.meta.resolve('./fileMock')),
+      fileURLToPath(import.meta.resolve('./fileMock.cjs')),
   },
   transform: {
     '\\.css\\.ts$': fileURLToPath(


### PR DESCRIPTION
Jest resolves the mock as CJS and thus cant require the ESM module that it currently is.