### PR TITLE
`vite (start)`: Enable httpsDevServer config option

### DIFF
--- a/fixtures/sku-with-https/package.json
+++ b/fixtures/sku-with-https/package.json
@@ -2,6 +2,10 @@
   "name": "@sku-fixtures/sku-with-https",
   "private": true,
   "type": "module",
+  "scripts": {
+    "start": "sku start",
+    "start:vite": "sku start --experimental-bundler --config sku.config.vite.mjs"
+  },
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/fixtures/sku-with-https/sku.config.vite.mjs
+++ b/fixtures/sku-with-https/sku.config.vite.mjs
@@ -3,6 +3,5 @@ import baseConfig from './sku.config.mjs';
 export default {
   ...baseConfig,
   __UNSAFE_EXPERIMENTAL__bundler: 'vite',
-  httpsDevServer: false, // not yet supported
   devServerMiddleware: './dev-middleware.vite.js',
 };

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -106,6 +106,7 @@
     "@vanilla-extract/jest-transform": "^1.1.0",
     "@vanilla-extract/vite-plugin": "^5.0.1",
     "@vanilla-extract/webpack-plugin": "^2.2.0",
+    "@vitejs/plugin-basic-ssl": "^2.0.0",
     "@vitejs/plugin-react-swc": "^3.8.0",
     "@vocab/core": "^1.6.2",
     "@vocab/phrase": "^2.0.1",

--- a/packages/sku/src/services/vite/helpers/createConfig.ts
+++ b/packages/sku/src/services/vite/helpers/createConfig.ts
@@ -4,14 +4,11 @@ import type { InlineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import { cjsInterop } from 'vite-plugin-cjs-interop';
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
-import basicSsl from '@vitejs/plugin-basic-ssl';
 
 import type { SkuContext } from '@/context/createSkuContext.js';
 import skuVitePreloadPlugin from '../plugins/skuVitePreloadPlugin.js';
 import { fixViteVanillaExtractDepScanPlugin } from '@/services/vite/plugins/esbuild/fixViteVanillaExtractDepScanPlugin.js';
 import { outDir, renderEntryChunkName } from './bundleConfig.js';
-import path from 'node:path';
-import { getAppHosts } from '@/utils/contextUtils/hosts.js';
 
 const require = createRequire(import.meta.url);
 
@@ -41,14 +38,6 @@ export const createViteConfig = ({
       react(),
       vanillaExtractPlugin(),
       skuVitePreloadPlugin(),
-      skuContext.httpsDevServer
-        ? basicSsl({
-            domains: getAppHosts(skuContext).filter(
-              (host) => host !== undefined,
-            ),
-            certDir: path.join(process.cwd(), '.ssl'),
-          })
-        : undefined,
       ...plugins,
     ],
     resolve: {

--- a/packages/sku/src/services/vite/helpers/createConfig.ts
+++ b/packages/sku/src/services/vite/helpers/createConfig.ts
@@ -4,11 +4,14 @@ import type { InlineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import { cjsInterop } from 'vite-plugin-cjs-interop';
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
+import basicSsl from '@vitejs/plugin-basic-ssl';
 
 import type { SkuContext } from '@/context/createSkuContext.js';
 import skuVitePreloadPlugin from '../plugins/skuVitePreloadPlugin.js';
 import { fixViteVanillaExtractDepScanPlugin } from '@/services/vite/plugins/esbuild/fixViteVanillaExtractDepScanPlugin.js';
 import { outDir, renderEntryChunkName } from './bundleConfig.js';
+import path from 'node:path';
+import { getAppHosts } from '@/utils/contextUtils/hosts.js';
 
 const require = createRequire(import.meta.url);
 
@@ -38,6 +41,14 @@ export const createViteConfig = ({
       react(),
       vanillaExtractPlugin(),
       skuVitePreloadPlugin(),
+      skuContext.httpsDevServer
+        ? basicSsl({
+            domains: getAppHosts(skuContext).filter(
+              (host) => host !== undefined,
+            ),
+            certDir: path.join(process.cwd(), '.ssl'),
+          })
+        : undefined,
       ...plugins,
     ],
     resolve: {

--- a/packages/sku/src/services/vite/helpers/server/createViteServer.ts
+++ b/packages/sku/src/services/vite/helpers/server/createViteServer.ts
@@ -28,6 +28,7 @@ export const createViteServer = async (skuContext: SkuContext) => {
       ],
     }),
     server: {
+      host: 'localhost',
       allowedHosts: getAppHosts(skuContext).filter(
         (host) => typeof host === 'string',
       ),

--- a/packages/sku/src/services/vite/helpers/server/createViteServer.ts
+++ b/packages/sku/src/services/vite/helpers/server/createViteServer.ts
@@ -6,6 +6,7 @@ import { createViteConfig } from '../createConfig.js';
 import skuViteHMRTelemetryPlugin from '@/services/vite/plugins/skuViteHMRTelemetry.js';
 import { skuViteStartTelemetryPlugin } from '../../plugins/skuViteStartTelemetry.js';
 import { getAppHosts } from '@/utils/contextUtils/hosts.js';
+import { skuViteHttpsDevServer } from '../../plugins/skuViteHttpsDevServer.js';
 
 export const createViteServer = async (skuContext: SkuContext) => {
   const base = process.env.BASE || '/';
@@ -23,6 +24,7 @@ export const createViteServer = async (skuContext: SkuContext) => {
           target: 'node',
           type: 'static',
         }),
+        skuContext.httpsDevServer && skuViteHttpsDevServer(skuContext),
       ],
     }),
     server: {

--- a/packages/sku/src/services/vite/helpers/server/createViteServer.ts
+++ b/packages/sku/src/services/vite/helpers/server/createViteServer.ts
@@ -5,6 +5,7 @@ import type { SkuContext } from '@/context/createSkuContext.js';
 import { createViteConfig } from '../createConfig.js';
 import skuViteHMRTelemetryPlugin from '@/services/vite/plugins/skuViteHMRTelemetry.js';
 import { skuViteStartTelemetryPlugin } from '../../plugins/skuViteStartTelemetry.js';
+import { getAppHosts } from '@/utils/contextUtils/hosts.js';
 
 export const createViteServer = async (skuContext: SkuContext) => {
   const base = process.env.BASE || '/';
@@ -25,9 +26,9 @@ export const createViteServer = async (skuContext: SkuContext) => {
       ],
     }),
     server: {
-      allowedHosts: skuContext.sites
-        .map(({ host }) => host || false)
-        .filter((host) => typeof host === 'string'),
+      allowedHosts: getAppHosts(skuContext).filter(
+        (host) => typeof host === 'string',
+      ),
     },
     base,
   });

--- a/packages/sku/src/services/vite/helpers/server/createViteServerSsr.ts
+++ b/packages/sku/src/services/vite/helpers/server/createViteServerSsr.ts
@@ -11,6 +11,7 @@ import type { SkuContext } from '@/context/createSkuContext.js';
 import { createSsrHtml } from '@/services/vite/helpers/html/createSsrHtml.js';
 import { createCollector } from '@/services/vite/loadable/collector.js';
 import { getAppHosts } from '@/utils/contextUtils/hosts.js';
+import { skuViteHttpsDevServer } from '../../plugins/skuViteHttpsDevServer.js';
 
 const base = process.env.BASE || '/';
 
@@ -49,6 +50,9 @@ export const createViteServerSsr = async ({
             (host) => typeof host === 'string',
           ),
         },
+        plugins: [
+          skuContext.httpsDevServer && skuViteHttpsDevServer(skuContext),
+        ],
         appType: 'custom',
         base,
       });

--- a/packages/sku/src/services/vite/helpers/server/createViteServerSsr.ts
+++ b/packages/sku/src/services/vite/helpers/server/createViteServerSsr.ts
@@ -10,6 +10,7 @@ import type { SkuContext } from '@/context/createSkuContext.js';
 
 import { createSsrHtml } from '@/services/vite/helpers/html/createSsrHtml.js';
 import { createCollector } from '@/services/vite/loadable/collector.js';
+import { getAppHosts } from '@/utils/contextUtils/hosts.js';
 
 const base = process.env.BASE || '/';
 
@@ -44,9 +45,9 @@ export const createViteServerSsr = async ({
         server: {
           middlewareMode: true,
           hmr: true,
-          allowedHosts: skuContext.sites
-            .map(({ host }) => host || false)
-            .filter((host) => typeof host === 'string'),
+          allowedHosts: getAppHosts(skuContext).filter(
+            (host) => typeof host === 'string',
+          ),
         },
         appType: 'custom',
         base,

--- a/packages/sku/src/services/vite/helpers/server/createViteServerSsr.ts
+++ b/packages/sku/src/services/vite/helpers/server/createViteServerSsr.ts
@@ -44,6 +44,7 @@ export const createViteServerSsr = async ({
           configType: 'ssr',
         }),
         server: {
+          host: 'localhost',
           middlewareMode: true,
           hmr: true,
           allowedHosts: getAppHosts(skuContext).filter(

--- a/packages/sku/src/services/vite/index.ts
+++ b/packages/sku/src/services/vite/index.ts
@@ -8,6 +8,7 @@ import { prerenderRoutes } from './helpers/prerenderRoutes.js';
 import { cleanTargetDirectory } from '@/utils/buildFileUtils.js';
 import { openBrowser } from '@/openBrowser/index.js';
 import { getAppHosts } from '@/utils/contextUtils/hosts.js';
+import chalk from 'chalk';
 
 export const viteService = {
   buildSsr: async (skuContext: SkuContext) => {
@@ -33,15 +34,8 @@ export const viteService = {
     const url = `${proto}://${hosts[0]}:${skuContext.port.client}${skuContext.initialPath}`;
     openBrowser(url);
 
-    if (skuContext.sites.length > 1) {
-      skuContext.sites.forEach((site) => {
-        console.log(
-          `Running ${site.name} on '${proto}://${site.host ?? 'localhost'}:${skuContext.port.client}'`,
-        );
-      });
-    } else {
-      server.printUrls();
-    }
+    printUrls(hosts, skuContext);
+
     server.bindCLIShortcuts({ print: true });
   },
   startSsr: async (skuContext: SkuContext) => {
@@ -57,14 +51,18 @@ export const viteService = {
     const url = `${proto}://${hosts[0]}:${skuContext.port.server}${skuContext.initialPath}`;
     openBrowser(url);
 
-    if (skuContext.sites.length > 1) {
-      skuContext.sites.forEach((site) => {
-        console.log(
-          `Running ${site.name} on '${proto}://${site.host ?? 'localhost'}:${skuContext.port.server}'`,
-        );
-      });
-    } else {
-      console.log(`Running on 'http://localhost:${skuContext.port.server}'`);
-    }
+    printUrls(hosts, skuContext);
   },
+};
+
+const printUrls = (
+  hosts: Array<string | undefined>,
+  skuContext: SkuContext,
+) => {
+  const proto = skuContext.httpsDevServer ? 'https' : 'http';
+  hosts.forEach((site) => {
+    console.log(
+      `${chalk.green('➜')}  ${chalk.bold('Local')}: ${chalk.cyan(`${proto}://${site}:${chalk.bold(skuContext.port.client)}`)}`,
+    );
+  });
 };

--- a/packages/sku/src/services/vite/plugins/skuViteHttpsDevServer.ts
+++ b/packages/sku/src/services/vite/plugins/skuViteHttpsDevServer.ts
@@ -1,0 +1,47 @@
+import type { SkuContext } from '@/context/createSkuContext.js';
+import { getAppHosts } from '@/utils/contextUtils/hosts.js';
+import basicSsl from '@vitejs/plugin-basic-ssl';
+import path from 'node:path';
+import type { Plugin } from 'vite';
+import { promises as fs } from 'node:fs';
+import debug from 'debug';
+import { hasErrorCode } from '@/utils/error-guards.js';
+
+const log = debug('sku:vite:https');
+
+/**
+ * Cleans up stale certs from the cert directory. This is useful when the user changes their hosts in their sku config and the old certs are no longer needed.
+ */
+const cleanupStaleCerts = (certDir: string): Plugin => ({
+  name: 'sku:cleanup-stale-certs',
+  // We want to call this before the ssl generation which happens in the "configResolved" hook. However, adding a "enfore:pre" flag in "configResolved"
+  // doesn't guarantee that it will delete the certs before the ssl generation since it's called async and in parallel.
+  // So, we use the "config" hook which is guaranteed to be called and waited on before the "configResolved" hook.
+  config: {
+    async handler() {
+      try {
+        await fs.rm(certDir, { recursive: true });
+        log(`Removed stale certs from ${certDir}`);
+      } catch (e) {
+        if (hasErrorCode(e) && e.code === 'ENOENT') {
+          log(`Failed removing stale certs. Directory not found: ${certDir}`);
+          return;
+        }
+
+        log(`Failed to remove stale certs from ${certDir}`, e);
+      }
+    },
+  },
+});
+
+export const skuViteHttpsDevServer = async (skuContext: SkuContext) => {
+  const certDir = path.join(process.cwd(), '.ssl');
+
+  return [
+    cleanupStaleCerts(certDir),
+    basicSsl({
+      domains: getAppHosts(skuContext).filter((host) => host !== undefined),
+      certDir,
+    }),
+  ];
+};

--- a/packages/sku/src/services/vite/plugins/skuViteMiddlewarePlugin.ts
+++ b/packages/sku/src/services/vite/plugins/skuViteMiddlewarePlugin.ts
@@ -45,7 +45,10 @@ export const skuViteMiddlewarePlugin = (skuContext: SkuContext): Plugin => ({
         next();
         return;
       }
-      const host = req.headers.host;
+
+      // `host` header is available in vite http requests. `:authority` pseudo-header is available in vite https requests. `:authority` is used in HTTP/2.
+      // @see https://stackoverflow.com/questions/70502726/what-is-the-purpose-of-http2-pseudo-headers-authority-method
+      const host = req.headers.host ?? (req.headers[':authority'] as string);
       const hostname = host?.split(':')[0];
 
       if (!hostname) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -653,6 +653,9 @@ importers:
       '@vanilla-extract/webpack-plugin':
         specifier: ^2.2.0
         version: 2.3.18(babel-plugin-macros@3.1.0)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.25.1))
+      '@vitejs/plugin-basic-ssl':
+        specifier: ^2.0.0
+        version: 2.0.0(vite@6.2.2(@types/node@18.19.80)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))
       '@vitejs/plugin-react-swc':
         specifier: ^3.8.0
         version: 3.8.0(vite@6.2.2(@types/node@18.19.80)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))
@@ -3194,6 +3197,12 @@ packages:
     resolution: {integrity: sha512-00AB9LQJZ5JM6jQCCn3upONPi4jqJnjXrN+uROgfixgxIpq0fMEfhnwOtAdECG7gRCy0T2jzpo1KO1Fh5wYsJg==}
     peerDependencies:
       webpack: ^4.30.0 || ^5.20.2
+
+  '@vitejs/plugin-basic-ssl@2.0.0':
+    resolution: {integrity: sha512-gc9Tjg8bUxBVSTzeWT3Njc0Cl3PakHFKdNfABnZWiUgbxqmHDEn7uECv3fHVylxoYgNzAcmU7ZrILz+BwSo3sA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    peerDependencies:
+      vite: ^6.0.0
 
   '@vitejs/plugin-react-swc@3.8.0':
     resolution: {integrity: sha512-T4sHPvS+DIqDP51ifPqa9XIRAz/kIvIi8oXcnOZZgHmMotgmmdxe/DD5tMFlt5nuIRzT0/QuiwmKlH0503Aapw==}
@@ -11318,6 +11327,10 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+
+  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.2.2(@types/node@18.19.80)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))':
+    dependencies:
+      vite: 6.2.2(@types/node@18.19.80)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0)
 
   '@vitejs/plugin-react-swc@3.8.0(vite@6.2.2(@types/node@18.19.80)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:

--- a/test-utils/waitForUrls.js
+++ b/test-utils/waitForUrls.js
@@ -5,13 +5,7 @@ export const waitForUrls = async (...urls) => {
 
   try {
     return await waitOn({
-      resources: urls.map((url) =>
-        url
-          .replace(/http(s?)\:/, 'http$1-get:')
-          // As of node 17, ipv6 is preferred, so explicitly use ipv4
-          // See https://github.com/jeffbski/wait-on/issues/133
-          .replace(/localhost/, '0.0.0.0'),
-      ),
+      resources: urls.map((url) => url.replace(/http(s?)\:/, 'http$1-get:')),
       headers: { accept: 'text/html, application/javascript' },
       timeout,
       // Log output of wait behaviour timing to allow

--- a/tests/sku-with-https.test.js
+++ b/tests/sku-with-https.test.js
@@ -25,7 +25,7 @@ describe('sku-with-https', () => {
         ? ['--experimental-bundler', '--config', 'sku.config.vite.mjs']
         : [];
     describe('start', () => {
-      const url = `http${bundler === 'vite' ? '' : 's'}://${bundler === 'vite' ? '[::1]' : 'localhost'}:${port}`;
+      const url = `https://localhost:${port}`;
 
       let process;
 


### PR DESCRIPTION
The sku config supports a `httpsDevServer` option that generates self-signed certificates so you can do local development on https. This has now been enabled in the experimental Vite bundler. 