### PR TITLE
Update `dangerouslySetESLint` docs to reflect eslint v9 config interface

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -85,11 +85,20 @@ If you believe other consumers would benefit from the addition/removal/modificat
 Example:
 
 ```ts
+import customPlugin from 'custom-eslint-plugin';
+
 export default {
-  dangerouslySetESLintConfig: (skuEslintConfig) => ({
+  dangerouslySetESLintConfig: (skuEslintConfig) => [
     ...skuEslintConfig,
-    someOtherConfig: 'dangerousValue',
-  }),
+    {
+      plugins: {
+        customPlugin,
+      },
+      rules: {
+        'customPlugin/rule1': 'warn',
+      },
+    },
+  ],
 } satisfies SkuConfig;
 ```
 


### PR DESCRIPTION
Bringing this up to date with the eslint v9 config structure. Sku's eslint config is an array, and an array must be returned by `dangerouslySetESLintConfig`. Also added a more realistic example of how to configure a custom plugin.