### PR TITLE
Update changeset config so peer dep changes only cause major releases when they go out of range

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,5 +11,8 @@
   },
   "snapshot": {
     "useCalculatedVersion": true
+  },
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
   }
 }


### PR DESCRIPTION
#1272 is currently showing a major release because a peer dep is being updated, despite that peer dep being `*` versioned. Though [this config is experimental](https://github.com/changesets/changesets/blob/9ce98a59b595bc328cf6c7f4141f3cd05dd15940/docs/experimental-options.md?plain=1#L13), it seems more sane than the default.

Others agree https://github.com/atlassian-labs/atlaspack/pull/439.