### PR TITLE
Escape stray appostraphe in app template

### DIFF
--- a/packages/sku/template/src/App/NextSteps.tsx
+++ b/packages/sku/template/src/App/NextSteps.tsx
@@ -113,7 +113,7 @@ export function NextSteps({ environment }: NextStepsProps) {
                 <Stack space="gutter">
                   <Heading level="3">Brand resources</Heading>
                   <Text>
-                    To align your project to SEEK's brand standards it is
+                    To align your project to SEEK&rsquo;s brand standards it is
                     recommended to install{' '}
                     <TextLink href="https://github.com/SEEK-Jobs/shared-web-assets">
                       Shared web assets

--- a/tests/sku-init/__snapshots__/sku-init.test.js.snap
+++ b/tests/sku-init/__snapshots__/sku-init.test.js.snap
@@ -238,7 +238,7 @@ export function NextSteps({ environment }: NextStepsProps) {
                 <Stack space="gutter">
                   <Heading level="3">Brand resources</Heading>
                   <Text>
-                    To align your project to SEEK's brand standards it is
+                    To align your project to SEEK&rsquo;s brand standards it is
                     recommended to install{' '}
                     <TextLink href="https://github.com/SEEK-Jobs/shared-web-assets">
                       Shared web assets


### PR DESCRIPTION
All other apostraphes in the template are escaped as `&rsquo;`.