### PR TITLE
Build `sku` before publishing

### DIFF
--- a/.changeset/stupid-maps-fry.md
+++ b/.changeset/stupid-maps-fry.md
@@ -2,4 +2,4 @@
 'sku': patch
 ---
 
-Test
+Fix release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build Sku
+        run: pnpm build
+
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
14.0.0 doesn't contain any built files,  because we aren't building before publishing. Even [this error on CI](https://github.com/seek-oss/sku/actions/runs/13172136187/job/36764283243#step:6:28), which likely caused the changelog issue, didn't stop the release.