### PR TITLE
Create `pnpm-plugin-sku` package

### DIFF
--- a/.changeset/two-hairs-know.md
+++ b/.changeset/two-hairs-know.md
@@ -1,0 +1,5 @@
+---
+'pnpm-plugin-sku': patch
+---
+
+Update `onlyBuiltDependencies` list, configure `ignoreBuiltDependencies`

--- a/packages/pnpm-plugin/README.md
+++ b/packages/pnpm-plugin/README.md
@@ -1,0 +1,17 @@
+# `pnpm-plugin-sku`
+
+[PNPM config dependency] for `sku` that configures recommended PNPM settings.
+
+## Usage
+
+> [!IMPORTANT]
+> This package is intended to be used with `pnpm` version [10.13] or later.
+> It will _not_ be automatically loaded in `pnpm` versions prior to 10.13.
+
+```sh
+pnpm add --config pnpm-plugin-sku
+pnpm install
+```
+
+[PNPM config dependency]: https://pnpm.io/config-dependencies
+[10.13]: https://github.com/pnpm/pnpm/releases/tag/v10.13.0

--- a/packages/pnpm-plugin/package.json
+++ b/packages/pnpm-plugin/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "pnpm-plugin-sku",
+  "version": "0.0.1",
+  "description": "PNPM config dependency for sku that configures recommended PNPM setting",
+  "main": "pnpmfile.cjs",
+  "type": "module",
+  "files": [
+    "pnpmfile.cjs"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/seek-oss/sku.git",
+    "directory": "packages/pnpm-plugin"
+  },
+  "author": "SEEK",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/seek-oss/sku/issues"
+  },
+  "homepage": "https://github.com/seek-oss/sku#readme"
+}

--- a/packages/pnpm-plugin/pnpmfile.cjs
+++ b/packages/pnpm-plugin/pnpmfile.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+  hooks: {
+    updateConfig(config) {
+      config.publicHoistPattern ??= [];
+      config.publicHoistPattern.push('eslint', 'prettier');
+
+      config.onlyBuiltDependencies ??= [];
+      config.onlyBuiltDependencies.push(
+        'sku',
+        '@swc/core',
+        'esbuild',
+        'unrs-resolver',
+      );
+
+      config.ignoreBuiltDependencies ??= [];
+      config.ignoreBuiltDependencies.push('core-js', 'core-js-pure');
+
+      return config;
+    },
+  },
+};


### PR DESCRIPTION
Part of a simpler solution to managing PNPM config, as attempted in #1311. By managing configuration with [a PNPM config dependency](https://pnpm.io/config-dependencies), we don't need to worry about syncing the user's `pnpm-workspace.yaml` file with the settings we want. Instead, `pnpm` will run the `pnpmfile.cjs` and use that as the resolve config when managing dependencies.

`pnpm-plugin` packages automatically have their `pnpmfile.cjs` file loaded by PNPM as of [v10.13](https://github.com/pnpm/pnpm/releases/tag/v10.13.0#:~:text=pnpm%20will%20now-,automatically%20load,-the%20pnpmfile.cjs%20file).

> [!NOTE]
> This package has [already been published manually](https://www.npmjs.com/package/pnpm-plugin-sku). There are changes in this PR that need to be published, hence the changeset. This was done to enable a granular NPM access token to be generated with permissions to publish this package. It's an annoying workaround for this chicken-and-egg problem that wouldn't be necessary if PNPM plugins under scopes could be automatically loaded. See the upstream issue I raised about this https://github.com/pnpm/pnpm/issues/9780.