### PR TITLE
Pass through extra CLI arguments to `jest`

### DIFF
--- a/.changeset/nasty-snails-chew.md
+++ b/.changeset/nasty-snails-chew.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`sku test`: Fixes a bug where extra CLI arguments were not being passed through to `jest`

--- a/packages/sku/src/program/commands/test/test.action.ts
+++ b/packages/sku/src/program/commands/test/test.action.ts
@@ -10,13 +10,14 @@ const { run } = jest;
 
 const log = debug('sku:jest');
 
-const testAction = async ({
-  args = [],
-  skuContext,
-}: {
-  args: string[];
-  skuContext: SkuContext;
-}) => {
+const testAction = async (
+  {
+    skuContext,
+  }: {
+    skuContext: SkuContext;
+  },
+  { args = [] }: { args: string[] },
+) => {
   await configureProject(skuContext);
   await runVocabCompile(skuContext);
 


### PR DESCRIPTION
#1175 introduced a regression where extra arguments to `sku test` were no longer being to [the test action](https://github.com/seek-oss/sku/blob/master/packages/sku/src/program/commands/test/test.action.ts), ultimately resulting in `jest` never getting them. Would be nice if `Commander`'s types helped here, but unfortunately they don't.

Will add a regression test for this behaviour in a followup PR.

`sku test` is the only CLI command that forwards extra arguments through, so no other commands are affected by this issue.