### PR TITLE
Fix package entrypoint errors rasied by publint

### DIFF
--- a/.changeset/giant-bars-give.md
+++ b/.changeset/giant-bars-give.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fix package entrypoint ordering errors raised by [publint](https://publint.dev/sku@14.0.5)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/seek-oss/sku.git"
+    "url": "git+https://github.com/seek-oss/sku.git"
   },
   "author": "SEEK",
   "license": "MIT",

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -15,16 +15,16 @@
     },
     "./jest-preset": "./dist/config/jest/jest-preset.js",
     "./config/eslint": {
-      "default": "./dist/services/eslint/config/index.js",
-      "types": "./dist/services/eslint/config/index.d.ts"
+      "types": "./dist/services/eslint/config/index.d.ts",
+      "default": "./dist/services/eslint/config/index.js"
     },
     "./config/storybook": {
-      "default": "./dist/config/storybook/index.cjs",
-      "types": "./dist/config/storybook/index.d.ts"
+      "types": "./dist/config/storybook/index.d.ts",
+      "default": "./dist/config/storybook/index.cjs"
     },
     "./vite/loadable": {
-      "default": "./dist/services/vite/loadable/index.js",
-      "types": "./dist/services/vite/loadable/index.d.ts"
+      "types": "./dist/services/vite/loadable/index.d.ts",
+      "default": "./dist/services/vite/loadable/index.js"
     },
     "./vite/client": {
       "types": "./dist/services/vite/client.d.ts"
@@ -55,7 +55,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/seek-oss/sku.git",
+    "url": "git+https://github.com/seek-oss/sku.git",
     "directory": "packages/sku"
   },
   "author": "SEEK",


### PR DESCRIPTION
> [publint](https://publint.dev/) is a [linter](https://en.wikipedia.org/wiki/Lint_(software)) that checks [npm](https://npmjs.com/) packages to ensure the widest compatibility across environments, such as [Vite](https://vite.dev/), [Webpack](https://webpack.js.org/), [Rollup](https://rollupjs.org/), [Node.js](https://nodejs.org/), etc. It also reports best practices and common configuration mistakes that aim to improve the overall quality of the package.

[Publint flagged a few issues with sku](https://publint.dev/sku@14.0.5), so I've fixed them.

In the future we might want to consider running this as a lint step across all our packages.