### PR TITLE
Add `resolveComponent` to the `loadable` options api.

### DIFF
--- a/.changeset/stale-moles-nail.md
+++ b/.changeset/stale-moles-nail.md
@@ -1,0 +1,31 @@
+---
+'sku': minor
+---
+
+`vite/loadable`: Add the `resolveComponent` option to the `loadable` function. The `loadable` function returns the `default` export by default. By using the `resolveComponent` function you can specify the correct component for `loadable` to use.
+
+**example usage**
+
+```typescript
+// src/MyComponent.tsx
+import React from 'react';
+
+export const MyComponent = () => {
+  return <div>Hello, world!</div>;
+};
+
+// src/App.tsx
+import { loadable } from 'sku/vite/loadable';
+
+const MyComponent = loadable(() => import('./MyComponent'), {
+  resolveComponent: (module) => module.MyComponent,
+});
+
+export const App = () => {
+  return (
+    <div>
+      <MyComponent />
+    </div>
+  );
+};
+```

--- a/.changeset/stale-moles-nail.md
+++ b/.changeset/stale-moles-nail.md
@@ -8,8 +8,6 @@
 
 ```typescript
 // src/MyComponent.tsx
-import React from 'react';
-
 export const MyComponent = () => {
   return <div>Hello, world!</div>;
 };

--- a/docs/docs/vite-support.md
+++ b/docs/docs/vite-support.md
@@ -41,7 +41,8 @@ Before starting with `vite` rendering make sure you've read the [static renderin
 
 Code splitting is possible with the new `sku/vite/loadable` entrypoint.
 
-The new `sku/vite/loadable` entrypoint relies on React's [`<Suspense />`](https://react.dev/reference/react/Suspense) component for the loading of a fallback state. You can wrap the `loadable` component in a `<Suspense />` component or provide a `fallback` option to the `loadable` function which will wrap it inside a `<Suspense />` component for you.
+The new `sku/vite/loadable` entrypoint relies on React's [`<Suspense />`](https://react.dev/reference/react/Suspense) component for the loading of a fallback state
+You can wrap the `loadable` component in a `<Suspense />` component or provide a `fallback` option to the `loadable` function which will wrap it inside a `<Suspense />` component for you.
 
 **Example of using `sku/vite/loadable`**
 
@@ -63,6 +64,11 @@ export default () => (
 In order to use `loadable` with the fallback option you would need to render the application inside the `renderToStringAsync` function in the `render.tsx` file. See the example [here](./docs/static-rendering.md#renderApp) for more information.
 
 If you run the vite command with the `--convert-loadable` flag, sku will automatically convert all the `loadable` components from `sku/@loadable/component` to the new imports.
+
+#### Using named exports
+
+The `loadable` function returns the `default` export by default.
+If you want to use a named export you can use the `resolveComponent` option to specify the correct component for `loadable` to use.
 
 ### Dev server middleware
 

--- a/fixtures/multiple-routes/src/handlers/AsyncComponent.jsx
+++ b/fixtures/multiple-routes/src/handlers/AsyncComponent.jsx
@@ -1,1 +1,1 @@
-export default () => <span>Some special async content</span>;
+export const AsyncComponent = () => <span>Some special async content</span>;

--- a/fixtures/multiple-routes/src/handlers/Details.jsx
+++ b/fixtures/multiple-routes/src/handlers/Details.jsx
@@ -4,7 +4,12 @@ import loadable from 'sku/@loadable/component';
 
 import * as styles from './Details.css.js';
 
-const AsyncComponent = loadable(() => import('./AsyncComponent'));
+const AsyncComponent = loadable(() => import('./AsyncComponent'), {
+  resolveComponent: (module) => {
+    console.log('resolveComponent', module);
+    return module.AsyncComponent;
+  },
+});
 
 export default function Details({ site }) {
   const { id } = useParams();

--- a/packages/sku/src/services/vite/loadable/loadable.tsx
+++ b/packages/sku/src/services/vite/loadable/loadable.tsx
@@ -24,14 +24,16 @@ export function loadable<T extends ComponentType<any>>(
   },
   moduleId: ModuleId = '', // Gets set via the plugin
 ): PreloadableComponent<T> {
-  const getDefaultExport = (module: { default: T } & Record<string, T>) =>
+  const getResolvedOrDefaultExport = (
+    module: { default: T } & Record<string, T>,
+  ) =>
     options?.resolveComponent
       ? options.resolveComponent(module)
       : module.default;
 
   const lazyFactory = async () => {
     const module = await factory();
-    return { default: getDefaultExport(module) };
+    return { default: getResolvedOrDefaultExport(module) };
   };
   const ReactLazyComponent = lazy(lazyFactory);
   let PreloadedComponent: T | undefined;
@@ -64,7 +66,7 @@ export function loadable<T extends ComponentType<any>>(
   LazyWithPreload.preload = () => {
     if (!factoryPromise) {
       factoryPromise = factory().then((module) => {
-        PreloadedComponent = getDefaultExport(module);
+        PreloadedComponent = getResolvedOrDefaultExport(module);
         return PreloadedComponent;
       });
     }

--- a/tests/__snapshots__/multiple-routes.test.js.snap
+++ b/tests/__snapshots__/multiple-routes.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`multiple-routes > bundler: vite > build and serve > should generate the expected files 1`] = `
 {
-  "AsyncComponent-DtuSLDgp.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "Details-CaxrQeMv.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "AsyncComponent-BbylO-Ju.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "Details-DGJnH813.css": "._1hpn1da0{color:#00f}
 ",
+  "Details-f3a0yRc4.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "Home-D-106MY_.css": ".ms22la0{color:red}
 ",
   "Home-DQBwRi9y.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
@@ -28,16 +28,16 @@ exports[`multiple-routes > bundler: vite > build and serve > should generate the
 
 <link rel="modulepreload" href="/static/place/vite-client.js" crossorigin >
 
-<link rel="modulepreload" href="/static/place/Details-CaxrQeMv.js" crossorigin >
+<link rel="modulepreload" href="/static/place/Details-f3a0yRc4.js" crossorigin >
 
-<link rel="modulepreload" href="/static/place/AsyncComponent-DtuSLDgp.js" crossorigin >
+<link rel="modulepreload" href="/static/place/AsyncComponent-BbylO-Ju.js" crossorigin >
 
   </head>
   <body>
     <div id="app"><!--$--><h1 class="_1hpn1da0">Welcome to the Details page - au<span>Some special async content</span></h1><!--/$--></div>
     <script id="__SKU_CLIENT_CONTEXT__" type="application/json">{"site":"au"}</script>
-<script type="module" src="/static/place/AsyncComponent-DtuSLDgp.js" ></script>
-<script type="module" src="/static/place/Details-CaxrQeMv.js" ></script>
+<script type="module" src="/static/place/AsyncComponent-BbylO-Ju.js" ></script>
+<script type="module" src="/static/place/Details-f3a0yRc4.js" ></script>
 <script type="module" src="/static/place/vite-client.js" ></script>
   </body>
 </html>",
@@ -89,16 +89,16 @@ exports[`multiple-routes > bundler: vite > build and serve > should generate the
 
 <link rel="modulepreload" href="/static/place/vite-client.js" crossorigin >
 
-<link rel="modulepreload" href="/static/place/Details-CaxrQeMv.js" crossorigin >
+<link rel="modulepreload" href="/static/place/Details-f3a0yRc4.js" crossorigin >
 
-<link rel="modulepreload" href="/static/place/AsyncComponent-DtuSLDgp.js" crossorigin >
+<link rel="modulepreload" href="/static/place/AsyncComponent-BbylO-Ju.js" crossorigin >
 
   </head>
   <body>
     <div id="app"><!--$--><h1 class="_1hpn1da0">Welcome to the Details page - nz<span>Some special async content</span></h1><!--/$--></div>
     <script id="__SKU_CLIENT_CONTEXT__" type="application/json">{"site":"nz"}</script>
-<script type="module" src="/static/place/AsyncComponent-DtuSLDgp.js" ></script>
-<script type="module" src="/static/place/Details-CaxrQeMv.js" ></script>
+<script type="module" src="/static/place/AsyncComponent-BbylO-Ju.js" ></script>
+<script type="module" src="/static/place/Details-f3a0yRc4.js" ></script>
 <script type="module" src="/static/place/vite-client.js" ></script>
   </body>
 </html>",
@@ -173,12 +173,12 @@ exports[`multiple-routes > bundler: vite > build and serve > should render detai
     >
     <link
       rel="modulepreload"
-      href="/static/place/Details-CaxrQeMv.js"
+      href="/static/place/Details-f3a0yRc4.js"
       crossorigin
     >
     <link
       rel="modulepreload"
-      href="/static/place/AsyncComponent-DtuSLDgp.js"
+      href="/static/place/AsyncComponent-BbylO-Ju.js"
       crossorigin
     >
   </head>
@@ -199,12 +199,12 @@ exports[`multiple-routes > bundler: vite > build and serve > should render detai
     </script>
     <script
       type="module"
-      src="/static/place/AsyncComponent-DtuSLDgp.js"
+      src="/static/place/AsyncComponent-BbylO-Ju.js"
     >
     </script>
     <script
       type="module"
-      src="/static/place/Details-CaxrQeMv.js"
+      src="/static/place/Details-f3a0yRc4.js"
     >
     </script>
     <script
@@ -219,14 +219,14 @@ POST HYDRATE DIFFS:
 --- sourceHtml
 +++ clientHtml
 @@ -43,11 +43,34 @@
-       href="/static/place/AsyncComponent-DtuSLDgp.js"
+       href="/static/place/AsyncComponent-BbylO-Ju.js"
        crossorigin
      >
 +    <link
 +      rel="modulepreload"
 +      as="script"
 +      crossorigin
-+      href="/Details-CaxrQeMv.js"
++      href="/Details-f3a0yRc4.js"
 +    >
 +    <link
 +      rel="stylesheet"
@@ -237,7 +237,7 @@ POST HYDRATE DIFFS:
 +      rel="modulepreload"
 +      as="script"
 +      crossorigin
-+      href="/AsyncComponent-DtuSLDgp.js"
++      href="/AsyncComponent-BbylO-Ju.js"
 +    >
 +    <link
 +      rel="modulepreload"


### PR DESCRIPTION
# Outline:

The `@loadable` package has the [resolveComponent](https://loadable-components.com/docs/api-loadable-component/#optionsresolvecomponent) option that allows users to specify which component the `loadable` function should use.

This PR is adding that option to the `vite/loadable` function.

# Changes:

- Add the `resolveComponent` option to the `loadable` options.
- Updated `multiple-routes` fixture to use the `resolveComponent` option.