### PR TITLE
Add ESLint rule to enforce dynamic action module imports, consolidate CLI command exports

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -80,6 +80,19 @@ module.exports = [
       'no-process-exit': 'off',
       'no-sync': 'off',
 
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/*.action.js'],
+              message:
+                'Please dynamically import action modules to keep the CLI fast',
+            },
+          ],
+        },
+      ],
+
       'import-x/no-unresolved': [
         'error',
         {

--- a/packages/sku/src/program/commands/configure/configure.command.ts
+++ b/packages/sku/src/program/commands/configure/configure.command.ts
@@ -1,8 +1,6 @@
 import { Command } from 'commander';
 
-export const configureCommand = new Command('configure');
-
-configureCommand
+export const configureCommand = new Command('configure')
   .description('Emit and update configuration files for your project.')
   .action(async (options) => {
     const { configureAction } = await import('./configure.action.js');

--- a/packages/sku/src/program/commands/format/format.command.ts
+++ b/packages/sku/src/program/commands/format/format.command.ts
@@ -1,8 +1,6 @@
 import { Command } from 'commander';
 
-export const formatCommand = new Command('format');
-
-formatCommand
+export const formatCommand = new Command('format')
   .description('Apply all available lint and formatting fixes.')
   .argument('[paths...]', 'paths to format')
   .action(async (paths, options) => {

--- a/packages/sku/src/program/commands/init/init.command.ts
+++ b/packages/sku/src/program/commands/init/init.command.ts
@@ -2,9 +2,7 @@ import { Command } from 'commander';
 import { packageManagerOption } from '../../options/packageManager/packageManager.option.js';
 import { setPackageManager } from '../../../services/packageManager/context/packageManager.js';
 
-export const initCommand = new Command('init');
-
-initCommand
+export const initCommand = new Command('init')
   .description('Initialize a new sku project')
   .argument('[projectName]', 'Project name')
   .option(

--- a/packages/sku/src/program/commands/lint/lint.command.ts
+++ b/packages/sku/src/program/commands/lint/lint.command.ts
@@ -1,8 +1,6 @@
 import { Command } from 'commander';
 
-export const lintCommand = new Command('lint');
-
-lintCommand
+export const lintCommand = new Command('lint')
   .description('Run lint tooling over your code.')
   .argument('[paths...]', 'paths to lint')
   .action(async (paths, options) => {

--- a/packages/sku/src/program/commands/pre-commit/pre-commit.command.ts
+++ b/packages/sku/src/program/commands/pre-commit/pre-commit.command.ts
@@ -1,8 +1,6 @@
 import { Command } from 'commander';
 
-export const preCommitCommand = new Command('pre-commit');
-
-preCommitCommand
+export const preCommitCommand = new Command('pre-commit')
   .description('Run the sku pre-commit hook.')
   .action(async (options) => {
     const { preCommitAction } = await import('./pre-commit.action.js');

--- a/packages/sku/src/program/commands/serve/serve.command.ts
+++ b/packages/sku/src/program/commands/serve/serve.command.ts
@@ -5,9 +5,7 @@ import {
   strictPortOption,
 } from '../../options/port/port.option.js';
 
-export const serveCommand = new Command('serve');
-
-serveCommand
+export const serveCommand = new Command('serve')
   .description(
     'Serve a production build of a statically-rendered application from your local machine.',
   )

--- a/packages/sku/src/program/commands/start-ssr/start-ssr.command.ts
+++ b/packages/sku/src/program/commands/start-ssr/start-ssr.command.ts
@@ -1,9 +1,7 @@
 import { Command } from 'commander';
 import { statsOption } from '@/program/options/stats/stats.option.js';
 
-const startSsrCommand = new Command('start-ssr');
-
-startSsrCommand
+export const startSsrCommand = new Command('start-ssr')
   .description(
     'Start the sku development server for a server-rendered application.',
   )
@@ -12,5 +10,3 @@ startSsrCommand
     const { startSsrAction } = await import('./start-ssr.action.js');
     await startSsrAction(options);
   });
-
-export { startSsrCommand };

--- a/packages/sku/src/program/commands/test/test.action.ts
+++ b/packages/sku/src/program/commands/test/test.action.ts
@@ -10,7 +10,7 @@ const log = debug('sku:jest');
 
 const { run } = jest;
 
-const testAction = async (
+export const testAction = async (
   {
     skuContext,
   }: {
@@ -35,5 +35,3 @@ const testAction = async (
 
   run(jestArgv);
 };
-
-export { testAction };

--- a/packages/sku/src/program/commands/translations/commands/compile/compile.command.ts
+++ b/packages/sku/src/program/commands/translations/commands/compile/compile.command.ts
@@ -1,14 +1,10 @@
 import { Command } from 'commander';
 import { watchOption } from '../../../../options/watch/watch.option.js';
 
-const compileCommand = new Command('compile');
-
-compileCommand
+export const compileCommand = new Command('compile')
   .description('Compile translations defined in .vocab directories.')
   .addOption(watchOption)
   .action(async (options) => {
     const { compileAction } = await import('./compile.action.js');
     await compileAction(options);
   });
-
-export { compileCommand };

--- a/packages/sku/src/program/commands/translations/commands/pull/pull.command.ts
+++ b/packages/sku/src/program/commands/translations/commands/pull/pull.command.ts
@@ -1,12 +1,8 @@
 import { Command } from 'commander';
 
-const pullCommand = new Command('pull');
-
-pullCommand
+export const pullCommand = new Command('pull')
   .description('Pull translations from Phrase')
   .action(async (options) => {
     const { pullAction } = await import('./pull.action.js');
     await pullAction(options);
   });
-
-export { pullCommand };

--- a/plop/generators/add-sku-command/templates/action.hbs
+++ b/plop/generators/add-sku-command/templates/action.hbs
@@ -1,5 +1,3 @@
-const {{camelCase commandName}}Action = () => {
+export const {{camelCase commandName}}Action = () => {
 
 };
-
-export { {{camelCase commandName}}Action };

--- a/plop/generators/add-sku-command/templates/command.hbs
+++ b/plop/generators/add-sku-command/templates/command.hbs
@@ -1,11 +1,7 @@
 import { Command } from 'commander';
 import { {{camelCase commandName}}Action } from './{{commandName}}.action.js';
 
-const {{camelCase commandName}}Command = new Command('{{commandName}}');
-
-{{camelCase commandName}}Command
+export const {{camelCase commandName}}Command = new Command('{{commandName}}')
   .description('<YOUR_DESCRIPTION_HERE>')
   .argument('<ARGUMENTS_HERE>', '<ARGUMENT_DESCRIPTION>')
   .action({{camelCase commandName}}Action);
-
-export { {{camelCase commandName}}Command };


### PR DESCRIPTION
- Added an ESLint rule that bans regular imports of `*.action.js` modules, which should hopefully ensure they stay dynamically imported
- Cleaned up some exports by exporting declarations directly
- Updated the `plop` templates to reflect these export changes for any future commands that may be added to the CLI