### PR TITLE
Add fixture for testing `polyfills` behaviour

### DIFF
--- a/fixtures/polyfills/.gitignore
+++ b/fixtures/polyfills/.gitignore
@@ -1,0 +1,9 @@
+# managed by sku
+.eslintcache
+.prettierrc
+coverage/
+dist/
+eslint.config.mjs
+report/
+tsconfig.json
+# end managed by sku

--- a/fixtures/polyfills/.prettierignore
+++ b/fixtures/polyfills/.prettierignore
@@ -1,0 +1,10 @@
+# managed by sku
+.eslintcache
+.prettierrc
+coverage/
+dist/
+eslint.config.mjs
+pnpm-lock.yaml
+report/
+tsconfig.json
+# end managed by sku

--- a/fixtures/polyfills/package.json
+++ b/fixtures/polyfills/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@sku-private/3rd-party-polyfill": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/fixtures/polyfills/package.json
+++ b/fixtures/polyfills/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@sku-fixtures/polyfills",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "scripts": {
+    "start": "sku start",
+    "start:vite": "sku start --experimental-bundler --config sku.config.vite.ts",
+    "build": "sku build",
+    "build:vite": "sku build --experimental-bundler --config sku.config.vite.ts"
+  },
+  "devDependencies": {
+    "@sku-private/test-utils": "workspace:*",
+    "dedent": "^1.5.1",
+    "sku": "workspace:*"
+  },
+  "skuSkipValidatePeerDeps": true
+}

--- a/fixtures/polyfills/sku.config.ts
+++ b/fixtures/polyfills/sku.config.ts
@@ -7,5 +7,5 @@ export default {
   publicPath: '/static/polyfills',
   port: 4200,
   dangerouslySetWebpackConfig: (config) => makeStableHashes(config),
-  polyfills: ['./src/polyfills/polyfills.ts'],
+  polyfills: ['./src/polyfills.ts', '@sku-private/3rd-party-polyfill'],
 } satisfies SkuConfig;

--- a/fixtures/polyfills/sku.config.ts
+++ b/fixtures/polyfills/sku.config.ts
@@ -1,0 +1,11 @@
+import { makeStableHashes } from '@sku-private/test-utils';
+import type { SkuConfig } from 'sku';
+
+export default {
+  clientEntry: 'src/client.tsx',
+  renderEntry: 'src/render.tsx',
+  publicPath: '/static/polyfills',
+  port: 4200,
+  dangerouslySetWebpackConfig: (config) => makeStableHashes(config),
+  polyfills: ['./src/polyfills/polyfills.ts'],
+} satisfies SkuConfig;

--- a/fixtures/polyfills/sku.config.vite.ts
+++ b/fixtures/polyfills/sku.config.vite.ts
@@ -1,0 +1,8 @@
+import type { SkuConfig } from 'sku';
+
+import baseConfig from './sku.config.js';
+
+export default {
+  ...baseConfig,
+  __UNSAFE_EXPERIMENTAL__bundler: 'vite',
+} satisfies SkuConfig;

--- a/fixtures/polyfills/src/App.tsx
+++ b/fixtures/polyfills/src/App.tsx
@@ -1,0 +1,1 @@
+export const App = () => <div>App with a polyfill</div>;

--- a/fixtures/polyfills/src/client.tsx
+++ b/fixtures/polyfills/src/client.tsx
@@ -6,4 +6,5 @@ export default () => {
   hydrateRoot(document.getElementById('app'), <App />);
 
   window.injected();
+  window.someRandomApi();
 };

--- a/fixtures/polyfills/src/client.tsx
+++ b/fixtures/polyfills/src/client.tsx
@@ -1,0 +1,9 @@
+import { hydrateRoot } from 'react-dom/client';
+
+import { App } from './App.tsx';
+
+export default () => {
+  hydrateRoot(document.getElementById('app'), <App />);
+
+  window.injected();
+};

--- a/fixtures/polyfills/src/polyfills.ts
+++ b/fixtures/polyfills/src/polyfills.ts
@@ -1,0 +1,1 @@
+import './polyfills/injectGlobal.ts';

--- a/fixtures/polyfills/src/polyfills/injectGlobal.ts
+++ b/fixtures/polyfills/src/polyfills/injectGlobal.ts
@@ -1,0 +1,5 @@
+window.injected = () => {
+  const p = document.createElement('p');
+  p.textContent = "This node was injected by the 'injected' global function.";
+  document.body.appendChild(p);
+};

--- a/fixtures/polyfills/src/polyfills/polyfills.ts
+++ b/fixtures/polyfills/src/polyfills/polyfills.ts
@@ -1,2 +1,0 @@
-import '@sku-private/3rd-party-polyfill';
-import './injectGlobal.ts';

--- a/fixtures/polyfills/src/polyfills/polyfills.ts
+++ b/fixtures/polyfills/src/polyfills/polyfills.ts
@@ -1,1 +1,2 @@
+import '@sku-private/3rd-party-polyfill';
 import './injectGlobal.ts';

--- a/fixtures/polyfills/src/polyfills/polyfills.ts
+++ b/fixtures/polyfills/src/polyfills/polyfills.ts
@@ -1,0 +1,1 @@
+import './injectGlobal.ts';

--- a/fixtures/polyfills/src/render.tsx
+++ b/fixtures/polyfills/src/render.tsx
@@ -1,0 +1,28 @@
+import html from 'dedent';
+import { renderToString } from 'react-dom/server';
+
+import { App } from './App.tsx';
+
+export default {
+  renderApp: ({ SkuProvider }) =>
+    renderToString(
+      <SkuProvider>
+        <App />
+      </SkuProvider>,
+    ),
+  renderDocument: ({ app, bodyTags, headTags }) => html /* html */ `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="UTF-8" />
+        <title>polyfill</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        ${headTags}
+      </head>
+      <body>
+        <div id="app">${app}</div>
+        ${bodyTags}
+      </body>
+    </html>
+  `,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,6 +328,9 @@ importers:
 
   fixtures/polyfills:
     dependencies:
+      '@sku-private/3rd-party-polyfill':
+        specifier: workspace:*
+        version: link:../../private/3rd-party-polyfill
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1167,6 +1170,8 @@ importers:
       typescript-transform-paths:
         specifier: ^3.5.2
         version: 3.5.5(typescript@5.8.3)
+
+  private/3rd-party-polyfill: {}
 
   private/eslint-plugin: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,25 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sku
 
+  fixtures/polyfills:
+    dependencies:
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@sku-private/test-utils':
+        specifier: workspace:*
+        version: link:../../private/test-utils
+      dedent:
+        specifier: ^1.5.1
+        version: 1.6.0(babel-plugin-macros@3.1.0)
+      sku:
+        specifier: workspace:*
+        version: link:../../packages/sku
+
   fixtures/public-path:
     dependencies:
       react:
@@ -675,6 +694,8 @@ importers:
       typescript-transform-paths:
         specifier: ^3.5.2
         version: 3.5.5(typescript@5.8.3)
+
+  packages/pnpm-plugin: {}
 
   packages/sku:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1282,6 +1282,9 @@ importers:
       '@sku-fixtures/multiple-routes':
         specifier: workspace:*
         version: link:../fixtures/multiple-routes
+      '@sku-fixtures/polyfills':
+        specifier: workspace:*
+        version: link:../fixtures/polyfills
       '@sku-fixtures/public-path':
         specifier: workspace:*
         version: link:../fixtures/public-path

--- a/private/3rd-party-polyfill/package.json
+++ b/private/3rd-party-polyfill/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@sku-private/3rd-party-polyfill",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "main": "polyfill.js"
+}

--- a/private/3rd-party-polyfill/polyfill.js
+++ b/private/3rd-party-polyfill/polyfill.js
@@ -1,0 +1,6 @@
+window.someRandomApi = () => {
+  const p = document.createElement('p');
+  p.textContent =
+    "This node was injected by the '3rd-party-polyfill' dependency.";
+  document.body.appendChild(p);
+};

--- a/tests/__snapshots__/polyfills.test.ts.snap
+++ b/tests/__snapshots__/polyfills.test.ts.snap
@@ -1,0 +1,177 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`polyfills > bundler webpack > build > should create valid app 1`] = `
+"<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>
+      polyfill
+    </title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1"
+    >
+    <link
+      data-chunk="main"
+      rel="preload"
+      as="script"
+      href="/static/polyfills/runtime.js"
+    >
+    <link
+      data-chunk="main"
+      rel="preload"
+      as="script"
+      href="/static/polyfills/2.js"
+    >
+    <link
+      data-chunk="main"
+      rel="preload"
+      as="script"
+      href="/static/polyfills/main.js"
+    >
+  </head>
+  <body>
+    <div id="app">
+      <div>
+        App with a polyfill
+      </div>
+    </div>
+    <script
+      id="__LOADABLE_REQUIRED_CHUNKS__"
+      type="application/json"
+    >
+      []
+    </script>
+    <script
+      id="__LOADABLE_REQUIRED_CHUNKS___ext"
+      type="application/json"
+    >
+      {"namedChunks":[]}
+    </script>
+    <script
+      async
+      data-chunk="main"
+      src="/static/polyfills/runtime.js"
+    >
+    </script>
+    <script
+      async
+      data-chunk="main"
+      src="/static/polyfills/2.js"
+    >
+    </script>
+    <script
+      async
+      data-chunk="main"
+      src="/static/polyfills/main.js"
+    >
+    </script>
+  </body>
+</html>"
+POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -64,5 +64,11 @@
+       src="/static/polyfills/main.js"
+     >
+     </script>
++    <p>
++      This node was injected by the 'injected' global function.
++    </p>
++    <p>
++      This node was injected by the '3rd-party-polyfill' dependency.
++    </p>
+   </body>
+ </html>
+\\ No newline at end of file
+`;
+
+exports[`polyfills > bundler webpack > start > should start a development server 1`] = `
+"<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>
+      polyfill
+    </title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1"
+    >
+    <link
+      data-chunk="main"
+      rel="preload"
+      as="script"
+      href="/runtime.js"
+    >
+    <link
+      data-chunk="main"
+      rel="preload"
+      as="script"
+      href="/2.js"
+    >
+    <link
+      data-chunk="main"
+      rel="preload"
+      as="script"
+      href="/main.js"
+    >
+  </head>
+  <body>
+    <div id="app">
+      <div>
+        App with a polyfill
+      </div>
+    </div>
+    <script
+      id="__LOADABLE_REQUIRED_CHUNKS__"
+      type="application/json"
+    >
+      []
+    </script>
+    <script
+      id="__LOADABLE_REQUIRED_CHUNKS___ext"
+      type="application/json"
+    >
+      {"namedChunks":[]}
+    </script>
+    <script
+      async
+      data-chunk="main"
+      src="/runtime.js"
+    >
+    </script>
+    <script
+      async
+      data-chunk="main"
+      src="/2.js"
+    >
+    </script>
+    <script
+      async
+      data-chunk="main"
+      src="/main.js"
+    >
+    </script>
+  </body>
+</html>"
+POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -64,5 +64,11 @@
+       src="/main.js"
+     >
+     </script>
++    <p>
++      This node was injected by the 'injected' global function.
++    </p>
++    <p>
++      This node was injected by the '3rd-party-polyfill' dependency.
++    </p>
+   </body>
+ </html>
+\\ No newline at end of file
+`;

--- a/tests/package.json
+++ b/tests/package.json
@@ -22,6 +22,7 @@
     "@sku-fixtures/library-file": "workspace:*",
     "@sku-fixtures/lint-format": "workspace:*",
     "@sku-fixtures/multiple-routes": "workspace:*",
+    "@sku-fixtures/polyfills": "workspace:*",
     "@sku-fixtures/public-path": "workspace:*",
     "@sku-fixtures/sku-test": "workspace:*",
     "@sku-fixtures/sku-webpack-plugin": "workspace:*",

--- a/tests/polyfills.test.ts
+++ b/tests/polyfills.test.ts
@@ -1,0 +1,75 @@
+import { describe, beforeAll, afterAll, it } from 'vitest';
+import { getAppSnapshot } from '@sku-private/puppeteer';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import {
+  waitForUrls,
+  runSkuScriptInDir,
+  getPort,
+  createCancelSignal,
+} from '@sku-private/test-utils';
+import skuConfig from '@sku-fixtures/polyfills/sku.config.ts';
+
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const appDir = path.dirname(
+  require.resolve('@sku-fixtures/polyfills/sku.config.ts'),
+);
+
+assert(skuConfig.port, 'sku config has port');
+
+describe('polyfills', () => {
+  const args: Record<string, string[]> = {
+    vite: ['--config', 'sku.config.vite.ts', '--experimental-bundler'],
+  };
+
+  describe.sequential.for(['webpack'])('bundler %s', async (bundler) => {
+    const port = await getPort();
+    const baseUrl = `http://localhost:${port}`;
+
+    describe('build', () => {
+      const { cancel, signal } = createCancelSignal();
+
+      beforeAll(async () => {
+        await runSkuScriptInDir('build', appDir, { args: args[bundler] });
+        runSkuScriptInDir('serve', appDir, {
+          args: ['--strict-port', `--port=${port}`],
+          signal,
+        });
+        await waitForUrls(baseUrl);
+      });
+
+      afterAll(async () => {
+        cancel();
+      });
+
+      it('should create valid app', async ({ expect }) => {
+        const app = await getAppSnapshot({ url: baseUrl, expect });
+        expect(app).toMatchSnapshot();
+      });
+    });
+
+    describe('start', () => {
+      const { cancel, signal } = createCancelSignal();
+      const devServerUrl = `http://localhost:${skuConfig.port}`;
+
+      beforeAll(async () => {
+        runSkuScriptInDir('start', appDir, {
+          signal,
+        });
+        await waitForUrls(devServerUrl);
+      });
+
+      afterAll(async () => {
+        cancel();
+      });
+
+      it('should start a development server', async ({ expect }) => {
+        const snapshot = await getAppSnapshot({ url: devServerUrl, expect });
+        expect(snapshot).toMatchSnapshot();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds a `polyfills` fixture that configures a local `polyfills.ts` and a 3rd-party dependency that both inject a global function. This global function is then called post-hydration, which is picked up by the `appSnapshot` diff.

> [!NOTE]
> Vite is not being tested yet for this fixture.