### PR TITLE
Replace TSConfig paths with subpath imports

### DIFF
--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "bin": "./bin.js",
   "scripts": {
-    "build": "tspc --project tsconfig.build.json",
-    "prepare": "ts-patch install -s"
+    "build": "tsc --project tsconfig.build.json"
   },
   "dependencies": {
     "@ast-grep/napi": "^0.37.0",
@@ -36,8 +35,6 @@
   "devDependencies": {
     "@types/diff": "^7.0.1",
     "@types/jscodeshift": "^17.3.0",
-    "@types/prompts": "^2.4.9",
-    "ts-patch": "^3.3.0",
-    "typescript-transform-paths": "^3.5.2"
+    "@types/prompts": "^2.4.9"
   }
 }

--- a/packages/codemod/tsconfig.json
+++ b/packages/codemod/tsconfig.json
@@ -11,17 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "declaration": true,
-    "types": ["node"],
-    "paths": {
-      "@/*": ["src/*"]
-    },
-    "plugins": [
-      // Transform paths in output .js files
-      { "transform": "typescript-transform-paths" },
-
-      // Transform paths in output .d.ts files (Include this line if you output declarations files)
-      { "transform": "typescript-transform-paths", "afterDeclarations": true }
-    ]
+    "types": ["node"]
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules", "**/__testfixtures__"]

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -33,6 +33,9 @@
     "./webpack-plugin": "./dist/services/webpack/config/plugins/sku-webpack-plugin/index.js",
     "./package.json": "./package.json"
   },
+  "imports": {
+    "#src/*": "./src/*"
+  },
   "engines": {
     "node": ">=20.15"
   },
@@ -47,10 +50,9 @@
   "type": "module",
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js",
-    "build": "tspc --project tsconfig.build.json",
+    "build": "tsc --project tsconfig.build.json",
     "postbuild": "cp dist/index.d.ts dist/index.d.cts && cp src/services/vite/client.d.ts dist/services/vite/client.d.ts",
-    "lint:tsc": "tsc --noEmit",
-    "prepare": "ts-patch install -s"
+    "lint:tsc": "tsc --noEmit"
   },
   "repository": {
     "type": "git",
@@ -223,7 +225,6 @@
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
     "react-router-dom": "^6.0.0",
-    "ts-patch": "^3.3.0",
     "type-fest": "^4.41.0",
     "typescript-transform-paths": "^3.5.2",
     "vitest": "^3.2.3"

--- a/packages/sku/src/bin/sku.ts
+++ b/packages/sku/src/bin/sku.ts
@@ -1,3 +1,3 @@
-import { program } from '@/program/index.js';
+import { program } from '#src/program/index.js';
 
 program.parse();

--- a/packages/sku/src/config/babel/babelConfig.ts
+++ b/packages/sku/src/config/babel/babelConfig.ts
@@ -1,4 +1,4 @@
-import { cwd } from '@/utils/cwd.js';
+import { cwd } from '#src/utils/cwd.js';
 import { createRequire } from 'node:module';
 import type { PluginItem } from '@babel/core';
 import { rootResolutionFileExtensions } from '../fileResolutionExtensions.js';

--- a/packages/sku/src/config/jest/jest-preset.ts
+++ b/packages/sku/src/config/jest/jest-preset.ts
@@ -1,7 +1,7 @@
 import escapeRegex from 'escape-string-regexp';
 import { fileURLToPath } from 'node:url';
-import { cwd } from '@/utils/cwd.js';
-import { getSkuContext } from '@/context/createSkuContext.js';
+import { cwd } from '#src/utils/cwd.js';
+import { getSkuContext } from '#src/context/createSkuContext.js';
 import type { Config } from 'jest';
 
 const { paths, rootResolution, jestDecorator } = getSkuContext();

--- a/packages/sku/src/config/jest/jsBabelTransform.ts
+++ b/packages/sku/src/config/jest/jsBabelTransform.ts
@@ -3,7 +3,7 @@ import { createTransformer } from 'babel-jest';
 import babelConfig from '../babel/babelConfig.js';
 import targets from '../targets.json' with { type: 'json' };
 
-import { getSkuContext } from '@/context/createSkuContext.js';
+import { getSkuContext } from '#src/context/createSkuContext.js';
 
 const { rootResolution } = getSkuContext();
 

--- a/packages/sku/src/config/jest/tsBabelTransform.ts
+++ b/packages/sku/src/config/jest/tsBabelTransform.ts
@@ -2,7 +2,7 @@ import { createTransformer } from 'babel-jest';
 
 import babelConfig from '../babel/babelConfig.js';
 import targets from '../targets.json' with { type: 'json' };
-import { getSkuContext } from '@/context/createSkuContext.js';
+import { getSkuContext } from '#src/context/createSkuContext.js';
 
 const { rootResolution } = getSkuContext();
 

--- a/packages/sku/src/config/storybook/storybookWebpackConfig.js
+++ b/packages/sku/src/config/storybook/storybookWebpackConfig.js
@@ -1,7 +1,7 @@
 import { merge as webpackMerge } from 'webpack-merge';
-import makeWebpackConfig from '@/services/webpack/config/webpack.config.js';
-import { resolvePackage } from '@/services/webpack/config/utils/resolvePackage.js';
-import { getSkuContext } from '@/context/createSkuContext.js';
+import makeWebpackConfig from '#src/services/webpack/config/webpack.config.js';
+import { resolvePackage } from '#src/services/webpack/config/utils/resolvePackage.js';
+import { getSkuContext } from '#src/context/createSkuContext.js';
 
 const hot = process.env.SKU_HOT !== 'false';
 

--- a/packages/sku/src/context/configPath.ts
+++ b/packages/sku/src/context/configPath.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { existsSync } from 'node:fs';
-import { getPathFromCwd } from '@/utils/cwd.js';
+import { getPathFromCwd } from '#src/utils/cwd.js';
 import _debug from 'debug';
 
 const debug = _debug('sku:config');

--- a/packages/sku/src/context/createSkuContext.ts
+++ b/packages/sku/src/context/createSkuContext.ts
@@ -1,14 +1,14 @@
-import type { SkuConfig, SkuRoute, SkuRouteObject } from '@/types/types.d.ts';
-import { getPathFromCwd } from '@/utils/cwd.js';
+import type { SkuConfig, SkuRoute, SkuRouteObject } from '../types/types.js';
+import { getPathFromCwd } from '#src/utils/cwd.js';
 import { existsSync } from 'node:fs';
 import defaultSkuConfig from './defaultSkuConfig.js';
 import validateConfig from './validateConfig.js';
-import isCompilePackage from '@/utils/isCompilePackage.js';
+import isCompilePackage from '#src/utils/isCompilePackage.js';
 import chalk from 'chalk';
 import defaultCompilePackages from './defaultCompilePackages.js';
 import defaultClientEntry from './defaultClientEntry.js';
 import _debug from 'debug';
-import { resolveAppSkuConfigPath } from '@/context/configPath.js';
+import { resolveAppSkuConfigPath } from '#src/context/configPath.js';
 
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';

--- a/packages/sku/src/context/defaultCompilePackages.ts
+++ b/packages/sku/src/context/defaultCompilePackages.ts
@@ -4,9 +4,12 @@ import { fdir as Fdir } from 'fdir';
 import _debug from 'debug';
 import { createRequire } from 'node:module';
 
-import toPosixPath from '@/utils/toPosixPath.js';
+import toPosixPath from '#src/utils/toPosixPath.js';
 
-import { rootDir, isPnpm } from '@/services/packageManager/packageManager.js';
+import {
+  rootDir,
+  isPnpm,
+} from '#src/services/packageManager/packageManager.js';
 
 const debug = _debug('sku:compilePackages');
 

--- a/packages/sku/src/context/defaultSkuConfig.ts
+++ b/packages/sku/src/context/defaultSkuConfig.ts
@@ -1,7 +1,7 @@
 import browserslistConfigSeek from 'browserslist-config-seek';
 import { join } from 'node:path';
-import isCompilePackage from '@/utils/isCompilePackage.js';
-import type { SkuConfig } from '@/types/types.js';
+import isCompilePackage from '#src/utils/isCompilePackage.js';
+import type { SkuConfig } from '#src/types/types.js';
 
 const defaultDecorator = <T>(a: T) => a;
 

--- a/packages/sku/src/context/validateConfig.ts
+++ b/packages/sku/src/context/validateConfig.ts
@@ -5,8 +5,8 @@ import didYouMean from 'didyoumean2';
 import configSchema from './configSchema.js';
 import defaultSkuConfig from './defaultSkuConfig.js';
 import defaultClientEntry from './defaultClientEntry.js';
-import type { SkuConfig } from '@/types/types.js';
-import { hasErrorMessage } from '@/utils/error-guards.js';
+import type { SkuConfig } from '#src/types/types.js';
+import { hasErrorMessage } from '#src/utils/error-guards.js';
 import type { ValidationError } from 'fastest-validator';
 
 const availableConfigKeys = Object.keys(defaultSkuConfig);

--- a/packages/sku/src/openBrowser/index.ts
+++ b/packages/sku/src/openBrowser/index.ts
@@ -3,12 +3,12 @@
 
 import chalk from 'chalk';
 import open from 'open';
-import isCI from '@/utils/isCI.js';
+import isCI from '#src/utils/isCI.js';
 import getDefaultBrowser from 'default-browser';
 import { fileURLToPath } from 'node:url';
 import { resolve } from 'node:path';
 import debug from 'debug';
-import { execAsync } from '@/utils/execAsync.js';
+import { execAsync } from '#src/utils/execAsync.js';
 
 const log = debug('sku:openBrowser');
 

--- a/packages/sku/src/program/commands/build-ssr/build-ssr.action.ts
+++ b/packages/sku/src/program/commands/build-ssr/build-ssr.action.ts
@@ -2,19 +2,19 @@ import { performance } from 'node:perf_hooks';
 import prettyMilliseconds from 'pretty-ms';
 import webpack from 'webpack';
 import chalk from 'chalk';
-import { run } from '@/services/webpack/runWebpack.js';
+import { run } from '#src/services/webpack/runWebpack.js';
 import {
   copyPublicFiles,
   cleanTargetDirectory,
   ensureTargetDirectory,
-} from '@/utils/buildFileUtils.js';
-import makeWebpackConfig from '@/services/webpack/config/webpack.config.ssr.js';
-import provider from '@/services/telemetry/index.js';
+} from '#src/utils/buildFileUtils.js';
+import makeWebpackConfig from '#src/services/webpack/config/webpack.config.ssr.js';
+import provider from '#src/services/telemetry/index.js';
 
-import { runVocabCompile } from '@/services/vocab/runVocab.js';
-import { configureProject, validatePeerDeps } from '@/utils/configure.js';
-import type { StatsChoices } from '@/program/options/stats/stats.option.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { runVocabCompile } from '#src/services/vocab/runVocab.js';
+import { configureProject, validatePeerDeps } from '#src/utils/configure.js';
+import type { StatsChoices } from '#src/program/options/stats/stats.option.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export const buildSsrAction = async ({
   stats,

--- a/packages/sku/src/program/commands/build/build.action.ts
+++ b/packages/sku/src/program/commands/build/build.action.ts
@@ -1,5 +1,5 @@
-import type { StatsChoices } from '@/program/options/stats/stats.option.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { StatsChoices } from '#src/program/options/stats/stats.option.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export const buildAction = async ({
   stats,

--- a/packages/sku/src/program/commands/build/build.command.ts
+++ b/packages/sku/src/program/commands/build/build.command.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { statsOption } from '../../options/stats/stats.option.js';
-import { convertLoadableOption } from '@/program/options/convertLoadable/convertLoadable.option.js';
+import { convertLoadableOption } from '#src/program/options/convertLoadable/convertLoadable.option.js';
 
 export const buildCommand = new Command('build')
   .description(

--- a/packages/sku/src/program/commands/build/vite-build-handler.ts
+++ b/packages/sku/src/program/commands/build/vite-build-handler.ts
@@ -1,11 +1,11 @@
-import type { SkuContext } from '@/context/createSkuContext.js';
-import { configureProject, validatePeerDeps } from '@/utils/configure.js';
-import { runVocabCompile } from '@/services/vocab/runVocab.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
+import { configureProject, validatePeerDeps } from '#src/utils/configure.js';
+import { runVocabCompile } from '#src/services/vocab/runVocab.js';
 import { performance } from 'node:perf_hooks';
-import provider from '@/services/telemetry/index.js';
+import provider from '#src/services/telemetry/index.js';
 import chalk from 'chalk';
 import prettyMilliseconds from 'pretty-ms';
-import { viteService } from '@/services/vite/index.js';
+import { viteService } from '#src/services/vite/index.js';
 
 export const viteBuildHandler = async ({
   skuContext,

--- a/packages/sku/src/program/commands/build/webpack-build-handler.ts
+++ b/packages/sku/src/program/commands/build/webpack-build-handler.ts
@@ -8,15 +8,15 @@ import {
   cleanTargetDirectory,
   ensureTargetDirectory,
   cleanStaticRenderEntry,
-} from '@/utils/buildFileUtils.js';
-import { run } from '@/services/webpack/runWebpack.js';
-import createHtmlRenderPlugin from '@/services/webpack/config/plugins/createHtmlRenderPlugin.js';
-import makeWebpackConfig from '@/services/webpack/config/webpack.config.js';
-import provider from '@/services/telemetry/index.js';
-import { runVocabCompile } from '@/services/vocab/runVocab.js';
-import { configureProject, validatePeerDeps } from '@/utils/configure.js';
-import type { StatsChoices } from '@/program/options/stats/stats.option.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+} from '#src/utils/buildFileUtils.js';
+import { run } from '#src/services/webpack/runWebpack.js';
+import createHtmlRenderPlugin from '#src/services/webpack/config/plugins/createHtmlRenderPlugin.js';
+import makeWebpackConfig from '#src/services/webpack/config/webpack.config.js';
+import provider from '#src/services/telemetry/index.js';
+import { runVocabCompile } from '#src/services/vocab/runVocab.js';
+import { configureProject, validatePeerDeps } from '#src/utils/configure.js';
+import type { StatsChoices } from '#src/program/options/stats/stats.option.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export const webpackBuildHandler = async ({
   stats,

--- a/packages/sku/src/program/commands/configure/configure.action.ts
+++ b/packages/sku/src/program/commands/configure/configure.action.ts
@@ -1,5 +1,5 @@
-import configure from '@/utils/configureApp.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import configure from '#src/utils/configureApp.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export const configureAction = ({ skuContext }: { skuContext: SkuContext }) => {
   configure(skuContext);

--- a/packages/sku/src/program/commands/format/format.action.ts
+++ b/packages/sku/src/program/commands/format/format.action.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
-import { configureProject } from '@/utils/configure.js';
-import { fix as esLintFix } from '@/services/eslint/runESLint.js';
-import { write as prettierWrite } from '@/services/prettier/runPrettier.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { configureProject } from '#src/utils/configure.js';
+import { fix as esLintFix } from '#src/services/eslint/runESLint.js';
+import { write as prettierWrite } from '#src/services/prettier/runPrettier.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export const formatAction = async (
   paths: string[],

--- a/packages/sku/src/program/commands/init/init.action.ts
+++ b/packages/sku/src/program/commands/init/init.action.ts
@@ -8,7 +8,7 @@ import { Eta } from 'eta';
 import debug from 'debug';
 import skuPackageJson from 'sku/package.json' with { type: 'json' };
 
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 import {
   packageManager,
@@ -16,18 +16,18 @@ import {
   getPackageManagerInstallPage,
   getInstallCommand,
   isAtLeastPnpmV10,
-} from '@/services/packageManager/packageManager.js';
-import { write as prettierWrite } from '@/services/prettier/runPrettier.js';
-import { fix as esLintFix } from '@/services/eslint/runESLint.js';
-import install from '@/services/packageManager/install.js';
+} from '#src/services/packageManager/packageManager.js';
+import { write as prettierWrite } from '#src/services/prettier/runPrettier.js';
+import { fix as esLintFix } from '#src/services/eslint/runESLint.js';
+import install from '#src/services/packageManager/install.js';
 
-import configure from '@/utils/configureApp.js';
+import configure from '#src/utils/configureApp.js';
 
-import { setCwd } from '@/utils/cwd.js';
-import banner from '@/utils/banners/banner.js';
-import toPosixPath from '@/utils/toPosixPath.js';
-import { isEmptyDir } from '@/utils/isEmptyDir.js';
-import { execAsync } from '@/utils/execAsync.js';
+import { setCwd } from '#src/utils/cwd.js';
+import banner from '#src/utils/banners/banner.js';
+import toPosixPath from '#src/utils/toPosixPath.js';
+import { isEmptyDir } from '#src/utils/isEmptyDir.js';
+import { execAsync } from '#src/utils/execAsync.js';
 
 const trace = debug('sku:init');
 

--- a/packages/sku/src/program/commands/lint/lint.action.ts
+++ b/packages/sku/src/program/commands/lint/lint.action.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { check as esLintCheck } from '@/services/eslint/runESLint.js';
-import { check as prettierCheck } from '@/services/prettier/runPrettier.js';
-import runTsc from '@/services/typescript/runTsc.js';
+import { check as esLintCheck } from '#src/services/eslint/runESLint.js';
+import { check as prettierCheck } from '#src/services/prettier/runPrettier.js';
+import runTsc from '#src/services/typescript/runTsc.js';
 
-import { runVocabCompile } from '@/services/vocab/runVocab.js';
-import { configureProject } from '@/utils/configure.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { runVocabCompile } from '#src/services/vocab/runVocab.js';
+import { configureProject } from '#src/utils/configure.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export const lintAction = async (
   paths: string[],

--- a/packages/sku/src/program/commands/pre-commit/pre-commit.action.ts
+++ b/packages/sku/src/program/commands/pre-commit/pre-commit.action.ts
@@ -1,6 +1,6 @@
 import preCommit from '../../../utils/preCommit.js';
-import { configureProject } from '@/utils/configure.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { configureProject } from '#src/utils/configure.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export const preCommitAction = async ({
   skuContext,

--- a/packages/sku/src/program/commands/serve/serve.action.ts
+++ b/packages/sku/src/program/commands/serve/serve.action.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import exists from '@/utils/exists.js';
+import exists from '#src/utils/exists.js';
 import express from 'express';
 import handler from 'serve-handler';
 import chalk from 'chalk';
@@ -8,19 +8,19 @@ import {
   checkHosts,
   getAppHosts,
   withHostile,
-} from '@/utils/contextUtils/hosts.js';
-import allocatePort from '@/utils/allocatePort.js';
-import { openBrowser } from '@/openBrowser/index.js';
-import getSiteForHost from '@/utils/contextUtils/getSiteForHost.js';
-import { resolveEnvironment } from '@/utils/contextUtils/resolveEnvironment.js';
-import provider from '@/services/telemetry/index.js';
-import createServer from '@/utils/createServer.js';
+} from '#src/utils/contextUtils/hosts.js';
+import allocatePort from '#src/utils/allocatePort.js';
+import { openBrowser } from '#src/openBrowser/index.js';
+import getSiteForHost from '#src/utils/contextUtils/getSiteForHost.js';
+import { resolveEnvironment } from '#src/utils/contextUtils/resolveEnvironment.js';
+import provider from '#src/services/telemetry/index.js';
+import createServer from '#src/utils/createServer.js';
 import {
   getRouteWithLanguage,
   getValidLanguagesForRoute,
-} from '@/utils/language-utils.js';
-import { configureProject, validatePeerDeps } from '@/utils/configure.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+} from '#src/utils/language-utils.js';
+import { configureProject, validatePeerDeps } from '#src/utils/configure.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export const serveAction = async ({
   site: preferredSite,

--- a/packages/sku/src/program/commands/setup-hosts/setup-hosts.action.ts
+++ b/packages/sku/src/program/commands/setup-hosts/setup-hosts.action.ts
@@ -1,6 +1,6 @@
-import { setupHosts, withHostile } from '@/utils/contextUtils/hosts.js';
-import provider from '@/services/telemetry/index.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { setupHosts, withHostile } from '#src/utils/contextUtils/hosts.js';
+import provider from '#src/services/telemetry/index.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 const setupHostsWithHostile = withHostile(setupHosts);
 

--- a/packages/sku/src/program/commands/start-ssr/start-ssr.action.ts
+++ b/packages/sku/src/program/commands/start-ssr/start-ssr.action.ts
@@ -1,5 +1,5 @@
 import type { StatsChoices } from '../../options/stats/stats.option.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export const startSsrAction = async ({
   stats,

--- a/packages/sku/src/program/commands/start-ssr/start-ssr.command.ts
+++ b/packages/sku/src/program/commands/start-ssr/start-ssr.command.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { statsOption } from '@/program/options/stats/stats.option.js';
+import { statsOption } from '#src/program/options/stats/stats.option.js';
 
 export const startSsrCommand = new Command('start-ssr')
   .description(

--- a/packages/sku/src/program/commands/start-ssr/webpack-start-ssr-handler.ts
+++ b/packages/sku/src/program/commands/start-ssr/webpack-start-ssr-handler.ts
@@ -5,29 +5,29 @@ import onDeath from 'death';
 import chalk from 'chalk';
 import debug from 'debug';
 
-import getCertificate from '@/utils/certificate.js';
+import getCertificate from '#src/utils/certificate.js';
 
 import {
   copyPublicFiles,
   ensureTargetDirectory,
   cleanTargetDirectory,
-} from '@/utils/buildFileUtils.js';
+} from '#src/utils/buildFileUtils.js';
 import {
   checkHosts,
   getAppHosts,
   withHostile,
-} from '@/utils/contextUtils/hosts.js';
-import makeWebpackConfig from '@/services/webpack/config/webpack.config.ssr.js';
-import getStatsConfig from '@/services/webpack/config/statsConfig.js';
-import allocatePort from '@/utils/allocatePort.js';
-import { openBrowser } from '@/openBrowser/index.js';
-import createServerManager from '@/services/serverManager.js';
+} from '#src/utils/contextUtils/hosts.js';
+import makeWebpackConfig from '#src/services/webpack/config/webpack.config.ssr.js';
+import getStatsConfig from '#src/services/webpack/config/statsConfig.js';
+import allocatePort from '#src/utils/allocatePort.js';
+import { openBrowser } from '#src/openBrowser/index.js';
+import createServerManager from '#src/services/serverManager.js';
 
-import { watchVocabCompile } from '@/services/vocab/runVocab.js';
-import { configureProject, validatePeerDeps } from '@/utils/configure.js';
+import { watchVocabCompile } from '#src/services/vocab/runVocab.js';
+import { configureProject, validatePeerDeps } from '#src/utils/configure.js';
 import type { StatsChoices } from '../../options/stats/stats.option.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
-import { requireFromCwd } from '@/utils/cwd.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
+import { requireFromCwd } from '#src/utils/cwd.js';
 
 const log = debug('sku:start-ssr');
 

--- a/packages/sku/src/program/commands/start/start.action.ts
+++ b/packages/sku/src/program/commands/start/start.action.ts
@@ -1,9 +1,9 @@
-import type { StatsChoices } from '@/program/options/stats/stats.option.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { StatsChoices } from '#src/program/options/stats/stats.option.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 import type { Command } from 'commander';
-import { configureProject, validatePeerDeps } from '@/utils/configure.js';
-import { watchVocabCompile } from '@/services/vocab/runVocab.js';
-import { checkHosts, withHostile } from '@/utils/contextUtils/hosts.js';
+import { configureProject, validatePeerDeps } from '#src/utils/configure.js';
+import { watchVocabCompile } from '#src/services/vocab/runVocab.js';
+import { checkHosts, withHostile } from '#src/utils/contextUtils/hosts.js';
 import chalk from 'chalk';
 
 export const startAction = async (

--- a/packages/sku/src/program/commands/start/start.command.ts
+++ b/packages/sku/src/program/commands/start/start.command.ts
@@ -1,10 +1,10 @@
 import { Command } from 'commander';
-import { statsOption } from '@/program/options/stats/stats.option.js';
+import { statsOption } from '#src/program/options/stats/stats.option.js';
 import {
   portOption,
   strictPortOption,
 } from '../../options/port/port.option.js';
-import { convertLoadableOption } from '@/program/options/convertLoadable/convertLoadable.option.js';
+import { convertLoadableOption } from '#src/program/options/convertLoadable/convertLoadable.option.js';
 
 export const startCommand = new Command('start')
   .description(

--- a/packages/sku/src/program/commands/start/vite-start-handler.ts
+++ b/packages/sku/src/program/commands/start/vite-start-handler.ts
@@ -1,6 +1,6 @@
-import { viteService } from '@/services/vite/index.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
-import { metricsMeasurers } from '@/services/telemetry/metricsMeasurers.js';
+import { viteService } from '#src/services/vite/index.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
+import { metricsMeasurers } from '#src/services/telemetry/metricsMeasurers.js';
 
 export const viteStartHandler = async (skuContext: SkuContext) => {
   await viteService.start(skuContext);

--- a/packages/sku/src/program/commands/start/webpack-start-handler.ts
+++ b/packages/sku/src/program/commands/start/webpack-start-handler.ts
@@ -4,24 +4,24 @@ import chalk from 'chalk';
 import exceptionFormatter from 'exception-formatter';
 import type { RequestHandler } from 'express';
 
-import { openBrowser } from '@/openBrowser/index.js';
-import getCertificate from '@/utils/certificate.js';
+import { openBrowser } from '#src/openBrowser/index.js';
+import getCertificate from '#src/utils/certificate.js';
 
-import getStatsConfig from '@/services/webpack/config/statsConfig.js';
-import createHtmlRenderPlugin from '@/services/webpack/config/plugins/createHtmlRenderPlugin.js';
-import makeWebpackConfig from '@/services/webpack/config/webpack.config.js';
+import getStatsConfig from '#src/services/webpack/config/statsConfig.js';
+import createHtmlRenderPlugin from '#src/services/webpack/config/plugins/createHtmlRenderPlugin.js';
+import makeWebpackConfig from '#src/services/webpack/config/webpack.config.js';
 
-import { getAppHosts } from '@/utils/contextUtils/hosts.js';
-import allocatePort from '@/utils/allocatePort.js';
-import getSiteForHost from '@/utils/contextUtils/getSiteForHost.js';
-import { resolveEnvironment } from '@/utils/contextUtils/resolveEnvironment.js';
-import { getMatchingRoute } from '@/utils/routeMatcher.js';
+import { getAppHosts } from '#src/utils/contextUtils/hosts.js';
+import allocatePort from '#src/utils/allocatePort.js';
+import getSiteForHost from '#src/utils/contextUtils/getSiteForHost.js';
+import { resolveEnvironment } from '#src/utils/contextUtils/resolveEnvironment.js';
+import { getMatchingRoute } from '#src/utils/routeMatcher.js';
 import {
   getLanguageFromRoute,
   getRouteWithLanguage,
-} from '@/utils/language-utils.js';
-import type { StatsChoices } from '@/program/options/stats/stats.option.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+} from '#src/utils/language-utils.js';
+import type { StatsChoices } from '#src/program/options/stats/stats.option.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 const localhost = '0.0.0.0';
 

--- a/packages/sku/src/program/commands/test/jest-test-handler.ts
+++ b/packages/sku/src/program/commands/test/jest-test-handler.ts
@@ -1,7 +1,7 @@
 import debug from 'debug';
 import { run } from 'jest';
 
-import isCI from '@/utils/isCI.js';
+import isCI from '#src/utils/isCI.js';
 
 const log = debug('sku:jest');
 

--- a/packages/sku/src/program/commands/test/test.action.ts
+++ b/packages/sku/src/program/commands/test/test.action.ts
@@ -1,8 +1,8 @@
-import { runVocabCompile } from '@/services/vocab/runVocab.js';
-import { configureProject } from '@/utils/configure.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { runVocabCompile } from '#src/services/vocab/runVocab.js';
+import { configureProject } from '#src/utils/configure.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 import { runJestTests } from './jest-test-handler.js';
-import { vitestHandler } from '@/program/commands/test/vitest-test-handler.js';
+import { vitestHandler } from '#src/program/commands/test/vitest-test-handler.js';
 
 export const testAction = async (
   {

--- a/packages/sku/src/program/commands/test/vitest-test-handler.ts
+++ b/packages/sku/src/program/commands/test/vitest-test-handler.ts
@@ -1,7 +1,7 @@
 import prompts from 'prompts';
-import installDep from '@/services/packageManager/install.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
-import isCI from '@/utils/isCI.js';
+import installDep from '#src/services/packageManager/install.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
+import isCI from '#src/utils/isCI.js';
 
 export const vitestHandler = async ({
   skuContext,

--- a/packages/sku/src/program/commands/translations/commands/compile/compile.action.ts
+++ b/packages/sku/src/program/commands/translations/commands/compile/compile.action.ts
@@ -2,8 +2,8 @@ import { compile } from '@vocab/core';
 import chalk from 'chalk';
 
 import { getResolvedVocabConfig } from '../../helpers/translation-helpers.js';
-import { configureProject } from '@/utils/configure.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { configureProject } from '#src/utils/configure.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 const log = (message: string) => console.log(chalk.cyan(message));
 

--- a/packages/sku/src/program/commands/translations/commands/pull/pull.action.ts
+++ b/packages/sku/src/program/commands/translations/commands/pull/pull.action.ts
@@ -5,8 +5,8 @@ import {
   ensureBranch,
   getResolvedVocabConfig,
 } from '../../helpers/translation-helpers.js';
-import { configureProject } from '@/utils/configure.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { configureProject } from '#src/utils/configure.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 const log = (message: string) => console.log(chalk.cyan(message));
 

--- a/packages/sku/src/program/commands/translations/commands/push/push.action.ts
+++ b/packages/sku/src/program/commands/translations/commands/push/push.action.ts
@@ -5,8 +5,8 @@ import {
   ensureBranch,
   getResolvedVocabConfig,
 } from '../../helpers/translation-helpers.js';
-import { configureProject } from '@/utils/configure.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { configureProject } from '#src/utils/configure.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 const log = (message: string) => console.log(chalk.cyan(message));
 

--- a/packages/sku/src/program/commands/translations/commands/validate/validate.action.ts
+++ b/packages/sku/src/program/commands/translations/commands/validate/validate.action.ts
@@ -2,8 +2,8 @@ import { validate } from '@vocab/core';
 import chalk from 'chalk';
 
 import { getResolvedVocabConfig } from '../../helpers/translation-helpers.js';
-import { configureProject } from '@/utils/configure.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { configureProject } from '#src/utils/configure.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 const log = (message: string) => console.log(chalk.cyan(message));
 

--- a/packages/sku/src/program/commands/translations/helpers/translation-helpers.ts
+++ b/packages/sku/src/program/commands/translations/helpers/translation-helpers.ts
@@ -1,7 +1,7 @@
 import { resolveConfig } from '@vocab/core';
 
-import { getVocabConfig } from '@/services/vocab/config/vocab.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { getVocabConfig } from '#src/services/vocab/config/vocab.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 import { execSync } from 'node:child_process';
 
 export const ensureBranch = async () => {

--- a/packages/sku/src/program/hooks/preAction/experimentalBundlersHook.ts
+++ b/packages/sku/src/program/hooks/preAction/experimentalBundlersHook.ts
@@ -1,5 +1,5 @@
-import { getAddCommand } from '@/services/packageManager/packageManager.js';
-import banner from '@/utils/banners/banner.js';
+import { getAddCommand } from '#src/services/packageManager/packageManager.js';
+import banner from '#src/utils/banners/banner.js';
 
 const blockedCommands = ['build', 'start', 'start-ssr'];
 

--- a/packages/sku/src/program/hooks/preAction/preAction.hook.ts
+++ b/packages/sku/src/program/hooks/preAction/preAction.hook.ts
@@ -1,8 +1,10 @@
 import type { Command } from 'commander';
 
-import { getSkuContext } from '@/context/createSkuContext.js';
-import provider, { initializeTelemetry } from '@/services/telemetry/index.js';
-import { experimentalBundlersHook } from '@/program/hooks/preAction/experimentalBundlersHook.js';
+import { getSkuContext } from '#src/context/createSkuContext.js';
+import provider, {
+  initializeTelemetry,
+} from '#src/services/telemetry/index.js';
+import { experimentalBundlersHook } from '#src/program/hooks/preAction/experimentalBundlersHook.js';
 
 export const preActionHook = (rootCommand: Command, actionCommand: Command) => {
   const { port, strictPort } = actionCommand.opts();

--- a/packages/sku/src/program/index.ts
+++ b/packages/sku/src/program/index.ts
@@ -3,9 +3,9 @@ import { commands } from './commands/index.js';
 import { debugOption } from './options/debug/debug.option.js';
 import { configOption } from './options/config/config.option.js';
 import { environmentOption } from './options/environment/environment.option.js';
-import { initDebug } from '@/utils/debug.js';
-import { experimentalBundlerOption } from '@/program/options/expirementalBundler/experimentalBundler.option.js';
-import { preActionHook } from '@/program/hooks/preAction/preAction.hook.js';
+import { initDebug } from '#src/utils/debug.js';
+import { experimentalBundlerOption } from '#src/program/options/expirementalBundler/experimentalBundler.option.js';
+import { preActionHook } from '#src/program/hooks/preAction/preAction.hook.js';
 import packageJson from 'sku/package.json' with { type: 'json' };
 
 const { name, description, version } = packageJson;

--- a/packages/sku/src/services/eslint/config/importOrder.ts
+++ b/packages/sku/src/services/eslint/config/importOrder.ts
@@ -1,5 +1,5 @@
 import { basename } from 'node:path';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 const internalRegex = (paths: SkuContext['paths']) =>
   `^(${paths.src.map((srcPath: string) => basename(srcPath)).join('|')})/`;

--- a/packages/sku/src/services/eslint/config/index.ts
+++ b/packages/sku/src/services/eslint/config/index.ts
@@ -4,7 +4,7 @@ import type { Linter } from 'eslint';
 
 import { createImportOrderConfig } from './importOrder.js';
 import { createEslintIgnoresConfig } from './ignores.js';
-import { getSkuContext } from '@/context/createSkuContext.js';
+import { getSkuContext } from '#src/context/createSkuContext.js';
 
 export const createEslintConfig = ({
   configPath,

--- a/packages/sku/src/services/eslint/eslintMigration.ts
+++ b/packages/sku/src/services/eslint/eslintMigration.ts
@@ -1,11 +1,11 @@
 import { rm } from 'node:fs/promises';
 import { includeIgnoreFile } from '@eslint/compat';
 
-import { createEslintIgnoresConfig } from '@/services/eslint/config/ignores.js';
+import { createEslintIgnoresConfig } from '#src/services/eslint/config/ignores.js';
 
-import { getPathFromCwd } from '@/utils/cwd.js';
-import exists from '@/utils/exists.js';
-import { SkuConfigUpdater } from '@/utils/SkuConfigUpdater.js';
+import { getPathFromCwd } from '#src/utils/cwd.js';
+import exists from '#src/utils/exists.js';
+import { SkuConfigUpdater } from '#src/utils/SkuConfigUpdater.js';
 
 const oldEslintConfigPath = getPathFromCwd('.eslintrc');
 const eslintIgnorePath = getPathFromCwd('.eslintignore');

--- a/packages/sku/src/services/packageManager/getPnpmConfigDependencies.ts
+++ b/packages/sku/src/services/packageManager/getPnpmConfigDependencies.ts
@@ -1,4 +1,4 @@
-import { execAsync } from '@/utils/execAsync.js';
+import { execAsync } from '#src/utils/execAsync.js';
 
 export const getPnpmConfigDependencies = async (): Promise<string[]> => {
   // `pnpm config get configDependencies` returns `[object Object]` for some reason, so we fetch the

--- a/packages/sku/src/services/packageManager/pnpmConfig.ts
+++ b/packages/sku/src/services/packageManager/pnpmConfig.ts
@@ -1,5 +1,5 @@
-import banner from '@/utils/banners/banner.js';
-import exists from '@/utils/exists.js';
+import banner from '#src/utils/banners/banner.js';
+import exists from '#src/utils/exists.js';
 import chalk from 'chalk';
 import path from 'node:path';
 

--- a/packages/sku/src/services/prettier/runPrettier.ts
+++ b/packages/sku/src/services/prettier/runPrettier.ts
@@ -1,9 +1,9 @@
-import exists from '@/utils/exists.js';
+import exists from '#src/utils/exists.js';
 import path, { dirname } from 'node:path';
 import chalk from 'chalk';
-import { runBin } from '@/utils/runBin.js';
-import { getPathFromCwd } from '@/utils/cwd.js';
-import { suggestScript } from '@/utils/suggestScript.js';
+import { runBin } from '#src/utils/runBin.js';
+import { getPathFromCwd } from '#src/utils/cwd.js';
+import { suggestScript } from '#src/utils/suggestScript.js';
 
 import { fileURLToPath } from 'node:url';
 

--- a/packages/sku/src/services/telemetry/index.ts
+++ b/packages/sku/src/services/telemetry/index.ts
@@ -1,12 +1,12 @@
 import os from 'node:os';
 
-import { requireFromCwd } from '@/utils/cwd.js';
-import isCI from '@/utils/isCI.js';
+import { requireFromCwd } from '#src/utils/cwd.js';
+import isCI from '#src/utils/isCI.js';
 import provider from './provider.js';
 import skuPackageJson from 'sku/package.json' with { type: 'json' };
 import debug from 'debug';
 
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 const log = debug('sku:telemetry');
 

--- a/packages/sku/src/services/telemetry/provider.ts
+++ b/packages/sku/src/services/telemetry/provider.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module';
 
 import { getAddCommand } from '../packageManager/packageManager.js';
-import banner from '@/utils/banners/banner.js';
+import banner from '#src/utils/banners/banner.js';
 
 const require = createRequire(import.meta.url);
 

--- a/packages/sku/src/services/typescript/config/tsconfig.ts
+++ b/packages/sku/src/services/typescript/config/tsconfig.ts
@@ -1,5 +1,5 @@
-import { cwd } from '@/utils/cwd.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { cwd } from '#src/utils/cwd.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export default ({ rootResolution, tsconfigDecorator }: SkuContext) => {
   const config = {

--- a/packages/sku/src/services/typescript/runTsc.ts
+++ b/packages/sku/src/services/typescript/runTsc.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
-import { runBin } from '@/utils/runBin.js';
-import { cwd } from '@/utils/cwd.js';
+import { runBin } from '#src/utils/runBin.js';
+import { cwd } from '#src/utils/cwd.js';
 
 const runTsc = () => {
   console.log(chalk.cyan(`Checking code with TypeScript compiler`));

--- a/packages/sku/src/services/vite/entries/vite-render.tsx
+++ b/packages/sku/src/services/vite/entries/vite-render.tsx
@@ -1,9 +1,9 @@
 import { createCollector } from '@sku-lib/vite/collector';
 import debug from 'debug';
-import { createPreRenderedHtml } from '@/services/vite/helpers/html/createPreRenderedHtml.js';
+import { createPreRenderedHtml } from '#src/services/vite/helpers/html/createPreRenderedHtml.js';
 
 import render from '__sku_alias__renderEntry';
-import type { ViteRenderFunction } from '@/types/types.js';
+import type { ViteRenderFunction } from '#src/types/types.js';
 
 const log = debug('sku:vite-render');
 

--- a/packages/sku/src/services/vite/helpers/config/baseConfig.ts
+++ b/packages/sku/src/services/vite/helpers/config/baseConfig.ts
@@ -5,18 +5,18 @@ import { cjsInterop } from 'vite-plugin-cjs-interop';
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import react from '@vitejs/plugin-react';
 
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 import { polyfillsPlugin } from '../../plugins/polyfillsPlugin.js';
 import { preloadPlugin } from '../../plugins/preloadPlugin/preloadPlugin.js';
-import { fixViteVanillaExtractDepScanPlugin } from '@/services/vite/plugins/esbuild/fixViteVanillaExtractDepScanPlugin.js';
+import { fixViteVanillaExtractDepScanPlugin } from '#src/services/vite/plugins/esbuild/fixViteVanillaExtractDepScanPlugin.js';
 
 import { createVocabChunks } from '@vocab/vite/chunks';
 import tsconfigPaths from 'vite-tsconfig-paths';
-import { getVocabConfig } from '@/services/vocab/config/vocab.js';
+import { getVocabConfig } from '#src/services/vocab/config/vocab.js';
 import vocabPluginVite from '@vocab/vite';
 import { dangerouslySetViteConfig } from '../../plugins/dangerouslySetViteConfig.js';
-import { setSsrNoExternal } from '@/services/vite/plugins/setSsrNoExternal.js';
-import browserslistToEsbuild from '@/services/vite/helpers/browserslist-to-esbuild.js';
+import { setSsrNoExternal } from '#src/services/vite/plugins/setSsrNoExternal.js';
+import browserslistToEsbuild from '#src/services/vite/helpers/browserslist-to-esbuild.js';
 
 const require = createRequire(import.meta.url);
 

--- a/packages/sku/src/services/vite/helpers/config/createConfig.ts
+++ b/packages/sku/src/services/vite/helpers/config/createConfig.ts
@@ -1,16 +1,16 @@
-import { createSkuViteConfig } from '@/services/vite/helpers/config/baseConfig.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { createSkuViteConfig } from '#src/services/vite/helpers/config/baseConfig.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 import {
   createOutDir,
   renderEntryChunkName,
-} from '@/services/vite/helpers/bundleConfig.js';
+} from '#src/services/vite/helpers/bundleConfig.js';
 import { createRequire } from 'node:module';
-import { middlewarePlugin } from '@/services/vite/plugins/middlewarePlugin.js';
-import { startTelemetryPlugin } from '@/services/vite/plugins/startTelemetry.js';
-import { HMRTelemetryPlugin } from '@/services/vite/plugins/HMRTelemetry.js';
-import { httpsDevServerPlugin } from '@/services/vite/plugins/httpsDevServerPlugin.js';
-import { getAppHosts } from '@/utils/contextUtils/hosts.js';
-import isCI from '@/utils/isCI.js';
+import { middlewarePlugin } from '#src/services/vite/plugins/middlewarePlugin.js';
+import { startTelemetryPlugin } from '#src/services/vite/plugins/startTelemetry.js';
+import { HMRTelemetryPlugin } from '#src/services/vite/plugins/HMRTelemetry.js';
+import { httpsDevServerPlugin } from '#src/services/vite/plugins/httpsDevServerPlugin.js';
+import { getAppHosts } from '#src/utils/contextUtils/hosts.js';
+import isCI from '#src/utils/isCI.js';
 
 const require = createRequire(import.meta.url);
 

--- a/packages/sku/src/services/vite/helpers/html/createPreRenderedHtml.tsx
+++ b/packages/sku/src/services/vite/helpers/html/createPreRenderedHtml.tsx
@@ -1,10 +1,10 @@
 import { LoadableProvider } from '@sku-lib/vite/loadable';
 import type { Collector } from '@sku-lib/vite/collector';
-import { renderToStringAsync } from '@/services/webpack/entry/render/render-to-string.js';
+import { renderToStringAsync } from '#src/services/webpack/entry/render/render-to-string.js';
 import debug from 'debug';
 import type { ReactNode } from 'react';
 
-import type { Render, RenderAppProps } from '@/types/types.js';
+import type { Render, RenderAppProps } from '#src/types/types.js';
 import { serializeConfig } from '../serializeConfig.js';
 import { getChunkName } from '@vocab/vite/chunks';
 

--- a/packages/sku/src/services/vite/helpers/prerender/prerenderConcurrently.ts
+++ b/packages/sku/src/services/vite/helpers/prerender/prerenderConcurrently.ts
@@ -2,8 +2,8 @@ import path from 'node:path';
 import url from 'node:url';
 import { Worker } from 'node:worker_threads';
 import os from 'node:os';
-import { getBuildRoutes } from '@/services/webpack/config/plugins/createHtmlRenderPlugin.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { getBuildRoutes } from '#src/services/webpack/config/plugins/createHtmlRenderPlugin.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const toAbsolute = (p: string) => path.resolve(__dirname, p);

--- a/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
+++ b/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
@@ -6,11 +6,11 @@ import { workerData } from 'node:worker_threads';
 import {
   createOutDir,
   renderEntryChunkName,
-} from '@/services/vite/helpers/bundleConfig.js';
+} from '#src/services/vite/helpers/bundleConfig.js';
 import { createCollector } from '@sku-lib/vite/collector';
-import { createPreRenderedHtml } from '@/services/vite/helpers/html/createPreRenderedHtml.js';
-import createCSPHandler from '@/services/webpack/entry/csp.js';
-import { ensureTargetDirectory } from '@/utils/buildFileUtils.js';
+import { createPreRenderedHtml } from '#src/services/vite/helpers/html/createPreRenderedHtml.js';
+import createCSPHandler from '#src/services/webpack/entry/csp.js';
+import { ensureTargetDirectory } from '#src/utils/buildFileUtils.js';
 
 import type { JobWorkerData } from './prerenderConcurrently.js';
 

--- a/packages/sku/src/services/vite/helpers/serializeConfig.ts
+++ b/packages/sku/src/services/vite/helpers/serializeConfig.ts
@@ -1,5 +1,5 @@
 import serializeJavascript from 'serialize-javascript';
-import clientContextKey from '@/utils/constants/clientContextKey.js';
+import clientContextKey from '#src/utils/constants/clientContextKey.js';
 
 export const serializeConfig = (config: object) =>
   `<script id="${clientContextKey}" type="application/json">${serializeJavascript(

--- a/packages/sku/src/services/vite/index.ts
+++ b/packages/sku/src/services/vite/index.ts
@@ -1,17 +1,17 @@
 import { build, createServer } from 'vite';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 import {
   createClientBuildConfig,
   createServerBuildConfig,
   createStartConfig,
 } from './helpers/config/createConfig.js';
-import { cleanTargetDirectory } from '@/utils/buildFileUtils.js';
+import { cleanTargetDirectory } from '#src/utils/buildFileUtils.js';
 import { createOutDir } from './helpers/bundleConfig.js';
-import { getAppHosts } from '@/utils/contextUtils/hosts.js';
+import { getAppHosts } from '#src/utils/contextUtils/hosts.js';
 import chalk from 'chalk';
-import { prerenderConcurrently } from '@/services/vite/helpers/prerender/prerenderConcurrently.js';
-import allocatePort from '@/utils/allocatePort.js';
+import { prerenderConcurrently } from '#src/services/vite/helpers/prerender/prerenderConcurrently.js';
+import allocatePort from '#src/utils/allocatePort.js';
 
 export const viteService = {
   build: async (skuContext: SkuContext) => {

--- a/packages/sku/src/services/vite/plugins/HMRTelemetry.ts
+++ b/packages/sku/src/services/vite/plugins/HMRTelemetry.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from 'vite';
-import provider from '@/services/telemetry/index.js';
+import provider from '#src/services/telemetry/index.js';
 import debug from 'debug';
 import js from 'dedent';
 

--- a/packages/sku/src/services/vite/plugins/dangerouslySetViteConfig.ts
+++ b/packages/sku/src/services/vite/plugins/dangerouslySetViteConfig.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from 'vite';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export function dangerouslySetViteConfig(skuContext: SkuContext): Plugin {
   return {

--- a/packages/sku/src/services/vite/plugins/httpsDevServerPlugin.ts
+++ b/packages/sku/src/services/vite/plugins/httpsDevServerPlugin.ts
@@ -1,5 +1,5 @@
-import type { SkuContext } from '@/context/createSkuContext.js';
-import { getAppHosts } from '@/utils/contextUtils/hosts.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
+import { getAppHosts } from '#src/utils/contextUtils/hosts.js';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 import path from 'node:path';
 import type { Plugin } from 'vite';

--- a/packages/sku/src/services/vite/plugins/middlewarePlugin.ts
+++ b/packages/sku/src/services/vite/plugins/middlewarePlugin.ts
@@ -1,15 +1,15 @@
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 import type { Plugin } from 'vite';
 import { createRequire } from 'node:module';
-import type { ViteRenderFunction } from '@/types/types.js';
-import { getMatchingRoute } from '@/utils/routeMatcher.js';
+import type { ViteRenderFunction } from '#src/types/types.js';
+import { getMatchingRoute } from '#src/utils/routeMatcher.js';
 import debug from 'debug';
 import {
   getLanguageFromRoute,
   getRouteWithLanguage,
-} from '@/utils/language-utils.js';
-import { metricsMeasurers } from '@/services/telemetry/metricsMeasurers.js';
-import createCSPHandler from '@/services/webpack/entry/csp.js';
+} from '#src/utils/language-utils.js';
+import { metricsMeasurers } from '#src/services/telemetry/metricsMeasurers.js';
+import createCSPHandler from '#src/services/webpack/entry/csp.js';
 
 const log = debug('sku:middleware:vite');
 

--- a/packages/sku/src/services/vite/plugins/polyfillsPlugin.ts
+++ b/packages/sku/src/services/vite/plugins/polyfillsPlugin.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'vite';
 
-import type { SkuContext } from '@/context/createSkuContext.js';
-import { resolvePolyfills } from '@/utils/resolvePolyfills.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
+import { resolvePolyfills } from '#src/utils/resolvePolyfills.js';
 
 export const polyfillsPlugin = (skuContext: SkuContext): Plugin => {
   const virtualModuleId = 'virtual:sku/polyfills';

--- a/packages/sku/src/services/vite/plugins/preloadPlugin/helpers/convertWebpackToViteImport.ts
+++ b/packages/sku/src/services/vite/plugins/preloadPlugin/helpers/convertWebpackToViteImport.ts
@@ -1,5 +1,5 @@
 import * as t from '@babel/types';
-import { VITE_LOADABLE_IMPORT } from '@/services/vite/plugins/preloadPlugin/helpers/constants.js';
+import { VITE_LOADABLE_IMPORT } from '#src/services/vite/plugins/preloadPlugin/helpers/constants.js';
 import type { NodePath } from '@babel/traverse';
 
 export const convertWebpackToViteImport = (

--- a/packages/sku/src/services/vite/plugins/setSsrNoExternal.ts
+++ b/packages/sku/src/services/vite/plugins/setSsrNoExternal.ts
@@ -2,8 +2,8 @@ import { type Plugin, mergeConfig } from 'vite';
 import {
   extractDependencyGraph,
   getSsrExternalsForCompiledDependency,
-} from '@/services/vite/helpers/config/dependencyGraph.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+} from '#src/services/vite/helpers/config/dependencyGraph.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export function setSsrNoExternal(skuContext: SkuContext): Plugin {
   return {

--- a/packages/sku/src/services/vite/plugins/startTelemetry.ts
+++ b/packages/sku/src/services/vite/plugins/startTelemetry.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'vite';
 import js from 'dedent';
-import provider from '@/services/telemetry/index.js';
-import { metricsMeasurers } from '@/services/telemetry/metricsMeasurers.js';
+import provider from '#src/services/telemetry/index.js';
+import { metricsMeasurers } from '#src/services/telemetry/metricsMeasurers.js';
 
 const initialPageLoadEventName = 'sku:initialPageLoad' as const;
 

--- a/packages/sku/src/services/vocab/config/vocab.ts
+++ b/packages/sku/src/services/vocab/config/vocab.ts
@@ -1,6 +1,6 @@
 import debug from 'debug';
 import { generator } from '@vocab/pseudo-localize';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 const log = debug('sku:vocab:config');
 

--- a/packages/sku/src/services/vocab/runVocab.ts
+++ b/packages/sku/src/services/vocab/runVocab.ts
@@ -1,6 +1,6 @@
 import { compile } from '@vocab/core';
 import { getVocabConfig } from './config/vocab.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export const runVocabCompile = async (skuContext: SkuContext) => {
   const vocabConfig = getVocabConfig(skuContext);

--- a/packages/sku/src/services/webpack/config/cache.ts
+++ b/packages/sku/src/services/webpack/config/cache.ts
@@ -1,5 +1,5 @@
-import isCI from '@/utils/isCI.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import isCI from '#src/utils/isCI.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 const disableCacheOverride = Boolean(process.env.SKU_DISABLE_CACHE);
 

--- a/packages/sku/src/services/webpack/config/plugins/bundleAnalyzer.ts
+++ b/packages/sku/src/services/webpack/config/plugins/bundleAnalyzer.ts
@@ -1,4 +1,4 @@
-import { getPathFromCwd } from '@/utils/cwd.js';
+import { getPathFromCwd } from '#src/utils/cwd.js';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 
 export const bundleReportFolder = 'report';

--- a/packages/sku/src/services/webpack/config/plugins/createHtmlRenderPlugin.ts
+++ b/packages/sku/src/services/webpack/config/plugins/createHtmlRenderPlugin.ts
@@ -5,12 +5,12 @@ import debug from 'debug';
 import {
   getRouteWithLanguage,
   getValidLanguagesForRoute,
-} from '@/utils/language-utils.js';
+} from '#src/utils/language-utils.js';
 
 import type { Stats } from 'webpack';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 import { join } from 'node:path';
-import type { RenderableRoute } from '@/types/types.js';
+import type { RenderableRoute } from '#src/types/types.js';
 
 // @ts-expect-error
 const { default: memoize } = nanoMemoize;

--- a/packages/sku/src/services/webpack/config/plugins/metrics-plugin/index.ts
+++ b/packages/sku/src/services/webpack/config/plugins/metrics-plugin/index.ts
@@ -1,7 +1,7 @@
 import { performance } from 'node:perf_hooks';
 import prettyMilliseconds from 'pretty-ms';
 import debug from 'debug';
-import provider from '@/services/telemetry/index.js';
+import provider from '#src/services/telemetry/index.js';
 import type { Compiler, WebpackPluginInstance } from 'webpack';
 
 const log = debug('sku:metrics');

--- a/packages/sku/src/services/webpack/config/plugins/sku-webpack-plugin/index.ts
+++ b/packages/sku/src/services/webpack/config/plugins/sku-webpack-plugin/index.ts
@@ -11,12 +11,12 @@ import {
   SVG,
   resolvePackage,
 } from '../../utils/index.js';
-import defaultCompilePackages from '@/context/defaultCompilePackages.js';
+import defaultCompilePackages from '#src/context/defaultCompilePackages.js';
 import validateOptions, {
   type SkuWebpackPluginOptions,
 } from './validateOptions.js';
-import targets from '@/config/targets.json' with { type: 'json' };
-import { rootResolutionFileExtensions } from '@/config/fileResolutionExtensions.js';
+import targets from '#src/config/targets.json' with { type: 'json' };
+import { rootResolutionFileExtensions } from '#src/config/fileResolutionExtensions.js';
 
 class SkuWebpackPlugin implements WebpackPluginInstance {
   options: SkuWebpackPluginOptions;

--- a/packages/sku/src/services/webpack/config/plugins/sku-webpack-plugin/validateOptions.ts
+++ b/packages/sku/src/services/webpack/config/plugins/sku-webpack-plugin/validateOptions.ts
@@ -2,7 +2,7 @@ import Validator from 'fastest-validator';
 import browserslist from 'browserslist';
 import chalk from 'chalk';
 import didYouMean from 'didyoumean2';
-import { hasErrorMessage } from '@/utils/error-guards.js';
+import { hasErrorMessage } from '#src/utils/error-guards.js';
 
 // @ts-expect-error
 const validator = new Validator();

--- a/packages/sku/src/services/webpack/config/statsConfig.ts
+++ b/packages/sku/src/services/webpack/config/statsConfig.ts
@@ -1,4 +1,4 @@
-import isCI from '@/utils/isCI.js';
+import isCI from '#src/utils/isCI.js';
 
 const getStatsConfig = ({
   stats,

--- a/packages/sku/src/services/webpack/config/types.ts
+++ b/packages/sku/src/services/webpack/config/types.ts
@@ -1,4 +1,4 @@
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export interface MakeWebpackConfigOptions {
   isIntegration?: boolean;

--- a/packages/sku/src/services/webpack/config/utils/index.ts
+++ b/packages/sku/src/services/webpack/config/utils/index.ts
@@ -1,4 +1,4 @@
-import { extensions } from '@/config/fileResolutionExtensions.js';
+import { extensions } from '#src/config/fileResolutionExtensions.js';
 
 export * from './loaders.js';
 export { resolvePackage } from './resolvePackage.js';

--- a/packages/sku/src/services/webpack/config/utils/loaders.ts
+++ b/packages/sku/src/services/webpack/config/utils/loaders.ts
@@ -1,4 +1,4 @@
-import babelConfig from '@/config/babel/babelConfig.js';
+import babelConfig from '#src/config/babel/babelConfig.js';
 import autoprefixer from 'autoprefixer';
 import cssnano from 'cssnano';
 import { createRequire } from 'node:module';

--- a/packages/sku/src/services/webpack/config/utils/resolvePackage.test.ts
+++ b/packages/sku/src/services/webpack/config/utils/resolvePackage.test.ts
@@ -1,7 +1,7 @@
 import { describe, beforeEach, test, vi } from 'vitest';
 import { createPackageResolver } from './resolvePackage.js';
 
-import { cwd } from '@/utils/cwd.js';
+import { cwd } from '#src/utils/cwd.js';
 
 describe.sequential('webpack utils', () => {
   describe('resolvePackage()', () => {

--- a/packages/sku/src/services/webpack/config/utils/resolvePackage.ts
+++ b/packages/sku/src/services/webpack/config/utils/resolvePackage.ts
@@ -4,8 +4,8 @@ import nanoMemoize from 'nano-memoize';
 import debug from 'debug';
 import { createRequire } from 'node:module';
 
-import { cwd } from '@/utils/cwd.js';
-import { hasErrorCode } from '@/utils/error-guards.js';
+import { cwd } from '#src/utils/cwd.js';
+import { hasErrorCode } from '#src/utils/error-guards.js';
 
 // @ts-expect-error
 const memoize = nanoMemoize?.default || nanoMemoize;

--- a/packages/sku/src/services/webpack/config/webpack.config.ssr.ts
+++ b/packages/sku/src/services/webpack/config/webpack.config.ssr.ts
@@ -15,15 +15,15 @@ import { VocabWebpackPlugin } from '@vocab/webpack';
 
 import { bundleAnalyzerPlugin } from './plugins/bundleAnalyzer.js';
 import { JAVASCRIPT, resolvePackage } from './utils/index.js';
-import { requireFromCwd } from '@/utils/cwd.js';
-import { getVocabConfig } from '@/services/vocab/config/vocab.js';
+import { requireFromCwd } from '#src/utils/cwd.js';
+import { getVocabConfig } from '#src/services/vocab/config/vocab.js';
 import getStatsConfig from './statsConfig.js';
 import getSourceMapSetting from './sourceMaps.js';
 import getCacheSettings from './cache.js';
 import modules from './resolveModules.js';
-import targets from '@/config/targets.json' with { type: 'json' };
+import targets from '#src/config/targets.json' with { type: 'json' };
 import type { MakeWebpackConfigOptions } from './types.js';
-import { resolvePolyfills } from '@/utils/resolvePolyfills.js';
+import { resolvePolyfills } from '#src/utils/resolvePolyfills.js';
 
 const require = createRequire(import.meta.url);
 

--- a/packages/sku/src/services/webpack/config/webpack.config.ts
+++ b/packages/sku/src/services/webpack/config/webpack.config.ts
@@ -13,16 +13,16 @@ import MetricsPlugin from './plugins/metrics-plugin/index.js';
 import { VocabWebpackPlugin } from '@vocab/webpack';
 
 import { JAVASCRIPT, resolvePackage } from './utils/index.js';
-import { cwd } from '@/utils/cwd.js';
+import { cwd } from '#src/utils/cwd.js';
 
-import { getVocabConfig } from '@/services/vocab/config/vocab.js';
+import { getVocabConfig } from '#src/services/vocab/config/vocab.js';
 import getStatsConfig from './statsConfig.js';
 import getSourceMapSetting from './sourceMaps.js';
 import getCacheSettings from './cache.js';
 import modules from './resolveModules.js';
-import targets from '@/config/targets.json' with { type: 'json' };
+import targets from '#src/config/targets.json' with { type: 'json' };
 import type { MakeWebpackConfigOptions } from './types.js';
-import { resolvePolyfills } from '@/utils/resolvePolyfills.js';
+import { resolvePolyfills } from '#src/utils/resolvePolyfills.js';
 
 const require = createRequire(import.meta.url);
 

--- a/packages/sku/src/services/webpack/entry/csp.ts
+++ b/packages/sku/src/services/webpack/entry/csp.ts
@@ -1,7 +1,7 @@
 import { createHash, type BinaryLike } from 'node:crypto';
 import { parse, valid, type HTMLElement } from 'node-html-parser';
 import { URL } from 'node:url';
-import type { RenderCallbackParams } from '@/types/types.js';
+import type { RenderCallbackParams } from '#src/types/types.js';
 
 const scriptTypeIgnoreList = ['application/json', 'application/ld+json'];
 

--- a/packages/sku/src/services/webpack/entry/makeExtractor.tsx
+++ b/packages/sku/src/services/webpack/entry/makeExtractor.tsx
@@ -1,6 +1,6 @@
 import { ChunkExtractor, ChunkExtractorManager } from '@loadable/server';
-import type { RenderCallbackParams } from '@/types/types.js';
-import defaultEntryPoint from '@/context/defaultClientEntry.js';
+import type { RenderCallbackParams } from '#src/types/types.js';
+import defaultEntryPoint from '#src/context/defaultClientEntry.js';
 import type { CSPHandler } from './csp.js';
 
 const getNewTags = ({ before, after }: { before: string; after: string }) => {

--- a/packages/sku/src/services/webpack/entry/render/index.ts
+++ b/packages/sku/src/services/webpack/entry/render/index.ts
@@ -2,9 +2,9 @@ import debug from 'debug';
 import { getChunkName } from '@vocab/webpack/chunk-name';
 import serializeJavascript from 'serialize-javascript';
 import makeExtractor from '../makeExtractor.js';
-import clientContextKey from '@/utils/constants/clientContextKey.js';
+import clientContextKey from '#src/utils/constants/clientContextKey.js';
 import createCSPHandler from '../csp.js';
-import type { RenderAppProps } from '@/types/types.js';
+import type { RenderAppProps } from '#src/types/types.js';
 
 import { renderToStringAsync } from './render-to-string.js';
 

--- a/packages/sku/src/services/webpack/entry/server/server.ts
+++ b/packages/sku/src/services/webpack/entry/server/server.ts
@@ -6,7 +6,7 @@ import createCSPHandler from '../csp.js';
 import serverExports from '__sku_alias__serverEntry';
 import webpackStats from '__sku_alias__webpackStats';
 import { createRequire } from 'node:module';
-import type { RenderCallbackParams } from '@/types/types.js';
+import type { RenderCallbackParams } from '#src/types/types.js';
 
 const publicPath = __SKU_PUBLIC_PATH__;
 const csp = __SKU_CSP__;

--- a/packages/sku/src/utils/buildFileUtils.ts
+++ b/packages/sku/src/utils/buildFileUtils.ts
@@ -4,7 +4,7 @@ import { fdir as Fdir } from 'fdir';
 
 import exists from './exists.js';
 import copyDirContents from './copyDirContents.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export const cleanTargetDirectory = async (
   target: string,

--- a/packages/sku/src/utils/certificate.ts
+++ b/packages/sku/src/utils/certificate.ts
@@ -5,10 +5,10 @@ import type { PathLike } from 'node:fs';
 import { generate } from 'selfsigned';
 import chalk from 'chalk';
 
-import provider from '@/services/telemetry/index.js';
-import { getPathFromCwd } from '@/utils/cwd.js';
-import exists from '@/utils/exists.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import provider from '#src/services/telemetry/index.js';
+import { getPathFromCwd } from '#src/utils/cwd.js';
+import exists from '#src/utils/exists.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 const certificateTtl = 1000 * 60 * 60 * 24;
 

--- a/packages/sku/src/utils/configure.ts
+++ b/packages/sku/src/utils/configure.ts
@@ -2,7 +2,7 @@ import { getPathFromCwd } from './cwd.js';
 import fs from 'node:fs';
 import { validatePeerDeps as _validatePeerDeps } from './validatePeerDeps.js';
 import { log } from './debug.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 let skipConfigure = false;
 let skipValidatePeerDeps = false;

--- a/packages/sku/src/utils/configureApp.ts
+++ b/packages/sku/src/utils/configureApp.ts
@@ -6,28 +6,28 @@ import chalk from 'chalk';
 
 import ensureGitignore from 'ensure-gitignore';
 
-import prettierConfig from '@/services/prettier/config/prettierConfig.js';
-import createTSConfig from '@/services/typescript/config/tsconfig.js';
-import { bundleReportFolder } from '@/services/webpack/config/plugins/bundleAnalyzer.js';
+import prettierConfig from '#src/services/prettier/config/prettierConfig.js';
+import createTSConfig from '#src/services/typescript/config/tsconfig.js';
+import { bundleReportFolder } from '#src/services/webpack/config/plugins/bundleAnalyzer.js';
 import {
   shouldMigrateOldEslintConfig,
   migrateEslintignore,
   cleanUpOldEslintFiles,
   addEslintIgnoreToSkuConfig,
-} from '@/services/eslint/eslintMigration.js';
+} from '#src/services/eslint/eslintMigration.js';
 
 import getCertificate from './certificate.js';
-import { getPathFromCwd, writeFileToCWD } from '@/utils/cwd.js';
+import { getPathFromCwd, writeFileToCWD } from '#src/utils/cwd.js';
 
-import { hasErrorMessage } from '@/utils/error-guards.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { hasErrorMessage } from '#src/utils/error-guards.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 import {
   isAtLeastPnpmV10,
   isAtLeastRecommendedPnpmVersion,
   rootDir,
-} from '@/services/packageManager/packageManager.js';
-import { validatePnpmConfig } from '@/services/packageManager/pnpmConfig.js';
-import { getPnpmConfigDependencies } from '@/services/packageManager/getPnpmConfigDependencies.js';
+} from '#src/services/packageManager/packageManager.js';
+import { validatePnpmConfig } from '#src/services/packageManager/pnpmConfig.js';
+import { getPnpmConfigDependencies } from '#src/services/packageManager/getPnpmConfigDependencies.js';
 
 const coverageFolder = 'coverage';
 

--- a/packages/sku/src/utils/contextUtils/getSiteForHost.ts
+++ b/packages/sku/src/utils/contextUtils/getSiteForHost.ts
@@ -1,4 +1,4 @@
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 const getSiteForHost = (
   hostname: string,

--- a/packages/sku/src/utils/contextUtils/hosts.test.ts
+++ b/packages/sku/src/utils/contextUtils/hosts.test.ts
@@ -1,5 +1,5 @@
 import { describe, beforeEach, afterEach, it, vi } from 'vitest';
-import { createSkuContext } from '@/context/createSkuContext.js';
+import { createSkuContext } from '#src/context/createSkuContext.js';
 import { checkHosts, setupHosts } from './hosts.js';
 
 describe('setupHosts', () => {

--- a/packages/sku/src/utils/contextUtils/hosts.ts
+++ b/packages/sku/src/utils/contextUtils/hosts.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 
 import { suggestScript } from '../suggestScript.js';
 import { hasErrorCode } from '../error-guards.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 import { promisify } from 'node:util';
 import { set, get } from 'hostile';
 

--- a/packages/sku/src/utils/contextUtils/resolveEnvironment.ts
+++ b/packages/sku/src/utils/contextUtils/resolveEnvironment.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 export const resolveEnvironment = ({
   environment: environmentOption,

--- a/packages/sku/src/utils/createServer.ts
+++ b/packages/sku/src/utils/createServer.ts
@@ -5,7 +5,7 @@ import {
 import { createServer as createHttpsServer } from 'node:https';
 
 import getCertificate from './certificate.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 const createServer = async ({
   requestListener,

--- a/packages/sku/src/utils/language-utils.ts
+++ b/packages/sku/src/utils/language-utils.ts
@@ -1,11 +1,11 @@
 import debug from 'debug';
 
 import routeMatcher from './routeMatcher.js';
-import type { SkuLanguage } from '@/types/types.js';
+import type { SkuLanguage } from '#src/types/types.js';
 import type {
   SkuContext,
   NormalizedRoute,
-} from '@/context/createSkuContext.js';
+} from '#src/context/createSkuContext.js';
 
 const log = debug('sku:language-middleware');
 

--- a/packages/sku/src/utils/lintStagedConfig.ts
+++ b/packages/sku/src/utils/lintStagedConfig.ts
@@ -1,8 +1,8 @@
 import {
   isYarn,
   getCommand,
-} from '@/services/packageManager/packageManager.js';
-import { lintExtensions } from '@/services/eslint/lint.js';
+} from '#src/services/packageManager/packageManager.js';
+import { lintExtensions } from '#src/services/eslint/lint.js';
 import type { Configuration } from 'lint-staged';
 
 const config: Configuration = {

--- a/packages/sku/src/utils/preCommit.ts
+++ b/packages/sku/src/utils/preCommit.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import config from '@/utils/lintStagedConfig.js';
+import config from '#src/utils/lintStagedConfig.js';
 
 const preCommit = async () => {
   let success = false;

--- a/packages/sku/src/utils/routeMatcher.ts
+++ b/packages/sku/src/utils/routeMatcher.ts
@@ -1,7 +1,7 @@
-import type { NormalizedRoute } from '@/context/createSkuContext.js';
+import type { NormalizedRoute } from '#src/context/createSkuContext.js';
 import { match } from 'path-to-regexp';
 import getSiteForHost from './contextUtils/getSiteForHost.js';
-import type { SkuSiteObject } from '@/types/types.js';
+import type { SkuSiteObject } from '#src/types/types.js';
 
 /**
  * Finds the appropriate route for a given URL

--- a/packages/sku/src/utils/suggestScript.ts
+++ b/packages/sku/src/utils/suggestScript.ts
@@ -1,10 +1,10 @@
 import {
   getRunCommand,
   getExecuteCommand,
-} from '@/services/packageManager/packageManager.js';
+} from '#src/services/packageManager/packageManager.js';
 
 import chalk from 'chalk';
-import { requireFromCwd } from '@/utils/cwd.js';
+import { requireFromCwd } from '#src/utils/cwd.js';
 
 const findPackageScriptName = (scriptContents: string): string | undefined => {
   let pkg;

--- a/packages/sku/src/utils/validatePeerDeps.ts
+++ b/packages/sku/src/utils/validatePeerDeps.ts
@@ -1,7 +1,7 @@
 import {
   getWhyCommand,
   isPnpm,
-} from '@/services/packageManager/packageManager.js';
+} from '#src/services/packageManager/packageManager.js';
 
 import { readFile } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
@@ -9,11 +9,11 @@ import { fdir as Fdir } from 'fdir';
 import semver from 'semver';
 import chalk from 'chalk';
 
-import banner from '@/utils/banners/banner.js';
-import provider from '@/services/telemetry/index.js';
+import banner from '#src/utils/banners/banner.js';
+import provider from '#src/services/telemetry/index.js';
 
-import { getPathFromCwd } from '@/utils/cwd.js';
-import type { SkuContext } from '@/context/createSkuContext.js';
+import { getPathFromCwd } from '#src/utils/cwd.js';
+import type { SkuContext } from '#src/context/createSkuContext.js';
 
 const asyncMap = (
   list: unknown[],

--- a/packages/sku/tsconfig.json
+++ b/packages/sku/tsconfig.json
@@ -14,17 +14,7 @@
     "esModuleInterop": true,
     "declaration": true,
     "types": ["webpack/module", "jest", "node"],
-    "lib": ["ESNext", "DOM"],
-    "paths": {
-      "@/*": ["src/*"]
-    },
-    "plugins": [
-      // Transform paths in output .js files
-      { "transform": "typescript-transform-paths" },
-
-      // Transform paths in output .d.ts files (Include this line if you output declarations files)
-      { "transform": "typescript-transform-paths", "afterDeclarations": true }
-    ]
+    "lib": ["ESNext", "DOM"]
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules", "**/@loadable"]

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -43,8 +43,7 @@
     "@types/debug": "^4.1.12",
     "@types/react": "^18.2.3",
     "vite": "^6.1.0",
-    "react": "^18.2.0",
-    "typescript-transform-paths": "^3.5.2"
+    "react": "^18.2.0"
   },
   "peerDependencies": {
     "@types/react": "^18.0.0",

--- a/packages/vite/tsconfig.json
+++ b/packages/vite/tsconfig.json
@@ -14,17 +14,7 @@
     "esModuleInterop": true,
     "declaration": true,
     "types": ["node"],
-    "lib": ["ESNext", "DOM"],
-    "paths": {
-      "@/*": ["src/*"]
-    },
-    "plugins": [
-      // Transform paths in output .js files
-      { "transform": "typescript-transform-paths" },
-
-      // Transform paths in output .d.ts files (Include this line if you output declarations files)
-      { "transform": "typescript-transform-paths", "afterDeclarations": true }
-    ]
+    "lib": ["ESNext", "DOM"]
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules"]

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -33,9 +33,6 @@
     "url": "https://github.com/seek-oss/sku/issues"
   },
   "homepage": "https://github.com/seek-oss/sku#readme",
-  "devDependencies": {
-    "typescript-transform-paths": "^3.5.2"
-  },
   "dependencies": {
     "@vanilla-extract/vite-plugin": "^5.0.2",
     "vitest": "^3.2.3"

--- a/packages/vitest/tsconfig.json
+++ b/packages/vitest/tsconfig.json
@@ -17,14 +17,7 @@
     "lib": ["ESNext", "DOM"],
     "paths": {
       "@/*": ["src/*"]
-    },
-    "plugins": [
-      // Transform paths in output .js files
-      { "transform": "typescript-transform-paths" },
-
-      // Transform paths in output .d.ts files (Include this line if you output declarations files)
-      { "transform": "typescript-transform-paths", "afterDeclarations": true }
-    ]
+    }
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules", "**/@loadable"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -748,12 +748,6 @@ importers:
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
-      ts-patch:
-        specifier: ^3.3.0
-        version: 3.3.0
-      typescript-transform-paths:
-        specifier: ^3.5.2
-        version: 3.5.5(typescript@5.8.3)
 
   packages/pnpm-plugin: {}
 
@@ -1180,9 +1174,6 @@ importers:
       react-router-dom:
         specifier: ^6.0.0
         version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      ts-patch:
-        specifier: ^3.3.0
-        version: 3.3.0
       type-fest:
         specifier: ^4.41.0
         version: 4.41.0
@@ -1208,9 +1199,6 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.3.1
-      typescript-transform-paths:
-        specifier: ^3.5.2
-        version: 3.5.5(typescript@5.8.3)
       vite:
         specifier: ^6.1.0
         version: 6.3.5(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
@@ -1223,10 +1211,6 @@ importers:
       vitest:
         specifier: ^3.2.3
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
-    devDependencies:
-      typescript-transform-paths:
-        specifier: ^3.5.2
-        version: 3.5.5(typescript@5.8.3)
 
   private/3rd-party-polyfill: {}
 
@@ -5592,10 +5576,6 @@ packages:
     resolution: {integrity: sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==}
     engines: {node: '>=0.10.0'}
 
-  global-prefix@4.0.0:
-    resolution: {integrity: sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==}
-    engines: {node: '>=16'}
-
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -5880,10 +5860,6 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
-
-  ini@4.1.3:
-    resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   inquirer@9.3.7:
     resolution: {integrity: sha512-LJKFHCSeIRq9hanN14IlOtPSTe3lNES7TYDTE2xxdAy1LS5rYphajK1qtwvj3YmQXvvk0U2Vbmcni8P9EIQW9w==}
@@ -6189,10 +6165,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  isexe@3.1.1:
-    resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
-    engines: {node: '>=16'}
 
   isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
@@ -8490,10 +8462,6 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
 
-  ts-patch@3.3.0:
-    resolution: {integrity: sha512-zAOzDnd5qsfEnjd9IGy1IRuvA7ygyyxxdxesbhMdutt8AHFjD8Vw8hU2rMF89HX1BKRWFYqKHrO8Q6lw0NeUZg==}
-    hasBin: true
-
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
@@ -9000,11 +8968,6 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
-    hasBin: true
-
-  which@4.0.0:
-    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
-    engines: {node: ^16.13.0 || >=18.0.0}
     hasBin: true
 
   why-is-node-running@2.3.0:
@@ -14258,12 +14221,6 @@ snapshots:
       is-windows: 1.0.2
       which: 1.3.1
 
-  global-prefix@4.0.0:
-    dependencies:
-      ini: 4.1.3
-      kind-of: 6.0.3
-      which: 4.0.0
-
   globals@14.0.0: {}
 
   globals@15.15.0: {}
@@ -14590,8 +14547,6 @@ snapshots:
 
   ini@1.3.8: {}
 
-  ini@4.1.3: {}
-
   inquirer@9.3.7:
     dependencies:
       '@inquirer/figures': 1.0.12
@@ -14863,8 +14818,6 @@ snapshots:
   isbinaryfile@5.0.4: {}
 
   isexe@2.0.0: {}
-
-  isexe@3.1.1: {}
 
   isobject@3.0.1: {}
 
@@ -17499,15 +17452,6 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-patch@3.3.0:
-    dependencies:
-      chalk: 4.1.2
-      global-prefix: 4.0.0
-      minimist: 1.2.8
-      resolve: 1.22.10
-      semver: 7.7.2
-      strip-ansi: 6.0.1
-
   tsconfck@3.1.6(typescript@5.8.3):
     optionalDependencies:
       typescript: 5.8.3
@@ -18238,10 +18182,6 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
-
-  which@4.0.0:
-    dependencies:
-      isexe: 3.1.1
 
   why-is-node-running@2.3.0:
     dependencies:


### PR DESCRIPTION
Soz dan.

Building packages containing tsconfig paths imports with `tsc` requires `ts-patch`, whereas [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) are native to Node and supported by TypeScript with `moduleResolution: node16/nodenext`.

I'm honestly still not sold on the need for these TBH. They _can_ shorten import paths if you need to traverse upwards a lot, but they can also lengthen them in some cases. It also results in two different ways of importing the same thing, instead of one. But removing them is more hassle than renaming them, so I'm happy to just move of using `ts-patch` for now.