### PR TITLE
`init`: Create a `pnpm-workspace.yaml` file when initializing a `sku` app with `pnpm>=10`

### DIFF
--- a/packages/sku/src/services/packageManager/packageManager.ts
+++ b/packages/sku/src/services/packageManager/packageManager.ts
@@ -4,6 +4,7 @@ import type { Command } from 'package-manager-detector';
 import { resolveCommand } from 'package-manager-detector/commands';
 import { INSTALL_PAGE } from 'package-manager-detector/constants';
 import { getPackageManager } from './context/packageManager.js';
+import semver from 'semver';
 
 type SupportedPackageManager = 'yarn' | 'pnpm' | 'npm';
 
@@ -78,6 +79,11 @@ const { rootDir, packageManager, packageManagerVersion } =
   resolvePackageManager();
 
 export { rootDir, packageManager, packageManagerVersion };
+
+export const isAtLeastPnpmV10 = () =>
+  packageManager === 'pnpm' &&
+  packageManagerVersion &&
+  semver.satisfies(packageManagerVersion, '>=10.0.0');
 
 export const getCommand = (
   agent: SupportedPackageManager,

--- a/tests/sku-init/__snapshots__/sku-init.test.ts.snap
+++ b/tests/sku-init/__snapshots__/sku-init.test.ts.snap
@@ -95,13 +95,6 @@ exports[`sku init > should create package.json 1`] = `
     "sku": "VERSION_IGNORED",
   },
   "name": "new-project",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "sku",
-      "@swc/core",
-      "esbuild",
-    ],
-  },
   "private": true,
   "scripts": {
     "build": "sku build",
@@ -113,6 +106,13 @@ exports[`sku init > should create package.json 1`] = `
   },
   "version": "0.1.0",
 }
+`;
+
+exports[`sku init > should create pnpm-workspace.yaml 1`] = `
+"publicHoistPattern:
+  - eslint
+  - prettier
+"
 `;
 
 exports[`sku init > should create sku.config.ts 1`] = `

--- a/tests/sku-init/sku-init.test.ts
+++ b/tests/sku-init/sku-init.test.ts
@@ -70,6 +70,7 @@ describe('sku init', () => {
     'eslint.config.mjs',
     'README.md',
     'src/App/NextSteps.tsx',
+    'pnpm-workspace.yaml',
   ])('should create %s', async (file, { expect }) => {
     const contents = await fs.readFile(
       path.join(fixtureDirectory, projectName, file),


### PR DESCRIPTION
Part of a larger bit of work to enable sku to manage a `pnpm-workspace.yaml` file where appropriate.

As a first step, new sku apps will be initialized with a `pnpm-workspace.yaml` file if pnpm>=10 is detected. Note that there's no `# start/end managed by sku` comments just yet as we're not "managing" any thing yet. Managing implies that we're actively controlling the contents of this special section. This will be implemented in a future PR.

Also note that there's no changeset for now as this code will likely change as the managing features are added over subsequent PR(s). I figured it wasn't worth writing a changeset for a partial feature that's going to change scope.

We're also in a situation where the sku repo happens to be on pnpm v10, so the tests align with what we'd expect, but we're not testing other versions/package managers. Currently we don't have a way to mock/configure these in tests, and honestly I don't think the effort is worth it right now.

Finally, I've removed the `onlyBuiltDependencies` config setup as I'm going to refactor this in a future PR to use the `pnpm-workspace.yaml` file instead.