### PR TITLE
`start`: Align webpack and vite `start` implementations

### DIFF
--- a/.changeset/full-squids-bake.md
+++ b/.changeset/full-squids-bake.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`start`: Align webpack and vite `start` implementations

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,8 +4,9 @@ coverage/
 dist/
 dist-ssr/
 dist-build/
-dist-start/
 storybook-static/
+custom-output-directory/
+dist-start/
 report/
 template/
 .changeset/*.md

--- a/packages/sku/src/program/commands/start/start.action.ts
+++ b/packages/sku/src/program/commands/start/start.action.ts
@@ -1,6 +1,10 @@
 import type { StatsChoices } from '@/program/options/stats/stats.option.js';
 import type { SkuContext } from '@/context/createSkuContext.js';
 import type { Command } from 'commander';
+import { configureProject, validatePeerDeps } from '@/utils/configure.js';
+import { watchVocabCompile } from '@/services/vocab/runVocab.js';
+import { checkHosts, withHostile } from '@/utils/contextUtils/hosts.js';
+import chalk from 'chalk';
 
 export const startAction = async (
   {
@@ -13,6 +17,17 @@ export const startAction = async (
   command: Command,
 ) => {
   const { environment } = command.optsWithGlobals();
+
+  console.log(chalk.blue(`sku start`));
+
+  await Promise.all([
+    await configureProject(skuContext),
+    await watchVocabCompile(skuContext),
+  ]);
+
+  withHostile(checkHosts)(skuContext);
+  validatePeerDeps(skuContext);
+
   if (skuContext.bundler === 'vite') {
     const { viteStartHandler } = await import('./vite-start-handler.js');
     viteStartHandler(skuContext);

--- a/packages/sku/src/program/commands/start/vite-start-handler.ts
+++ b/packages/sku/src/program/commands/start/vite-start-handler.ts
@@ -1,10 +1,8 @@
 import { viteService } from '@/services/vite/index.js';
 import type { SkuContext } from '@/context/createSkuContext.js';
 import { metricsMeasurers } from '@/services/telemetry/metricsMeasurers.js';
-import { watchVocabCompile } from '@/services/vocab/runVocab.js';
 
 export const viteStartHandler = async (skuContext: SkuContext) => {
-  await watchVocabCompile(skuContext);
   await viteService.start(skuContext);
 
   metricsMeasurers.skuStart.mark();

--- a/packages/sku/src/program/commands/start/webpack-start-handler.ts
+++ b/packages/sku/src/program/commands/start/webpack-start-handler.ts
@@ -10,18 +10,12 @@ import getCertificate from '@/utils/certificate.js';
 import getStatsConfig from '@/services/webpack/config/statsConfig.js';
 import createHtmlRenderPlugin from '@/services/webpack/config/plugins/createHtmlRenderPlugin.js';
 import makeWebpackConfig from '@/services/webpack/config/webpack.config.js';
-import { watchVocabCompile } from '@/services/vocab/runVocab.js';
 
-import {
-  checkHosts,
-  getAppHosts,
-  withHostile,
-} from '@/utils/contextUtils/hosts.js';
+import { getAppHosts } from '@/utils/contextUtils/hosts.js';
 import allocatePort from '@/utils/allocatePort.js';
 import getSiteForHost from '@/utils/contextUtils/getSiteForHost.js';
 import { resolveEnvironment } from '@/utils/contextUtils/resolveEnvironment.js';
 import { getMatchingRoute } from '@/utils/routeMatcher.js';
-import { configureProject, validatePeerDeps } from '@/utils/configure.js';
 import {
   getLanguageFromRoute,
   getRouteWithLanguage,
@@ -54,18 +48,10 @@ export const webpackStartHandler = async ({
     hosts,
   } = skuContext;
 
-  await configureProject(skuContext);
-  validatePeerDeps(skuContext);
-  console.log(chalk.blue(`sku start`));
-
-  await watchVocabCompile(skuContext);
-
   const environment = resolveEnvironment({
     environment: environmentOption,
     skuContext,
   });
-
-  console.log();
 
   const availablePort = await allocatePort({
     port: port.client,
@@ -90,8 +76,6 @@ export const webpackStartHandler = async ({
 
   const clientCompiler = webpack(clientWebpackConfig);
   const renderCompiler = webpack(renderWebpackConfig);
-
-  await withHostile(checkHosts)(skuContext);
 
   renderCompiler.watch({}, (err, stats) => {
     if (err) {

--- a/packages/sku/src/utils/configure.ts
+++ b/packages/sku/src/utils/configure.ts
@@ -1,6 +1,6 @@
 import { getPathFromCwd } from './cwd.js';
 import fs from 'node:fs';
-import _validatePeerDeps from './validatePeerDeps.js';
+import { validatePeerDeps as _validatePeerDeps } from './validatePeerDeps.js';
 import { log } from './debug.js';
 import type { SkuContext } from '@/context/createSkuContext.js';
 
@@ -22,7 +22,7 @@ export const configureProject = async (skuContext: SkuContext) => {
     return;
   }
 
-  const configure = (await import('../utils/configureApp.js')).default;
+  const { default: configure } = await import('../utils/configureApp.js');
   await configure(skuContext);
 };
 

--- a/packages/sku/src/utils/validatePeerDeps.ts
+++ b/packages/sku/src/utils/validatePeerDeps.ts
@@ -22,7 +22,7 @@ const asyncMap = (
 
 const singletonPackages = ['@vanilla-extract/css'];
 
-const validatePeerDeps = async ({ paths }: SkuContext) => {
+export const validatePeerDeps = async ({ paths }: SkuContext) => {
   if (isPnpm) {
     // pnpm doesn't nest dependencies in the same way as yarn or npm, so the method used below won't
     // work for detecting duplicate packages
@@ -133,5 +133,3 @@ const validatePeerDeps = async ({ paths }: SkuContext) => {
     console.error(e);
   }
 };
-
-export default validatePeerDeps;


### PR DESCRIPTION
`vite`'s start implementation was not running `configure`, not was it validating peer deps.

This PR hoists common functionality between the webpack and vite start handlers into the start action. Additionally, some slight optimizations to promise handling and logging were made.