### PR TITLE
Version 14 custom builds docs

### DIFF
--- a/docs/docs/code-splitting.md
+++ b/docs/docs/code-splitting.md
@@ -10,7 +10,7 @@ import loadable from 'sku/@loadable/component';
 
 const AsyncComponent = loadable(() => import('./AsyncComponent'));
 
-const MyComponent => () => (
+const MyComponent = () => (
   <div>
     <AsyncComponent />
   </div>
@@ -28,8 +28,8 @@ The most common use case for code splitting is splitting out each top level rout
 ```js
 // sku.config.js
 export default {
-  routes: ['/', '/details']
-  publicPath: 'https://somecdn.com'
+  routes: ['/', '/details'],
+  publicPath: 'https://somecdn.com',
 };
 ```
 

--- a/docs/docs/custom-builds.md
+++ b/docs/docs/custom-builds.md
@@ -3,10 +3,10 @@
 If your project has a custom [webpack](https://webpack.js.org) build, you can use the `SkuWebpackPlugin` in your webpack config as part of your plugins array:
 
 ```js
-const SkuWebpackPlugin = require('sku/webpack-plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+import SkuWebpackPlugin from 'sku/webpack-plugin';
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 
-module.exports = {
+export default {
   plugins: [
     new SkuWebpackPlugin({
       target: 'browser', // or 'node' for SSR builds
@@ -21,7 +21,7 @@ module.exports = {
 If you want to consume sku packages, you can pass an array of [`compilePackages`](./configuration?id=compilepackages). For example, if you wanted to import a sku package called `my-sku-package`:
 
 ```js
-module.exports = {
+export default {
   plugins: [
     new SkuWebpackPlugin({
       compilePackages: ['my-sku-package'],


### PR DESCRIPTION
- Change `custom-builds.md` examples from `commonjs` to `ESM` to reflect the change to entrypoints.
- Fix two code errors in the `pre` blocks in `code-splitting.md`