### PR TITLE
Fix lint error

### DIFF
--- a/tests/sku-init/sku-init.test.ts
+++ b/tests/sku-init/sku-init.test.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 import fs from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { runSkuScriptInDir } from '@sku-private/test-utils';
-import skuPackageJson from '../../packages/sku/package.json' with { type: 'json' };
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 


### PR DESCRIPTION
#1303 merged because it skipped linting, but there was a lint error, so master is broken right now. This fixes the lint error.

This happens occasionally as a result of [the skip check workflow](https://github.com/seek-oss/sku/blob/77d6a2dfd19a79f2653d731b07d48233c479cdd1/.github/workflows/validate.yml#L6). Maybe we just ditch it if this happens again?