### PR TITLE
Fix missing support for `.bmp` file mocking in jest tests

### DIFF
--- a/.changeset/shy-jobs-remain.md
+++ b/.changeset/shy-jobs-remain.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fix missing support for mocking `.bmp` file imports in jest tests

--- a/packages/sku/src/config/jest/jest-preset.js
+++ b/packages/sku/src/config/jest/jest-preset.js
@@ -27,7 +27,7 @@ export default jestDecorator({
   ],
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
   moduleNameMapper: {
-    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|svg|avif)$':
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|svg|avif|bmp)$':
       fileURLToPath(import.meta.resolve('./fileMock.cjs')),
   },
   transform: {


### PR DESCRIPTION
Though this is technically a new feature, it's more of a fix for a feature that should've been available given that [we already support loading `.bmp` files](https://github.com/seek-oss/sku/blob/d67e569c23aed8263502e9acc754dfe55752237c/packages/sku/src/services/webpack/config/utils/index.ts#L13).