### PR TITLE
`vite (start)`: `initialPath` will now render when starting the server

### DIFF
--- a/.changeset/spotty-cycles-report.md
+++ b/.changeset/spotty-cycles-report.md
@@ -2,4 +2,4 @@
 'sku': minor
 ---
 
-`vite:start`: `initialPath` will now be added to the url output when starting a server
+`vite (start)`: `initialPath` will now be added to the url output when starting a server

--- a/.changeset/spotty-cycles-report.md
+++ b/.changeset/spotty-cycles-report.md
@@ -1,0 +1,5 @@
+---
+'sku': minor
+---
+
+`vite:start`: `initialPath` will now be added to the url output when starting a server

--- a/packages/sku/src/services/vite/index.ts
+++ b/packages/sku/src/services/vite/index.ts
@@ -71,8 +71,10 @@ const printUrls = (
 ) => {
   const proto = skuContext.httpsDevServer ? 'https' : 'http';
   hosts.forEach((site) => {
-    console.log(
-      `${chalk.green('➜')}  ${chalk.bold('Local')}: ${chalk.cyan(`${proto}://${site}:${chalk.bold(skuContext.port.client)}`)}`,
+    const initialPath = chalk.dim(`${skuContext.initialPath}`);
+    const url = chalk.cyan(
+      `${proto}://${site}:${chalk.bold(skuContext.port.client)}${initialPath}`,
     );
+    console.log(`${chalk.green('➜')}  ${chalk.bold('Local')}: ${url}`);
   });
 };

--- a/packages/sku/src/services/vite/index.ts
+++ b/packages/sku/src/services/vite/index.ts
@@ -71,7 +71,8 @@ const printUrls = (
 ) => {
   const proto = skuContext.httpsDevServer ? 'https' : 'http';
   hosts.forEach((site) => {
-    const initialPath = chalk.dim(`${skuContext.initialPath}`);
+    const initialPath =
+      skuContext.initialPath !== '/' ? skuContext.initialPath : '';
     const url = chalk.cyan(
       `${proto}://${site}:${chalk.bold(skuContext.port.client)}${initialPath}`,
     );


### PR DESCRIPTION
The `initialPath` in the sku config makes the server start at a specific route when running `sku start`. This works in the experimental Vite bundler, but it would not show the path in the CLI output. This means that if your app has no root page and you CMD + Click to open the output url from the CLI you will be greeted with a 404 error. 

This PR adds the initial route to the CLI output so the correct url can be opened easier.

**Before**

![CleanShot 2025-06-11 at 14 04 59](https://github.com/user-attachments/assets/44172ae2-17b5-49fa-b54a-22438c8d2e78)

**After**

![CleanShot 2025-06-11 at 14 06 25](https://github.com/user-attachments/assets/ec368d06-1c7a-4eb1-89e1-0bb5bab49f7d)
