### PR TITLE
`vitest`: Fix watch mode

### DIFF
--- a/.changeset/flat-dingos-drive.md
+++ b/.changeset/flat-dingos-drive.md
@@ -1,0 +1,6 @@
+---
+'@sku-lib/vitest': patch
+'sku': patch
+---
+
+`vitest`: Fix watch mode

--- a/.changeset/flat-dingos-drive.md
+++ b/.changeset/flat-dingos-drive.md
@@ -3,4 +3,10 @@
 'sku': patch
 ---
 
-`vitest`: Fix watch mode
+`vitest`: Honour watch mode when running `sku test`
+
+Previously it was not possible to run Vitest in watch mode via `sku test`. `sku test` should now behave similarly to [the `vitest` CLI][vitest cli], so `sku test`, `sku test watch` and `sku test -w/--watch` will all trigger watch mode.
+
+To run tests once and exit, you can execute `sku test run`, `sku test --run` or `sku test --no-watch` .
+
+[vitest cli]: https://vitest.dev/guide/cli

--- a/packages/sku/src/program/commands/test/vitest-test-handler.ts
+++ b/packages/sku/src/program/commands/test/vitest-test-handler.ts
@@ -10,15 +10,17 @@ export const vitestHandler = async ({
   skuContext: SkuContext;
   args: string[];
 }) => {
-  let vitestImport = null;
+  let skuLibVitest = null;
+
   try {
-    vitestImport = await import('@sku-lib/vitest');
+    skuLibVitest = await import('@sku-lib/vitest');
   } catch (e: any) {
     if (e.code !== 'ERR_MODULE_NOT_FOUND' || isCI) {
       console.error(e.message);
       return;
     }
-    // If @sku-lib/vitest is not installed, and we're not on CI we prompt to install.
+
+    // If @sku-lib/vitest is not installed, and we're not on CI we prompt to install
     console.log('@sku-lib/vitest is not installed');
     const res = await prompts(
       {
@@ -29,20 +31,24 @@ export const vitestHandler = async ({
       },
       { onCancel: () => process.exit(1) },
     );
+
     if (!res.install) {
       console.log('Exiting without running tests.');
       return;
     }
+
     await installDep({
       deps: ['@sku-lib/vitest'],
       type: 'dev',
       logLevel: 'regular',
     });
+
     // Retry running Vitest after installation
     await vitestHandler({ skuContext, args });
     return;
   }
-  await vitestImport.runVitest({
+
+  await skuLibVitest.runVitest({
     setupFiles: skuContext.paths.setupTests,
     args,
   });

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,4 +1,4 @@
-import { createVitest, parseCLI } from 'vitest/node';
+import { startVitest, parseCLI } from 'vitest/node';
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 
 export const runVitest = async ({
@@ -10,26 +10,18 @@ export const runVitest = async ({
 }) => {
   const results = parseCLI(['vitest', ...args]);
 
-  const vitest = await createVitest(
+  await startVitest(
     'test',
+    results.filter,
     { config: false, ...results.options },
     {
       plugins: [vanillaExtractPlugin()],
       test: {
-        watch: false,
         environment: 'jsdom',
         globals: true,
         setupFiles,
-        include: [
-          '**/__tests__/**/*.test.{js,jsx,ts,tsx}',
-          '**/?(*.)+(spec|test).{js,jsx,ts,tsx}',
-        ],
       },
     },
     {},
   );
-
-  await vitest.start(results.filter);
-
-  process.exit(0);
 };

--- a/tests/node/test-command.test.ts
+++ b/tests/node/test-command.test.ts
@@ -39,4 +39,6 @@ describe.for(testFrameworks)('[%s]: sku-test', (testRunner) => {
 
     expect(await process.findByText(expected[testRunner])).toBeInTheConsole();
   });
+
+  // TODO: Add tests that interact with watch mode
 });

--- a/tests/node/test-command.test.ts
+++ b/tests/node/test-command.test.ts
@@ -11,7 +11,8 @@ const { sku } = scopeToFixture('sku-test');
 
 describe.for(testFrameworks)('[%s]: sku-test', (testRunner) => {
   const args: TestFrameworkValues<string[]> = {
-    vitest: ['--config=sku.config.vitest.ts'],
+    // Vitest needs the `run` argument as it defaults to watch mode
+    vitest: ['--config=sku.config.vitest.ts', 'run'],
     jest: [],
   };
 


### PR DESCRIPTION
The `createVitest` API we were using is more tailored towords creating custom test-runners/micro-managing vitest for specific use cases. We don't really need that much control, so I've swapped it out for the [`startVitest`](https://vitest.dev/advanced/api/#startvitest) API. This API both creates vitest instance and starts a test run, _and_ it works with watch mode.

I've also refactored the vitest handler a little bit for clarity, and simplified the vitest config a little bit.

Finally, added a TODO about adding some tests for watch mode. I think this should be much easier thanks to #1317, but don't have the bandwidth to work on that right now.