### PR TITLE
`sku test`: Don't configure twice

### DIFF
--- a/.changeset/lucky-numbers-ring.md
+++ b/.changeset/lucky-numbers-ring.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`sku test`: Fixes a bug where `sku configure` would be run twice instead of once

--- a/.changeset/lucky-numbers-ring.md
+++ b/.changeset/lucky-numbers-ring.md
@@ -2,4 +2,4 @@
 'sku': patch
 ---
 
-`sku test`: Fixes a bug where `sku configure` would be run twice instead of once
+`sku test`: Fixes a bug where project configuration and Vocab translation compilation were running twice instead of once

--- a/packages/sku/src/program/commands/test/jest-test-handler.ts
+++ b/packages/sku/src/program/commands/test/jest-test-handler.ts
@@ -3,7 +3,6 @@ import { run } from 'jest';
 
 import isCI from '@/utils/isCI.js';
 import { runVocabCompile } from '@/services/vocab/runVocab.js';
-import { configureProject } from '@/utils/configure.js';
 import type { SkuContext } from '@/context/createSkuContext.js';
 
 const log = debug('sku:jest');
@@ -16,7 +15,6 @@ export const runJestTests = async (
   },
   { args = [] }: { args: string[] },
 ) => {
-  await configureProject(skuContext);
   await runVocabCompile(skuContext);
 
   // https://jestjs.io/docs/configuration#preset-string

--- a/packages/sku/src/program/commands/test/jest-test-handler.ts
+++ b/packages/sku/src/program/commands/test/jest-test-handler.ts
@@ -2,21 +2,10 @@ import debug from 'debug';
 import { run } from 'jest';
 
 import isCI from '@/utils/isCI.js';
-import { runVocabCompile } from '@/services/vocab/runVocab.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
 
 const log = debug('sku:jest');
 
-export const runJestTests = async (
-  {
-    skuContext,
-  }: {
-    skuContext: SkuContext;
-  },
-  { args = [] }: { args: string[] },
-) => {
-  await runVocabCompile(skuContext);
-
+export const runJestTests = async ({ args = [] }: { args: string[] }) => {
   // https://jestjs.io/docs/configuration#preset-string
   const jestPreset = 'sku';
   log(`Using '${jestPreset}' Jest preset`);

--- a/packages/sku/src/program/commands/test/test.action.ts
+++ b/packages/sku/src/program/commands/test/test.action.ts
@@ -19,5 +19,6 @@ export const testAction = async (
     await vitestHandler({ skuContext, args });
     return;
   }
-  runJestTests({ skuContext }, { args });
+
+  runJestTests({ args });
 };


### PR DESCRIPTION
`configure` is already run inside [the `test` action](https://github.com/seek-oss/sku/blob/1ea7bdc72eadabe4c7faf77f39c51b57d4fcd3f0/packages/sku/src/program/commands/test/test.action.ts#L15), so this second call inside `runJestTests` is redundant.