### PR TITLE
Strip assertions during `vite` builds

### DIFF
--- a/.changeset/bumpy-lies-raise.md
+++ b/.changeset/bumpy-lies-raise.md
@@ -1,0 +1,5 @@
+---
+'sku': minor
+---
+
+`vite build`: Strip assertions during production build

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -108,7 +108,7 @@
     "@vanilla-extract/vite-plugin": "^5.0.2",
     "@vanilla-extract/webpack-plugin": "^2.2.0",
     "@vitejs/plugin-basic-ssl": "^2.0.0",
-    "@vitejs/plugin-react-swc": "^3.8.0",
+    "@vitejs/plugin-react": "^4.4.1",
     "@vocab/core": "^1.6.2",
     "@vocab/phrase": "^2.0.1",
     "@vocab/pseudo-localize": "^1.0.1",

--- a/packages/sku/src/services/vite/helpers/createConfig.ts
+++ b/packages/sku/src/services/vite/helpers/createConfig.ts
@@ -35,6 +35,8 @@ export const createViteConfig = ({
   const vocabConfig = getVocabConfig(skuContext);
   const isStartCommand = Boolean(skuContext.commandName?.startsWith('start'));
 
+  const isProductionBuild = process.env.NODE_ENV === 'production';
+
   return {
     base: isStartCommand ? '/' : skuContext.publicPath,
     root: process.cwd(),
@@ -45,7 +47,23 @@ export const createViteConfig = ({
       cjsInterop({
         dependencies: ['@apollo/client', 'lodash'],
       }),
-      react(),
+      react({
+        babel: {
+          plugins: [
+            ...(isProductionBuild
+              ? [
+                  [
+                    require.resolve('babel-plugin-unassert'),
+                    {
+                      variables: ['assert', 'invariant'],
+                      modules: ['assert', 'node:assert', 'tiny-invariant'],
+                    },
+                  ],
+                ]
+              : []),
+          ],
+        },
+      }),
       vanillaExtractPlugin(),
       preloadPlugin({
         convertFromWebpack: skuContext.convertLoadable, // Convert loadable import from webpack to vite. Can be put behind a flag.

--- a/packages/sku/src/services/vite/helpers/createConfig.ts
+++ b/packages/sku/src/services/vite/helpers/createConfig.ts
@@ -1,7 +1,7 @@
 import { createRequire, builtinModules } from 'node:module';
 import type { InlineConfig } from 'vite';
 
-import react from '@vitejs/plugin-react-swc';
+import react from '@vitejs/plugin-react';
 import { cjsInterop } from 'vite-plugin-cjs-interop';
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -694,9 +694,9 @@ importers:
       '@vitejs/plugin-basic-ssl':
         specifier: ^2.0.0
         version: 2.0.0(vite@6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
-      '@vitejs/plugin-react-swc':
-        specifier: ^3.8.0
-        version: 3.9.0(vite@6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      '@vitejs/plugin-react':
+        specifier: ^4.4.1
+        version: 4.4.1(vite@6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
       '@vocab/core':
         specifier: ^1.6.2
         version: 1.6.3
@@ -1791,6 +1791,18 @@ packages:
 
   '@babel/plugin-transform-react-jsx-development@7.27.1':
     resolution: {integrity: sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3334,10 +3346,11 @@ packages:
     peerDependencies:
       vite: ^6.0.0
 
-  '@vitejs/plugin-react-swc@3.9.0':
-    resolution: {integrity: sha512-jYFUSXhwMCYsh/aQTgSGLIN3Foz5wMbH9ahb0Zva//UzwZYbMiZd7oT3AU9jHT9DLswYDswsRwPU9jVF3yA48Q==}
+  '@vitejs/plugin-react@4.4.1':
+    resolution: {integrity: sha512-IpEm5ZmeXAP/osiBXVVP5KjFMzbWOonMs0NaQQl+xYnUAcq4oHUBsF2+p4MgKWG4YMmFYJU8A6sxRPuowllm6w==}
+    engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4 || ^5 || ^6
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
   '@vitest/expect@3.1.3':
     resolution: {integrity: sha512-7FTQQuuLKmN1Ig/h+h/GO+44Q1IlglPlR2es4ab7Yvfx+Uk5xsv+Ykk+MEt/M2Yn/xGmzaLKxGw2lgy2bwuYqg==}
@@ -7524,6 +7537,10 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -9627,6 +9644,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.1)':
     dependencies:
       '@babel/core': 7.27.1
@@ -11629,12 +11656,16 @@ snapshots:
     dependencies:
       vite: 6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
 
-  '@vitejs/plugin-react-swc@3.9.0(vite@6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
+  '@vitejs/plugin-react@4.4.1(vite@6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
     dependencies:
-      '@swc/core': 1.11.24
+      '@babel/core': 7.27.1
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.27.1)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.27.1)
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
       vite: 6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
     transitivePeerDependencies:
-      - '@swc/helpers'
+      - supports-color
 
   '@vitest/expect@3.1.3':
     dependencies:
@@ -16605,6 +16636,8 @@ snapshots:
       warning: 4.0.3
 
   react-refresh@0.14.2: {}
+
+  react-refresh@0.17.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@18.3.21)(react@18.3.1):
     dependencies:

--- a/tests/assertion-removal.test.ts
+++ b/tests/assertion-removal.test.ts
@@ -26,7 +26,7 @@ assert(skuConfig.serverPort, 'skuConfig has serverPort');
 const backendUrl = `http://localhost:${skuConfig.serverPort}`;
 
 describe('assertion-removal', () => {
-  describe.for(['webpack'])('bundler %s', (bundler) => {
+  describe.for(['vite', 'webpack'])('bundler %s', (bundler) => {
     describe('build', async () => {
       const port = await getPort();
       const url = `http://localhost:${port}`;

--- a/tests/assertion-removal.test.ts
+++ b/tests/assertion-removal.test.ts
@@ -7,6 +7,7 @@ import {
   startAssetServer,
   run,
   createCancelSignal,
+  getPort,
 } from '@sku-private/test-utils';
 
 import skuConfigImport from '@sku-fixtures/assertion-removal/sku.config.ts';
@@ -25,30 +26,39 @@ assert(skuConfig.serverPort, 'skuConfig has serverPort');
 const backendUrl = `http://localhost:${skuConfig.serverPort}`;
 
 describe('assertion-removal', () => {
-  describe('build', () => {
-    const url = 'http://localhost:8239';
-    const { cancel, signal } = createCancelSignal();
+  describe.for(['webpack'])('bundler %s', (bundler) => {
+    describe('build', async () => {
+      const port = await getPort();
+      const url = `http://localhost:${port}`;
+      const { cancel, signal } = createCancelSignal();
+      const args: Record<string, string[]> = {
+        vite: ['--config', 'sku.config.vite.ts', '--experimental-bundler'],
+      };
 
-    beforeAll(async () => {
-      await runSkuScriptInDir('build', appDir);
-      runSkuScriptInDir('serve', appDir, { signal });
-      await waitForUrls(url);
-    });
+      beforeAll(async () => {
+        await runSkuScriptInDir('build', appDir, { args: args[bundler] });
+        runSkuScriptInDir('serve', appDir, {
+          args: ['--strict-port', `--port=${port}`],
+          signal,
+        });
+        await waitForUrls(url);
+      });
 
-    afterAll(async () => {
-      cancel();
-    });
+      afterAll(() => {
+        cancel();
+      });
 
-    it('should not contain "assert" or "invariant" in production', async ({
-      expect,
-    }) => {
-      const appPage = await browser.newPage();
-      const response = await appPage.goto(url, { waitUntil: 'networkidle0' });
-      const sourceHtml = await response?.text();
-      await appPage.close();
-      expect(sourceHtml).toContain(
-        'It rendered without throwing an assertion error',
-      );
+      it('should not contain "assert" or "invariant" in production', async ({
+        expect,
+      }) => {
+        const appPage = await browser.newPage();
+        const response = await appPage.goto(url, { waitUntil: 'networkidle0' });
+        const sourceHtml = await response?.text();
+        await appPage.close();
+        expect(sourceHtml).toContain(
+          'It rendered without throwing an assertion error',
+        );
+      });
     });
   });
 
@@ -68,7 +78,7 @@ describe('assertion-removal', () => {
       await waitForUrls(backendUrl, 'http://localhost:4004');
     });
 
-    afterAll(async () => {
+    afterAll(() => {
       cancel();
       closeAssetServer();
     });


### PR DESCRIPTION
During production webpack builds, assertions are stripped from the bundle. Currently this is handled by https://github.com/unassert-js/babel-plugin-unassert. Vite builds need to emulate this behaviour.

For Vite there are 3 viable options: 
1. the babel plugin we already use
2. https://github.com/unassert-js/rollup-plugin-unassert
3. https://github.com/unassert-js/swc-plugin-unassert

Given that we likely want to run a few more babel plugins during vite builds, I chose to opt for the babel plugin. I would've liked to use the SWC plugin, but the plugin doesn't quite support the features we need (specifically custom assert methods and modules).

There are 2 easy ways to run babel plugins in Vite:
1. https://www.npmjs.com/package/vite-plugin-babel
2. https://www.npmjs.com/package/@vitejs/plugin-react

While option 1 seems like the obvious choice, by switching from `@vitejs/plugin-react-swc` to `@vitejs/plugin-react`, we can pass the babel plugin directly to it (`@vitejs/plugin-react-swc` only supports SWC plugins).

We may one day want to switch entirely to SWC, but until then it will be much easier to achieve feature parity with webpack by sticking to babel.
