### PR TITLE
Fix translations bug that caused translation chunks to sometimes not be present in the document HEAD

### DIFF
--- a/.changeset/many-papayas-cheat.md
+++ b/.changeset/many-papayas-cheat.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fixes a bug where multi-language sites would not generate a reference to a translation chunk in some cases

--- a/packages/sku/src/utils/language-utils.ts
+++ b/packages/sku/src/utils/language-utils.ts
@@ -26,14 +26,13 @@ export function getValidLanguagesForRoute({
     if (route.languages) {
       languagesToRender = route.languages.slice();
     } else if (routeIsForSpecificSite) {
-      if (route.siteIndex) {
-        languagesToRender =
-          sites[route.siteIndex].languages?.slice() || languages;
-      }
+      languagesToRender =
+        sites[route.siteIndex ?? 0].languages?.slice() || languages;
     } else {
       languagesToRender = languages;
     }
   }
+
   const languageNames = languagesToRender.map((lang) =>
     lang && typeof lang !== 'string' ? lang.name : lang,
   );


### PR DESCRIPTION
This bug specifically affected configurations that set a site-level language but do not specific route-level languages. E.g.

```ts
{
  name: 'en',
  languages: ['en'],
  routes: ['/hello'],
},
{
  name: 'fr',
  languages: ['fr'],
  routes: ['/bonjour'],
},
```

Routes configured with specific languages are not affected.