### PR TITLE
`sku init`: Ensure React 18 is installed in new projects

### DIFF
--- a/.changeset/gold-rivers-sort.md
+++ b/.changeset/gold-rivers-sort.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`sku init`: Ensure latest React 18 version is installed in new projects as React 19 is not yet supported

--- a/packages/sku/src/context/configPath.ts
+++ b/packages/sku/src/context/configPath.ts
@@ -51,7 +51,7 @@ export const resolveAppSkuConfigPath = (): string | null => {
   }
 
   console.warn(
-    `Failed to find a supported ${chalk.bold('sku.config')} file (supported formats are ${supportedSkuConfigExtensions.map((ext) => `sku.config.${ext}}`).join(', ')})`,
+    `Failed to find a supported ${chalk.bold('sku.config')} file (supported formats are ${supportedSkuConfigExtensions.map((ext) => `sku.config.${ext}`).join(', ')})`,
   );
 
   return null;

--- a/packages/sku/src/lib/program/commands/init/init.action.ts
+++ b/packages/sku/src/lib/program/commands/init/init.action.ts
@@ -60,9 +60,6 @@ export const initAction = async (
   setCwd(root);
 
   trace(`Creating project "${projectName}" in "${root}"`);
-  console.log({
-    packageManager,
-  });
 
   const appName = path.basename(root);
 

--- a/packages/sku/src/lib/program/commands/init/init.action.ts
+++ b/packages/sku/src/lib/program/commands/init/init.action.ts
@@ -189,13 +189,14 @@ export const initAction = async (
     }),
   );
 
-  const deps = ['braid-design-system', 'react', 'react-dom'];
+  // TODO: Remove versions from react deps once we support React 19
+  const deps = ['braid-design-system', 'react@^18.3.1', 'react-dom@^18.3.1'];
 
   const devDeps = [
     '@vanilla-extract/css',
     'sku',
-    '@types/react',
-    '@types/react-dom',
+    '@types/react@^18.3.12',
+    '@types/react-dom@^18.3.1',
   ];
 
   console.log(


### PR DESCRIPTION
Currently React 19 will be installed when running `sku init`. This change sets explicit React 18 versions (the current latest v18 versions) in `sku init`. While React 19 will work with `sku`, there are still some peer dependency warnings, so until we officially support it we should ensure new projects are initialized with React 18.

Also removed a stray console.log, and fixed a bad log from a previous PR.