### PR TITLE
add new cjsInterop key to the sku config

### DIFF
--- a/.changeset/major-hoops-glow.md
+++ b/.changeset/major-hoops-glow.md
@@ -1,0 +1,6 @@
+---
+'sku': minor
+---
+
+- Change `__unsafeDangerouslySetViteConfig` to `__UNSAFE_EXPERIMENTAL__dangerouslySetViteConfig` to align with the existing naming convention.
+- Add `__UNSAFE_EXPERIMENTAL__cjsInteropDependencies` to the `SkuConfig` type. This experimental feature allows users to specify CJS dependencies that should be treated as ESM by `vite`.

--- a/.changeset/major-hoops-glow.md
+++ b/.changeset/major-hoops-glow.md
@@ -3,4 +3,4 @@
 ---
 
 - Change `__unsafeDangerouslySetViteConfig` to `__UNSAFE_EXPERIMENTAL__dangerouslySetViteConfig` to align with the existing naming convention.
-- Add `__UNSAFE_EXPERIMENTAL__cjsInteropDependencies` to the `SkuConfig` type. This experimental feature allows users to specify CJS dependencies that should be treated as ESM by `vite`.
+- Add `__UNSAFE_EXPERIMENTAL__cjsInteropDependencies` to the `SkuConfig` type. This is an array of cjs import paths that have both a default and named exports. This is used to enable CommonJS interop for these dependencies when using the `vite` bundler.

--- a/packages/sku/src/context/defaultSkuConfig.ts
+++ b/packages/sku/src/context/defaultSkuConfig.ts
@@ -37,7 +37,7 @@ export default {
   dangerouslySetJestConfig: defaultDecorator,
   dangerouslySetESLintConfig: defaultDecorator,
   dangerouslySetTSConfig: defaultDecorator,
-  __unstableDangerouslySetViteConfig: defaultDecorator,
+  __UNSAFE_EXPERIMENTAL__dangerouslySetViteConfig: defaultDecorator,
   eslintIgnore: [],
   supportedBrowsers: browserslistConfigSeek,
   cspEnabled: false,

--- a/packages/sku/src/context/defaultSkuConfig.ts
+++ b/packages/sku/src/context/defaultSkuConfig.ts
@@ -8,6 +8,7 @@ const defaultDecorator = <T>(a: T) => a;
 export default {
   __UNSAFE_EXPERIMENTAL__bundler: 'webpack',
   __UNSAFE_EXPERIMENTAL__testRunner: 'jest',
+  __UNSAFE_EXPERIMENTAL__cjsInteropDependencies: [],
   clientEntry: 'src/client.js',
   renderEntry: 'src/render.js',
   serverEntry: 'src/server.js',

--- a/packages/sku/src/services/vite/helpers/config/baseConfig.ts
+++ b/packages/sku/src/services/vite/helpers/config/baseConfig.ts
@@ -40,7 +40,11 @@ const getBaseConfig = (skuContext: SkuContext): InlineConfig => {
       vocabConfig && vocabPluginVite.default({ vocabConfig }),
       tsconfigPaths(),
       cjsInterop({
-        dependencies: ['@apollo/client', 'lodash'],
+        dependencies: [
+          '@apollo/client',
+          'lodash',
+          ...skuContext.skuConfig.__UNSAFE_EXPERIMENTAL__cjsInteropDependencies,
+        ],
       }),
       react({
         babel: {

--- a/packages/sku/src/services/vite/plugins/dangerouslySetViteConfig.ts
+++ b/packages/sku/src/services/vite/plugins/dangerouslySetViteConfig.ts
@@ -4,6 +4,7 @@ import type { SkuContext } from '@/context/createSkuContext.js';
 export function dangerouslySetViteConfig(skuContext: SkuContext): Plugin {
   return {
     name: 'vite-plugin-dangerously-set-config',
-    config: skuContext.skuConfig.__unstableDangerouslySetViteConfig,
+    config:
+      skuContext.skuConfig.__UNSAFE_EXPERIMENTAL__dangerouslySetViteConfig,
   };
 }

--- a/packages/sku/src/types/types.ts
+++ b/packages/sku/src/types/types.ts
@@ -137,6 +137,23 @@ export interface SkuConfig {
    * @default: []
    */
   __UNSAFE_EXPERIMENTAL__cjsInteropDependencies?: string[];
+
+  /**
+   * This function provides a way to modify sku's Vite configuration.
+   * It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
+   *
+   * Before customizing your Vite configuration, please reach out in [#sku-support](https://seek.enterprise.slack.com/archives/CDL5VP5NU) to discuss your requirements and potential alternative solutions.
+   *
+   * As sku creates two Vite configs (`client` & `server|render`), this function will actually run twice.
+   * If you only need to modify one of these configs, then you can check `env.mode` from the second argument within.
+   *
+   * Sku provides no guarantees that its Vite configuration will remain compatible with any customizations made within this function.
+   * It is the responsibility of the user to ensure that their customizations are compatible with sku.
+   *
+   * @link https://seek-oss.github.io/sku/#/./docs/configuration?id=dangerouslysetviteconfig
+   */
+  __UNSAFE_EXPERIMENTAL__dangerouslySetViteConfig?: Plugin['config'];
+
   /**
    * The client entry point to the app. The client entry is the file that executes your browser code.
    *
@@ -235,22 +252,6 @@ export interface SkuConfig {
    * @link https://seek-oss.github.io/sku/#/./docs/configuration?id=dangerouslysetwebpackconfig
    */
   dangerouslySetWebpackConfig?: (skuWebpackConfig: any) => any;
-
-  /**
-   * This function provides a way to modify sku's Vite configuration.
-   * It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
-   *
-   * Before customizing your Vite configuration, please reach out in [#sku-support](https://seek.enterprise.slack.com/archives/CDL5VP5NU) to discuss your requirements and potential alternative solutions.
-   *
-   * As sku creates two Vite configs (`client` & `server|render`), this function will actually run twice.
-   * If you only need to modify one of these configs, then you can check `env.mode` from the second argument within.
-   *
-   * Sku provides no guarantees that its Vite configuration will remain compatible with any customizations made within this function.
-   * It is the responsibility of the user to ensure that their customizations are compatible with sku.
-   *
-   * @link https://seek-oss.github.io/sku/#/./docs/configuration?id=dangerouslysetviteconfig
-   */
-  __unstableDangerouslySetViteConfig?: Plugin['config'];
 
   /**
    * Path to a file in your project that exports a function that can receive the Express server.

--- a/packages/sku/src/types/types.ts
+++ b/packages/sku/src/types/types.ts
@@ -129,7 +129,9 @@ export interface SkuConfig {
    */
   __UNSAFE_EXPERIMENTAL__testRunner?: 'vitest' | 'jest';
   /**
-   * An array of cjs dependencies that vite should treat as ESM.
+   * An array of cjs import paths that have both a default and named exports.
+   * This is used to enable CommonJS interop for these dependencies when using the `vite` bundler.
+   * See https://github.com/cyco130/vite-plugin-cjs-interop for more information.
    * This is an experimental option that may change or be removed without notice.
    *
    * Note: This option is only relevant when using the `vite` bundler.

--- a/packages/sku/src/types/types.ts
+++ b/packages/sku/src/types/types.ts
@@ -129,6 +129,15 @@ export interface SkuConfig {
    */
   __UNSAFE_EXPERIMENTAL__testRunner?: 'vitest' | 'jest';
   /**
+   * An array of cjs dependencies that vite should treat as ESM.
+   * This is an experimental option that may change or be removed without notice.
+   *
+   * Note: This option is only relevant when using the `vite` bundler.
+   *
+   * @default: []
+   */
+  __UNSAFE_EXPERIMENTAL__cjsInteropDependencies?: string[];
+  /**
    * The client entry point to the app. The client entry is the file that executes your browser code.
    *
    * @default "./src/client.js"


### PR DESCRIPTION
Add the `__UNSAFE_EXPERIMENTAL__cjsInteropDependencies` key to the `sku.config.ts`. These dependencies will be used internally by the cjsInterop plugin.