### PR TITLE
disable clearScreen when running tests

### DIFF
--- a/packages/sku/src/services/vite/helpers/createConfig.ts
+++ b/packages/sku/src/services/vite/helpers/createConfig.ts
@@ -31,6 +31,7 @@ export const createViteConfig = ({
 
   return {
     root: process.cwd(),
+    clearScreen: process.env.NODE_ENV !== 'test',
     plugins: [
       cjsInterop({
         dependencies: ['@apollo/client', 'lodash'],


### PR DESCRIPTION
Disable clearScreen when running vite in a `test` environment.