### PR TITLE
`setup-hosts`: Add ipv6 hosts alongside ipv4

### DIFF
--- a/.changeset/slimy-pots-press.md
+++ b/.changeset/slimy-pots-press.md
@@ -2,4 +2,4 @@
 'sku': minor
 ---
 
-setup-hosts: ipv6 hosts are now added alongside their v4 counterpart.
+`setup-hosts` ipv6 hosts are now added alongside their ipv4 counterpart

--- a/.changeset/slimy-pots-press.md
+++ b/.changeset/slimy-pots-press.md
@@ -1,0 +1,5 @@
+---
+'sku': minor
+---
+
+setup-hosts: ipv6 hosts are now added alongside their v4 counterpart.

--- a/packages/sku/src/program/commands/serve/serve.action.ts
+++ b/packages/sku/src/program/commands/serve/serve.action.ts
@@ -4,7 +4,11 @@ import express from 'express';
 import handler from 'serve-handler';
 import chalk from 'chalk';
 import didYouMean from 'didyoumean2';
-import { checkHosts, getAppHosts } from '@/utils/contextUtils/hosts.js';
+import {
+  checkHosts,
+  getAppHosts,
+  withHostile,
+} from '@/utils/contextUtils/hosts.js';
 import allocatePort from '@/utils/allocatePort.js';
 import openBrowser from '@/openBrowser/index.js';
 import getSiteForHost from '@/utils/contextUtils/getSiteForHost.js';
@@ -80,7 +84,7 @@ export const serveAction = async ({
     process.exit(1);
   }
 
-  await checkHosts(skuContext);
+  await withHostile(checkHosts)(skuContext);
 
   const appHosts = getAppHosts(skuContext);
 

--- a/packages/sku/src/program/commands/setup-hosts/setup-hosts.action.ts
+++ b/packages/sku/src/program/commands/setup-hosts/setup-hosts.action.ts
@@ -1,6 +1,8 @@
-import { setupHosts } from '@/utils/contextUtils/hosts.js';
+import { setupHosts, withHostile } from '@/utils/contextUtils/hosts.js';
 import provider from '@/services/telemetry/index.js';
 import type { SkuContext } from '@/context/createSkuContext.js';
+
+const setupHostsWithHostile = withHostile(setupHosts);
 
 export const setupHostsAction = async ({
   skuContext,
@@ -8,7 +10,7 @@ export const setupHostsAction = async ({
   skuContext: SkuContext;
 }) => {
   try {
-    await setupHosts(skuContext);
+    await setupHostsWithHostile(skuContext);
     provider.count('setup_hosts', { status: 'success' });
   } catch {
     provider.count('setup_hosts', { status: 'failed' });

--- a/packages/sku/src/program/commands/start-ssr/webpack-start-ssr-handler.ts
+++ b/packages/sku/src/program/commands/start-ssr/webpack-start-ssr-handler.ts
@@ -12,7 +12,11 @@ import {
   ensureTargetDirectory,
   cleanTargetDirectory,
 } from '@/utils/buildFileUtils.js';
-import { checkHosts, getAppHosts } from '@/utils/contextUtils/hosts.js';
+import {
+  checkHosts,
+  getAppHosts,
+  withHostile,
+} from '@/utils/contextUtils/hosts.js';
 import makeWebpackConfig from '@/services/webpack/config/webpack.config.ssr.js';
 import getStatsConfig from '@/services/webpack/config/statsConfig.js';
 import allocatePort from '@/utils/allocatePort.js';
@@ -78,7 +82,7 @@ export const webpackStartSsrHandler = async ({
     skuContext,
   });
 
-  await checkHosts(skuContext);
+  await withHostile(checkHosts)(skuContext);
 
   const appHosts = getAppHosts(skuContext) as string | string[] | undefined;
 

--- a/packages/sku/src/program/commands/start/webpack-start-handler.ts
+++ b/packages/sku/src/program/commands/start/webpack-start-handler.ts
@@ -12,7 +12,11 @@ import createHtmlRenderPlugin from '@/services/webpack/config/plugins/createHtml
 import makeWebpackConfig from '@/services/webpack/config/webpack.config.js';
 import { watchVocabCompile } from '@/services/vocab/runVocab.js';
 
-import { checkHosts, getAppHosts } from '@/utils/contextUtils/hosts.js';
+import {
+  checkHosts,
+  getAppHosts,
+  withHostile,
+} from '@/utils/contextUtils/hosts.js';
 import allocatePort from '@/utils/allocatePort.js';
 import getSiteForHost from '@/utils/contextUtils/getSiteForHost.js';
 import { resolveEnvironment } from '@/utils/contextUtils/resolveEnvironment.js';
@@ -85,7 +89,7 @@ export const webpackStartHandler = async ({
   const clientCompiler = webpack(clientWebpackConfig);
   const renderCompiler = webpack(renderWebpackConfig);
 
-  await checkHosts(skuContext);
+  await withHostile(checkHosts)(skuContext);
 
   renderCompiler.watch({}, (err, stats) => {
     if (err) {

--- a/packages/sku/src/utils/contextUtils/hosts.test.ts
+++ b/packages/sku/src/utils/contextUtils/hosts.test.ts
@@ -1,0 +1,151 @@
+import { createSkuContext } from '@/context/createSkuContext.js';
+import { checkHosts, setupHosts } from './hosts.js';
+import { jest } from '@jest/globals';
+
+describe('setupHosts', () => {
+  beforeEach(() => {
+    // Silence the logging for the tests
+    jest.spyOn(global.console, 'log').mockImplementation(() => {});
+    jest.spyOn(global.console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should set site-specific hosts', async () => {
+    const context = createSkuContext({});
+    const mockSetHosts = jest.fn(async () => {});
+
+    await setupHosts({
+      getSystemHosts: async () => [],
+      setSystemHost: mockSetHosts,
+    })({
+      ...context,
+      sites: [
+        { name: 'foo', host: 'dev.seek.com' },
+        { name: 'bar', host: 'local.seek.com' },
+      ],
+      hosts: [],
+    });
+
+    expect(mockSetHosts).toHaveBeenCalledWith('127.0.0.1', 'dev.seek.com');
+    expect(mockSetHosts).toHaveBeenCalledWith('127.0.0.1', 'local.seek.com');
+  });
+
+  it('should set app-wide hosts', async () => {
+    const context = createSkuContext({});
+    const mockSetHosts = jest.fn(async () => {});
+
+    await setupHosts({
+      getSystemHosts: async () => [],
+      setSystemHost: mockSetHosts,
+    })({
+      ...context,
+      sites: [],
+      hosts: ['local.seek.com', 'dev.seek.com'],
+    });
+
+    expect(mockSetHosts).toHaveBeenCalledWith('127.0.0.1', 'local.seek.com');
+    expect(mockSetHosts).toHaveBeenCalledWith('127.0.0.1', 'dev.seek.com');
+  });
+
+  it('should combine app-wide and site-specific hosts', async () => {
+    const context = createSkuContext({});
+    const mockSetHosts = jest.fn(async () => {});
+
+    await setupHosts({
+      getSystemHosts: async () => [],
+      setSystemHost: mockSetHosts,
+    })({
+      ...context,
+      sites: [{ name: 'foo', host: 'dev.seek.com' }],
+      hosts: ['local.seek.com'],
+    });
+
+    expect(mockSetHosts).toHaveBeenCalledWith('127.0.0.1', 'local.seek.com');
+    expect(mockSetHosts).toHaveBeenCalledWith('127.0.0.1', 'dev.seek.com');
+  });
+
+  it('should set ipv4 and ipv6 hosts', async () => {
+    const context = createSkuContext({});
+    const mockSetHosts = jest.fn(async () => {});
+
+    await setupHosts({
+      getSystemHosts: async () => [],
+      setSystemHost: mockSetHosts,
+    })({
+      ...context,
+      hosts: ['local.seek.com'],
+    });
+
+    expect(mockSetHosts).toHaveBeenCalledTimes(2);
+    expect(mockSetHosts).toHaveBeenCalledWith('127.0.0.1', 'local.seek.com');
+    expect(mockSetHosts).toHaveBeenCalledWith('::1', 'local.seek.com');
+  });
+
+  it('should not set hosts if none are defined', async () => {
+    const context = createSkuContext({});
+    const mockSetHosts = jest.fn(async () => {});
+
+    await setupHosts({
+      getSystemHosts: async () => [],
+      setSystemHost: mockSetHosts,
+    })({
+      ...context,
+      sites: [],
+      hosts: [],
+    });
+
+    expect(mockSetHosts).not.toHaveBeenCalled();
+  });
+
+  it('should throw an error if setting hosts fails', async () => {
+    const context = createSkuContext({});
+    const mockSetHosts = jest
+      .fn(async () => {})
+      .mockRejectedValue(new Error('Failed to set hosts'));
+
+    await expect(async () => {
+      await setupHosts({
+        getSystemHosts: async () => [],
+        setSystemHost: mockSetHosts,
+      })({
+        ...context,
+        sites: [],
+        hosts: ['dev.seek.com'],
+      });
+    }).rejects.toThrow('Failed to set hosts');
+  });
+});
+
+describe('checkHosts', () => {
+  beforeEach(() => {
+    // Silence the logging for the tests
+    jest.spyOn(global.console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // All this function does is output info to the console so rather than testing the output we can just that it doesn't throw.
+  it('should not throw errors', async () => {
+    const context = createSkuContext({});
+    const mockGetHosts = jest.fn(async () => []);
+
+    await expect(
+      checkHosts({
+        setSystemHost: async () => {},
+        getSystemHosts: mockGetHosts,
+      })({
+        ...context,
+        sites: [
+          { name: 'foo', host: 'dev.seek.com' },
+          { name: 'bar', host: 'local.seek.com' },
+        ],
+        hosts: [],
+      }),
+    ).resolves.not.toThrow();
+  });
+});

--- a/packages/sku/src/utils/contextUtils/hosts.ts
+++ b/packages/sku/src/utils/contextUtils/hosts.ts
@@ -1,13 +1,19 @@
-import { promisify } from 'node:util';
-import { set, get } from 'hostile';
 import chalk from 'chalk';
 
 import { suggestScript } from '../suggestScript.js';
 import { hasErrorCode } from '../error-guards.js';
 import type { SkuContext } from '@/context/createSkuContext.js';
+import { promisify } from 'node:util';
+import { set, get } from 'hostile';
 
-const setSystemHost = promisify(set);
-const getSystemHosts = promisify(get);
+type Line = string | [string, /* host */ string /* ip */];
+type SetSystemHostFunction = (ip: string, host: string) => Promise<void>;
+type GetSystemHostFunction = (preserveFormatting: boolean) => Promise<Line[]>;
+
+type HostSystemActions = {
+  setSystemHost: SetSystemHostFunction;
+  getSystemHosts: GetSystemHostFunction;
+};
 
 export const getAppHosts = ({ sites: configuredSites, hosts }: SkuContext) =>
   configuredSites
@@ -15,58 +21,66 @@ export const getAppHosts = ({ sites: configuredSites, hosts }: SkuContext) =>
     .map((site) => site.host)
     .concat(hosts);
 
-export const setupHosts = async (skuContext: SkuContext) => {
-  try {
-    const appHosts = getAppHosts(skuContext).filter(
-      (host) => host !== 'localhost',
+export const setupHosts =
+  ({ setSystemHost }: HostSystemActions) =>
+  async (skuContext: SkuContext): Promise<void> => {
+    try {
+      const appHosts = getAppHosts(skuContext).filter(
+        (host) => host !== 'localhost',
+      );
+
+      for (const host of appHosts) {
+        if (host) {
+          await setSystemHost('127.0.0.1', host);
+          await setSystemHost('::1', host);
+          console.log(
+            `Successfully added '${chalk.bold(host)}' to your hosts file`,
+          );
+        }
+      }
+    } catch (e: unknown) {
+      if (hasErrorCode(e) && e.code === 'EACCES') {
+        console.log(
+          chalk.red('Error: setup-hosts must be run with root privileges'),
+        );
+      } else {
+        console.error(e);
+      }
+
+      throw e;
+    }
+  };
+
+export const checkHosts =
+  ({ getSystemHosts }: HostSystemActions) =>
+  async (skuContext: SkuContext): Promise<void> => {
+    const systemHosts = await getSystemHosts(false);
+    const missingHosts = getAppHosts(skuContext).filter(
+      (appHost) => !systemHosts.find(([_, host]) => appHost === host),
     );
 
-    for (const host of appHosts) {
-      if (host) {
-        await setSystemHost('127.0.0.1', host);
-        console.log(
-          `Successfully added '${chalk.bold(host)}' to your hosts file`,
-        );
+    try {
+      if (missingHosts.length > 0) {
+        missingHosts.forEach((appHost) => {
+          console.log(
+            chalk.yellow(
+              `Host '${chalk.bold(appHost)}' is not configured in your hosts file`,
+            ),
+          );
+        });
+
+        suggestScript('setup-hosts', { sudo: true });
       }
+    } catch {
+      // swallow error as this just a warning check
     }
-  } catch (e: unknown) {
-    if (hasErrorCode(e) && e.code === 'EACCES') {
-      console.log(
-        chalk.red('Error: setup-hosts must be run with root privileges'),
-      );
-    } else {
-      console.error(e);
-    }
+  };
 
-    throw e;
-  }
-};
-
-const getMissingHosts = async (skuContext: SkuContext) => {
-  const systemHosts = await getSystemHosts(false);
-  const appHosts = getAppHosts(skuContext);
-
-  return appHosts.filter(
-    (appHost) => !systemHosts.find(([_, host]) => appHost === host),
-  );
-};
-
-export const checkHosts = async (skuContext: SkuContext) => {
-  try {
-    const missingHosts = await getMissingHosts(skuContext);
-
-    if (missingHosts.length > 0) {
-      missingHosts.forEach((appHost) => {
-        console.log(
-          chalk.yellow(
-            `Host '${chalk.bold(appHost)}' is not configured in your hosts file`,
-          ),
-        );
-      });
-
-      suggestScript('setup-hosts', { sudo: true });
-    }
-  } catch {
-    // swallow error as this just a warning check
-  }
-};
+/**
+ * Inject `hostile` actions into a function that requires host file manipulation.
+ */
+export const withHostile = <T>(fn: (system: HostSystemActions) => T): T =>
+  fn({
+    getSystemHosts: promisify(get),
+    setSystemHost: promisify(set),
+  });


### PR DESCRIPTION
When running the `setup-hosts` command, only ipv4 hosts were configured. This works most of the time, but some bundlers (such as Vite) prefer serving on ipv6 ports. This change adds the ipv6 localhost equivalent to the hosts file alongside v4 to increase compatibility with bundlers that prefer it.

I've also added some tests to make sure we don't break this accidentally and add to the documentation-as-code. 