### PR TITLE
Fix `sku-init` test pollution

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "tsx": "^4.19.4",
     "typescript": "~5.8.0",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.1.1",
+    "vitest": "^3.2.3",
     "vitest-environment-puppeteer": "^11.0.3",
     "vitest-puppeteer": "^11.0.3"
   },

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -227,6 +227,6 @@
     "ts-patch": "^3.3.0",
     "type-fest": "^4.41.0",
     "typescript-transform-paths": "^3.5.2",
-    "vitest": "^3.1.1"
+    "vitest": "^3.2.3"
   }
 }

--- a/packages/sku/src/utils/SkuConfigUpdater.test.ts
+++ b/packages/sku/src/utils/SkuConfigUpdater.test.ts
@@ -1,7 +1,4 @@
 import { describe, it } from 'vitest';
-/**
- * @jest-environment node
- */
 import { createFixture } from 'fs-fixture';
 import dedent from 'dedent';
 import { SkuConfigUpdater } from './SkuConfigUpdater.js';

--- a/packages/sku/src/utils/toPosixPath.test.ts
+++ b/packages/sku/src/utils/toPosixPath.test.ts
@@ -1,9 +1,5 @@
 import { describe, it } from 'vitest';
 
-/**
- * @jest-environment node
- */
-
 import toPosixPath from './toPosixPath.js';
 
 describe('toPosixPath', () => {

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -35,6 +35,6 @@
   "homepage": "https://github.com/seek-oss/sku#readme",
   "dependencies": {
     "@vanilla-extract/vite-plugin": "^5.0.2",
-    "vitest": "^3.1.1"
+    "vitest": "^3.2.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 5.4.4
       debug:
         specifier: ^4.3.1
-        version: 4.4.0
+        version: 4.4.1
       dedent:
         specifier: ^1.5.1
         version: 1.6.0(babel-plugin-macros@3.1.0)
@@ -84,14 +84,14 @@ importers:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
       vitest:
-        specifier: ^3.1.1
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@18.19.100)(jiti@2.4.2)(jsdom@20.0.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+        specifier: ^3.2.3
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@18.19.100)(jiti@2.4.2)(jsdom@20.0.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
       vitest-environment-puppeteer:
         specifier: ^11.0.3
-        version: 11.0.3(debug@4.4.0)(typescript@5.8.3)
+        version: 11.0.3(debug@4.4.1)(typescript@5.8.3)
       vitest-puppeteer:
         specifier: ^11.0.3
-        version: 11.0.3(debug@4.4.0)(puppeteer@24.8.2(typescript@5.8.3))(typescript@5.8.3)
+        version: 11.0.3(debug@4.4.1)(puppeteer@24.8.2(typescript@5.8.3))(typescript@5.8.3)
 
   docs:
     devDependencies:
@@ -159,7 +159,7 @@ importers:
         version: 18.3.7(@types/react@18.3.21)
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.17.2(babel-plugin-macros@3.1.0)
+        version: 1.17.3(babel-plugin-macros@3.1.0)
       sku:
         specifier: workspace:*
         version: link:../../packages/sku
@@ -268,7 +268,7 @@ importers:
     dependencies:
       '@vanilla-extract/css':
         specifier: ^1.17.1
-        version: 1.17.2(babel-plugin-macros@3.1.0)
+        version: 1.17.3(babel-plugin-macros@3.1.0)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -309,7 +309,7 @@ importers:
         version: link:../../test-utils
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.17.2(babel-plugin-macros@3.1.0)
+        version: 1.17.3(babel-plugin-macros@3.1.0)
       dedent:
         specifier: ^1.5.1
         version: 1.6.0(babel-plugin-macros@3.1.0)
@@ -321,7 +321,7 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^3.2.1
-        version: 3.2.1(vitest@3.1.3(@types/debug@4.1.12)(@types/node@18.19.100)(jiti@2.4.2)(jsdom@20.0.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+        version: 3.2.1(vitest@3.2.3(@types/debug@4.1.12)(@types/node@18.19.100)(jiti@2.4.2)(jsdom@20.0.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
       sku:
         specifier: workspace:*
         version: link:../../packages/sku
@@ -358,7 +358,7 @@ importers:
         version: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.99.8)
       webpack-dev-server:
         specifier: ^5.0.2
-        version: 5.2.0(debug@4.4.0)(webpack-cli@5.1.4)(webpack@5.99.8)
+        version: 5.2.0(debug@4.4.1)(webpack-cli@5.1.4)(webpack@5.99.8)
 
   fixtures/sku-with-https:
     dependencies:
@@ -374,7 +374,7 @@ importers:
         version: link:../../test-utils
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.17.2(babel-plugin-macros@3.1.0)
+        version: 1.17.3(babel-plugin-macros@3.1.0)
       dedent:
         specifier: ^1.5.1
         version: 1.6.0(babel-plugin-macros@3.1.0)
@@ -418,7 +418,7 @@ importers:
         version: link:../../test-utils
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.17.2(babel-plugin-macros@3.1.0)
+        version: 1.17.3(babel-plugin-macros@3.1.0)
       sku:
         specifier: workspace:*
         version: link:../../packages/sku
@@ -440,13 +440,13 @@ importers:
         version: 8.6.12(@types/react@18.3.21)(storybook@8.6.12(prettier@3.5.3))
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.3
-        version: 3.0.6(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))
+        version: 3.0.6(webpack@5.99.8(@swc/core@1.11.24))
       '@storybook/react':
         specifier: ^8.1.5
         version: 8.6.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
       '@storybook/react-webpack5':
         specifier: ^8.1.5
-        version: 8.6.12(@swc/core@1.11.24)(esbuild@0.25.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
+        version: 8.6.12(@swc/core@1.11.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
       '@types/react':
         specifier: ^18.2.3
         version: 18.3.21
@@ -455,7 +455,7 @@ importers:
         version: 18.3.7(@types/react@18.3.21)
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.17.2(babel-plugin-macros@3.1.0)
+        version: 1.17.3(babel-plugin-macros@3.1.0)
       sku:
         specifier: workspace:*
         version: link:../../packages/sku
@@ -480,13 +480,13 @@ importers:
         version: link:../../test-utils
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.3
-        version: 3.0.6(webpack@5.99.8(@swc/core@1.11.24))
+        version: 3.0.6(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))
       '@storybook/react':
         specifier: ^8.1.5
         version: 8.6.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
       '@storybook/react-webpack5':
         specifier: ^8.1.5
-        version: 8.6.12(@swc/core@1.11.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
+        version: 8.6.12(@swc/core@1.11.24)(esbuild@0.25.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
       '@types/react':
         specifier: ^18.2.3
         version: 18.3.21
@@ -495,7 +495,7 @@ importers:
         version: 18.3.7(@types/react@18.3.21)
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.17.2(babel-plugin-macros@3.1.0)
+        version: 1.17.3(babel-plugin-macros@3.1.0)
       dedent:
         specifier: ^1.5.1
         version: 1.6.0(babel-plugin-macros@3.1.0)
@@ -600,7 +600,7 @@ importers:
         version: 18.3.7(@types/react@18.3.21)
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.17.2(babel-plugin-macros@3.1.0)
+        version: 1.17.3(babel-plugin-macros@3.1.0)
       dedent:
         specifier: ^1.5.1
         version: 1.6.0(babel-plugin-macros@3.1.0)
@@ -627,7 +627,7 @@ importers:
         version: 2.4.2
       tinyglobby:
         specifier: ^0.2.13
-        version: 0.2.13
+        version: 0.2.14
       typescript:
         specifier: ~5.8.0
         version: 5.8.3
@@ -703,7 +703,7 @@ importers:
         version: 5.15.2(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: ^0.6.0
-        version: 0.6.0(react-refresh@0.17.0)(type-fest@4.41.0)(webpack-dev-server@5.2.0(debug@4.4.0)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4)))(webpack-hot-middleware@2.26.1)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))
+        version: 0.6.0(react-refresh@0.17.0)(type-fest@4.41.0)(webpack-dev-server@5.2.0(debug@4.4.1)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4)))(webpack-hot-middleware@2.26.1)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))
       '@storybook/react-webpack5':
         specifier: ^7.0.0 || ^8.0.0
         version: 8.6.12(@swc/core@1.11.24)(esbuild@0.25.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
@@ -814,7 +814,7 @@ importers:
         version: 1.1.0
       debug:
         specifier: ^4.3.1
-        version: 4.4.0
+        version: 4.4.1
       dedent:
         specifier: ^1.5.1
         version: 1.6.0(babel-plugin-macros@3.1.0)
@@ -967,7 +967,7 @@ importers:
         version: 4.10.2
       webpack-dev-server:
         specifier: ^5.0.2
-        version: 5.2.0(debug@4.4.0)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))
+        version: 5.2.0(debug@4.4.1)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -1049,7 +1049,7 @@ importers:
         version: 3.0.4(@swc/core@1.11.24)(esbuild@0.25.4)
       '@vanilla-extract/css':
         specifier: ^1.17.0
-        version: 1.17.2(babel-plugin-macros@3.1.0)
+        version: 1.17.3(babel-plugin-macros@3.1.0)
       '@vocab/react':
         specifier: ^1.1.11
         version: 1.1.12(react@18.3.1)
@@ -1084,14 +1084,14 @@ importers:
         specifier: ^3.5.2
         version: 3.5.5(typescript@5.8.3)
       vitest:
-        specifier: ^3.1.1
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@18.19.100)(jiti@2.4.2)(jsdom@20.0.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+        specifier: ^3.2.3
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@18.19.100)(jiti@2.4.2)(jsdom@20.0.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
 
   packages/vite:
     dependencies:
       debug:
         specifier: ^4.3.1
-        version: 4.4.0
+        version: 4.4.1
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -1112,8 +1112,8 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2(@types/node@18.19.100)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(vite@6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(yaml@2.7.1)
       vitest:
-        specifier: ^3.1.1
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@18.19.100)(jiti@2.4.2)(jsdom@20.0.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+        specifier: ^3.2.3
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@18.19.100)(jiti@2.4.2)(jsdom@20.0.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
 
   test-utils:
     devDependencies:
@@ -1176,7 +1176,7 @@ importers:
         version: 6.1.6
       wait-on:
         specifier: ^8.0.1
-        version: 8.0.3(debug@4.4.0)
+        version: 8.0.3(debug@4.4.1)
       webpack-stats-plugin:
         specifier: ^1.0.3
         version: 1.1.3
@@ -1269,7 +1269,7 @@ importers:
         version: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.99.8)
       webpack-dev-server:
         specifier: ^5.0.2
-        version: 5.2.0(debug@4.4.0)(webpack-cli@5.1.4)(webpack@5.99.8)
+        version: 5.2.0(debug@4.4.1)(webpack-cli@5.1.4)(webpack@5.99.8)
 
   vite-test-utils:
     devDependencies:
@@ -2994,6 +2994,9 @@ packages:
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
 
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
   '@types/compression@1.7.5':
     resolution: {integrity: sha512-AAQvK5pxMpaT+nDvhHrsBhLSYG5yQdtkaJE1WYieSNY2mVFKAgmU4ks65rkZD5oqnGCFLyQpUr1CqI4DmUMyDg==}
 
@@ -3014,6 +3017,9 @@ packages:
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/diff@7.0.2':
     resolution: {integrity: sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==}
@@ -3371,8 +3377,8 @@ packages:
   '@vanilla-extract/css-utils@0.1.4':
     resolution: {integrity: sha512-3WRxMGa/VQaL32jZqRUpnnoVFSws5iPIUpQr+XlT4jXhtMeKYcA20rFK2k2Amkg04sqrO84A8hNMeABWZQesEg==}
 
-  '@vanilla-extract/css@1.17.2':
-    resolution: {integrity: sha512-gowpfR1zJSplDO7NkGf2Vnw9v9eG1P3aUlQpxa1pOjcknbgWw7UPzIboB6vGJZmoUvDZRFmipss3/Q+RRfhloQ==}
+  '@vanilla-extract/css@1.17.3':
+    resolution: {integrity: sha512-jHivr1UPoJTX5Uel4AZSOwrCf4mO42LcdmnhJtUxZaRWhW4FviFbIfs0moAWWld7GOT+2XnuVZjjA/K32uUnMQ==}
 
   '@vanilla-extract/css@1.17.4':
     resolution: {integrity: sha512-m3g9nQDWPtL+sTFdtCGRMI1Vrp86Ay4PBYq1Bo7Bnchj5ElNtAJpOqD+zg+apthVA4fB7oVpMWNjwpa6ElDWFQ==}
@@ -3385,9 +3391,6 @@ packages:
 
   '@vanilla-extract/jest-transform@1.1.15':
     resolution: {integrity: sha512-pMEE+2qUKdZoGwdYitL5fGDnoWZoMOXNWrv53VMXSjM/YXQ33RgjFcOD0i0H8g4kMqgjJnQor97avUO8AGLbgw==}
-
-  '@vanilla-extract/private@1.0.7':
-    resolution: {integrity: sha512-v9Yb0bZ5H5Kr8ciwPXyEToOFD7J/fKKH93BYP7NCSZg02VYsA/pNFrLeVDJM2OO/vsygduPKuiEI6ORGQ4IcBw==}
 
   '@vanilla-extract/private@1.0.9':
     resolution: {integrity: sha512-gT2jbfZuaaCLrAxwXbRgIhGhcXbRZCG3v4TTUnjw0EJ7ArdBRxkq4msNJkbuRkCgfIK5ATmprB5t9ljvLeFDEA==}
@@ -3428,34 +3431,34 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@3.1.3':
-    resolution: {integrity: sha512-7FTQQuuLKmN1Ig/h+h/GO+44Q1IlglPlR2es4ab7Yvfx+Uk5xsv+Ykk+MEt/M2Yn/xGmzaLKxGw2lgy2bwuYqg==}
+  '@vitest/expect@3.2.3':
+    resolution: {integrity: sha512-W2RH2TPWVHA1o7UmaFKISPvdicFJH+mjykctJFoAkUw+SPTJTGjUNdKscFBrqM7IPnCVu6zihtKYa7TkZS1dkQ==}
 
-  '@vitest/mocker@3.1.3':
-    resolution: {integrity: sha512-PJbLjonJK82uCWHjzgBJZuR7zmAOrSvKk1QBxrennDIgtH4uK0TB1PvYmc0XBCigxxtiAVPfWtAdy4lpz8SQGQ==}
+  '@vitest/mocker@3.2.3':
+    resolution: {integrity: sha512-cP6fIun+Zx8he4rbWvi+Oya6goKQDZK+Yq4hhlggwQBbrlOQ4qtZ+G4nxB6ZnzI9lyIb+JnvyiJnPC2AGbKSPA==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.1.3':
-    resolution: {integrity: sha512-i6FDiBeJUGLDKADw2Gb01UtUNb12yyXAqC/mmRWuYl+m/U9GS7s8us5ONmGkGpUUo7/iAYzI2ePVfOZTYvUifA==}
+  '@vitest/pretty-format@3.2.3':
+    resolution: {integrity: sha512-yFglXGkr9hW/yEXngO+IKMhP0jxyFw2/qys/CK4fFUZnSltD+MU7dVYGrH8rvPcK/O6feXQA+EU33gjaBBbAng==}
 
-  '@vitest/runner@3.1.3':
-    resolution: {integrity: sha512-Tae+ogtlNfFei5DggOsSUvkIaSuVywujMj6HzR97AHK6XK8i3BuVyIifWAm/sE3a15lF5RH9yQIrbXYuo0IFyA==}
+  '@vitest/runner@3.2.3':
+    resolution: {integrity: sha512-83HWYisT3IpMaU9LN+VN+/nLHVBCSIUKJzGxC5RWUOsK1h3USg7ojL+UXQR3b4o4UBIWCYdD2fxuzM7PQQ1u8w==}
 
-  '@vitest/snapshot@3.1.3':
-    resolution: {integrity: sha512-XVa5OPNTYUsyqG9skuUkFzAeFnEzDp8hQu7kZ0N25B1+6KjGm4hWLtURyBbsIAOekfWQ7Wuz/N/XXzgYO3deWQ==}
+  '@vitest/snapshot@3.2.3':
+    resolution: {integrity: sha512-9gIVWx2+tysDqUmmM1L0hwadyumqssOL1r8KJipwLx5JVYyxvVRfxvMq7DaWbZZsCqZnu/dZedaZQh4iYTtneA==}
 
-  '@vitest/spy@3.1.3':
-    resolution: {integrity: sha512-x6w+ctOEmEXdWaa6TO4ilb7l9DxPR5bwEb6hILKuxfU1NqWT2mpJD9NJN7t3OTfxmVlOMrvtoFJGdgyzZ605lQ==}
+  '@vitest/spy@3.2.3':
+    resolution: {integrity: sha512-JHu9Wl+7bf6FEejTCREy+DmgWe+rQKbK+y32C/k5f4TBIAlijhJbRBIRIOCEpVevgRsCQR2iHRUH2/qKVM/plw==}
 
-  '@vitest/utils@3.1.3':
-    resolution: {integrity: sha512-2Ltrpht4OmHO9+c/nmHtF09HWiyWdworqnHIwjfvDyWjuwKbdkcS9AnhsDn+8E2RM4x++foD1/tNuLPVvWG1Rg==}
+  '@vitest/utils@3.2.3':
+    resolution: {integrity: sha512-4zFBCU5Pf+4Z6v+rwnZ1HU1yzOKKvDkMXZrymE2PBlbjKJRlrOxbvpfPSvJTGRIwGoahaOGvp+kbCoxifhzJ1Q==}
 
   '@vocab/core@1.6.3':
     resolution: {integrity: sha512-2MIY9FNGe80zS0M0DiQNxUKEdVxJQDvqfHEoS0fGvKl0UCouH77cF3CgRdCOUAgmEQfTvkGa6nmJQSXmoK6Aaw==}
@@ -4507,15 +4510,6 @@ packages:
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.4.0:
-    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
-    engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -8302,6 +8296,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
   strip-outer@1.0.1:
     resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
     engines: {node: '>=0.10.0'}
@@ -8424,20 +8421,20 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyglobby@0.2.13:
-    resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
+  tinyglobby@0.2.14:
+    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.0.2:
-    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+  tinypool@1.1.0:
+    resolution: {integrity: sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
-  tinyspy@3.0.2:
-    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+  tinyspy@4.0.3:
+    resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
     engines: {node: '>=14.0.0'}
 
   title-case@3.0.3:
@@ -8756,8 +8753,8 @@ packages:
   virtual-resource-loader@2.0.0:
     resolution: {integrity: sha512-wAHewgsYJWYW3OHGXjanMgsbMVLz4tu4aIw/tnnMHEJfhUxV7t4FpT5EMuZmcvtZkq+Q8QGyLk2NVneD5kXqkw==}
 
-  vite-node@3.1.3:
-    resolution: {integrity: sha512-uHV4plJ2IxCl4u1up1FQRrqclylKAogbtBfOTwcuJ28xFi+89PZ57BRh+naIRvH70HPwxy5QHYzg1OrEaC7AbA==}
+  vite-node@3.2.3:
+    resolution: {integrity: sha512-gc8aAifGuDIpZHrPjuHyP4dpQmYXqWw7D1GmDnWeNWP654UEXzVfQ5IHPSK5HaHkwB/+p1atpYpSdw/2kOv8iQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -8828,16 +8825,16 @@ packages:
     peerDependencies:
       puppeteer: '>=19'
 
-  vitest@3.1.3:
-    resolution: {integrity: sha512-188iM4hAHQ0km23TN/adso1q5hhwKqUpv+Sd6p5sOuh6FhQnRNW3IsiIpvxqahtBabsJ2SLZgmGSpcYK4wQYJw==}
+  vitest@3.2.3:
+    resolution: {integrity: sha512-E6U2ZFXe3N/t4f5BwUaVCKRLHqUpk1CBWeMh78UT4VaTPH/2dyvH6ALl29JTovEPu9dVKr/K/J4PkXgrMbw4Ww==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.1.3
-      '@vitest/ui': 3.1.3
+      '@vitest/browser': 3.2.3
+      '@vitest/ui': 3.2.3
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -9240,7 +9237,7 @@ snapshots:
       '@babel/traverse': 7.27.1
       '@babel/types': 7.27.1
       convert-source-map: 2.0.0
-      debug: 4.4.0
+      debug: 4.4.1
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -9292,7 +9289,7 @@ snapshots:
       '@babel/core': 7.27.1
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.0
+      debug: 4.4.1
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -10021,7 +10018,7 @@ snapshots:
       '@babel/parser': 7.27.2
       '@babel/template': 7.27.2
       '@babel/types': 7.27.1
-      debug: 4.4.0
+      debug: 4.4.1
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -10310,7 +10307,7 @@ snapshots:
   '@eslint/config-array@0.20.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.0
+      debug: 4.4.1
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -10324,7 +10321,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0
+      debug: 4.4.1
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -10726,7 +10723,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.6.0(react-refresh@0.17.0)(type-fest@4.41.0)(webpack-dev-server@5.2.0(debug@4.4.0)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4)))(webpack-hot-middleware@2.26.1)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.6.0(react-refresh@0.17.0)(type-fest@4.41.0)(webpack-dev-server@5.2.0(debug@4.4.1)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4)))(webpack-hot-middleware@2.26.1)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))':
     dependencies:
       anser: 2.3.2
       core-js-pure: 3.42.0
@@ -10738,7 +10735,7 @@ snapshots:
       webpack: 5.99.8(@swc/core@1.11.24)(esbuild@0.25.4)
     optionalDependencies:
       type-fest: 4.41.0
-      webpack-dev-server: 5.2.0(debug@4.4.0)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))
+      webpack-dev-server: 5.2.0(debug@4.4.1)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))
       webpack-hot-middleware: 2.26.1
 
   '@polka/url@1.0.0-next.29': {}
@@ -10752,7 +10749,7 @@ snapshots:
 
   '@puppeteer/browsers@2.10.4':
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -11059,7 +11056,7 @@ snapshots:
 
   '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.8.3)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))':
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -11073,7 +11070,7 @@ snapshots:
 
   '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.8.3)(webpack@5.99.8(@swc/core@1.11.24))':
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -11276,6 +11273,10 @@ snapshots:
     dependencies:
       '@types/node': 18.19.100
 
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
   '@types/compression@1.7.5':
     dependencies:
       '@types/express': 4.17.21
@@ -11300,6 +11301,8 @@ snapshots:
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/diff@7.0.2': {}
 
@@ -11586,7 +11589,7 @@ snapshots:
       '@typescript-eslint/types': 8.32.1
       '@typescript-eslint/typescript-estree': 8.32.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.32.1
-      debug: 4.4.0
+      debug: 4.4.1
       eslint: 9.26.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -11601,7 +11604,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.32.1(typescript@5.8.3)
       '@typescript-eslint/utils': 8.32.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)
-      debug: 4.4.0
+      debug: 4.4.1
       eslint: 9.26.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
@@ -11614,7 +11617,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.32.1
       '@typescript-eslint/visitor-keys': 8.32.1
-      debug: 4.4.0
+      debug: 4.4.1
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -11701,10 +11704,10 @@ snapshots:
 
   '@vanilla-extract/compiler@0.1.3(@types/node@18.19.100)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)':
     dependencies:
-      '@vanilla-extract/css': 1.17.2(babel-plugin-macros@3.1.0)
+      '@vanilla-extract/css': 1.17.3(babel-plugin-macros@3.1.0)
       '@vanilla-extract/integration': 8.0.2(babel-plugin-macros@3.1.0)
       vite: 6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
-      vite-node: 3.1.3(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+      vite-node: 3.2.3(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -11722,10 +11725,10 @@ snapshots:
 
   '@vanilla-extract/css-utils@0.1.4': {}
 
-  '@vanilla-extract/css@1.17.2(babel-plugin-macros@3.1.0)':
+  '@vanilla-extract/css@1.17.3(babel-plugin-macros@3.1.0)':
     dependencies:
       '@emotion/hash': 0.9.2
-      '@vanilla-extract/private': 1.0.7
+      '@vanilla-extract/private': 1.0.9
       css-what: 6.1.0
       cssesc: 3.0.0
       csstype: 3.1.3
@@ -11765,7 +11768,7 @@ snapshots:
       '@babel/core': 7.27.1
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.27.1)
       '@vanilla-extract/babel-plugin-debug-ids': 1.2.0
-      '@vanilla-extract/css': 1.17.2(babel-plugin-macros@3.1.0)
+      '@vanilla-extract/css': 1.17.3(babel-plugin-macros@3.1.0)
       dedent: 1.6.0(babel-plugin-macros@3.1.0)
       esbuild: 0.25.4
       eval: 0.1.8
@@ -11783,8 +11786,6 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
-
-  '@vanilla-extract/private@1.0.7': {}
 
   '@vanilla-extract/private@1.0.9': {}
 
@@ -11815,7 +11816,7 @@ snapshots:
   '@vanilla-extract/webpack-plugin@2.3.19(babel-plugin-macros@3.1.0)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))':
     dependencies:
       '@vanilla-extract/integration': 8.0.2(babel-plugin-macros@3.1.0)
-      debug: 4.4.0
+      debug: 4.4.1
       loader-utils: 2.0.4
       picocolors: 1.1.1
       webpack: 5.99.8(@swc/core@1.11.24)(esbuild@0.25.4)
@@ -11838,7 +11839,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.1(vitest@3.1.3(@types/debug@4.1.12)(@types/node@18.19.100)(jiti@2.4.2)(jsdom@20.0.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
+  '@vitest/coverage-v8@3.2.1(vitest@3.2.3(@types/debug@4.1.12)(@types/node@18.19.100)(jiti@2.4.2)(jsdom@20.0.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -11853,47 +11854,49 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@18.19.100)(jiti@2.4.2)(jsdom@20.0.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+      vitest: 3.2.3(@types/debug@4.1.12)(@types/node@18.19.100)(jiti@2.4.2)(jsdom@20.0.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@3.1.3':
+  '@vitest/expect@3.2.3':
     dependencies:
-      '@vitest/spy': 3.1.3
-      '@vitest/utils': 3.1.3
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.3
+      '@vitest/utils': 3.2.3
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.3(vite@6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
+  '@vitest/mocker@3.2.3(vite@6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
     dependencies:
-      '@vitest/spy': 3.1.3
+      '@vitest/spy': 3.2.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       vite: 6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
 
-  '@vitest/pretty-format@3.1.3':
+  '@vitest/pretty-format@3.2.3':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.1.3':
+  '@vitest/runner@3.2.3':
     dependencies:
-      '@vitest/utils': 3.1.3
+      '@vitest/utils': 3.2.3
       pathe: 2.0.3
+      strip-literal: 3.0.0
 
-  '@vitest/snapshot@3.1.3':
+  '@vitest/snapshot@3.2.3':
     dependencies:
-      '@vitest/pretty-format': 3.1.3
+      '@vitest/pretty-format': 3.2.3
       magic-string: 0.30.17
       pathe: 2.0.3
 
-  '@vitest/spy@3.1.3':
+  '@vitest/spy@3.2.3':
     dependencies:
-      tinyspy: 3.0.2
+      tinyspy: 4.0.3
 
-  '@vitest/utils@3.1.3':
+  '@vitest/utils@3.2.3':
     dependencies:
-      '@vitest/pretty-format': 3.1.3
+      '@vitest/pretty-format': 3.2.3
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
@@ -11901,7 +11904,7 @@ snapshots:
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.11.2
       chokidar: 3.6.0
-      debug: 4.4.0
+      debug: 4.4.1
       fast-glob: 3.3.3
       fastest-validator: 1.19.1
       find-up: 5.0.0
@@ -11915,7 +11918,7 @@ snapshots:
     dependencies:
       '@vocab/core': 1.6.3
       csv-stringify: 6.5.2
-      debug: 4.4.0
+      debug: 4.4.1
       picocolors: 1.1.1
     transitivePeerDependencies:
       - supports-color
@@ -11934,7 +11937,7 @@ snapshots:
     dependencies:
       '@vocab/core': 1.6.3
       cjs-module-lexer: 1.4.3
-      debug: 4.4.0
+      debug: 4.4.1
       es-module-lexer: 1.7.0
       picocolors: 1.1.1
       vite: 6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
@@ -11945,7 +11948,7 @@ snapshots:
     dependencies:
       '@vocab/core': 1.6.3
       cjs-module-lexer: 1.4.3
-      debug: 4.4.0
+      debug: 4.4.1
       es-module-lexer: 1.7.0
       picocolors: 1.1.1
       virtual-resource-loader: 2.0.0
@@ -11957,7 +11960,7 @@ snapshots:
     dependencies:
       '@vocab/core': 1.6.3
       cjs-module-lexer: 1.4.3
-      debug: 4.4.0
+      debug: 4.4.1
       es-module-lexer: 1.7.0
       picocolors: 1.1.1
       virtual-resource-loader: 2.0.0
@@ -12056,7 +12059,7 @@ snapshots:
       webpack: 5.99.8(@swc/core@1.11.24)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.99.8)
     optionalDependencies:
-      webpack-dev-server: 5.2.0(debug@4.4.0)(webpack-cli@5.1.4)(webpack@5.99.8)
+      webpack-dev-server: 5.2.0(debug@4.4.1)(webpack-cli@5.1.4)(webpack@5.99.8)
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -12097,7 +12100,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -12305,9 +12308,9 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.9.0(debug@4.4.0):
+  axios@1.9.0(debug@4.4.1):
     dependencies:
-      follow-redirects: 1.15.9(debug@4.4.0)
+      follow-redirects: 1.15.9(debug@4.4.1)
       form-data: 4.0.2
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -12515,7 +12518,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.0
+      debug: 4.4.1
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       on-finished: 2.4.1
@@ -13185,10 +13188,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.0:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
@@ -13355,7 +13354,7 @@ snapshots:
 
   docsify-server-renderer@4.13.1:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       docsify: 4.13.1
       node-fetch: 2.7.0
       resolve-pathname: 3.0.0
@@ -13640,7 +13639,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.25.4):
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       esbuild: 0.25.4
     transitivePeerDependencies:
       - supports-color
@@ -13729,12 +13728,12 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.11.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.0
+      debug: 4.4.1
       eslint: 9.26.0(jiti@2.4.2)
       get-tsconfig: 4.10.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.14
       unrs-resolver: 1.7.2
     optionalDependencies:
       eslint-plugin-import-x: 4.11.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)
@@ -13750,7 +13749,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/utils': 8.32.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)
       comment-parser: 1.4.1
-      debug: 4.4.0
+      debug: 4.4.1
       eslint: 9.26.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
       get-tsconfig: 4.10.0
@@ -13780,7 +13779,7 @@ snapshots:
       '@es-joy/jsdoccomment': 0.49.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.4.0
+      debug: 4.4.1
       escape-string-regexp: 4.0.0
       eslint: 9.26.0(jiti@2.4.2)
       espree: 10.3.0
@@ -13870,7 +13869,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0
+      debug: 4.4.1
       escape-string-regexp: 4.0.0
       eslint-scope: 8.3.0
       eslint-visitor-keys: 4.2.0
@@ -14028,7 +14027,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.0
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -14064,7 +14063,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -14164,7 +14163,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -14264,9 +14263,9 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  follow-redirects@1.15.9(debug@4.4.0):
+  follow-redirects@1.15.9(debug@4.4.1):
     optionalDependencies:
-      debug: 4.4.0
+      debug: 4.4.1
 
   for-each@0.3.5:
     dependencies:
@@ -14436,7 +14435,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.0
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -14751,21 +14750,21 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.0
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.9(@types/express@4.17.21)(debug@4.4.0):
+  http-proxy-middleware@2.0.9(@types/express@4.17.21)(debug@4.4.1):
     dependencies:
       '@types/http-proxy': 1.17.16
-      http-proxy: 1.18.1(debug@4.4.0)
+      http-proxy: 1.18.1(debug@4.4.1)
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
@@ -14774,10 +14773,10 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy@1.18.1(debug@4.4.0):
+  http-proxy@1.18.1(debug@4.4.1):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.9(debug@4.4.0)
+      follow-redirects: 1.15.9(debug@4.4.1)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -14785,14 +14784,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -15165,7 +15164,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -15691,7 +15690,7 @@ snapshots:
     dependencies:
       chalk: 5.4.1
       commander: 13.1.0
-      debug: 4.4.0
+      debug: 4.4.1
       lilconfig: 3.1.3
       listr2: 8.3.3
       micromatch: 4.0.8
@@ -16285,7 +16284,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.1
       get-uri: 6.0.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -16708,7 +16707,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.1
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -16741,7 +16740,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.10.4
       chromium-bidi: 5.1.0(devtools-protocol@0.0.1439962)
-      debug: 4.4.0
+      debug: 4.4.1
       devtools-protocol: 0.0.1439962
       typed-query-selector: 2.12.0
       ws: 8.18.2
@@ -17155,7 +17154,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -17258,7 +17257,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -17442,7 +17441,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.1
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color
@@ -17504,7 +17503,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -17515,7 +17514,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -17683,6 +17682,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   strip-outer@1.0.1:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -17828,16 +17831,16 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyglobby@0.2.13:
+  tinyglobby@0.2.14:
     dependencies:
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
 
-  tinypool@1.0.2: {}
+  tinypool@1.1.0: {}
 
   tinyrainbow@2.0.0: {}
 
-  tinyspy@3.0.2: {}
+  tinyspy@4.0.3: {}
 
   title-case@3.0.3:
     dependencies:
@@ -18165,10 +18168,10 @@ snapshots:
 
   virtual-resource-loader@2.0.0: {}
 
-  vite-node@3.1.3(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1):
+  vite-node@3.2.3(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0
+      debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
@@ -18196,7 +18199,7 @@ snapshots:
 
   vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)):
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.8.3)
     optionalDependencies:
@@ -18212,7 +18215,7 @@ snapshots:
       picomatch: 4.0.2
       postcss: 8.5.3
       rollup: 4.40.2
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 18.19.100
       fsevents: 2.3.3
@@ -18221,7 +18224,7 @@ snapshots:
       tsx: 4.19.4
       yaml: 2.7.1
 
-  vitest-dev-server@11.0.3(debug@4.4.0):
+  vitest-dev-server@11.0.3(debug@4.4.1):
     dependencies:
       chalk: 4.1.2
       cwd: 0.10.0
@@ -18229,51 +18232,53 @@ snapshots:
       prompts: 2.4.2
       spawnd: 11.0.0
       tree-kill: 1.2.2
-      wait-on: 8.0.3(debug@4.4.0)
+      wait-on: 8.0.3(debug@4.4.1)
     transitivePeerDependencies:
       - debug
 
-  vitest-environment-puppeteer@11.0.3(debug@4.4.0)(typescript@5.8.3):
+  vitest-environment-puppeteer@11.0.3(debug@4.4.1)(typescript@5.8.3):
     dependencies:
       chalk: 4.1.2
       cosmiconfig: 9.0.0(typescript@5.8.3)
       deepmerge: 4.3.1
-      vitest-dev-server: 11.0.3(debug@4.4.0)
+      vitest-dev-server: 11.0.3(debug@4.4.1)
     transitivePeerDependencies:
       - debug
       - typescript
 
-  vitest-puppeteer@11.0.3(debug@4.4.0)(puppeteer@24.8.2(typescript@5.8.3))(typescript@5.8.3):
+  vitest-puppeteer@11.0.3(debug@4.4.1)(puppeteer@24.8.2(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
       expect-puppeteer: 11.0.0
       puppeteer: 24.8.2(typescript@5.8.3)
-      vitest-environment-puppeteer: 11.0.3(debug@4.4.0)(typescript@5.8.3)
+      vitest-environment-puppeteer: 11.0.3(debug@4.4.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - debug
       - typescript
 
-  vitest@3.1.3(@types/debug@4.1.12)(@types/node@18.19.100)(jiti@2.4.2)(jsdom@20.0.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1):
+  vitest@3.2.3(@types/debug@4.1.12)(@types/node@18.19.100)(jiti@2.4.2)(jsdom@20.0.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1):
     dependencies:
-      '@vitest/expect': 3.1.3
-      '@vitest/mocker': 3.1.3(vite@6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
-      '@vitest/pretty-format': 3.1.3
-      '@vitest/runner': 3.1.3
-      '@vitest/snapshot': 3.1.3
-      '@vitest/spy': 3.1.3
-      '@vitest/utils': 3.1.3
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.3
+      '@vitest/mocker': 3.2.3(vite@6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      '@vitest/pretty-format': 3.2.3
+      '@vitest/runner': 3.2.3
+      '@vitest/snapshot': 3.2.3
+      '@vitest/spy': 3.2.3
+      '@vitest/utils': 3.2.3
       chai: 5.2.0
-      debug: 4.4.0
+      debug: 4.4.1
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3
+      picomatch: 4.0.2
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.13
-      tinypool: 1.0.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.0
       tinyrainbow: 2.0.0
       vite: 6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
-      vite-node: 3.1.3(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+      vite-node: 3.2.3(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -18297,9 +18302,9 @@ snapshots:
     dependencies:
       xml-name-validator: 4.0.0
 
-  wait-on@8.0.3(debug@4.4.0):
+  wait-on@8.0.3(debug@4.4.1):
     dependencies:
-      axios: 1.9.0(debug@4.4.0)
+      axios: 1.9.0(debug@4.4.1)
       joi: 17.13.3
       lodash: 4.17.21
       minimist: 1.2.8
@@ -18367,7 +18372,7 @@ snapshots:
       webpack: 5.99.8(@swc/core@1.11.24)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
-      webpack-dev-server: 5.2.0(debug@4.4.0)(webpack-cli@5.1.4)(webpack@5.99.8)
+      webpack-dev-server: 5.2.0(debug@4.4.1)(webpack-cli@5.1.4)(webpack@5.99.8)
 
   webpack-dev-middleware@6.1.3(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4)):
     dependencies:
@@ -18411,7 +18416,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.99.8(@swc/core@1.11.24)(webpack-cli@5.1.4)
 
-  webpack-dev-server@5.2.0(debug@4.4.0)(webpack-cli@5.1.4)(webpack@5.99.8):
+  webpack-dev-server@5.2.0(debug@4.4.1)(webpack-cli@5.1.4)(webpack@5.99.8):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -18428,7 +18433,7 @@ snapshots:
       connect-history-api-fallback: 2.0.0
       express: 4.21.2
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.0)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.1)
       ipaddr.js: 2.2.0
       launch-editor: 2.10.0
       open: 10.1.2
@@ -18449,7 +18454,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@5.2.0(debug@4.4.0)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4)):
+  webpack-dev-server@5.2.0(debug@4.4.1)(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -18466,7 +18471,7 @@ snapshots:
       connect-history-api-fallback: 2.0.0
       express: 4.21.2
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.0)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.1)
       ipaddr.js: 2.2.0
       launch-editor: 2.10.0
       open: 10.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,7 +159,7 @@ importers:
         version: 18.3.7(@types/react@18.3.21)
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.17.3(babel-plugin-macros@3.1.0)
+        version: 1.17.4(babel-plugin-macros@3.1.0)
       sku:
         specifier: workspace:*
         version: link:../../packages/sku
@@ -268,7 +268,7 @@ importers:
     dependencies:
       '@vanilla-extract/css':
         specifier: ^1.17.1
-        version: 1.17.3(babel-plugin-macros@3.1.0)
+        version: 1.17.4(babel-plugin-macros@3.1.0)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -309,7 +309,7 @@ importers:
         version: link:../../test-utils
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.17.3(babel-plugin-macros@3.1.0)
+        version: 1.17.4(babel-plugin-macros@3.1.0)
       dedent:
         specifier: ^1.5.1
         version: 1.6.0(babel-plugin-macros@3.1.0)
@@ -374,7 +374,7 @@ importers:
         version: link:../../test-utils
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.17.3(babel-plugin-macros@3.1.0)
+        version: 1.17.4(babel-plugin-macros@3.1.0)
       dedent:
         specifier: ^1.5.1
         version: 1.6.0(babel-plugin-macros@3.1.0)
@@ -418,7 +418,7 @@ importers:
         version: link:../../test-utils
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.17.3(babel-plugin-macros@3.1.0)
+        version: 1.17.4(babel-plugin-macros@3.1.0)
       sku:
         specifier: workspace:*
         version: link:../../packages/sku
@@ -440,13 +440,13 @@ importers:
         version: 8.6.12(@types/react@18.3.21)(storybook@8.6.12(prettier@3.5.3))
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.3
-        version: 3.0.6(webpack@5.99.8(@swc/core@1.11.24))
+        version: 3.0.6(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))
       '@storybook/react':
         specifier: ^8.1.5
         version: 8.6.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
       '@storybook/react-webpack5':
         specifier: ^8.1.5
-        version: 8.6.12(@swc/core@1.11.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
+        version: 8.6.12(@swc/core@1.11.24)(esbuild@0.25.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
       '@types/react':
         specifier: ^18.2.3
         version: 18.3.21
@@ -455,7 +455,7 @@ importers:
         version: 18.3.7(@types/react@18.3.21)
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.17.3(babel-plugin-macros@3.1.0)
+        version: 1.17.4(babel-plugin-macros@3.1.0)
       sku:
         specifier: workspace:*
         version: link:../../packages/sku
@@ -480,13 +480,13 @@ importers:
         version: link:../../test-utils
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.3
-        version: 3.0.6(webpack@5.99.8(@swc/core@1.11.24)(esbuild@0.25.4))
+        version: 3.0.6(webpack@5.99.8(@swc/core@1.11.24))
       '@storybook/react':
         specifier: ^8.1.5
         version: 8.6.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
       '@storybook/react-webpack5':
         specifier: ^8.1.5
-        version: 8.6.12(@swc/core@1.11.24)(esbuild@0.25.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
+        version: 8.6.12(@swc/core@1.11.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
       '@types/react':
         specifier: ^18.2.3
         version: 18.3.21
@@ -495,7 +495,7 @@ importers:
         version: 18.3.7(@types/react@18.3.21)
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.17.3(babel-plugin-macros@3.1.0)
+        version: 1.17.4(babel-plugin-macros@3.1.0)
       dedent:
         specifier: ^1.5.1
         version: 1.6.0(babel-plugin-macros@3.1.0)
@@ -600,7 +600,7 @@ importers:
         version: 18.3.7(@types/react@18.3.21)
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.17.3(babel-plugin-macros@3.1.0)
+        version: 1.17.4(babel-plugin-macros@3.1.0)
       dedent:
         specifier: ^1.5.1
         version: 1.6.0(babel-plugin-macros@3.1.0)
@@ -1049,7 +1049,7 @@ importers:
         version: 3.0.4(@swc/core@1.11.24)(esbuild@0.25.4)
       '@vanilla-extract/css':
         specifier: ^1.17.0
-        version: 1.17.3(babel-plugin-macros@3.1.0)
+        version: 1.17.4(babel-plugin-macros@3.1.0)
       '@vocab/react':
         specifier: ^1.1.11
         version: 1.1.12(react@18.3.1)
@@ -1977,6 +1977,10 @@ packages:
 
   '@babel/runtime@7.27.1':
     resolution: {integrity: sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.27.6':
+    resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
@@ -3376,9 +3380,6 @@ packages:
 
   '@vanilla-extract/css-utils@0.1.4':
     resolution: {integrity: sha512-3WRxMGa/VQaL32jZqRUpnnoVFSws5iPIUpQr+XlT4jXhtMeKYcA20rFK2k2Amkg04sqrO84A8hNMeABWZQesEg==}
-
-  '@vanilla-extract/css@1.17.3':
-    resolution: {integrity: sha512-jHivr1UPoJTX5Uel4AZSOwrCf4mO42LcdmnhJtUxZaRWhW4FviFbIfs0moAWWld7GOT+2XnuVZjjA/K32uUnMQ==}
 
   '@vanilla-extract/css@1.17.4':
     resolution: {integrity: sha512-m3g9nQDWPtL+sTFdtCGRMI1Vrp86Ay4PBYq1Bo7Bnchj5ElNtAJpOqD+zg+apthVA4fB7oVpMWNjwpa6ElDWFQ==}
@@ -10005,6 +10006,8 @@ snapshots:
 
   '@babel/runtime@7.27.1': {}
 
+  '@babel/runtime@7.27.6': {}
+
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -10638,14 +10641,14 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.27.6
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.27.6
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -11704,7 +11707,7 @@ snapshots:
 
   '@vanilla-extract/compiler@0.1.3(@types/node@18.19.100)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)':
     dependencies:
-      '@vanilla-extract/css': 1.17.3(babel-plugin-macros@3.1.0)
+      '@vanilla-extract/css': 1.17.4(babel-plugin-macros@3.1.0)
       '@vanilla-extract/integration': 8.0.2(babel-plugin-macros@3.1.0)
       vite: 6.3.5(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
       vite-node: 3.2.3(@types/node@18.19.100)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
@@ -11724,23 +11727,6 @@ snapshots:
       - yaml
 
   '@vanilla-extract/css-utils@0.1.4': {}
-
-  '@vanilla-extract/css@1.17.3(babel-plugin-macros@3.1.0)':
-    dependencies:
-      '@emotion/hash': 0.9.2
-      '@vanilla-extract/private': 1.0.9
-      css-what: 6.1.0
-      cssesc: 3.0.0
-      csstype: 3.1.3
-      dedent: 1.6.0(babel-plugin-macros@3.1.0)
-      deep-object-diff: 1.1.9
-      deepmerge: 4.3.1
-      lru-cache: 10.4.3
-      media-query-parser: 2.0.2
-      modern-ahocorasick: 1.1.0
-      picocolors: 1.1.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
 
   '@vanilla-extract/css@1.17.4(babel-plugin-macros@3.1.0)':
     dependencies:
@@ -11768,7 +11754,7 @@ snapshots:
       '@babel/core': 7.27.1
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.27.1)
       '@vanilla-extract/babel-plugin-debug-ids': 1.2.0
-      '@vanilla-extract/css': 1.17.3(babel-plugin-macros@3.1.0)
+      '@vanilla-extract/css': 1.17.4(babel-plugin-macros@3.1.0)
       dedent: 1.6.0(babel-plugin-macros@3.1.0)
       esbuild: 0.25.4
       eval: 0.1.8
@@ -15849,7 +15835,7 @@ snapshots:
 
   media-query-parser@2.0.2:
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.27.6
 
   media-typer@0.3.0: {}
 
@@ -16453,7 +16439,7 @@ snapshots:
 
   polished@4.3.1:
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.27.6
 
   possible-typed-array-names@1.1.0: {}
 
@@ -16812,7 +16798,7 @@ snapshots:
 
   react-clientside-effect@1.2.7(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.27.6
       react: 18.3.1
 
   react-docgen-typescript@2.2.2(typescript@5.8.3):
@@ -16844,7 +16830,7 @@ snapshots:
 
   react-focus-lock@2.13.6(@types/react@18.3.21)(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.27.6
       focus-lock: 1.3.6
       prop-types: 15.8.1
       react: 18.3.1
@@ -16870,7 +16856,7 @@ snapshots:
 
   react-popper-tooltip@4.4.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.27.6
       '@popperjs/core': 2.11.8
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)

--- a/tests/__snapshots__/sku-test.test.ts.snap
+++ b/tests/__snapshots__/sku-test.test.ts.snap
@@ -15,7 +15,7 @@ All files |       0 |        0 |       0 |       0 |
 
 exports[`[vitest]: sku-test > should pass through unknown flags to vitest 1`] = `
 "
- RUN  v3.1.3 sku/fixtures/sku-test
+ RUN  sku/fixtures/sku-test
       Coverage enabled with v8
 
 stdout | src/index.test.ts

--- a/tests/sku-init/sku-init.test.ts
+++ b/tests/sku-init/sku-init.test.ts
@@ -44,6 +44,7 @@ describe('sku init', () => {
 
   afterAll(async () => {
     await fs.rm(projectDirectory, { recursive: true, force: true });
+    spawnSync('git', ['restore', 'pnpm-lock.yaml']);
     console.log(
       "Running 'pnpm install' to clean up lockfile after sku-init test...",
     );

--- a/tests/sku-init/sku-init.test.ts
+++ b/tests/sku-init/sku-init.test.ts
@@ -9,13 +9,14 @@ const __dirname = path.dirname(new URL(import.meta.url).pathname);
 const fixtureDirectory = __dirname;
 const projectName = 'new-project';
 const projectDirectory = path.join(fixtureDirectory, projectName);
+const lockFilePath = path.join(process.cwd(), 'pnpm-lock.yaml');
 
 describe('sku init', () => {
-  let stdout: string;
-  let stderr: string;
+  let pnpmLockFile: string;
 
   beforeAll(
     async () => {
+      pnpmLockFile = await fs.readFile(lockFilePath, 'utf-8');
       await fs.rm(projectDirectory, { recursive: true, force: true });
 
       await fs.rm(path.join(fixtureDirectory, projectName), {
@@ -31,7 +32,7 @@ describe('sku init', () => {
         throw new Error('Process was aborted early');
       }
 
-      ({ stdout, stderr } = result);
+      const { stdout, stderr } = result;
 
       console.log('sku init stdout');
       console.log(stdout);
@@ -44,10 +45,10 @@ describe('sku init', () => {
 
   afterAll(async () => {
     await fs.rm(projectDirectory, { recursive: true, force: true });
-    spawnSync('git', ['restore', 'pnpm-lock.yaml']);
     console.log(
-      "Running 'pnpm install' to clean up lockfile after sku-init test...",
+      "Restoring original lock file and running 'pnpm install' to clean after sku-init test...",
     );
+    await fs.writeFile(lockFilePath, pnpmLockFile, 'utf-8');
     spawnSync('pnpm', ['install']);
     console.log('Cleanup complete');
   });

--- a/tests/sku-test.test.ts
+++ b/tests/sku-test.test.ts
@@ -31,6 +31,7 @@ describe.for(['vitest', 'jest'])('[%s]: sku-test', (testRunner) => {
 
     expect(
       stripVTControlCharacters(output)
+        .replaceAll(/v\d\.\d\.\d /g, '')
         .replaceAll(/(\d+\.?\d*)s|(\d*)ms/g, '0ms')
         .replaceAll(/\b\d{1,2}:\d{2}:\d{2}\b/g, '00:00:00'),
     ).toMatchSnapshot();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,24 +1,53 @@
-import { defineConfig } from 'vitest/config';
+import { defaultExclude, defineConfig } from 'vitest/config';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export const TEST_TIMEOUT = 50_000;
+const defaultInclude = '**/*.{test,spec}.?(c|m)[jt]s?(x)';
 
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
-    environment: 'puppeteer',
     setupFiles: ['./vite-test-utils/vitest-setup.ts'],
-    globalSetup: 'vitest-environment-puppeteer/global-init',
     // Increasing the number so functions using TEST_TIMEOUT can timeout before the test does.
     hookTimeout: TEST_TIMEOUT + 1000,
     testTimeout: TEST_TIMEOUT + 1000,
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/cypress/**',
-      '**/.{idea,git,cache,output,temp}/**',
-      '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*',
-      '**/fixtures/**',
+    exclude: [...defaultExclude, '**/fixtures/**'],
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'sku',
+          include: [`packages/sku/${defaultInclude}`],
+          sequence: {
+            groupOrder: 0,
+          },
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'sku-puppeteer',
+          environment: 'puppeteer',
+          globalSetup: 'vitest-environment-puppeteer/global-init',
+          include: [`tests/${defaultInclude}`],
+          exclude: ['tests/sku-init/**'],
+          sequence: {
+            groupOrder: 0,
+          },
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'sku-init',
+          include: [`tests/sku-init/${defaultInclude}`],
+          sequence: {
+            // sku-init tests must run after the all other tests as it runs `pnpm install`.
+            // Running it during other tests may cause dependency changes to pollute test results.
+            groupOrder: 1,
+          },
+        },
+      },
     ],
   },
 });


### PR DESCRIPTION
This PR utilizes vitest [`projects`](https://vitest.dev/guide/projects.html#test-projects) (previously named `workspaces`) to separate tests by environment, as well as isolate `sku-init` from the rest of the tests as I believe it is occasionally causing test pollution because it runs `pnpm install`.

I think this is happening in #1283. It seems to only happen when there are new non-major versions of specifically the packages installed by `sku init`.

I've defined 3 projects in the vitest config:
- `sku`: for unit tests within the `sku` package that run in the default `node` environment
- `sku-puppeteer`: for e2e tests that require `puppeteer`
- `sku-init`: to isolate the `sku-init` test and run it last to ensure it doesn't pollute dependencies and cause issues in other tests