### PR TITLE
`vite start`: Improve error handling during static render

### DIFF
--- a/.changeset/few-hairs-hug.md
+++ b/.changeset/few-hairs-hug.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`vite start`: Improve error handling during static render

--- a/fixtures/assertion-removal/package.json
+++ b/fixtures/assertion-removal/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@sku-fixtures/assertion-removal",
   "private": true,
+  "type": "module",
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/fixtures/assertion-removal/sku.config.vite.ts
+++ b/fixtures/assertion-removal/sku.config.vite.ts
@@ -1,0 +1,8 @@
+import type { SkuConfig } from 'sku';
+
+import baseConfig from './sku.config.ts';
+
+export default {
+  __UNSAFE_EXPERIMENTAL__bundler: 'vite',
+  ...baseConfig,
+} satisfies SkuConfig;

--- a/tests/assertion-removal.test.ts
+++ b/tests/assertion-removal.test.ts
@@ -19,8 +19,7 @@ const appDir = path.dirname(
   require.resolve('@sku-fixtures/assertion-removal/sku.config.ts'),
 );
 const distDir = path.resolve(appDir, 'dist');
-// TODO: fix this casting.
-const skuConfig = skuConfigImport as unknown as typeof skuConfigImport.default;
+const skuConfig = skuConfigImport;
 
 assert(skuConfig.serverPort, 'skuConfig has serverPort');
 const backendUrl = `http://localhost:${skuConfig.serverPort}`;
@@ -60,7 +59,7 @@ describe('assertion-removal', () => {
     beforeAll(async () => {
       await runSkuScriptInDir('build-ssr', appDir);
       run('node', {
-        args: ['server'],
+        args: ['server.cjs'],
         cwd: distDir,
         stdio: 'inherit',
         signal,


### PR DESCRIPTION
Currently, as soon as an error is thrown during the static render, the dev server crashes. With this change, the dev server will now display the stack trace in the browser and keep running, allowing you to fix the error and refresh the page without needing to restart the entire dev server.

You can test this out by running the `assertion-removal` fixture, which intentionally throws an error, with vite. Note that the `assertion-removal` tests aren't yet tested with vite.