### PR TITLE
throw an error when the specified config file is not found

### DIFF
--- a/.changeset/easy-beds-argue.md
+++ b/.changeset/easy-beds-argue.md
@@ -1,0 +1,10 @@
+---
+'sku': major
+---
+
+`sku` no longer defaults to using a default sku config when it can not find the config file specified with the `--config` flag.
+It will now instead throw an error and exit the program.
+
+This change is made to ensure that users are aware that the configuration file is either missing or incorrectly specified, rather than silently falling back to a default configuration that may not be appropriate for their use case.
+
+If you encounter this error, please ensure that the `--config` flag points to a valid configuration file.

--- a/packages/sku/src/context/configPath.ts
+++ b/packages/sku/src/context/configPath.ts
@@ -35,7 +35,9 @@ export const resolveAppSkuConfigPath = ({
       return resolvedCustomConfigPath;
     }
 
-    debug('Custom sku config file does not exist:', resolvedCustomConfigPath);
+    throw new Error(
+      `No sku config file found for path: ${configPath}. Make sure the path is correct or that you have a sku.config.ts file in your project root.`,
+    );
   }
 
   const supportedSkuConfigPath = resolveSupportedSkuConfigPath();


### PR DESCRIPTION
`sku` now throws an error when the `--config` option is passed and the config file can't be read. 

`sku` would only let the user know of this mistake if they were logging with the `--debug` flag before and may cause unintended side effects.

This change makes sure that `sku` exits the program when it can't find the specified file.