### PR TITLE
Ignore correct eslint config

### DIFF
--- a/.changeset/long-owls-burn.md
+++ b/.changeset/long-owls-burn.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Ignore correct eslint config file

--- a/docs/docs/linting.md
+++ b/docs/docs/linting.md
@@ -11,7 +11,7 @@ By default, `sku` ignores the following files and directories:
 [
   '**/*.vocab/index.ts', // If `languages` is configured in your sku config
   '**/.eslintcache',
-  '**/eslint.config.js',
+  '**/eslint.config.mjs',
   '**/.prettierrc',
   '**/coverage/',
   '**/dist/', // Or your custom configured `target`

--- a/packages/sku/src/services/eslint/config/ignores.ts
+++ b/packages/sku/src/services/eslint/config/ignores.ts
@@ -19,7 +19,7 @@ export const createEslintIgnoresConfig = ({
   const ignores = [
     hasLanguagesConfig && '**/*.vocab/index.ts',
     '**/.eslintcache',
-    '**/eslint.config.js',
+    '**/eslint.config.mjs',
     '**/.prettierrc',
     '**/coverage/',
     targetIgnore,


### PR DESCRIPTION
The original eslint v9 change swapped from `.eslintrc` to `eslint.config.js`. During the ESM migration we then swapped to `eslint.config.mjs`, but these references to that file weren't updated.