### PR TITLE
Update root resolution ordering, support `.jsx` and `.cjs`

### DIFF
--- a/.changeset/mighty-groups-tell.md
+++ b/.changeset/mighty-groups-tell.md
@@ -1,0 +1,5 @@
+---
+'sku': minor
+---
+
+Support root resolution of `.jsx` and `.cjs` files

--- a/.changeset/plenty-doodles-train.md
+++ b/.changeset/plenty-doodles-train.md
@@ -1,0 +1,7 @@
+---
+'sku': patch
+---
+
+Re-order root resolution file extensions in order of most common to least common file types
+
+Files with no extension will now be resolved in the following order: `.ts` ->  `.tsx` ->  `.mts` ->  `.cts` ->  `.js` ->  `.jsx` ->  `.mjs` ->  `.cjs` -> `.json`

--- a/packages/sku/src/config/babel/babelConfig.ts
+++ b/packages/sku/src/config/babel/babelConfig.ts
@@ -1,6 +1,7 @@
 import { cwd } from '@/utils/cwd.js';
 import { createRequire } from 'node:module';
 import type { PluginItem } from '@babel/core';
+import { rootResolutionFileExtensions } from '../fileResolutionExtensions.js';
 
 const require = createRequire(import.meta.url);
 
@@ -32,7 +33,7 @@ export default ({
       require.resolve('babel-plugin-module-resolver'),
       {
         root: rootResolution ? [cwd()] : undefined,
-        extensions: ['.mjs', '.js', '.json', '.ts', '.tsx'],
+        extensions: rootResolutionFileExtensions,
       },
     ],
     require.resolve('babel-plugin-macros'),

--- a/packages/sku/src/config/fileResolutionExtensions.ts
+++ b/packages/sku/src/config/fileResolutionExtensions.ts
@@ -1,0 +1,14 @@
+// TODO: Figure out a better way to share this config. This is currently copy-pasted from
+// `eslint-config-seek`
+export const extensions = {
+  js: ['js', 'jsx', 'mjs', 'cjs'],
+  ts: ['ts', 'tsx', 'mts', 'cts'],
+};
+
+const prependDot = (ext: string) => `.${ext}`;
+
+export const rootResolutionFileExtensions = [
+  ...extensions.ts.map(prependDot),
+  ...extensions.js.map(prependDot),
+  '.json',
+];

--- a/packages/sku/src/services/webpack/config/plugins/sku-webpack-plugin/index.ts
+++ b/packages/sku/src/services/webpack/config/plugins/sku-webpack-plugin/index.ts
@@ -16,6 +16,7 @@ import validateOptions, {
   type SkuWebpackPluginOptions,
 } from './validateOptions.js';
 import targets from '@/config/targets.json' with { type: 'json' };
+import { rootResolutionFileExtensions } from '@/config/fileResolutionExtensions.js';
 
 class SkuWebpackPlugin implements WebpackPluginInstance {
   options: SkuWebpackPluginOptions;
@@ -176,21 +177,14 @@ class SkuWebpackPlugin implements WebpackPluginInstance {
     compiler.options.module.rules.push(...rules);
 
     if (!compiler.options.resolve.extensions) {
-      compiler.options.resolve.extensions = [
-        '.mjs',
-        '.js',
-        '.json',
-        '.ts',
-        '.tsx',
-      ];
+      compiler.options.resolve.extensions = rootResolutionFileExtensions;
     } else {
-      if (!compiler.options.resolve.extensions.includes('.ts')) {
-        compiler.options.resolve.extensions.push('.ts');
-      }
+      const dedupedExtensions = new Set([
+        ...rootResolutionFileExtensions,
+        ...compiler.options.resolve.extensions,
+      ]);
 
-      if (!compiler.options.resolve.extensions.includes('.tsx')) {
-        compiler.options.resolve.extensions.push('.tsx');
-      }
+      compiler.options.resolve.extensions = Array.from(dedupedExtensions);
     }
 
     new VanillaExtractPlugin({

--- a/packages/sku/src/services/webpack/config/utils/index.ts
+++ b/packages/sku/src/services/webpack/config/utils/index.ts
@@ -1,12 +1,7 @@
+import { extensions } from '@/config/fileResolutionExtensions.js';
+
 export * from './loaders.js';
 export { resolvePackage } from './resolvePackage.js';
-
-// TODO: Figure out a better way to share this config. This is currently copy-pasted from
-// `eslint-config-seek`
-const extensions = {
-  js: ['js', 'cjs', 'mjs', 'jsx'],
-  ts: ['ts', 'cts', 'mts', 'tsx'],
-};
 
 export const TYPESCRIPT = new RegExp(`\.(${extensions.ts.join('|')})$`);
 export const JAVASCRIPT = new RegExp(`\.(${extensions.js.join('|')})$`);


### PR DESCRIPTION
Vite is a bit stricter about what can go inside a `.js` file, disallowing any JSX syntax. While we want to align with this restriction, currently consumers aren't able to as we don't support importing `.jsx` files without an extension. This PR fixes that, while also enabling root resolution of `.jsx` files too. `.cjs` was thrown in there too as it's supported by `sku` in other ways already (e.g. linting, babel transformation, etc.).

Additionally, as the file extensions are checked in the order defined by the array, it makes sense to put the most common file extensions first. For most internal apps, this would be TypeScript files, hence the re-ordering. The `m` and `c` prefixed extensions are less common, so they were de-prioritized relative to their less-specific versions.

This will also help unblock ongoing vite testing work.