### PR TITLE
`sku init`: Install specific version of `sku`

### DIFF
--- a/.changeset/tidy-papers-read.md
+++ b/.changeset/tidy-papers-read.md
@@ -1,0 +1,7 @@
+---
+'sku': patch
+---
+
+`sku init`: Specify an exact version of `sku` when isntalling dependencies
+
+This fixes an issue where running `sku init` with a snapshot version of `sku` would install the latest version of `sku` instead of the specified version.

--- a/packages/sku/src/program/commands/init/init.action.ts
+++ b/packages/sku/src/program/commands/init/init.action.ts
@@ -7,6 +7,7 @@ import { fdir as Fdir } from 'fdir';
 import { Eta } from 'eta';
 import debug from 'debug';
 import semver from 'semver';
+import skuPackageJson from 'sku/package.json' with { type: 'json' };
 
 import type { SkuContext } from '@/context/createSkuContext.js';
 
@@ -216,7 +217,9 @@ export const initAction = async (
 
   const devDeps = [
     '@vanilla-extract/css',
-    'sku',
+    // Specify an exact version so running `sku init` with a snapshot installs the snapshot version
+    // instead of the latest version.
+    `sku@${skuPackageJson.version}`,
     '@types/react@^18.3.12',
     '@types/react-dom@^18.3.1',
   ];

--- a/packages/sku/src/services/telemetry/index.ts
+++ b/packages/sku/src/services/telemetry/index.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import { requireFromCwd } from '@/utils/cwd.js';
 import isCI from '@/utils/isCI.js';
 import provider from './provider.js';
-import skuPackageJson from '../../../package.json' with { type: 'json' };
+import skuPackageJson from 'sku/package.json' with { type: 'json' };
 import debug from 'debug';
 
 import type { SkuContext } from '@/context/createSkuContext.js';

--- a/tests/sku-init/sku-init.test.ts
+++ b/tests/sku-init/sku-init.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import fs from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { runSkuScriptInDir } from '@sku-private/test-utils';
+import skuPackageJson from '../../packages/sku/package.json' with { type: 'json' };
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
@@ -58,8 +59,16 @@ describe('sku init', () => {
       path.join(fixtureDirectory, projectName, 'package.json'),
       'utf-8',
     );
+    const packageJson = JSON.parse(contents);
 
-    expect(replaceDependencyVersions(JSON.parse(contents))).toMatchSnapshot();
+    // `workspace:` prefix comes from the default `saveWorkspaceProtocol` value.
+    // See https://pnpm.io/settings#saveworkspaceprotocol.
+    // In NPM, Yarn, or PNPM if configured in such a way, this will be just the version.
+    expect(packageJson.devDependencies.sku).toEqual(
+      `workspace:${skuPackageJson.version}`,
+    );
+
+    expect(replaceDependencyVersions(packageJson)).toMatchSnapshot();
   });
 
   it.for([

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node-lts/tsconfig.json",
   "compilerOptions": {
+    "module": "node18",
     "allowImportingTsExtensions": true,
     "allowJs": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
Running `sku init` from a snapshot version of `sku` would result in the latest version of `sku` installed, rather than the version of the snapshot. This is now fixed.