### PR TITLE
Small CLI, test-utils package and postinstall fixes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -59,7 +59,7 @@ jobs:
         id: babel-loader-cache
         uses: actions/cache@v4
         with:
-          path: 'fixtures/*/node_modules/.cache/babel-loader'
+          path: "fixtures/*/node_modules/.cache/babel-loader"
           key: babel-loader-${{ runner.os }}-${{ hashFiles('./pnpm-lock.yaml') }}
 
       - name: Install Puppeteer
@@ -85,7 +85,7 @@ jobs:
           restore-keys: jest-${{ runner.os }}-
 
       - name: restore access to dist/sku
-        run: sudo chmod +x /home/runner/work/sku/sku/packages/sku/dist/bin/sku.js
+        run: sudo chmod +x /home/runner/work/sku/sku/packages/sku/bin.js
 
       - name: Test
         run: aa-exec --profile=chrome pnpm run test && aa-exec --profile=chrome pnpm run test:sku-init

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -84,8 +84,5 @@ jobs:
           key: jest-${{ runner.os }}-${{ hashFiles('./pnpm-lock.yaml') }}
           restore-keys: jest-${{ runner.os }}-
 
-      - name: restore access to dist/sku
-        run: sudo chmod +x /home/runner/work/sku/sku/packages/sku/dist/bin/sku.js
-
       - name: Test
         run: aa-exec --profile=chrome pnpm run test && aa-exec --profile=chrome pnpm run test:sku-init

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -85,7 +85,7 @@ jobs:
           restore-keys: jest-${{ runner.os }}-
 
       - name: restore access to dist/sku
-        run: sudo chmod +x /home/runner/work/sku/sku/packages/sku/bin.js
+        run: sudo chmod +x /home/runner/work/sku/sku/packages/sku/dist/bin/sku.js
 
       - name: Test
         run: aa-exec --profile=chrome pnpm run test && aa-exec --profile=chrome pnpm run test:sku-init

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -59,7 +59,7 @@ jobs:
         id: babel-loader-cache
         uses: actions/cache@v4
         with:
-          path: "fixtures/*/node_modules/.cache/babel-loader"
+          path: 'fixtures/*/node_modules/.cache/babel-loader'
           key: babel-loader-${{ runner.os }}-${{ hashFiles('./pnpm-lock.yaml') }}
 
       - name: Install Puppeteer

--- a/packages/sku/bin.js
+++ b/packages/sku/bin.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import './dist/bin/sku.js';

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -4,7 +4,7 @@
   "description": "Front-end development toolkit, powered by Webpack, Babel, Vanilla Extract and Jest",
   "types": "./sku-types.d.ts",
   "bin": {
-    "sku": "dist/bin/sku.js"
+    "sku": "bin.js"
   },
   "exports": {
     ".": "./sku-types.d.ts",
@@ -31,7 +31,8 @@
     "CHANGELOG.md",
     "sku-types.d.ts",
     "tsconfig.json",
-    "src/@loadable"
+    "src/@loadable",
+    "bin.js"
   ],
   "type": "module",
   "scripts": {

--- a/packages/sku/scripts/postinstall.js
+++ b/packages/sku/scripts/postinstall.js
@@ -60,7 +60,7 @@ try {
   let configure;
   try {
     log('postinstall', 'starting load of configure');
-    configure = (await import('../src/lib/configure.js')).default;
+    configure = (await import('../dist/lib/configure.js')).default;
   } catch (error) {
     console.error(
       'An error occurred loading configure script. Please check that sku.config.js is correct and try again.',

--- a/packages/sku/src/bin/sku.ts
+++ b/packages/sku/src/bin/sku.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { program } from '../lib/program/index.js';
 
 program.parse();

--- a/test-utils/package.json
+++ b/test-utils/package.json
@@ -2,6 +2,7 @@
   "name": "@sku-private/test-utils",
   "private": true,
   "type": "module",
+  "main": "index.js",
   "dependencies": {
     "@types/css": "^0.0.38",
     "@types/diffable-html": "^5.0.2",

--- a/test-utils/process.ts
+++ b/test-utils/process.ts
@@ -12,7 +12,7 @@ import { createRequire } from 'node:module';
 
 const execFile = promisify(_execFile);
 const require = createRequire(import.meta.url);
-const skuBin = require.resolve('../packages/sku/dist/bin/sku.js');
+const skuBin = require.resolve('../packages/sku/bin.js');
 
 export const run = async (
   file: string,


### PR DESCRIPTION
This PR fixes a few small things:
- The `chmod` that we use on CI is only necessary because sku's CLI is pointing to a file inside `dist` (`dist/bin/sku.js`). This actually results in a secondary problem in the sku repo where PNPM can't find the binary file to install into `node_modules/.bin` unless sku has been built first. The fix for both of these issues is to point sku's binary to a checked in file that then imports `dist/bin/sku.js`.
- There was a reference to `src` in the `postinstall` script. I've pointed it to `dist` instead. This has probably been silently failing during testing in other repos. We should probably have better error handling in the postinstall script, instead of successfully exiting even when there's an error.
- Also fixed a warning in tests caused by the test-utils package not having a `main` field, or really any entrypoint at all.