### PR TITLE
Update prettier, swap to patch-version flexibile dep range

### DIFF
--- a/.changeset/slow-geckos-laugh.md
+++ b/.changeset/slow-geckos-laugh.md
@@ -1,0 +1,9 @@
+---
+'sku': patch
+---
+
+Change `prettier` dependency range from minor-version flexible to patch-version flexible. Update `prettier` dependency to `~3.5.0`.
+
+This change may result in some code formatting changes. Please review the [Prettier 3.5.0 release notes].
+
+[Prettier 3.5.0 release notes]: https://prettier.io/blog/2025/02/09/3.5.0

--- a/.changeset/slow-geckos-laugh.md
+++ b/.changeset/slow-geckos-laugh.md
@@ -1,5 +1,5 @@
 ---
-'sku': patch
+'sku': minor
 ---
 
 Change `prettier` dependency range from minor-version flexible to patch-version flexible. Update `prettier` dependency to `~3.5.0`.

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -163,7 +163,7 @@
     "picomatch": "^3.0.1",
     "postcss": "^8.4.0",
     "postcss-loader": "^8.0.0",
-    "prettier": "^3.4.1",
+    "prettier": "~3.5.0",
     "pretty-ms": "^7.0.1",
     "react-refresh": "^0.14.0",
     "resolve-from": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -850,7 +850,7 @@ importers:
         specifier: ^8.0.0
         version: 8.1.1(postcss@8.5.3)(typescript@5.8.2)(webpack@5.98.0(@swc/core@1.11.8)(esbuild@0.25.0))
       prettier:
-        specifier: ^3.4.1
+        specifier: ~3.5.0
         version: 3.5.3
       pretty-ms:
         specifier: ^7.0.1


### PR DESCRIPTION
While patch versions of `prettier` _could_ contain formatting changes, they typically don't. So rather than letting the `prettier` version jump minor versions in lockfile maintenance PRs, by controlling the minor/major version in `sku` we can give an explicit signal that formatting changes may occur, while hopefully making lockfile maintenance smoother for consumers.

We do this for `typescript` for a similar reason: `typescript` minor versions are actually major versions, so code-changes/incompatibilities can occur.