### PR TITLE
Reduce config loading log noise

### DIFF
--- a/.changeset/silly-terms-sell.md
+++ b/.changeset/silly-terms-sell.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Reduce config loading log noise

--- a/packages/sku/src/context/configPath.ts
+++ b/packages/sku/src/context/configPath.ts
@@ -50,7 +50,7 @@ export const resolveAppSkuConfigPath = (): string | null => {
     return supportedSkuConfigPath;
   }
 
-  console.warn(
+  debug(
     `Failed to find a supported ${chalk.bold('sku.config')} file (supported formats are ${supportedSkuConfigExtensions.map((ext) => `sku.config.${ext}`).join(', ')})`,
   );
 

--- a/packages/sku/src/context/configPath.ts
+++ b/packages/sku/src/context/configPath.ts
@@ -1,6 +1,9 @@
 import chalk from 'chalk';
 import { existsSync } from 'node:fs';
 import { getPathFromCwd } from '../lib/cwd.js';
+import _debug from 'debug';
+
+const debug = _debug('sku:config');
 
 let configPath: string | undefined;
 
@@ -31,21 +34,18 @@ export const resolveAppSkuConfigPath = (): string | null => {
     const resolvedCustomConfigPath = getPathFromCwd(customSkuConfigPath);
 
     if (existsSync(resolvedCustomConfigPath)) {
-      console.log('Loading custom sku config:', resolvedCustomConfigPath);
+      debug('Loading custom sku config:', resolvedCustomConfigPath);
 
       return resolvedCustomConfigPath;
     }
 
-    console.warn(
-      'Custom sku config file does not exist:',
-      resolvedCustomConfigPath,
-    );
+    debug('Custom sku config file does not exist:', resolvedCustomConfigPath);
   }
 
   const supportedSkuConfigPath = resolveSupportedSkuConfigPath();
 
   if (supportedSkuConfigPath) {
-    console.log('Loading sku config:', supportedSkuConfigPath);
+    debug('Loading sku config:', supportedSkuConfigPath);
 
     return supportedSkuConfigPath;
   }

--- a/packages/sku/src/context/index.ts
+++ b/packages/sku/src/context/index.ts
@@ -10,6 +10,9 @@ import defaultCompilePackages from './defaultCompilePackages.js';
 import isCompilePackage from '../lib/isCompilePackage.js';
 import type { SkuConfig, SkuRoute, SkuRouteObject } from '../types/types.js';
 import { resolveAppSkuConfigPath } from './configPath.js';
+import _debug from 'debug';
+
+const debug = _debug('sku:config');
 
 const jiti = createJiti(import.meta.url);
 
@@ -20,7 +23,7 @@ const getSkuConfig = async (): Promise<{
   const appSkuConfigPath = resolveAppSkuConfigPath();
 
   if (!appSkuConfigPath) {
-    console.warn('No sku config file found. Using default configuration.');
+    debug('No sku config file found. Using default configuration.');
     return {
       appSkuConfig: {},
       appSkuConfigPath: null,


### PR DESCRIPTION
These logs end up being quite noisy as the config context is sometimes loaded multiple times, especially during tests. Demoting these logs to debug logs.