### PR TITLE
`vite start`: Don't clean up local SSL certs every time the dev server starts

### DIFF
--- a/.changeset/nasty-flowers-relax.md
+++ b/.changeset/nasty-flowers-relax.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`vite start`: Don't clean up local SSL certs every time the dev server starts

--- a/packages/sku/src/services/vite/helpers/server/createViteServer.ts
+++ b/packages/sku/src/services/vite/helpers/server/createViteServer.ts
@@ -6,7 +6,7 @@ import { createViteConfig } from '../createConfig.js';
 import skuViteHMRTelemetryPlugin from '@/services/vite/plugins/skuViteHMRTelemetry.js';
 import { skuViteStartTelemetryPlugin } from '../../plugins/skuViteStartTelemetry.js';
 import { getAppHosts } from '@/utils/contextUtils/hosts.js';
-import { getHttpsDevServerPlugin } from '../../plugins/skuViteHttpsDevServer.js';
+import { skuViteHttpsDevServer } from '../../plugins/skuViteHttpsDevServer.js';
 
 export const createViteServer = async (skuContext: SkuContext) =>
   createServer({
@@ -22,7 +22,7 @@ export const createViteServer = async (skuContext: SkuContext) =>
           target: 'node',
           type: 'static',
         }),
-        getHttpsDevServerPlugin(skuContext),
+        skuViteHttpsDevServer(skuContext),
       ],
     }),
     server: {

--- a/packages/sku/src/services/vite/helpers/server/createViteServer.ts
+++ b/packages/sku/src/services/vite/helpers/server/createViteServer.ts
@@ -1,12 +1,12 @@
-import { createServer } from 'vite';
 import { skuViteMiddlewarePlugin } from '@/services/vite/plugins/skuViteMiddlewarePlugin.js';
+import { createServer } from 'vite';
 import type { SkuContext } from '@/context/createSkuContext.js';
 
 import { createViteConfig } from '../createConfig.js';
 import skuViteHMRTelemetryPlugin from '@/services/vite/plugins/skuViteHMRTelemetry.js';
 import { skuViteStartTelemetryPlugin } from '../../plugins/skuViteStartTelemetry.js';
 import { getAppHosts } from '@/utils/contextUtils/hosts.js';
-import { skuViteHttpsDevServer } from '../../plugins/skuViteHttpsDevServer.js';
+import { getHttpsDevServerPlugin } from '../../plugins/skuViteHttpsDevServer.js';
 
 export const createViteServer = async (skuContext: SkuContext) =>
   createServer({
@@ -22,7 +22,7 @@ export const createViteServer = async (skuContext: SkuContext) =>
           target: 'node',
           type: 'static',
         }),
-        skuContext.httpsDevServer && skuViteHttpsDevServer(skuContext),
+        getHttpsDevServerPlugin(skuContext),
       ],
     }),
     server: {

--- a/packages/sku/src/services/vite/helpers/server/createViteServerSsr.ts
+++ b/packages/sku/src/services/vite/helpers/server/createViteServerSsr.ts
@@ -11,7 +11,7 @@ import type { SkuContext } from '@/context/createSkuContext.js';
 import { createSsrHtml } from '@/services/vite/helpers/html/createSsrHtml.js';
 import { createCollector } from '@/services/vite/loadable/collector.js';
 import { getAppHosts } from '@/utils/contextUtils/hosts.js';
-import { skuViteHttpsDevServer } from '../../plugins/skuViteHttpsDevServer.js';
+import { getHttpsDevServerPlugin } from '../../plugins/skuViteHttpsDevServer.js';
 
 const base = process.env.BASE || '/';
 
@@ -51,9 +51,7 @@ export const createViteServerSsr = async ({
             (host) => typeof host === 'string',
           ),
         },
-        plugins: [
-          skuContext.httpsDevServer && skuViteHttpsDevServer(skuContext),
-        ],
+        plugins: [getHttpsDevServerPlugin(skuContext)],
         appType: 'custom',
         base,
       });

--- a/packages/sku/src/services/vite/helpers/server/createViteServerSsr.ts
+++ b/packages/sku/src/services/vite/helpers/server/createViteServerSsr.ts
@@ -11,7 +11,7 @@ import type { SkuContext } from '@/context/createSkuContext.js';
 import { createSsrHtml } from '@/services/vite/helpers/html/createSsrHtml.js';
 import { createCollector } from '@/services/vite/loadable/collector.js';
 import { getAppHosts } from '@/utils/contextUtils/hosts.js';
-import { getHttpsDevServerPlugin } from '../../plugins/skuViteHttpsDevServer.js';
+import { skuViteHttpsDevServer } from '../../plugins/skuViteHttpsDevServer.js';
 
 const base = process.env.BASE || '/';
 
@@ -51,7 +51,7 @@ export const createViteServerSsr = async ({
             (host) => typeof host === 'string',
           ),
         },
-        plugins: [getHttpsDevServerPlugin(skuContext)],
+        plugins: [skuViteHttpsDevServer(skuContext)],
         appType: 'custom',
         base,
       });

--- a/packages/sku/src/services/vite/plugins/skuViteHttpsDevServer.ts
+++ b/packages/sku/src/services/vite/plugins/skuViteHttpsDevServer.ts
@@ -3,7 +3,7 @@ import { getAppHosts } from '@/utils/contextUtils/hosts.js';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 import path from 'node:path';
 
-export const getHttpsDevServerPlugin = (skuContext: SkuContext) => {
+export const skuViteHttpsDevServer = (skuContext: SkuContext) => {
   if (skuContext.httpsDevServer) {
     const certDir = path.join(process.cwd(), '.ssl');
 

--- a/packages/sku/src/services/vite/plugins/skuViteHttpsDevServer.ts
+++ b/packages/sku/src/services/vite/plugins/skuViteHttpsDevServer.ts
@@ -2,46 +2,16 @@ import type { SkuContext } from '@/context/createSkuContext.js';
 import { getAppHosts } from '@/utils/contextUtils/hosts.js';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 import path from 'node:path';
-import type { Plugin } from 'vite';
-import { promises as fs } from 'node:fs';
-import debug from 'debug';
-import { hasErrorCode } from '@/utils/error-guards.js';
 
-const log = debug('sku:vite:https');
+export const getHttpsDevServerPlugin = (skuContext: SkuContext) => {
+  if (skuContext.httpsDevServer) {
+    const certDir = path.join(process.cwd(), '.ssl');
 
-/**
- * Cleans up stale certs from the cert directory. This is useful when the user changes their hosts in their sku config and the old certs are no longer needed.
- */
-const cleanupStaleCerts = (certDir: string): Plugin => ({
-  name: 'sku:cleanup-stale-certs',
-  // We want to call this before the ssl generation which happens in the "configResolved" hook. However, adding a "enfore:pre" flag in "configResolved"
-  // doesn't guarantee that it will delete the certs before the ssl generation since it's called async and in parallel.
-  // So, we use the "config" hook which is guaranteed to be called and waited on before the "configResolved" hook.
-  config: {
-    async handler() {
-      try {
-        await fs.rm(certDir, { recursive: true });
-        log(`Removed stale certs from ${certDir}`);
-      } catch (e) {
-        if (hasErrorCode(e) && e.code === 'ENOENT') {
-          log(`Failed removing stale certs. Directory not found: ${certDir}`);
-          return;
-        }
-
-        log(`Failed to remove stale certs from ${certDir}`, e);
-      }
-    },
-  },
-});
-
-export const skuViteHttpsDevServer = async (skuContext: SkuContext) => {
-  const certDir = path.join(process.cwd(), '.ssl');
-
-  return [
-    cleanupStaleCerts(certDir),
-    basicSsl({
+    return basicSsl({
       domains: getAppHosts(skuContext).filter((host) => host !== undefined),
       certDir,
-    }),
-  ];
+    });
+  }
+
+  return null;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,13 +431,13 @@ importers:
         version: 8.6.12(@types/react@18.3.21)(storybook@8.6.12(prettier@3.5.3))
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.3
-        version: 3.0.6(webpack@5.99.8(@swc/core@1.11.24))
+        version: 3.0.6(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))
       '@storybook/react':
         specifier: ^8.1.5
         version: 8.6.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
       '@storybook/react-webpack5':
         specifier: ^8.1.5
-        version: 8.6.12(@swc/core@1.11.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
+        version: 8.6.12(@swc/core@1.11.24)(esbuild@0.25.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
       '@types/react':
         specifier: ^18.2.3
         version: 18.3.21
@@ -471,13 +471,13 @@ importers:
         version: link:../../test-utils
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.3
-        version: 3.0.6(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))
+        version: 3.0.6(webpack@5.99.8(@swc/core@1.11.24))
       '@storybook/react':
         specifier: ^8.1.5
         version: 8.6.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
       '@storybook/react-webpack5':
         specifier: ^8.1.5
-        version: 8.6.12(@swc/core@1.11.24)(esbuild@0.25.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
+        version: 8.6.12(@swc/core@1.11.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
       '@types/react':
         specifier: ^18.2.3
         version: 18.3.21


### PR DESCRIPTION
Sorry @williamlark. 

While it would be nice to handle, the logic to clean up existing SSL certs makes it necessary to trust the certs in the browser them every time the dev server starts. Removing this logic aligns the vite behaviour with the webpack behaviour.

While it would be nice to handle the situation where an apps hosts change, this doesn't happen that often so IMO isn't worth optimizing for (at the expense of a poorer dev experience). **EDIT**: it turns out that this is really only an issue if you delete the host from the `hosts` config. That host still has a valid certificate, but since it's only used for local dev this isn't a huge concern.

Also did a tiny refactor to pull the conditional plugin logic into a getter.