### PR TITLE
`init`: Populate `packageManager` field in `package.json` if the new app is at the repo root

### DIFF
--- a/.changeset/some-parks-sneeze.md
+++ b/.changeset/some-parks-sneeze.md
@@ -1,0 +1,5 @@
+---
+'sku': minor
+---
+
+`init`: Populate `packageManager` field in `package.json` if the new app is at the repo root

--- a/packages/sku/src/program/commands/init/init.action.ts
+++ b/packages/sku/src/program/commands/init/init.action.ts
@@ -16,6 +16,8 @@ import {
   getPackageManagerInstallPage,
   getInstallCommand,
   isAtLeastPnpmV10,
+  rootDir,
+  packageManagerVersion,
 } from '@/services/packageManager/packageManager.js';
 import { write as prettierWrite } from '@/services/prettier/runPrettier.js';
 import { fix as esLintFix } from '@/services/eslint/runESLint.js';
@@ -130,6 +132,14 @@ export const initAction = async (
       format: 'sku format',
     },
   };
+
+  const isRepoRoot = rootDir === null || rootDir === root;
+  const shouldConfigurePackageManagerField =
+    isRepoRoot && packageManagerVersion;
+
+  if (shouldConfigurePackageManagerField) {
+    packageJson.packageManager = `${packageManager}@${packageManagerVersion}`;
+  }
 
   const packageJsonString = JSON.stringify(packageJson, null, 2);
 


### PR DESCRIPTION
The `packageManager` field in `package.json` will now be populated with the appropriate config based on the package manager used to execute `sku init`.

The implementation only includes `packageManager` if `sku init` wasn't run inside a monorepo.

This was tested with a snapshot, both for a new repo and in a monorepo. Our current `sku-init` test was not affected because the test is performed inside the `sku` monorepo. I believe the changes in #1317 will result in the `packageManager` field being visible in the `package.json` snapshot test in the `sku-init` suite.