### PR TITLE
`vite`: Add `polyfills` support

### DIFF
--- a/.changeset/loose-aliens-change.md
+++ b/.changeset/loose-aliens-change.md
@@ -1,0 +1,5 @@
+---
+'sku': minor
+---
+
+`vite`: Add support for `polyfills` config

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -123,6 +123,7 @@ export default [
             '__sku_alias__serverEntry',
             '__sku_alias__clientEntry',
             '__sku_alias__webpackStats',
+            'virtual:sku/polyfills',
           ],
         },
       ],

--- a/packages/sku/src/services/vite/entries/vite-client.tsx
+++ b/packages/sku/src/services/vite/entries/vite-client.tsx
@@ -1,5 +1,4 @@
-// '__sku_alias__clientEntry' is a vite alias
-// pointing to the consuming apps client entry
+import 'virtual:sku/polyfills';
 import client from '__sku_alias__clientEntry';
 import dedent from 'dedent';
 

--- a/packages/sku/src/services/vite/helpers/config/baseConfig.ts
+++ b/packages/sku/src/services/vite/helpers/config/baseConfig.ts
@@ -6,6 +6,7 @@ import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import react from '@vitejs/plugin-react';
 
 import type { SkuContext } from '@/context/createSkuContext.js';
+import { polyfillsPlugin } from '../../plugins/polyfillsPlugin.js';
 import { preloadPlugin } from '../../plugins/preloadPlugin/preloadPlugin.js';
 import { fixViteVanillaExtractDepScanPlugin } from '@/services/vite/plugins/esbuild/fixViteVanillaExtractDepScanPlugin.js';
 
@@ -16,6 +17,7 @@ import vocabPluginVite from '@vocab/vite';
 import { dangerouslySetViteConfig } from '../../plugins/dangerouslySetViteConfig.js';
 import { setSsrNoExternal } from '@/services/vite/plugins/setSsrNoExternal.js';
 import browserslistToEsbuild from '@/services/vite/helpers/browserslist-to-esbuild.js';
+
 const require = createRequire(import.meta.url);
 
 const getBaseConfig = (skuContext: SkuContext): InlineConfig => {
@@ -59,6 +61,7 @@ const getBaseConfig = (skuContext: SkuContext): InlineConfig => {
       preloadPlugin({
         convertFromWebpack: skuContext.convertLoadable, // Convert loadable import from webpack to vite. Can be put behind a flag.
       }),
+      polyfillsPlugin(skuContext),
       setSsrNoExternal(skuContext),
     ],
     resolve: {

--- a/packages/sku/src/services/vite/plugins/polyfillsPlugin.ts
+++ b/packages/sku/src/services/vite/plugins/polyfillsPlugin.ts
@@ -1,0 +1,26 @@
+import type { Plugin } from 'vite';
+
+import type { SkuContext } from '@/context/createSkuContext.js';
+import { resolvePolyfills } from '@/utils/resolvePolyfills.js';
+
+export const polyfillsPlugin = (skuContext: SkuContext): Plugin => {
+  const virtualModuleId = 'virtual:sku/polyfills';
+  const resolvedVirtualModuleId = `\0${virtualModuleId}`;
+  const resolvedPolyfills = resolvePolyfills(skuContext.polyfills);
+
+  return {
+    name: 'vite-plugin-sku-polyfills',
+    resolveId(id) {
+      if (id === virtualModuleId) {
+        return resolvedVirtualModuleId;
+      }
+    },
+    load(id) {
+      if (id === resolvedVirtualModuleId) {
+        return resolvedPolyfills
+          .map((polyfillPath) => `import '${polyfillPath}';`)
+          .join('\n');
+      }
+    },
+  };
+};

--- a/packages/sku/src/services/webpack/config/webpack.config.ssr.ts
+++ b/packages/sku/src/services/webpack/config/webpack.config.ssr.ts
@@ -15,7 +15,7 @@ import { VocabWebpackPlugin } from '@vocab/webpack';
 
 import { bundleAnalyzerPlugin } from './plugins/bundleAnalyzer.js';
 import { JAVASCRIPT, resolvePackage } from './utils/index.js';
-import { cwd, requireFromCwd } from '@/utils/cwd.js';
+import { requireFromCwd } from '@/utils/cwd.js';
 import { getVocabConfig } from '@/services/vocab/config/vocab.js';
 import getStatsConfig from './statsConfig.js';
 import getSourceMapSetting from './sourceMaps.js';
@@ -23,6 +23,7 @@ import getCacheSettings from './cache.js';
 import modules from './resolveModules.js';
 import targets from '@/config/targets.json' with { type: 'json' };
 import type { MakeWebpackConfigOptions } from './types.js';
+import { resolvePolyfills } from '@/utils/resolvePolyfills.js';
 
 const require = createRequire(import.meta.url);
 
@@ -59,9 +60,7 @@ const makeWebpackConfig = ({
 
   const internalInclude = [join(__dirname, '../entry'), ...paths.src];
 
-  const resolvedPolyfills = polyfills.map((polyfill) =>
-    require.resolve(polyfill, { paths: [cwd()] }),
-  );
+  const resolvedPolyfills = resolvePolyfills(polyfills);
   const proto = httpsDevServer ? 'https' : 'http';
   const clientServer = `${proto}://127.0.0.1:${clientPort}/`;
 

--- a/packages/sku/src/services/webpack/config/webpack.config.ts
+++ b/packages/sku/src/services/webpack/config/webpack.config.ts
@@ -22,6 +22,7 @@ import getCacheSettings from './cache.js';
 import modules from './resolveModules.js';
 import targets from '@/config/targets.json' with { type: 'json' };
 import type { MakeWebpackConfigOptions } from './types.js';
+import { resolvePolyfills } from '@/utils/resolvePolyfills.js';
 
 const require = createRequire(import.meta.url);
 
@@ -62,10 +63,7 @@ const makeWebpackConfig = ({
 
   const vocabOptions = getVocabConfig(skuContext);
 
-  const resolvedPolyfills =
-    polyfills?.map((polyfill) =>
-      require.resolve(polyfill, { paths: [cwd()] }),
-    ) || [];
+  const resolvedPolyfills = resolvePolyfills(polyfills);
 
   const skuClientEntry = require.resolve('../entry/client/index.js');
 

--- a/packages/sku/src/types/declarations/global.d.ts
+++ b/packages/sku/src/types/declarations/global.d.ts
@@ -3,6 +3,7 @@ declare module '__sku_alias__clientEntry';
 declare module '__sku_alias__libraryEntry';
 declare module '__sku_alias__renderEntry';
 declare module '__sku_alias__webpackStats';
+declare module 'virtual:sku/polyfills';
 
 declare const __SKU_DEFAULT_SERVER_PORT__: string;
 

--- a/packages/sku/src/utils/resolvePolyfills.ts
+++ b/packages/sku/src/utils/resolvePolyfills.ts
@@ -1,0 +1,10 @@
+import { createRequire } from 'node:module';
+import { cwd } from './cwd.js';
+
+export const resolvePolyfills = (polyfills: string[]): string[] => {
+  const require = createRequire(import.meta.url);
+
+  return polyfills.map((polyfill) =>
+    require.resolve(polyfill, { paths: [cwd()] }),
+  );
+};

--- a/tests/__snapshots__/polyfills.test.ts.snap
+++ b/tests/__snapshots__/polyfills.test.ts.snap
@@ -1,5 +1,143 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`polyfills > bundler vite > build > should create valid app 1`] = `
+"<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>
+      polyfill
+    </title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1"
+    >
+    <link
+      rel="modulepreload"
+      href="/static/polyfills/vite-client-CkkFE6wW.js"
+      crossorigin
+    >
+  </head>
+  <body>
+    <div id="app">
+      <div>
+        App with a polyfill
+      </div>
+    </div>
+    <script
+      type="module"
+      src="/static/polyfills/vite-client-CkkFE6wW.js"
+    >
+    </script>
+  </body>
+</html>"
+POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -26,5 +26,11 @@
+       src="/static/polyfills/vite-client-CkkFE6wW.js"
+     >
+     </script>
++    <p>
++      This node was injected by the 'injected' global function.
++    </p>
++    <p>
++      This node was injected by the '3rd-party-polyfill' dependency.
++    </p>
+   </body>
+ </html>
+\\ No newline at end of file
+`;
+
+exports[`polyfills > bundler vite > start > should start a development server 1`] = `
+"<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>
+      polyfill
+    </title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1"
+    >
+    <link
+      data-chunk="main"
+      rel="preload"
+      as="script"
+      href="/runtime.js"
+    >
+    <link
+      data-chunk="main"
+      rel="preload"
+      as="script"
+      href="/2.js"
+    >
+    <link
+      data-chunk="main"
+      rel="preload"
+      as="script"
+      href="/main.js"
+    >
+  </head>
+  <body>
+    <div id="app">
+      <div>
+        App with a polyfill
+      </div>
+    </div>
+    <script
+      id="__LOADABLE_REQUIRED_CHUNKS__"
+      type="application/json"
+    >
+      []
+    </script>
+    <script
+      id="__LOADABLE_REQUIRED_CHUNKS___ext"
+      type="application/json"
+    >
+      {"namedChunks":[]}
+    </script>
+    <script
+      async
+      data-chunk="main"
+      src="/runtime.js"
+    >
+    </script>
+    <script
+      async
+      data-chunk="main"
+      src="/2.js"
+    >
+    </script>
+    <script
+      async
+      data-chunk="main"
+      src="/main.js"
+    >
+    </script>
+  </body>
+</html>"
+POST HYDRATE DIFFS: 
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -64,5 +64,11 @@
+       src="/main.js"
+     >
+     </script>
++    <p>
++      This node was injected by the 'injected' global function.
++    </p>
++    <p>
++      This node was injected by the '3rd-party-polyfill' dependency.
++    </p>
+   </body>
+ </html>
+\\ No newline at end of file
+`;
+
 exports[`polyfills > bundler webpack > build > should create valid app 1`] = `
 "<!DOCTYPE html>
 <html>

--- a/tests/polyfills.test.ts
+++ b/tests/polyfills.test.ts
@@ -25,51 +25,54 @@ describe('polyfills', () => {
     vite: ['--config', 'sku.config.vite.ts', '--experimental-bundler'],
   };
 
-  describe.sequential.for(['webpack'])('bundler %s', async (bundler) => {
-    const port = await getPort();
-    const baseUrl = `http://localhost:${port}`;
+  describe.sequential.for(['webpack', 'vite'])(
+    'bundler %s',
+    async (bundler) => {
+      const port = await getPort();
+      const baseUrl = `http://localhost:${port}`;
 
-    describe('build', () => {
-      const { cancel, signal } = createCancelSignal();
+      describe('build', () => {
+        const { cancel, signal } = createCancelSignal();
 
-      beforeAll(async () => {
-        await runSkuScriptInDir('build', appDir, { args: args[bundler] });
-        runSkuScriptInDir('serve', appDir, {
-          args: ['--strict-port', `--port=${port}`],
-          signal,
+        beforeAll(async () => {
+          await runSkuScriptInDir('build', appDir, { args: args[bundler] });
+          runSkuScriptInDir('serve', appDir, {
+            args: ['--strict-port', `--port=${port}`],
+            signal,
+          });
+          await waitForUrls(baseUrl);
         });
-        await waitForUrls(baseUrl);
-      });
 
-      afterAll(async () => {
-        cancel();
-      });
-
-      it('should create valid app', async ({ expect }) => {
-        const app = await getAppSnapshot({ url: baseUrl, expect });
-        expect(app).toMatchSnapshot();
-      });
-    });
-
-    describe('start', () => {
-      const { cancel, signal } = createCancelSignal();
-      const devServerUrl = `http://localhost:${skuConfig.port}`;
-
-      beforeAll(async () => {
-        runSkuScriptInDir('start', appDir, {
-          signal,
+        afterAll(async () => {
+          cancel();
         });
-        await waitForUrls(devServerUrl);
+
+        it('should create valid app', async ({ expect }) => {
+          const app = await getAppSnapshot({ url: baseUrl, expect });
+          expect(app).toMatchSnapshot();
+        });
       });
 
-      afterAll(async () => {
-        cancel();
-      });
+      describe('start', () => {
+        const { cancel, signal } = createCancelSignal();
+        const devServerUrl = `http://localhost:${skuConfig.port}`;
 
-      it('should start a development server', async ({ expect }) => {
-        const snapshot = await getAppSnapshot({ url: devServerUrl, expect });
-        expect(snapshot).toMatchSnapshot();
+        beforeAll(async () => {
+          runSkuScriptInDir('start', appDir, {
+            signal,
+          });
+          await waitForUrls(devServerUrl);
+        });
+
+        afterAll(async () => {
+          cancel();
+        });
+
+        it('should start a development server', async ({ expect }) => {
+          const snapshot = await getAppSnapshot({ url: devServerUrl, expect });
+          expect(snapshot).toMatchSnapshot();
+        });
       });
-    });
-  });
+    },
+  );
 });


### PR DESCRIPTION
Virtual modules seemed like the easiest way to inject polyfills into the client entry. Rollup does support multiple entries [just like webpack](https://github.com/seek-oss/sku/blob/a51ee0f635213e0b23777e34e5903892a5d23359/packages/sku/src/services/webpack/config/webpack.config.ts#L72), however to ensure import order is maintained you still need to actual do the side-effect imports in the client entry. See [this FAQ section](https://rollupjs.org/faqs/#how-do-i-add-polyfills-to-a-rollup-bundle) for more details.

Since we want to mimic the existing `polyfills` API, I opted instead to create a plugin that resolves the `virtual:sku/polyfills` virtual module to a module containing side-effect imports for all the resolved polyfills. This seems to work well. The result in the output bundle is that the imported modules get inlined at the top of the main bundle, before everything else.

> [!NOTE]
> `polyfills.test.ts` mainly contains indentation changes. The only actual change was adding `vite` to the list of bundlers.