### PR TITLE
`vite`: Emit initial start time telemetry for `sku start`

### DIFF
--- a/.changeset/some-pugs-guess.md
+++ b/.changeset/some-pugs-guess.md
@@ -1,0 +1,5 @@
+---
+'sku': minor
+---
+
+`vite`: Emit start time metric for `sku start`

--- a/packages/sku/src/program/commands/start/vite-start-handler.ts
+++ b/packages/sku/src/program/commands/start/vite-start-handler.ts
@@ -1,6 +1,9 @@
 import { viteService } from '@/services/vite/index.js';
 import type { SkuContext } from '@/context/createSkuContext.js';
+import { metricsMeasurers } from '@/services/telemetry/metricsMeasurers.js';
 
 export const viteStartHandler = async (skuContext: SkuContext) => {
   await viteService.start(skuContext);
+
+  metricsMeasurers.skuStart.mark();
 };

--- a/packages/sku/src/services/telemetry/metricsMeasurers.ts
+++ b/packages/sku/src/services/telemetry/metricsMeasurers.ts
@@ -1,0 +1,42 @@
+import debug from 'debug';
+
+const log = debug('sku:metrics');
+
+const skuStartMarkName = 'skuStartComplete';
+const skuStart = {
+  mark: () => {
+    performance.mark(skuStartMarkName);
+  },
+  measure: () => {
+    const result = performance.measure('skuStart', {}, skuStartMarkName);
+
+    log(`Sku dev server start took ${Math.round(result.duration)}ms`);
+
+    return result;
+  },
+};
+
+const initialPageLoadMarkName = 'initialPageLoadStart';
+const initialPageLoad = {
+  mark: () => {
+    performance.mark(initialPageLoadMarkName);
+  },
+  isInitialPageLoad: true,
+  measure() {
+    this.isInitialPageLoad = false;
+
+    const result = performance.measure(
+      'initialPageLoad',
+      initialPageLoadMarkName,
+    );
+
+    log(`Initial page load took ${Math.round(result.duration)}ms`);
+
+    return result;
+  },
+};
+
+export const metricsMeasurers = {
+  skuStart,
+  initialPageLoad,
+};

--- a/packages/sku/src/services/vite/helpers/server/createViteServer.ts
+++ b/packages/sku/src/services/vite/helpers/server/createViteServer.ts
@@ -4,6 +4,7 @@ import type { SkuContext } from '@/context/createSkuContext.js';
 
 import { createViteConfig } from '../createConfig.js';
 import skuViteHMRTelemetryPlugin from '@/services/vite/plugins/skuViteHMRTelemetry.js';
+import { skuViteStartTelemetryPlugin } from '../../plugins/skuViteStartTelemetry.js';
 
 export const createViteServer = async (skuContext: SkuContext) => {
   const base = process.env.BASE || '/';
@@ -13,6 +14,10 @@ export const createViteServer = async (skuContext: SkuContext) => {
       skuContext,
       plugins: [
         skuViteMiddlewarePlugin(skuContext),
+        skuViteStartTelemetryPlugin({
+          target: 'node',
+          type: 'static',
+        }),
         skuViteHMRTelemetryPlugin({
           target: 'node',
           type: 'static',

--- a/packages/sku/src/services/vite/index.ts
+++ b/packages/sku/src/services/vite/index.ts
@@ -41,8 +41,8 @@ export const viteService = {
     const server = await createViteServerSsr({
       skuContext,
     });
+    server.listen(skuContext.port.server);
 
-    await server.listen(skuContext.port.server);
     if (skuContext.sites.length > 1) {
       skuContext.sites.forEach((site) => {
         console.log(

--- a/packages/sku/src/services/vite/plugins/skuViteMiddlewarePlugin.ts
+++ b/packages/sku/src/services/vite/plugins/skuViteMiddlewarePlugin.ts
@@ -2,6 +2,7 @@ import type { SkuContext } from '@/context/createSkuContext.js';
 import type { Plugin } from 'vite';
 import { createRequire } from 'node:module';
 import type { ViteRenderFunction } from '@/types/types.js';
+import { metricsMeasurers } from '@/services/telemetry/metricsMeasurers.js';
 
 const require = createRequire(import.meta.url);
 
@@ -10,6 +11,10 @@ export const skuViteMiddlewarePlugin = (skuContext: SkuContext): Plugin => ({
   configureServer(server) {
     return () => {
       server.middlewares.use(async (req, res, next) => {
+        if (metricsMeasurers.initialPageLoad.isInitialPageLoad) {
+          metricsMeasurers.initialPageLoad.mark();
+        }
+
         const host = req.headers.host;
         const hostname = host?.split(':')[0];
         const site =

--- a/packages/sku/src/services/vite/plugins/skuViteStartTelemetry.ts
+++ b/packages/sku/src/services/vite/plugins/skuViteStartTelemetry.ts
@@ -1,0 +1,55 @@
+import type { Plugin } from 'vite';
+import js from 'dedent';
+import provider from '@/services/telemetry/index.js';
+import { metricsMeasurers } from '@/services/telemetry/metricsMeasurers.js';
+
+const initialPageLoadEventName = 'sku:initialPageLoad' as const;
+
+export const skuViteStartTelemetryPlugin = ({
+  target,
+  type,
+}: {
+  target: string;
+  type: string;
+}): Plugin => ({
+  name: 'vite-plugin-sku-server-middleware',
+  transformIndexHtml: {
+    order: 'pre',
+    handler: () => [
+      {
+        tag: 'script',
+        attrs: {
+          type: 'module',
+        },
+        children: skuPageLoadTelemetryClient,
+        injectTo: 'head',
+      },
+    ],
+  },
+  configureServer(server) {
+    server.ws.on(initialPageLoadEventName, () => {
+      if (metricsMeasurers.initialPageLoad.isInitialPageLoad) {
+        const { duration: skuStartDuration } =
+          metricsMeasurers.skuStart.measure();
+
+        const { duration: initialLoadDuration } =
+          metricsMeasurers.initialPageLoad.measure();
+
+        const initialStartTime = skuStartDuration + initialLoadDuration;
+
+        provider.timing('start.webpack.initial', initialStartTime, {
+          target,
+          type,
+        });
+      }
+    });
+  },
+});
+
+const skuPageLoadTelemetryClient = js/* js */ `
+  addEventListener("load", () => {
+    if (import.meta.hot) {
+      import.meta.hot.send('${initialPageLoadEventName}');
+    }
+  })
+`;


### PR DESCRIPTION
This takes a similar approach to #1211, though it's not quite the same. The issue with `sku start` in a Vite world is that a user could theoretically start the CLI, but then open the initial route in the browser 10 minutes later. Since Vite bundles on-request in dev mode, we can't simply time how long it takes for that initial request to finish, we also need to account for the gap between running `sku start` and actually requesting a route.

This PR implements a solution by tracking 2 separate times: the amount of time taken for the vite dev server to start listening, and how long it takes between the first request being sent and the browser triggering the `load` event. We inject a small client-side script that sets an event listener on the `load` event and sends a websocket message to the dev server. _Only_ when this event is received to we calculate the total time for CLI start and initial request and then emit telemetry.

Unfortunately I couldn't isolate the entire implementation to just a single vite plugin, as we have to mark the initial load time from within the request middleware so we can ensure it starts as soon as we get a request in. An alternative I considered was injecting a separate middleware in the `skuViteStartTelemetry` plugin just before the request middleware, but that relies on the ordering of middlewares which doesn't seem like a good idea IMO.

For reasons I don't understand ([potentially involving `renderToPipeableStream`](https://github.com/vitejs/vite-plugin-react/issues/222)), injecting the script via `transformIndexHtml` during `start-ssr` doesn't seem to work, so for now this telemetry is only emitted for Vite `sku start`, not `sku start-ssr`. We not be able to use `transformIndexHtml` to inject the script during SSR, and might need to just inject it manually during the pre-render.

In the `vite-test-app` fixture, CLI start time is ~4.5s, and initial page load time is ~1-2s, for a total "initial start" time of ~5.5-6.5s.