### PR TITLE
Refactor codemod test tools

### DIFF
--- a/packages/sku-codemod/src/codemods/transform-vite-loadable/__tests__/transform-vite-loadable.test.ts
+++ b/packages/sku-codemod/src/codemods/transform-vite-loadable/__tests__/transform-vite-loadable.test.ts
@@ -21,8 +21,13 @@ const tests = [
 describe('[CODEMOD]: "transform-vite-loadable"', () => {
   it.for(tests)('"$fixtureName"', async ({ fixtureName, shouldNotChange }) => {
     const testRunner = shouldNotChange ? runNoChangeTest : runTest;
-    testRunner(__dirname, 'transform-vite-loadable', fixtureName, {
-      extension: 'tsx',
+    testRunner({
+      dirName: __dirname,
+      transformName: 'transform-vite-loadable',
+      fixtureName,
+      testOptions: {
+        extension: 'tsx',
+      },
     });
   });
 });

--- a/plop/generators/add-sku-codemod/templates/test.hbs
+++ b/plop/generators/add-sku-codemod/templates/test.hbs
@@ -8,8 +8,13 @@ const tests = [
 
 describe('[CODEMOD]: "{{ codemodName }}"', () => {
   it.for(tests)('"$fixtureName"', async ({ fixtureName }) => {
-    runTest(__dirname, '{{ codemodName }}', fixtureName, {
-      extension: 'tsx',
+    runTest({
+      dirName: __dirname,
+      transformName: '{{ codemodName }}',
+      fixtureName,
+      testOptions: {
+        extension: 'tsx',
+      }
     });
   });
 });


### PR DESCRIPTION
Slight refactor of the `test-uitls` for codemod. Opting for an object as the parameters vs a list of parameters.