### PR TITLE
Mark private packages as private

### DIFF
--- a/private/eslint-plugin/package.json
+++ b/private/eslint-plugin/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@sku-private/eslint-plugin",
+  "private": true,
   "type": "module",
   "main": "index.cjs"
 }

--- a/private/puppeteer/package.json
+++ b/private/puppeteer/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@sku-private/puppeteer",
+  "private": true,
   "type": "module",
   "main": "index.ts",
   "devDependencies": {


### PR DESCRIPTION
Private packages should be marked as such otherwise [changesets will attempt to publish them](https://github.com/seek-oss/sku/actions/runs/16360258785/job/46226719958#step:7:35). Luckily we own the `@sku-private` scope, and the token in the repo doesn't have permissions to publish to that scope, so nothing actually published.