### PR TITLE
Revert addition of `--disable-warning` flag to sku binary

### DIFF
--- a/.changeset/shaky-banks-melt.md
+++ b/.changeset/shaky-banks-melt.md
@@ -1,0 +1,7 @@
+---
+'sku': patch
+---
+
+Revert addition of `--disable-warning` flag to `sku` binary
+
+This flag was added to suppress certain warnings about experimental features being used by `sku`. However, the method use to set this flag is not compatible with certain distributions of Linux without additional configuration, so it has been removed.

--- a/packages/sku/bin.js
+++ b/packages/sku/bin.js
@@ -1,3 +1,3 @@
-#!/usr/bin/env -S node --disable-warning=ExperimentalWarning
+#!/usr/bin/env node
 
 import './dist/bin/sku.js';


### PR DESCRIPTION
Alpine linux's `env` (from busybox) [doesn't support the `-S` flag](https://forum.gitlab.com/t/error-usr-bin-env-unrecognized-option-s-with-alpine-linux-image-causes-ci-script-to-fail/64063), which means we can't use it to suppress warnings in sku. There are methods to make it work, but they aren't worth implementing for the small value they add.

As we move on to newer Node versions (eventually), the need to suppress these warnings will go away.