### PR TITLE
Fix root resolution extension order

### DIFF
--- a/.changeset/flat-nights-allow.md
+++ b/.changeset/flat-nights-allow.md
@@ -1,0 +1,7 @@
+---
+'sku': patch
+---
+
+Modify root resolution extension order
+
+Fixes a bug that caused multiple versions of the same package to be bundled in certain situations

--- a/packages/sku/src/config/fileResolutionExtensions.ts
+++ b/packages/sku/src/config/fileResolutionExtensions.ts
@@ -1,14 +1,14 @@
 // TODO: Figure out a better way to share this config. This is currently copy-pasted from
 // `eslint-config-seek`
 export const extensions = {
-  js: ['js', 'jsx', 'mjs', 'cjs'],
-  ts: ['ts', 'tsx', 'mts', 'cts'],
+  js: ['mjs', 'cjs', 'js', 'jsx'],
+  ts: ['mts', 'cts', 'ts', 'tsx'],
 };
 
 const prependDot = (ext: string) => `.${ext}`;
 
 export const rootResolutionFileExtensions = [
-  ...extensions.ts.map(prependDot),
   ...extensions.js.map(prependDot),
   '.json',
+  ...extensions.ts.map(prependDot),
 ];


### PR DESCRIPTION
Refines the changes made in https://github.com/seek-oss/sku/pull/1219.

Resolving the more generic `.js` extension _before_ the more specific `.mjs` and `.cjs` extensions seems to cause a bug in certain situations that results in both the CJS and MJS versions of a package (`graphql`, but could affect others) being bundled.

I spent some time verifying that this code change was the cause, and that the bundle is affected, but couldn't quite figure out _why_ this change affected the bundle. What makes the situation even stranger is that the app in question disables `rootResolution`, so AFIACT `babel-plugin-module-resolver` shouldn't be affecting file extensions at all in the app. 🤷

Ultimately I decided to modify the extension order to be similar to what it was before (`['.mjs', '.js', '.json', '.ts', '.tsx']`):
- JS extensions first, starting with the more specific `.mjs` and `.cjs`
- `.json`
- Finally TS extensions, again prioritizing the more specific `.mts` and `.cts` (which I doubt anyone uses anyway)

This _should_ be less of an issue in Vite as it handles source code module resolution for us.