### PR TITLE
`sku init`: Add `pnpm.onlyBuiltDependencies` to package.json if pnpm v10 is detected

### DIFF
--- a/.changeset/brave-cameras-sip.md
+++ b/.changeset/brave-cameras-sip.md
@@ -1,0 +1,11 @@
+---
+'sku': patch
+---
+
+`sku init`: Add a `pnpm.onlyBuiltDependencies` field to the `package.json` file if `pnpm` v10 is detected
+
+As of [`pnpm` v10], dependency lifecycle scripts are no longer run by default. Instead, explicit permission must be given on a per-dependency basis.
+
+New `sku` projects will have this field added automatically if `pnpm` v10 is detected in order to ensure `sku` and its dependencies can run necessary lifecycle scripts after installation.
+
+[`pnpm` v10]: https://github.com/pnpm/pnpm/releases/tag/v10.0.0

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -155,6 +155,7 @@
     "@types/prettier": "^2.7.3",
     "@types/react": "^18.2.3",
     "@types/react-dom": "^18.2.3",
+    "@types/semver": "^7.5.8",
     "@types/webpack-bundle-analyzer": "^4.7.0",
     "@types/wrap-ansi": "^3.0.0",
     "@vanilla-extract/css": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -873,6 +873,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.3
         version: 18.3.1
+      '@types/semver':
+        specifier: ^7.5.8
+        version: 7.5.8
       '@types/webpack-bundle-analyzer':
         specifier: ^4.7.0
         version: 4.7.0(@swc/core@1.7.36)(esbuild@0.24.0)


### PR DESCRIPTION
Want to get this fix out before cutting v14 so it's not gated behind a major version.

Pnpm v10 is now the latest version of pnpm, so consumers will likely be upgrading from v9 soon. I'm not too concerned about existing applications just yet, but ideally new applications created by `sku init` should function correctly out of the box.

This PR implements some logic to add an appropriate [`pnpm.onlyBuiltDependencies`](https://pnpm.io/package_json#pnpmonlybuiltdependencies) field to `package.json` during `sku init`.

I haven't updated the sku repo to pnpm v10 just yet, but I did test it out and confirmed that the `sku-init` snapshot was updated.