### PR TITLE
`vite`: Ensure bundled pre-render entrypoint has a consistent name

### DIFF
--- a/.changeset/flat-berries-swim.md
+++ b/.changeset/flat-berries-swim.md
@@ -1,0 +1,6 @@
+---
+'sku': patch
+---
+
+`vite`: Ensure bundled pre-render entrypoint has a consistent name, regardless of the configured
+`renderEntry`

--- a/packages/sku/src/services/vite/helpers/bundleConfig.ts
+++ b/packages/sku/src/services/vite/helpers/bundleConfig.ts
@@ -1,0 +1,7 @@
+export const outDir = {
+  client: 'dist',
+  ssr: 'dist/server',
+  ssg: 'dist/render',
+};
+
+export const renderEntryChunkName = 'render.js';

--- a/packages/sku/src/services/vite/helpers/createConfig.ts
+++ b/packages/sku/src/services/vite/helpers/createConfig.ts
@@ -8,6 +8,7 @@ import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import type { SkuContext } from '@/context/createSkuContext.js';
 import skuVitePreloadPlugin from '../plugins/skuVitePreloadPlugin.js';
 import { fixViteVanillaExtractDepScanPlugin } from '@/services/vite/plugins/esbuild/fixViteVanillaExtractDepScanPlugin.js';
+import { outDir, renderEntryChunkName } from './bundleConfig.js';
 
 const require = createRequire(import.meta.url);
 
@@ -22,12 +23,6 @@ export const createViteConfig = ({
   configType?: 'client' | 'ssr' | 'ssg';
   plugins?: InlineConfig['plugins'];
 }) => {
-  const outDir = {
-    client: 'dist',
-    ssr: 'dist/server',
-    ssg: 'dist/render',
-  };
-
   const input = {
     client: clientEntry,
     ssr: skuContext.paths.serverEntry,
@@ -67,6 +62,8 @@ export const createViteConfig = ({
       rollupOptions: {
         input: input[configType],
         output: {
+          entryFileNames:
+            configType === 'ssg' ? renderEntryChunkName : undefined,
           experimentalMinChunkSize: undefined,
         },
       },

--- a/packages/sku/src/services/vite/helpers/prerenderRoutes.ts
+++ b/packages/sku/src/services/vite/helpers/prerenderRoutes.ts
@@ -5,6 +5,7 @@ import { getBuildRoutes } from '@/services/webpack/config/plugins/createHtmlRend
 import { createPreRenderedHtml } from './html/createPreRenderedHtml.js';
 import { createCollector } from '@/services/vite/loadable/collector.js';
 import { ensureTargetDirectory } from '@/utils/buildFileUtils.js';
+import { outDir, renderEntryChunkName } from './bundleConfig.js';
 
 const resolve = (p: string) => path.resolve(process.cwd(), p);
 
@@ -14,7 +15,9 @@ export const prerenderRoutes = async (skuContext: SkuContext) => {
     await readFile(resolve('./dist/.vite/manifest.json'), 'utf-8'),
   );
   for (const route of routes) {
-    const render = (await import(resolve('./dist/render/render.js'))).default;
+    const render = (
+      await import(resolve(path.join(outDir.ssg, renderEntryChunkName)))
+    ).default;
     const loadableCollector = createCollector({
       manifest,
       base: skuContext.publicPath.startsWith('/') ? '/' : '',


### PR DESCRIPTION
This fixes a bug where route pre-rendering would fail during `sku build` if you configured `renderEntry` with a file name other than `render.jsx`. For example, if your entrypoint was `src/render-custom.jsx`, the bundled pre-render file would be called `pre-render.js`, but pre-rendering expects it to be called `render.js`.

This change was upstreamed from https://github.com/seek-oss/sku/compare/master...braid-fixture-vite where I tried to make a `render-vite.jsx` entrypoint for testing a fixture with vite but ran into this issue.

