### PR TITLE
Fix tab opening

### DIFF
--- a/.changeset/smart-horses-mix.md
+++ b/.changeset/smart-horses-mix.md
@@ -2,4 +2,6 @@
 'sku': patch
 ---
 
-`start`: Browser tabs will be reused when starting a server
+`start`: Properly reuses Chrome tabs when starting a server.
+
+Fixes an issue of always opening a new tab in Chrome when one could be reused.

--- a/.changeset/smart-horses-mix.md
+++ b/.changeset/smart-horses-mix.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`start`: Browser tabs will be reused when starting a server

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "bin": "./bin.js",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tspc --project tsconfig.build.json",
     "prepare": "ts-patch install -s"
   },
   "dependencies": {

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "bin": "./bin.js",
   "scripts": {
-    "build": "tspc --project tsconfig.build.json",
+    "build": "tsc --project tsconfig.build.json",
     "prepare": "ts-patch install -s"
   },
   "dependencies": {

--- a/packages/sku/bin.js
+++ b/packages/sku/bin.js
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-import './dist/bin/sku.js';

--- a/packages/sku/bin/bin.js
+++ b/packages/sku/bin/bin.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import '../dist/bin/sku.js';

--- a/packages/sku/bin/openChrome.applescript
+++ b/packages/sku/bin/openChrome.applescript
@@ -1,6 +1,9 @@
 (*
-File copied from create-react-app
-https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/openChrome.applescript
+Copyright (c) 2015-present, Facebook, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file at
+https://github.com/facebookincubator/create-react-app/blob/master/LICENSE
 *)
 
 property targetTab: null

--- a/packages/sku/bin/openChrome.applescript
+++ b/packages/sku/bin/openChrome.applescript
@@ -1,4 +1,8 @@
 (*
+
+File copied from create-react-app
+https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/openChrome.applescript
+
 Copyright (c) 2015-present, Facebook, Inc.
 
 This source code is licensed under the MIT license found in the

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -4,7 +4,7 @@
   "description": "Front-end development toolkit, powered by Webpack, Babel, Vanilla Extract and Jest",
   "types": "./dist/index.d.ts",
   "bin": {
-    "sku": "bin.js"
+    "sku": "bin/bin.js"
   },
   "exports": {
     ".": {
@@ -42,12 +42,12 @@
     "template",
     "CHANGELOG.md",
     "src/@loadable",
-    "bin.js"
+    "bin"
   ],
   "type": "module",
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js",
-    "build": "tspc --project tsconfig.build.json",
+    "build": "tsc --project tsconfig.build.json",
     "postbuild": "cp dist/index.d.ts dist/index.d.cts && cp src/services/vite/client.d.ts dist/services/vite/client.d.ts",
     "lint:tsc": "tsc --noEmit",
     "prepare": "ts-patch install -s"

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -47,7 +47,7 @@
   "type": "module",
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js",
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tspc --project tsconfig.build.json",
     "postbuild": "cp dist/index.d.ts dist/index.d.cts && cp src/services/vite/client.d.ts dist/services/vite/client.d.ts",
     "lint:tsc": "tsc --noEmit",
     "prepare": "ts-patch install -s"

--- a/packages/sku/src/openBrowser/index.ts
+++ b/packages/sku/src/openBrowser/index.ts
@@ -8,6 +8,9 @@ import isCI from '@/utils/isCI.js';
 import getDefaultBrowser from 'default-browser';
 import { fileURLToPath } from 'node:url';
 import { resolve } from 'node:path';
+import debug from 'debug';
+
+const log = debug('sku:openBrowser');
 
 export const BIN_DIR = resolve(fileURLToPath(import.meta.url), '../../../bin');
 
@@ -78,11 +81,12 @@ export const openBrowser = async (url: string) => {
         );
         return true;
       }
-    } catch {
-      // Ignore errors
+    } catch (error) {
+      // Ignore errors and just log them
+      log('Failed to open browser with AppleScript:', error);
     }
   }
-
+  log('Opening in a new tab in the browser:', preferredBrowser);
   open(url);
 };
 

--- a/packages/sku/src/openBrowser/index.ts
+++ b/packages/sku/src/openBrowser/index.ts
@@ -2,10 +2,14 @@
 // https://github.com/facebook/create-react-app/commit/d2de54b25cc25800df1764058997e3e274bd79ac
 
 import chalk from 'chalk';
-import { execSync } from 'node:child_process';
+import { type ExecOptions, exec } from 'node:child_process';
 import open from 'open';
 import isCI from '@/utils/isCI.js';
 import getDefaultBrowser from 'default-browser';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+export const BIN_DIR = resolve(fileURLToPath(import.meta.url), '../../../bin');
 
 const OSX_CHROME = 'google chrome';
 
@@ -21,59 +25,75 @@ const supportedChromiumBrowsers = [
   'Arc',
 ];
 
-export const openBrowser = async (url: string) => {
-  if (process.env.OPEN_TAB !== 'false' && !isCI) {
-    let defaultBrowser = ''; // Has to be set to string otherwise it may be undefined on line 47.
-    try {
-      const { name } = await getDefaultBrowser();
-      defaultBrowser = name;
-    } catch {
-      console.log(chalk.yellow.bold('Failed to detect default browser.'));
-      console.log(
-        chalk.yellow(
-          `For a better ${chalk.italic('start')} experience on macOS, go to ${chalk.italic(
-            'System Preferences > Privacy & Security > Automation > Terminal/Application',
-          )} and enable Finder permissions.`,
-        ),
-      );
-    }
+async function getBrowserPreference() {
+  const envBrowser =
+    process.env.BROWSER === OSX_CHROME
+      ? 'Google Chrome'
+      : (process.env.BROWSER ?? '');
 
-    const availableBrowser = process.env.BROWSER;
-
-    const shouldTryOpenChromiumWithAppleScript =
-      process.platform === 'darwin' &&
-      (typeof availableBrowser !== 'string' ||
-        availableBrowser === OSX_CHROME) &&
-      supportedChromiumBrowsers.includes(defaultBrowser);
-
-    if (shouldTryOpenChromiumWithAppleScript) {
-      // Will use the first open browser found from list
-      const supportedChromiumBrowsersByPreference = new Set([
-        defaultBrowser,
-        ...supportedChromiumBrowsers,
-      ]);
-
-      for (const chromiumBrowser of supportedChromiumBrowsersByPreference) {
-        try {
-          // Try our best to reuse existing tab
-          // on OS X Google Chrome with AppleScript
-          execSync(`ps cax | grep "${chromiumBrowser}"`);
-          execSync(
-            `osascript openChrome.applescript "${encodeURI(
-              url,
-            )}" "${chromiumBrowser}"`,
-            {
-              cwd: __dirname,
-              stdio: 'ignore',
-            },
-          );
-          return true;
-        } catch {
-          // Ignore errors.
-        }
-      }
-    }
-
-    open(url);
+  try {
+    const { name } = await getDefaultBrowser();
+    return name ?? envBrowser;
+  } catch {
+    console.log(chalk.yellow.bold('Failed to detect default browser.'));
+    console.log(
+      chalk.yellow(
+        `For a better ${chalk.italic('start')} experience on macOS, go to ${chalk.italic(
+          'System Preferences > Privacy & Security > Automation > Terminal/Application',
+        )} and enable Finder permissions.`,
+      ),
+    );
+    return envBrowser;
   }
+}
+
+export const openBrowser = async (url: string) => {
+  if (process.env.OPEN_TAB === 'false' || isCI) {
+    return;
+  }
+
+  const preferredBrowser = await getBrowserPreference();
+
+  const shouldTryOpenChromiumWithAppleScript =
+    process.platform === 'darwin' &&
+    (!preferredBrowser || supportedChromiumBrowsers.includes(preferredBrowser));
+
+  if (shouldTryOpenChromiumWithAppleScript) {
+    try {
+      const ps = await execAsync('ps cax');
+      const openedBrowser =
+        preferredBrowser && ps.includes(preferredBrowser)
+          ? preferredBrowser
+          : supportedChromiumBrowsers.find((b) => ps.includes(b));
+
+      if (openedBrowser) {
+        // Try our best to reuse existing tab with AppleScript
+        await execAsync(
+          `osascript openChrome.applescript "${encodeURI(
+            url,
+          )}" "${openedBrowser}"`,
+          {
+            cwd: BIN_DIR,
+          },
+        );
+        return true;
+      }
+    } catch {
+      // Ignore errors
+    }
+  }
+
+  open(url);
 };
+
+function execAsync(command: string, options?: ExecOptions): Promise<string> {
+  return new Promise((res, rej) => {
+    exec(command, options, (error, stdout) => {
+      if (error) {
+        rej(error);
+      } else {
+        res(stdout.toString());
+      }
+    });
+  });
+}

--- a/packages/sku/src/services/vite/helpers/config/createConfig.ts
+++ b/packages/sku/src/services/vite/helpers/config/createConfig.ts
@@ -10,10 +10,13 @@ import { startTelemetryPlugin } from '@/services/vite/plugins/startTelemetry.js'
 import { HMRTelemetryPlugin } from '@/services/vite/plugins/HMRTelemetry.js';
 import { httpsDevServerPlugin } from '@/services/vite/plugins/httpsDevServerPlugin.js';
 import { getAppHosts } from '@/utils/contextUtils/hosts.js';
+import isCI from '@/utils/isCI.js';
 
 const require = createRequire(import.meta.url);
 
 const clientEntry = require.resolve('../../entries/vite-client.js');
+
+const shouldOpenTab = process.env.OPEN_TAB !== 'false' && !isCI;
 
 export const createViteSsgConfig = (skuContext: SkuContext) =>
   createSkuViteConfig(
@@ -91,7 +94,7 @@ export const createViteDevConfig = (skuContext: SkuContext) =>
         allowedHosts: getAppHosts(skuContext).filter(
           (host) => typeof host === 'string',
         ),
-        open: skuContext.initialPath || true,
+        open: shouldOpenTab && (skuContext.initialPath || true),
       },
     },
     skuContext,
@@ -114,7 +117,7 @@ export const createViteDevSsrConfig = (skuContext: SkuContext) =>
         allowedHosts: getAppHosts(skuContext).filter(
           (host) => typeof host === 'string',
         ),
-        open: skuContext.initialPath || true,
+        open: shouldOpenTab && (skuContext.initialPath || true),
       },
       plugins: [httpsDevServerPlugin(skuContext)],
       appType: 'custom',

--- a/packages/sku/src/services/vite/helpers/config/createConfig.ts
+++ b/packages/sku/src/services/vite/helpers/config/createConfig.ts
@@ -91,6 +91,7 @@ export const createViteDevConfig = (skuContext: SkuContext) =>
         allowedHosts: getAppHosts(skuContext).filter(
           (host) => typeof host === 'string',
         ),
+        open: skuContext.initialPath || true,
       },
     },
     skuContext,
@@ -113,6 +114,7 @@ export const createViteDevSsrConfig = (skuContext: SkuContext) =>
         allowedHosts: getAppHosts(skuContext).filter(
           (host) => typeof host === 'string',
         ),
+        open: skuContext.initialPath || true,
       },
       plugins: [httpsDevServerPlugin(skuContext)],
       appType: 'custom',

--- a/packages/sku/src/services/vite/index.ts
+++ b/packages/sku/src/services/vite/index.ts
@@ -8,7 +8,6 @@ import {
   createViteSsgConfig,
 } from './helpers/config/createConfig.js';
 import { cleanTargetDirectory } from '@/utils/buildFileUtils.js';
-import { openBrowser } from '@/openBrowser/index.js';
 import { getAppHosts } from '@/utils/contextUtils/hosts.js';
 import chalk from 'chalk';
 import { prerenderConcurrently } from '@/services/vite/helpers/prerender/prerenderConcurrently.js';
@@ -41,10 +40,6 @@ export const viteService = {
     await server.listen(availablePort);
 
     const hosts = getAppHosts(skuContext);
-    const proto = skuContext.httpsDevServer ? 'https' : 'http';
-    const url = `${proto}://${hosts[0]}:${availablePort}${skuContext.initialPath}`;
-    openBrowser(url);
-
     printUrls(hosts, skuContext);
 
     server.bindCLIShortcuts({ print: true });
@@ -57,10 +52,6 @@ export const viteService = {
     server.listen(skuContext.port.server);
 
     const hosts = getAppHosts(skuContext);
-    const proto = skuContext.httpsDevServer ? 'https' : 'http';
-    const url = `${proto}://${hosts[0]}:${skuContext.port.server}${skuContext.initialPath}`;
-    openBrowser(url);
-
     printUrls(hosts, skuContext);
   },
 };

--- a/test-utils/process.ts
+++ b/test-utils/process.ts
@@ -2,7 +2,7 @@ import { createRequire } from 'node:module';
 import spawn, { type Options, SubprocessError } from 'nano-spawn';
 
 const require = createRequire(import.meta.url);
-const skuBin = require.resolve('../packages/sku/bin.js');
+const skuBin = require.resolve('../packages/sku/bin/bin.js');
 const skuCodemodBin = require.resolve('../packages/codemod/bin.js');
 
 export const createCancelSignal = () => {


### PR DESCRIPTION
When starting a dev server a browser is opened to the dev url with the initial path included. When closing and restarting the dev server, the previously opened tab should be reused when available. This is an intended feature that apparently used to work but broke for some reason. _Edit_:  Looks like this broke in the [v14 release](https://github.com/seek-oss/sku/releases/tag/sku%4014.0.0).

Digging into it, I found some errors that we were silencing. `__dirname` wasn't available since sku is now `type: module`. Also, the applescript wasn't published with our application so it would always fall back to opening in a new tab.

Changes I made to fix this:
* Moved `openChrome.applescript` and `bin.js` into a top level bin directory that is included with our package (included in `package.json:files`
* Minor changes to the openBrowser function. Took a couple things from [Vites implementation](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/openBrowser.ts) and added debug logging.
* The Vite bundler now uses `server.open` option to open the browser so we don't have to rely on our own openBrowser code.