### PR TITLE
`sku init`: Update template to use a named export for `App`

### DIFF
--- a/.changeset/rich-points-write.md
+++ b/.changeset/rich-points-write.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`sku init`: Update template to use a named export for `App`

--- a/packages/sku/template/src/App/App.tsx
+++ b/packages/sku/template/src/App/App.tsx
@@ -10,7 +10,7 @@ interface AppProps {
   environment: 'development' | 'production';
 }
 
-export default ({ environment }: AppProps) => (
+export const App = ({ environment }: AppProps) => (
   <StrictMode>
     <BraidProvider theme={seekJobs}>
       <NextSteps environment={environment} />

--- a/packages/sku/template/src/client.tsx
+++ b/packages/sku/template/src/client.tsx
@@ -1,6 +1,6 @@
 import { hydrateRoot } from 'react-dom/client';
 
-import App from './App/App';
+import { App } from './App/App';
 import type { ClientContext } from './types';
 
 export default ({ environment }: ClientContext) => {

--- a/packages/sku/template/src/render.tsx
+++ b/packages/sku/template/src/render.tsx
@@ -1,7 +1,7 @@
 import { renderToString } from 'react-dom/server';
 import type { Render } from 'sku';
 
-import App from './App/App';
+import { App } from './App/App';
 import type { ClientContext } from './types';
 
 interface RenderContext {


### PR DESCRIPTION
Default exports are worse for HMR. In vite, updating a default exported component will cause a full page refresh. 