### PR TITLE
small codemod change

### DIFF
--- a/packages/sku-codemod/src/codemods/transform-vite-loadable/__testfixtures__/loadableNameFixture.input.tsx
+++ b/packages/sku-codemod/src/codemods/transform-vite-loadable/__testfixtures__/loadableNameFixture.input.tsx
@@ -1,3 +1,4 @@
+// This file also tests the double quotes.
 import loadable from 'sku/@loadable/component';
 
 const LoadableComponent = loadable(() => import('./MyComponent'));

--- a/packages/sku-codemod/src/codemods/transform-vite-loadable/__testfixtures__/loadableNameFixture.output.tsx
+++ b/packages/sku-codemod/src/codemods/transform-vite-loadable/__testfixtures__/loadableNameFixture.output.tsx
@@ -1,3 +1,4 @@
+// This file also tests the double quotes.
 import { loadable } from 'sku/vite/loadable';
 
 const LoadableComponent = loadable(() => import('./MyComponent'));

--- a/packages/sku-codemod/src/codemods/transform-vite-loadable/transform-vite-loadable.ts
+++ b/packages/sku-codemod/src/codemods/transform-vite-loadable/transform-vite-loadable.ts
@@ -11,7 +11,10 @@ export const transform = (source: string) => {
         {
           has: {
             kind: 'string',
-            pattern: "'sku/@loadable/component'",
+            has: {
+              kind: 'string_fragment',
+              regex: 'sku\/@loadable\/component',
+            },
           },
         },
         {

--- a/tests/sku-codemods/sku-codemods.test.ts
+++ b/tests/sku-codemods/sku-codemods.test.ts
@@ -7,7 +7,7 @@ import { createFixture } from 'fs-fixture';
 const filesToTest = [
   {
     filename: 'customNameFixture.tsx',
-    input: dedent/* typescript */ `import customLoadable from 'sku/@loadable/component';
+    input: dedent/* typescript */ `import customLoadable from "sku/@loadable/component";
 
         const LoadableComponent = customLoadable(() => import('./MyComponent'));`,
     output: dedent/* typescript */ `import { loadable as customLoadable } from 'sku/vite/loadable';


### PR DESCRIPTION
I changed the matching behavior of the pattern match to a regex matcher on the `string_fragment`.

You can see the matcher [here](https://ast-grep.github.io/playground.html#eyJtb2RlIjoiQ29uZmlnIiwibGFuZyI6InR5cGVzY3JpcHQiLCJxdWVyeSI6ImNvbnNvbGUubG9nKCRNQVRDSCkiLCJyZXdyaXRlIjoibG9nZ2VyLmxvZygkTUFUQ0gpIiwic3RyaWN0bmVzcyI6InNtYXJ0Iiwic2VsZWN0b3IiOiIiLCJjb25maWciOiIjIFlBTUwgUnVsZSBpcyBtb3JlIHBvd2VyZnVsIVxuIyBodHRwczovL2FzdC1ncmVwLmdpdGh1Yi5pby9ndWlkZS9ydWxlLWNvbmZpZy5odG1sI3J1bGVcblxucnVsZTogXG4gIGtpbmQ6ICdpbXBvcnRfc3RhdGVtZW50J1xuICBhbGw6XG4gICAgLSBoYXM6XG4gICAgICAgIGtpbmQ6ICdzdHJpbmcnXG4gICAgICAgIGhhczogXG4gICAgICAgICAga2luZDogJ3N0cmluZ19mcmFnbWVudCdcbiAgICAgICAgICByZWdleDogJ3NrdVxcL0Bsb2FkYWJsZVxcL2NvbXBvbmVudCdcbiAgICAtIGhhczpcbiAgICAgICAga2luZDogJ2ltcG9ydF9jbGF1c2UnXG4gICAgICAgIGhhczogXG4gICAgICAgICAga2luZDogJ2lkZW50aWZpZXInXG4iLCJzb3VyY2UiOiJpbXBvcnQgY3VzdG9tTG9hZGFibGUgZnJvbSAnc2t1L0Bsb2FkYWJsZS9jb21wb25lbnQnO1xuXG5jb25zdCBMb2FkYWJsZUNvbXBvbmVudCA9IGN1c3RvbUxvYWRhYmxlKCgpID0+IGltcG9ydCgnLi9NeUNvbXBvbmVudCcpKTtcbiJ9)

the tree output is in the bottom left. 

this means we can now match regardless of quotation marks used.