### PR TITLE
destructure the correct param in the test command handler

### DIFF
--- a/packages/sku/src/lib/program/commands/test/test.command.ts
+++ b/packages/sku/src/lib/program/commands/test/test.command.ts
@@ -4,8 +4,9 @@ const testCommand = new Command('test');
 
 testCommand
   .description('Run unit tests.')
-  .allowUnknownOption(true)
-  .action(async ({ args }) => {
+  .allowUnknownOption()
+  .allowExcessArguments()
+  .action(async (_, { args }) => {
     const { testAction } = await import('./test.action.js');
     testAction({ args });
   });


### PR DESCRIPTION
The test command was destructuring the `args` key from the wrong parameter.

I've also added the `allowExessArguments` option to pass extra arguments into the test if needed.