### PR TITLE
`vite`: Disable publicDir support

### DIFF
--- a/packages/sku/src/services/vite/helpers/config/baseConfig.ts
+++ b/packages/sku/src/services/vite/helpers/config/baseConfig.ts
@@ -43,6 +43,7 @@ const getBaseConfig = (skuContext: SkuContext): InlineConfig => {
 
   return {
     base: skuContext.publicPath,
+    publicDir: false,
     root: process.cwd(),
     clearScreen: process.env.NODE_ENV !== 'test',
     plugins: [


### PR DESCRIPTION
`publicDir` is Vites equivalent to `public`. While we assess whether this config property is valuable in our current state and going forward, we've decided to disable support for this when using Vite bundler. 