### PR TITLE
Use `jiti` require to synchronously load sku config

### DIFF
--- a/.changeset/pretty-beds-nail.md
+++ b/.changeset/pretty-beds-nail.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`sku test`: Fixes a bug where `jest` would fail to run tests on Node versions that enable require(esm) by default (>=22.12.0)

--- a/.changeset/pretty-beds-nail.md
+++ b/.changeset/pretty-beds-nail.md
@@ -2,4 +2,6 @@
 'sku': patch
 ---
 
-`sku test`: Fixes a bug where `jest` would fail to run tests on Node versions that enable require(esm) by default (>=22.12.0)
+`sku test`: Fixes a bug where `jest` would fail to run tests on Node versions that enable require(esm) by default (>=[22.12.0][node 22.12])
+
+[node 22.12]: https://nodejs.org/en/blog/release/v22.12.0


### PR DESCRIPTION
Sku currently uses a top-level await to load config using [`jiti`](https://www.npmjs.com/package/jiti). When loading sku's jest preset, Jest will try to `require` the module first. In Node <22.12.0, this `require` would fail with `ERR_REQUIRE_ESM`, [which would then be caught, causing a dynamic import to be used instead](https://github.com/jestjs/jest/blob/70340d0b6c50a864586eaca2fca4b5549dd5ef56/packages/jest-util/src/requireOrImportModule.ts#L28-L35), which can handle top-level await.

However, in Node >=22.12.0, [require(esm) support is enabled by default](https://nodejs.org/en/blog/release/v22.12.0), causing a different error, specifically `ERR_REQUIRE_ASYNC_MODULE`. This is a valid error, as our module tree does contain a top level await, but once again a dynamic import _should_ work just fine. Unfortunately, [the logic to also handle this error](https://github.com/jestjs/jest/blob/main/packages/jest-util/src/requireOrImportModule.ts#L64-L69) will only be released in Jest v30, which is currently still in beta.

So for the time being, we'll use jiti's `require` API to synchronously load an app's sku config, removing the top-level await altogether.

> [!NOTE]
> We would've caught this error in our `jest-test` fixture if sku was on Node 22 LTS, but we're still on 20. This fix was tested on Node >=22.12.0, both in sku and in an affect repo, but for now I'm keeping sku's node version to the latest v20 LTS. In a followup PR I'll add a matrix to our test workflow so we can run it against multiple Node LTS major versions.


