### PR TITLE
Remove `esbuild` references

### DIFF
--- a/packages/sku/src/config/targets.json
+++ b/packages/sku/src/config/targets.json
@@ -1,4 +1,3 @@
 {
-  "browserslistNodeTarget": "node 20.15",
-  "esbuildNodeTarget": "node20.15"
+  "browserslistNodeTarget": "node 20.15"
 }

--- a/packages/sku/src/lib/program/commands/init/init.action.ts
+++ b/packages/sku/src/lib/program/commands/init/init.action.ts
@@ -136,6 +136,7 @@ export const initAction = async (
     // Allows `pnpm` to run `sku`'s, and its dependencies', build scripts
     // See https://pnpm.io/package_json#pnpmonlybuiltdependencies
     packageJson.pnpm = {
+      // We transitively depend on `esbuild` via Vanilla Extract
       onlyBuiltDependencies: ['sku', '@swc/core', 'esbuild'],
     };
   }

--- a/postinstall.mjs
+++ b/postinstall.mjs
@@ -27,8 +27,6 @@ const [, minimumSupportedVersion] = node.split('=');
 const targets = {
   // https://github.com/browserslist/browserslist?tab=readme-ov-file#full-list
   browserslistNodeTarget: `node ${minimumSupportedVersion}`,
-  // https://esbuild.github.io/api/#target
-  esbuildNodeTarget: `node${minimumSupportedVersion}`,
 };
 
 await writeFile(


### PR DESCRIPTION
We no longer depend on `esbuild` so don't need to worry about an `esbuildNodeTarget` anymore.