### PR TITLE
Replace `git-diff` dep with `diff` for app snapshot diffing

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1011,16 +1011,22 @@ importers:
         version: 3.5.5(typescript@5.8.2)
 
   test-utils:
-    dependencies:
+    devDependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
+      '@prettier/sync':
+        specifier: ^0.5.2
+        version: 0.5.2(prettier@3.5.3)
       '@types/css':
         specifier: ^0.0.38
         version: 0.0.38
+      '@types/diff':
+        specifier: ^7.0.1
+        version: 7.0.1
       '@types/diffable-html':
         specifier: ^5.0.2
         version: 5.0.2
-      '@types/git-diff':
-        specifier: ^2.0.7
-        version: 2.0.7
       '@types/hostile':
         specifier: ^1.3.5
         version: 1.3.5
@@ -1039,12 +1045,12 @@ importers:
       death:
         specifier: ^1.1.0
         version: 1.1.0
+      diff:
+        specifier: ^7.0.0
+        version: 7.0.0
       diffable-html:
         specifier: ^5.0.0
         version: 5.0.0
-      git-diff:
-        specifier: ^2.0.6
-        version: 2.0.6
       hostile:
         specifier: ^1.3.3
         version: 1.4.0
@@ -1066,13 +1072,6 @@ importers:
       webpack-stats-plugin:
         specifier: ^1.0.3
         version: 1.1.3
-    devDependencies:
-      '@jest/globals':
-        specifier: ^29.7.0
-        version: 29.7.0
-      '@prettier/sync':
-        specifier: ^0.5.2
-        version: 0.5.2(prettier@3.5.3)
 
   tests:
     devDependencies:
@@ -2813,6 +2812,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/diff@7.0.1':
+    resolution: {integrity: sha512-R/BHQFripuhW6XPXy05hIvXJQdQ4540KnTvEFHSLjXfHYM41liOLKgIJEyYYiQe796xpaMHfe4Uj/p7Uvng2vA==}
+
   '@types/diffable-html@5.0.2':
     resolution: {integrity: sha512-VS6yWnAFw8Dm1BhrTwt84V5VWbdysOOF32vbCtQJMtJxzpLGAIZ5P+1NfRX0elYluZ70vwPkm9msdrHBB2ijFQ==}
 
@@ -2845,9 +2847,6 @@ packages:
 
   '@types/gh-pages@6.1.0':
     resolution: {integrity: sha512-Ma9bmKkE+WUtywENLC1rSLXTW66cJHJMWX2RQrJTMKhYM8o+73bRJ1ebfo3RWXUcG+HW3khky2nhVaN7nCsa3Q==}
-
-  '@types/git-diff@2.0.7':
-    resolution: {integrity: sha512-hipFAUcmf3c+45+Y8+J/xk7gT+0HBuT3O8OTtrnoP6R9gI0r2xESZNdYiA0pj7kQyPCwmkgbnxmfwQ9Ld2lZLQ==}
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
@@ -4387,8 +4386,8 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  diff@3.5.0:
-    resolution: {integrity: sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==}
+  diff@7.0.0:
+    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
     engines: {node: '>=0.3.1'}
 
   diffable-html@5.0.0:
@@ -5158,10 +5157,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  git-diff@2.0.6:
-    resolution: {integrity: sha512-/Iu4prUrydE3Pb3lCBMbcSNIf81tgGt0W1ZwknnyF62t3tHmtiJTRj0f+1ZIhp3+Rh0ktz1pJVoa7ZXUCskivA==}
-    engines: {node: '>= 4.8.0'}
-
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -5504,10 +5499,6 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
-
-  interpret@1.4.0:
-    resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
-    engines: {node: '>= 0.10'}
 
   interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
@@ -7455,10 +7446,6 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
-  rechoir@0.6.2:
-    resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
-    engines: {node: '>= 0.10'}
-
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
@@ -7758,15 +7745,6 @@ packages:
   shell-quote@1.8.2:
     resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
     engines: {node: '>= 0.4'}
-
-  shelljs.exec@1.1.8:
-    resolution: {integrity: sha512-vFILCw+lzUtiwBAHV8/Ex8JsFjelFMdhONIsgKNLgTzeRckp2AOYRQtHJE/9LhNvdMmE27AGtzWx0+DHpwIwSw==}
-    engines: {node: '>= 4.0.0'}
-
-  shelljs@0.8.5:
-    resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -10874,6 +10852,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/diff@7.0.1': {}
+
   '@types/diffable-html@5.0.2': {}
 
   '@types/doctrine@0.0.9': {}
@@ -10916,8 +10896,6 @@ snapshots:
   '@types/fined@1.1.5': {}
 
   '@types/gh-pages@6.1.0': {}
-
-  '@types/git-diff@2.0.7': {}
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -12761,7 +12739,7 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
-  diff@3.5.0: {}
+  diff@7.0.0: {}
 
   diffable-html@5.0.0:
     dependencies:
@@ -13841,14 +13819,6 @@ snapshots:
       fs-extra: 11.3.0
       globby: 11.1.0
 
-  git-diff@2.0.6:
-    dependencies:
-      chalk: 2.4.2
-      diff: 3.5.0
-      loglevel: 1.9.2
-      shelljs: 0.8.5
-      shelljs.exec: 1.1.8
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -14263,8 +14233,6 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
-
-  interpret@1.4.0: {}
 
   interpret@3.1.1: {}
 
@@ -16436,10 +16404,6 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
-  rechoir@0.6.2:
-    dependencies:
-      resolve: 1.22.10
-
   rechoir@0.8.0:
     dependencies:
       resolve: 1.22.10
@@ -16821,14 +16785,6 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.2: {}
-
-  shelljs.exec@1.1.8: {}
-
-  shelljs@0.8.5:
-    dependencies:
-      glob: 7.2.3
-      interpret: 1.4.0
-      rechoir: 0.6.2
 
   side-channel-list@1.0.0:
     dependencies:

--- a/test-utils/appSnapshotSerializer.cjs
+++ b/test-utils/appSnapshotSerializer.cjs
@@ -1,6 +1,10 @@
 // @ts-check
-const diff = require('git-diff');
+const Diff = require('diff');
 const { formatHtml } = require('./formatHtml.cjs');
+
+const emptyDiff = `===================================================================
+--- sourceHtml
++++ clientHtml`;
 
 const appSnapshotSerializer = {
   /**
@@ -11,14 +15,21 @@ const appSnapshotSerializer = {
     const formattedSourceHtml = formatHtml(sourceHtml);
     const formattedClientHtml = formatHtml(clientRenderContent);
 
-    const htmlDiff = diff(formattedSourceHtml, formattedClientHtml, {
-      color: false,
-      noHeaders: true,
-    });
+    const htmlDiff = Diff.createTwoFilesPatch(
+      'sourceHtml',
+      'clientHtml',
+      formattedSourceHtml,
+      formattedClientHtml,
+      undefined,
+      undefined,
+      { ignoreNewlineAtEof: true, context: 3 },
+    ).trim();
+
+    const isEmptyDiff = htmlDiff === emptyDiff;
 
     const snapshotItems = [
       serializer(formattedSourceHtml),
-      `POST HYDRATE DIFFS: ${htmlDiff ? `\n${htmlDiff}` : 'NO DIFF'}`,
+      `POST HYDRATE DIFFS: ${isEmptyDiff ? 'NO DIFF' : `\n${htmlDiff}`}`,
     ];
 
     return snapshotItems.join('\n');

--- a/test-utils/appSnapshotSerializer.cjs
+++ b/test-utils/appSnapshotSerializer.cjs
@@ -15,15 +15,17 @@ const appSnapshotSerializer = {
     const formattedSourceHtml = formatHtml(sourceHtml);
     const formattedClientHtml = formatHtml(clientRenderContent);
 
-    const htmlDiff = Diff.createTwoFilesPatch(
-      'sourceHtml',
-      'clientHtml',
-      formattedSourceHtml,
-      formattedClientHtml,
-      undefined,
-      undefined,
-      { ignoreNewlineAtEof: true, context: 3 },
-    ).trim();
+    const htmlDiff = diff
+      .createTwoFilesPatch(
+        'sourceHtml',
+        'clientHtml',
+        formattedSourceHtml,
+        formattedClientHtml,
+        undefined,
+        undefined,
+        { ignoreNewlineAtEof: true, context: 3 },
+      )
+      .trim();
 
     const isEmptyDiff = htmlDiff === emptyDiff;
 

--- a/test-utils/appSnapshotSerializer.cjs
+++ b/test-utils/appSnapshotSerializer.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const Diff = require('diff');
+const diff = require('diff');
 const { formatHtml } = require('./formatHtml.cjs');
 
 const emptyDiff = `===================================================================

--- a/test-utils/package.json
+++ b/test-utils/package.json
@@ -3,18 +3,20 @@
   "private": true,
   "type": "module",
   "main": "index.js",
-  "dependencies": {
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "@prettier/sync": "^0.5.2",
     "@types/css": "^0.0.38",
+    "@types/diff": "^7.0.1",
     "@types/diffable-html": "^5.0.2",
-    "@types/git-diff": "^2.0.7",
     "@types/hostile": "^1.3.5",
     "@types/wait-on": "^5.3.4",
     "@types/webpack-stats-plugin": "^0.3.5",
     "cross-spawn": "^7.0.3",
     "css": "^3.0.0",
     "death": "^1.1.0",
+    "diff": "^7.0.0",
     "diffable-html": "^5.0.0",
-    "git-diff": "^2.0.6",
     "hostile": "^1.3.3",
     "node-dir": "^0.1.17",
     "prettier": "^3.4.1",
@@ -23,9 +25,5 @@
     "wait-on": "^8.0.1",
     "webpack-stats-plugin": "^1.0.3"
   },
-  "skuSkipValidatePeerDeps": true,
-  "devDependencies": {
-    "@jest/globals": "^29.7.0",
-    "@prettier/sync": "^0.5.2"
-  }
+  "skuSkipValidatePeerDeps": true
 }

--- a/tests/__snapshots__/braid-design-system.test.js.snap
+++ b/tests/__snapshots__/braid-design-system.test.js.snap
@@ -3026,6 +3026,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -65,6 +65,7 @@
                  type="checkbox"
                  id="id_1"
                  aria-checked="false"
@@ -3042,7 +3046,6 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
-
 `;
 
 exports[`braid-design-system build should return built seekAnz site 1`] = `
@@ -3255,6 +3258,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -65,6 +65,7 @@
                  type="checkbox"
                  id="id_1"
                  aria-checked="false"
@@ -3271,7 +3278,6 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
-
 `;
 
 exports[`braid-design-system start should return development jobStreet site 1`] = `
@@ -3497,6 +3503,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -71,6 +71,7 @@
                  type="checkbox"
                  id="id_1"
                  aria-checked="false"
@@ -3513,7 +3523,6 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
-
 `;
 
 exports[`braid-design-system start should return development seekAnz site 1`] = `
@@ -3739,6 +3748,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -71,6 +71,7 @@
                  type="checkbox"
                  id="id_1"
                  aria-checked="false"
@@ -3755,5 +3768,4 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
-
 `;

--- a/tests/__snapshots__/library-build.test.js.snap
+++ b/tests/__snapshots__/library-build.test.js.snap
@@ -51,6 +51,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -21,5 +21,8 @@
      <script>
        window.MyLibrary();
      </script>
@@ -60,5 +64,4 @@ POST HYDRATE DIFFS:
    </body>
  </html>
 \\ No newline at end of file
-
 `;

--- a/tests/__snapshots__/library-file.test.js.snap
+++ b/tests/__snapshots__/library-file.test.js.snap
@@ -51,6 +51,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -21,5 +21,8 @@
      <script>
        window.MyLibrary();
      </script>
@@ -60,5 +64,4 @@ POST HYDRATE DIFFS:
    </body>
  </html>
 \\ No newline at end of file
-
 `;

--- a/tests/__snapshots__/multiple-routes.test.js.snap
+++ b/tests/__snapshots__/multiple-routes.test.js.snap
@@ -656,6 +656,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -62,7 +62,7 @@
    <body>
      <div id="app">
        <h1 class="_1hpn1da0">
@@ -664,7 +668,6 @@ POST HYDRATE DIFFS:
          <span>
            Some special async content
          </span>
-
 `;
 
 exports[`multiple-routes build and serve should return home page 1`] = `
@@ -919,6 +922,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -62,7 +62,7 @@
    <body>
      <div id="app">
        <h1 class="Details_root__1hpn1da0">
@@ -927,7 +934,6 @@ POST HYDRATE DIFFS:
          <span>
            Some special async content
          </span>
-
 `;
 
 exports[`multiple-routes start should render home page correctly 1`] = `

--- a/tests/__snapshots__/sku-webpack-plugin.test.js.snap
+++ b/tests/__snapshots__/sku-webpack-plugin.test.js.snap
@@ -26,6 +26,10 @@ exports[`sku-webpack-plugin build should create valid app 1`] = `
   </body>
 </html>"
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -1,4 +1,4 @@
 -<!doctype html>
 +<!DOCTYPE html>
  <html>
@@ -51,7 +55,6 @@ POST HYDRATE DIFFS:
    </body>
  </html>
 \\ No newline at end of file
-
 `;
 
 exports[`sku-webpack-plugin build should generate the expected files 1`] = `
@@ -2669,6 +2672,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -20,5 +20,18 @@
      >
    </head>
    <body>
@@ -2688,5 +2695,4 @@ POST HYDRATE DIFFS:
    </body>
  </html>
 \\ No newline at end of file
-
 `;

--- a/tests/__snapshots__/sku-with-https.test.js.snap
+++ b/tests/__snapshots__/sku-with-https.test.js.snap
@@ -90,6 +90,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -41,7 +41,7 @@
      <div id="app">
        <div class="_2vdre50">
          <div class="_2vdre51">
@@ -98,12 +102,15 @@ POST HYDRATE DIFFS:
          </div>
          <img src="/a85d2645cc4d80a20b5b.png">
        </div>
-
 `;
 
 exports[`sku-with-https serve should support the supplied middleware 1`] = `
 "OK"
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -1,1 +1,7 @@
 -OK
 \\ No newline at end of file
 +<html>
@@ -114,7 +121,6 @@ POST HYDRATE DIFFS:
 +  </body>
 +</html>
 \\ No newline at end of file
-
 `;
 
 exports[`sku-with-https start should start a development server 1`] = `
@@ -207,6 +213,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -41,7 +41,7 @@
      <div id="app">
        <div class="styles_root__2vdre50">
          <div class="styles_nested__2vdre51">
@@ -215,12 +225,15 @@ POST HYDRATE DIFFS:
          </div>
          <img src="/a85d2645cc4d80a20b5b.png">
        </div>
-
 `;
 
 exports[`sku-with-https start should support the supplied middleware 1`] = `
 "OK"
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -1,1 +1,7 @@
 -OK
 \\ No newline at end of file
 +<html>
@@ -231,12 +244,15 @@ POST HYDRATE DIFFS:
 +  </body>
 +</html>
 \\ No newline at end of file
-
 `;
 
 exports[`sku-with-https start-ssr should support the supplied middleware 1`] = `
 "OK"
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -1,1 +1,7 @@
 -OK
 \\ No newline at end of file
 +<html>
@@ -247,5 +263,4 @@ POST HYDRATE DIFFS:
 +  </body>
 +</html>
 \\ No newline at end of file
-
 `;

--- a/tests/__snapshots__/styling.test.ts.snap
+++ b/tests/__snapshots__/styling.test.ts.snap
@@ -99,6 +99,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -38,7 +38,7 @@
        <div>
          <div>
            Render type:
@@ -107,7 +111,6 @@ POST HYDRATE DIFFS:
          </div>
          <div>
            <span
-
 `;
 
 exports[`styling build should generate the expected files 1`] = `
@@ -334,6 +337,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -38,7 +38,7 @@
        <div>
          <div>
            Render type:
@@ -342,5 +349,4 @@ POST HYDRATE DIFFS:
          </div>
          <div>
            <span
-
 `;

--- a/tests/__snapshots__/translations.test.ts.snap
+++ b/tests/__snapshots__/translations.test.ts.snap
@@ -194,6 +194,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -37,8 +37,7 @@
    <body>
      <div id="app">
        <div>
@@ -203,7 +207,6 @@ POST HYDRATE DIFFS:
        </div>
      </div>
      <script
-
 `;
 
 exports[`translations should render fr 1`] = `

--- a/tests/__snapshots__/typescript-css-modules.test.ts.snap
+++ b/tests/__snapshots__/typescript-css-modules.test.ts.snap
@@ -92,6 +92,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -44,7 +44,7 @@
          </div>
          <div>
            Render type:
@@ -100,7 +104,6 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
-
 `;
 
 exports[`typescript-css-modules build should generate the expected files 1`] = `
@@ -314,6 +317,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -47,7 +47,7 @@
          </div>
          <div>
            Render type:
@@ -322,7 +329,6 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
-
 `;
 
 exports[`typescript-css-modules build-ssr should generate the expected files 1`] = `
@@ -435,6 +441,10 @@ SOURCE HTML: <!DOCTYPE html>
   </body>
 </html>
 POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -44,7 +44,7 @@
          </div>
          <div>
            Render type:
@@ -443,5 +453,4 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
-
 `;


### PR DESCRIPTION
While trying to test a fixture with vite on [this branch](https://github.com/seek-oss/sku/compare/master...braid-fixture-vite), I ran into an issue where the app snapshot diff was different between my local machine and CI. Specifically, the diff on CI was correct, but locally I couldn't get a correct diff.

Running a manual `git diff` locally gives the correct diff, so presumably the issue lies in `git-diff`. I chose to just swap out `git-diff` with the [`diff`](https://www.npmjs.com/package/diff) library as `git-diff` seems unmaintained, and `diff` is very popular and seems actively maintained. `diff` is a JS implementation of a text diff.

The diffs in the snapshots are exactly the same after this change, except for a few extra lines containing some header information and diff locations.