### PR TITLE
`vite start`: Inline Vanilla Extract CSS to fix FOUC

### DIFF
--- a/.changeset/wide-insects-retire.md
+++ b/.changeset/wide-insects-retire.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`vite start`: Inline Vanilla Extract CSS to fix FOUC

--- a/packages/sku/src/services/vite/helpers/config/baseConfig.ts
+++ b/packages/sku/src/services/vite/helpers/config/baseConfig.ts
@@ -65,7 +65,9 @@ const getBaseConfig = (skuContext: SkuContext): InlineConfig => {
           ],
         },
       }),
-      vanillaExtractPlugin(),
+      vanillaExtractPlugin({
+        unstable_mode: 'inlineCssInDev',
+      }),
       preloadPlugin({
         convertFromWebpack: skuContext.convertLoadable, // Convert loadable import from webpack to vite. Can be put behind a flag.
       }),

--- a/tests/browser/__snapshots__/braid-design-system.test.ts.snap
+++ b/tests/browser/__snapshots__/braid-design-system.test.ts.snap
@@ -3365,6 +3365,4512 @@ exports[`braid-design-system > bundler vite > start > should return development 
 <!DOCTYPE html>
 <html>
   <head>
+    <style
+      type="text/css"
+      data-vanilla-extract-inline-dev-css
+    >
+      .reset_base__1j8ojzz0 {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+  -webkit-tap-highlight-color: transparent;
+}
+.reset_block__1j8ojzz1 {
+  display: block;
+}
+.reset_body__1j8ojzz2 {
+  line-height: 1;
+}
+.reset_list__1j8ojzz3 {
+  list-style: none;
+}
+.reset_quote__1j8ojzz4 {
+  quotes: none;
+}
+.reset_quote__1j8ojzz4:before, .reset_quote__1j8ojzz4:after {
+  content: '';
+}
+.reset_table__1j8ojzz5 {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+.reset_appearance__1j8ojzz6 {
+  appearance: none;
+}
+.reset_transparent__1j8ojzz7 {
+  background-color: transparent;
+}
+.reset_focusVisible__1j8ojzz8 {
+  outline: var(--focusRingSize__xorl4v10) solid transparent;
+  transition: outline-color .125s ease;
+}
+.reset_focusVisible__1j8ojzz8:focus-visible {
+  outline-color: var(--borderColor-focus__xorl4vm);
+}
+.reset_mark__1j8ojzza {
+  color: inherit;
+}
+.reset_select__1j8ojzzb:disabled {
+  opacity: 1;
+}
+.reset_select__1j8ojzzb::-ms-expand {
+  display: none;
+}
+.reset_input__1j8ojzzd[type="number"] {
+  -moz-appearance: textfield;
+}
+.reset_input__1j8ojzzd[type="number"]::-webkit-inner-spin-button,.reset_input__1j8ojzzd[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.reset_input__1j8ojzzd::-ms-clear {
+  display: none;
+}
+.reset_input__1j8ojzzd::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+}
+.reset_a__1j8ojzzg {
+  text-decoration: none;
+  color: inherit;
+}
+.sprinkles_overflow_hidden__iv7so50 {
+  overflow: hidden;
+}
+.sprinkles_overflow_scroll__iv7so51 {
+  overflow: scroll;
+}
+.sprinkles_overflow_visible__iv7so52 {
+  overflow: visible;
+}
+.sprinkles_overflow_auto__iv7so53 {
+  overflow: auto;
+}
+.sprinkles_userSelect_none__iv7so54 {
+  user-select: none;
+}
+.sprinkles_outline_none__iv7so55 {
+  outline: none;
+}
+.sprinkles_outline_focus__iv7so56 {
+  outline: var(--focusRingSize__xorl4v10) solid transparent;
+  transition: outline-color .125s ease;
+}
+.sprinkles_outline_focus__iv7so56:focus-visible {
+  outline-color: var(--borderColor-focus__xorl4vm);
+}
+.sprinkles_opacity_0__iv7so57 {
+  opacity: 0;
+}
+.sprinkles_zIndex_0__iv7so58 {
+  z-index: 0;
+}
+.sprinkles_zIndex_1__iv7so59 {
+  z-index: 1;
+}
+.sprinkles_zIndex_2__iv7so5a {
+  z-index: 2;
+}
+.sprinkles_zIndex_dropdownBackdrop__iv7so5b {
+  z-index: 90;
+}
+.sprinkles_zIndex_dropdown__iv7so5c {
+  z-index: 100;
+}
+.sprinkles_zIndex_sticky__iv7so5d {
+  z-index: 200;
+}
+.sprinkles_zIndex_modalBackdrop__iv7so5e {
+  z-index: 290;
+}
+.sprinkles_zIndex_modal__iv7so5f {
+  z-index: 300;
+}
+.sprinkles_zIndex_notification__iv7so5g {
+  z-index: 400;
+}
+.sprinkles_cursor_default__iv7so5h {
+  cursor: default;
+}
+.sprinkles_cursor_pointer__iv7so5i {
+  cursor: pointer;
+}
+.sprinkles_pointerEvents_none__iv7so5j {
+  pointer-events: none;
+}
+.sprinkles_top_0__iv7so5k {
+  top: 0;
+}
+.sprinkles_bottom_0__iv7so5l {
+  bottom: 0;
+}
+.sprinkles_left_0__iv7so5m {
+  left: 0;
+}
+.sprinkles_right_0__iv7so5n {
+  right: 0;
+}
+.sprinkles_height_full__iv7so5o {
+  height: 100%;
+}
+.sprinkles_height_touchable__iv7so5p {
+  height: var(--touchableSize__xorl4v9);
+}
+.sprinkles_width_full__iv7so5q {
+  width: 100%;
+}
+.sprinkles_width_touchable__iv7so5r {
+  width: var(--touchableSize__xorl4v9);
+}
+.sprinkles_minWidth_0__iv7so5s {
+  min-width: 0%;
+}
+.sprinkles_maxWidth_xsmall__iv7so5t {
+  max-width: var(--contentWidth-xsmall__xorl4v11);
+}
+.sprinkles_maxWidth_small__iv7so5u {
+  max-width: var(--contentWidth-small__xorl4v12);
+}
+.sprinkles_maxWidth_medium__iv7so5v {
+  max-width: var(--contentWidth-medium__xorl4v13);
+}
+.sprinkles_maxWidth_large__iv7so5w {
+  max-width: var(--contentWidth-large__xorl4v14);
+}
+.sprinkles_maxWidth_content__iv7so5x {
+  max-width: fit-content;
+}
+.sprinkles_transition_fast__iv7so5y {
+  transition: var(--transition-fast__xorl4v5i);
+}
+.sprinkles_transition_touchable__iv7so5z {
+  transition: var(--transition-touchable__xorl4v5j);
+}
+.sprinkles_transform_touchable_active__iv7so510:active {
+  transform: var(--transform-touchable__xorl4v5k);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_body_lightMode__iv7so512 {
+  background: var(--backgroundColor-body__xorl4v1t);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_body_darkMode__iv7so513 {
+  background: var(--backgroundColor-body__xorl4v1t);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_bodyDark_lightMode__iv7so514 {
+  background: var(--backgroundColor-bodyDark__xorl4v1u);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_bodyDark_darkMode__iv7so515 {
+  background: var(--backgroundColor-bodyDark__xorl4v1u);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_brand_lightMode__iv7so516 {
+  background: var(--backgroundColor-brand__xorl4v1v);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_brand_darkMode__iv7so517 {
+  background: var(--backgroundColor-brand__xorl4v1v);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_brandAccent_lightMode__iv7so518 {
+  background: var(--backgroundColor-brandAccent__xorl4v1w);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_brandAccent_darkMode__iv7so519 {
+  background: var(--backgroundColor-brandAccent__xorl4v1w);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_brandAccentActive_lightMode__iv7so51a {
+  background: var(--backgroundColor-brandAccentActive__xorl4v1x);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_brandAccentActive_darkMode__iv7so51b {
+  background: var(--backgroundColor-brandAccentActive__xorl4v1x);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_brandAccentHover_lightMode__iv7so51c {
+  background: var(--backgroundColor-brandAccentHover__xorl4v1y);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_brandAccentHover_darkMode__iv7so51d {
+  background: var(--backgroundColor-brandAccentHover__xorl4v1y);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_brandAccentSoft_lightMode__iv7so51e {
+  background: var(--backgroundColor-brandAccentSoft__xorl4v1z);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_brandAccentSoft_darkMode__iv7so51f {
+  background: var(--backgroundColor-brandAccentSoft__xorl4v1z);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_brandAccentSoftActive_lightMode__iv7so51g {
+  background: var(--backgroundColor-brandAccentSoftActive__xorl4v20);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_brandAccentSoftActive_darkMode__iv7so51h {
+  background: var(--backgroundColor-brandAccentSoftActive__xorl4v20);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_brandAccentSoftHover_lightMode__iv7so51i {
+  background: var(--backgroundColor-brandAccentSoftHover__xorl4v21);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_brandAccentSoftHover_darkMode__iv7so51j {
+  background: var(--backgroundColor-brandAccentSoftHover__xorl4v21);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_caution_lightMode__iv7so51k {
+  background: var(--backgroundColor-caution__xorl4v22);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_caution_darkMode__iv7so51l {
+  background: var(--backgroundColor-caution__xorl4v22);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_cautionLight_lightMode__iv7so51m {
+  background: var(--backgroundColor-cautionLight__xorl4v23);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_cautionLight_darkMode__iv7so51n {
+  background: var(--backgroundColor-cautionLight__xorl4v23);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_critical_lightMode__iv7so51o {
+  background: var(--backgroundColor-critical__xorl4v24);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_critical_darkMode__iv7so51p {
+  background: var(--backgroundColor-critical__xorl4v24);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_criticalActive_lightMode__iv7so51q {
+  background: var(--backgroundColor-criticalActive__xorl4v25);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_criticalActive_darkMode__iv7so51r {
+  background: var(--backgroundColor-criticalActive__xorl4v25);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_criticalHover_lightMode__iv7so51s {
+  background: var(--backgroundColor-criticalHover__xorl4v26);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_criticalHover_darkMode__iv7so51t {
+  background: var(--backgroundColor-criticalHover__xorl4v26);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_criticalLight_lightMode__iv7so51u {
+  background: var(--backgroundColor-criticalLight__xorl4v27);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_criticalLight_darkMode__iv7so51v {
+  background: var(--backgroundColor-criticalLight__xorl4v27);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_criticalSoft_lightMode__iv7so51w {
+  background: var(--backgroundColor-criticalSoft__xorl4v28);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_criticalSoft_darkMode__iv7so51x {
+  background: var(--backgroundColor-criticalSoft__xorl4v28);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_criticalSoftActive_lightMode__iv7so51y {
+  background: var(--backgroundColor-criticalSoftActive__xorl4v29);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_criticalSoftActive_darkMode__iv7so51z {
+  background: var(--backgroundColor-criticalSoftActive__xorl4v29);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_criticalSoftHover_lightMode__iv7so520 {
+  background: var(--backgroundColor-criticalSoftHover__xorl4v2a);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_criticalSoftHover_darkMode__iv7so521 {
+  background: var(--backgroundColor-criticalSoftHover__xorl4v2a);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_formAccent_lightMode__iv7so522 {
+  background: var(--backgroundColor-formAccent__xorl4v2b);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_formAccent_darkMode__iv7so523 {
+  background: var(--backgroundColor-formAccent__xorl4v2b);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_formAccentActive_lightMode__iv7so524 {
+  background: var(--backgroundColor-formAccentActive__xorl4v2c);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_formAccentActive_darkMode__iv7so525 {
+  background: var(--backgroundColor-formAccentActive__xorl4v2c);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_formAccentHover_lightMode__iv7so526 {
+  background: var(--backgroundColor-formAccentHover__xorl4v2d);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_formAccentHover_darkMode__iv7so527 {
+  background: var(--backgroundColor-formAccentHover__xorl4v2d);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_formAccentSoft_lightMode__iv7so528 {
+  background: var(--backgroundColor-formAccentSoft__xorl4v2e);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_formAccentSoft_darkMode__iv7so529 {
+  background: var(--backgroundColor-formAccentSoft__xorl4v2e);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_formAccentSoftActive_lightMode__iv7so52a {
+  background: var(--backgroundColor-formAccentSoftActive__xorl4v2f);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_formAccentSoftActive_darkMode__iv7so52b {
+  background: var(--backgroundColor-formAccentSoftActive__xorl4v2f);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_formAccentSoftHover_lightMode__iv7so52c {
+  background: var(--backgroundColor-formAccentSoftHover__xorl4v2g);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_formAccentSoftHover_darkMode__iv7so52d {
+  background: var(--backgroundColor-formAccentSoftHover__xorl4v2g);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_info_lightMode__iv7so52e {
+  background: var(--backgroundColor-info__xorl4v2h);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_info_darkMode__iv7so52f {
+  background: var(--backgroundColor-info__xorl4v2h);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_infoLight_lightMode__iv7so52g {
+  background: var(--backgroundColor-infoLight__xorl4v2i);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_infoLight_darkMode__iv7so52h {
+  background: var(--backgroundColor-infoLight__xorl4v2i);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_neutral_lightMode__iv7so52i {
+  background: var(--backgroundColor-neutral__xorl4v2j);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_neutral_darkMode__iv7so52j {
+  background: var(--backgroundColor-neutral__xorl4v2j);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_neutralActive_lightMode__iv7so52k {
+  background: var(--backgroundColor-neutralActive__xorl4v2k);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_neutralActive_darkMode__iv7so52l {
+  background: var(--backgroundColor-neutralActive__xorl4v2k);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_neutralHover_lightMode__iv7so52m {
+  background: var(--backgroundColor-neutralHover__xorl4v2l);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_neutralHover_darkMode__iv7so52n {
+  background: var(--backgroundColor-neutralHover__xorl4v2l);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_neutralLight_lightMode__iv7so52o {
+  background: var(--backgroundColor-neutralLight__xorl4v2m);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_neutralLight_darkMode__iv7so52p {
+  background: var(--backgroundColor-neutralLight__xorl4v2m);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_neutralSoft_lightMode__iv7so52q {
+  background: var(--backgroundColor-neutralSoft__xorl4v2n);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_neutralSoft_darkMode__iv7so52r {
+  background: var(--backgroundColor-neutralSoft__xorl4v2n);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_neutralSoftActive_lightMode__iv7so52s {
+  background: var(--backgroundColor-neutralSoftActive__xorl4v2o);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_neutralSoftActive_darkMode__iv7so52t {
+  background: var(--backgroundColor-neutralSoftActive__xorl4v2o);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_neutralSoftHover_lightMode__iv7so52u {
+  background: var(--backgroundColor-neutralSoftHover__xorl4v2p);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_neutralSoftHover_darkMode__iv7so52v {
+  background: var(--backgroundColor-neutralSoftHover__xorl4v2p);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_positive_lightMode__iv7so52w {
+  background: var(--backgroundColor-positive__xorl4v2q);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_positive_darkMode__iv7so52x {
+  background: var(--backgroundColor-positive__xorl4v2q);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_positiveLight_lightMode__iv7so52y {
+  background: var(--backgroundColor-positiveLight__xorl4v2r);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_positiveLight_darkMode__iv7so52z {
+  background: var(--backgroundColor-positiveLight__xorl4v2r);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_promote_lightMode__iv7so530 {
+  background: var(--backgroundColor-promote__xorl4v2s);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_promote_darkMode__iv7so531 {
+  background: var(--backgroundColor-promote__xorl4v2s);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_promoteLight_lightMode__iv7so532 {
+  background: var(--backgroundColor-promoteLight__xorl4v2t);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_promoteLight_darkMode__iv7so533 {
+  background: var(--backgroundColor-promoteLight__xorl4v2t);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_surface_lightMode__iv7so534 {
+  background: var(--backgroundColor-surface__xorl4v2u);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_surface_darkMode__iv7so535 {
+  background: var(--backgroundColor-surface__xorl4v2u);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_surfaceDark_lightMode__iv7so536 {
+  background: var(--backgroundColor-surfaceDark__xorl4v2v);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_surfaceDark_darkMode__iv7so537 {
+  background: var(--backgroundColor-surfaceDark__xorl4v2v);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_small_lightMode__iv7so538 {
+  box-shadow: var(--shadow-small__xorl4v5l);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_small_darkMode__iv7so539 {
+  box-shadow: var(--shadow-small__xorl4v5l);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_medium_lightMode__iv7so53a {
+  box-shadow: var(--shadow-medium__xorl4v5m);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_medium_darkMode__iv7so53b {
+  box-shadow: var(--shadow-medium__xorl4v5m);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_large_lightMode__iv7so53c {
+  box-shadow: var(--shadow-large__xorl4v5n);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_large_darkMode__iv7so53d {
+  box-shadow: var(--shadow-large__xorl4v5n);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderBrandAccent_lightMode__iv7so53e {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-brandAccent__xorl4vf);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderBrandAccent_darkMode__iv7so53f {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-brandAccent__xorl4vf);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderBrandAccentLight_lightMode__iv7so53g {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-brandAccentLight__xorl4vg);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderBrandAccentLight_darkMode__iv7so53h {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-brandAccentLight__xorl4vg);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderBrandAccentLarge_lightMode__iv7so53i {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-brandAccent__xorl4vf);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderBrandAccentLarge_darkMode__iv7so53j {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-brandAccent__xorl4vf);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderBrandAccentLightLarge_lightMode__iv7so53k {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-brandAccentLight__xorl4vg);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderBrandAccentLightLarge_darkMode__iv7so53l {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-brandAccentLight__xorl4vg);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderCaution_lightMode__iv7so53m {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-caution__xorl4vh);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderCaution_darkMode__iv7so53n {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-caution__xorl4vh);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderCautionLight_lightMode__iv7so53o {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-cautionLight__xorl4vi);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderCautionLight_darkMode__iv7so53p {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-cautionLight__xorl4vi);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderCritical_lightMode__iv7so53q {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-critical__xorl4vj);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderCritical_darkMode__iv7so53r {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-critical__xorl4vj);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderCriticalLarge_lightMode__iv7so53s {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-critical__xorl4vj);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderCriticalLarge_darkMode__iv7so53t {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-critical__xorl4vj);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderCriticalLight_lightMode__iv7so53u {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-criticalLight__xorl4vk);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderCriticalLight_darkMode__iv7so53v {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-criticalLight__xorl4vk);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderCriticalLightLarge_lightMode__iv7so53w {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-criticalLight__xorl4vk);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderCriticalLightLarge_darkMode__iv7so53x {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-criticalLight__xorl4vk);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderField_lightMode__iv7so53y {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-field__xorl4vl);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderField_darkMode__iv7so53z {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-field__xorl4vl);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderFormAccent_lightMode__iv7so540 {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-formAccent__xorl4vn);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderFormAccent_darkMode__iv7so541 {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-formAccent__xorl4vn);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderFormAccentLarge_lightMode__iv7so542 {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-formAccent__xorl4vn);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderFormAccentLarge_darkMode__iv7so543 {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-formAccent__xorl4vn);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderFormAccentLight_lightMode__iv7so544 {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-formAccentLight__xorl4vo);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderFormAccentLight_darkMode__iv7so545 {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-formAccentLight__xorl4vo);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderFormAccentLightLarge_lightMode__iv7so546 {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-formAccentLight__xorl4vo);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderFormAccentLightLarge_darkMode__iv7so547 {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-formAccentLight__xorl4vo);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderInfo_lightMode__iv7so548 {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-info__xorl4vp);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderInfo_darkMode__iv7so549 {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-info__xorl4vp);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderInfoLight_lightMode__iv7so54a {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-infoLight__xorl4vq);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderInfoLight_darkMode__iv7so54b {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-infoLight__xorl4vq);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderNeutral_lightMode__iv7so54c {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-neutral__xorl4vr);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderNeutral_darkMode__iv7so54d {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-neutral__xorl4vr);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderNeutralLarge_lightMode__iv7so54e {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-neutral__xorl4vr);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderNeutralLarge_darkMode__iv7so54f {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-neutral__xorl4vr);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderNeutralInverted_lightMode__iv7so54g {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-neutralInverted__xorl4vs);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderNeutralInverted_darkMode__iv7so54h {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-neutralInverted__xorl4vs);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderNeutralInvertedLarge_lightMode__iv7so54i {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-neutralInverted__xorl4vs);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderNeutralInvertedLarge_darkMode__iv7so54j {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-neutralInverted__xorl4vs);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderNeutralLight_lightMode__iv7so54k {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-neutralLight__xorl4vt);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderNeutralLight_darkMode__iv7so54l {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-neutralLight__xorl4vt);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderPositive_lightMode__iv7so54m {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-positive__xorl4vu);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderPositive_darkMode__iv7so54n {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-positive__xorl4vu);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderPositiveLight_lightMode__iv7so54o {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-positiveLight__xorl4vv);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderPositiveLight_darkMode__iv7so54p {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-positiveLight__xorl4vv);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderPromote_lightMode__iv7so54q {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-promote__xorl4vw);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderPromote_darkMode__iv7so54r {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-promote__xorl4vw);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderPromoteLight_lightMode__iv7so54s {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-promoteLight__xorl4vx);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderPromoteLight_darkMode__iv7so54t {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-promoteLight__xorl4vx);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_outlineFocus_lightMode__iv7so54u {
+  box-shadow: 0 0 0 var(--focusRingSize__xorl4v10) var(--borderColor-focus__xorl4vm);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_outlineFocus_darkMode__iv7so54v {
+  box-shadow: 0 0 0 var(--focusRingSize__xorl4v10) var(--borderColor-focus__xorl4vm);
+}
+.sprinkles_display_none_mobile__iv7so54w {
+  display: none;
+}
+.sprinkles_display_block_mobile__iv7so550 {
+  display: block;
+}
+.sprinkles_display_inline_mobile__iv7so554 {
+  display: inline;
+}
+.sprinkles_display_inlineBlock_mobile__iv7so558 {
+  display: inline-block;
+}
+.sprinkles_display_flex_mobile__iv7so55c {
+  display: flex;
+}
+.sprinkles_position_relative_mobile__iv7so55g {
+  position: relative;
+}
+.sprinkles_position_absolute_mobile__iv7so55k {
+  position: absolute;
+}
+.sprinkles_position_fixed_mobile__iv7so55o {
+  position: fixed;
+}
+.sprinkles_position_sticky_mobile__iv7so55s {
+  position: sticky;
+}
+.sprinkles_borderRadius_none_mobile__iv7so55w {
+  border-radius: 0px;
+}
+.sprinkles_borderRadius_full_mobile__iv7so560 {
+  border-radius: 9999px;
+}
+.sprinkles_borderRadius_small_mobile__iv7so564 {
+  border-radius: var(--borderRadius-small__xorl4vb);
+}
+.sprinkles_borderRadius_standard_mobile__iv7so568 {
+  border-radius: var(--borderRadius-standard__xorl4vc);
+}
+.sprinkles_borderRadius_large_mobile__iv7so56c {
+  border-radius: var(--borderRadius-large__xorl4vd);
+}
+.sprinkles_borderRadius_xlarge_mobile__iv7so56g {
+  border-radius: var(--borderRadius-xlarge__xorl4ve);
+}
+.sprinkles_gap_gutter_mobile__iv7so56k {
+  gap: var(--space-gutter__xorl4v0);
+}
+.sprinkles_gap_xxsmall_mobile__iv7so56o {
+  gap: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_gap_xsmall_mobile__iv7so56s {
+  gap: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_gap_small_mobile__iv7so56w {
+  gap: var(--space-small__xorl4v3);
+}
+.sprinkles_gap_medium_mobile__iv7so570 {
+  gap: var(--space-medium__xorl4v4);
+}
+.sprinkles_gap_large_mobile__iv7so574 {
+  gap: var(--space-large__xorl4v5);
+}
+.sprinkles_gap_xlarge_mobile__iv7so578 {
+  gap: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_gap_xxlarge_mobile__iv7so57c {
+  gap: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_gap_xxxlarge_mobile__iv7so57g {
+  gap: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_gap_none_mobile__iv7so57k {
+  gap: 0;
+}
+.sprinkles_paddingTop_gutter_mobile__iv7so57o {
+  padding-top: var(--space-gutter__xorl4v0);
+}
+.sprinkles_paddingTop_xxsmall_mobile__iv7so57s {
+  padding-top: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_paddingTop_xsmall_mobile__iv7so57w {
+  padding-top: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_paddingTop_small_mobile__iv7so580 {
+  padding-top: var(--space-small__xorl4v3);
+}
+.sprinkles_paddingTop_medium_mobile__iv7so584 {
+  padding-top: var(--space-medium__xorl4v4);
+}
+.sprinkles_paddingTop_large_mobile__iv7so588 {
+  padding-top: var(--space-large__xorl4v5);
+}
+.sprinkles_paddingTop_xlarge_mobile__iv7so58c {
+  padding-top: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_paddingTop_xxlarge_mobile__iv7so58g {
+  padding-top: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_paddingTop_xxxlarge_mobile__iv7so58k {
+  padding-top: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_paddingTop_none_mobile__iv7so58o {
+  padding-top: 0;
+}
+.sprinkles_paddingBottom_gutter_mobile__iv7so58s {
+  padding-bottom: var(--space-gutter__xorl4v0);
+}
+.sprinkles_paddingBottom_xxsmall_mobile__iv7so58w {
+  padding-bottom: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_paddingBottom_xsmall_mobile__iv7so590 {
+  padding-bottom: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_paddingBottom_small_mobile__iv7so594 {
+  padding-bottom: var(--space-small__xorl4v3);
+}
+.sprinkles_paddingBottom_medium_mobile__iv7so598 {
+  padding-bottom: var(--space-medium__xorl4v4);
+}
+.sprinkles_paddingBottom_large_mobile__iv7so59c {
+  padding-bottom: var(--space-large__xorl4v5);
+}
+.sprinkles_paddingBottom_xlarge_mobile__iv7so59g {
+  padding-bottom: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_paddingBottom_xxlarge_mobile__iv7so59k {
+  padding-bottom: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_paddingBottom_xxxlarge_mobile__iv7so59o {
+  padding-bottom: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_paddingBottom_none_mobile__iv7so59s {
+  padding-bottom: 0;
+}
+.sprinkles_paddingRight_gutter_mobile__iv7so59w {
+  padding-right: var(--space-gutter__xorl4v0);
+}
+.sprinkles_paddingRight_xxsmall_mobile__iv7so5a0 {
+  padding-right: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_paddingRight_xsmall_mobile__iv7so5a4 {
+  padding-right: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_paddingRight_small_mobile__iv7so5a8 {
+  padding-right: var(--space-small__xorl4v3);
+}
+.sprinkles_paddingRight_medium_mobile__iv7so5ac {
+  padding-right: var(--space-medium__xorl4v4);
+}
+.sprinkles_paddingRight_large_mobile__iv7so5ag {
+  padding-right: var(--space-large__xorl4v5);
+}
+.sprinkles_paddingRight_xlarge_mobile__iv7so5ak {
+  padding-right: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_paddingRight_xxlarge_mobile__iv7so5ao {
+  padding-right: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_paddingRight_xxxlarge_mobile__iv7so5as {
+  padding-right: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_paddingRight_none_mobile__iv7so5aw {
+  padding-right: 0;
+}
+.sprinkles_paddingLeft_gutter_mobile__iv7so5b0 {
+  padding-left: var(--space-gutter__xorl4v0);
+}
+.sprinkles_paddingLeft_xxsmall_mobile__iv7so5b4 {
+  padding-left: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_paddingLeft_xsmall_mobile__iv7so5b8 {
+  padding-left: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_paddingLeft_small_mobile__iv7so5bc {
+  padding-left: var(--space-small__xorl4v3);
+}
+.sprinkles_paddingLeft_medium_mobile__iv7so5bg {
+  padding-left: var(--space-medium__xorl4v4);
+}
+.sprinkles_paddingLeft_large_mobile__iv7so5bk {
+  padding-left: var(--space-large__xorl4v5);
+}
+.sprinkles_paddingLeft_xlarge_mobile__iv7so5bo {
+  padding-left: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_paddingLeft_xxlarge_mobile__iv7so5bs {
+  padding-left: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_paddingLeft_xxxlarge_mobile__iv7so5bw {
+  padding-left: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_paddingLeft_none_mobile__iv7so5c0 {
+  padding-left: 0;
+}
+.sprinkles_marginTop_gutter_mobile__iv7so5c4 {
+  margin-top: var(--space-gutter__xorl4v0);
+}
+.sprinkles_marginTop_xxsmall_mobile__iv7so5c8 {
+  margin-top: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_marginTop_xsmall_mobile__iv7so5cc {
+  margin-top: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_marginTop_small_mobile__iv7so5cg {
+  margin-top: var(--space-small__xorl4v3);
+}
+.sprinkles_marginTop_medium_mobile__iv7so5ck {
+  margin-top: var(--space-medium__xorl4v4);
+}
+.sprinkles_marginTop_large_mobile__iv7so5co {
+  margin-top: var(--space-large__xorl4v5);
+}
+.sprinkles_marginTop_xlarge_mobile__iv7so5cs {
+  margin-top: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_marginTop_xxlarge_mobile__iv7so5cw {
+  margin-top: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_marginTop_xxxlarge_mobile__iv7so5d0 {
+  margin-top: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_marginTop_none_mobile__iv7so5d4 {
+  margin-top: 0;
+}
+.sprinkles_marginBottom_gutter_mobile__iv7so5d8 {
+  margin-bottom: var(--space-gutter__xorl4v0);
+}
+.sprinkles_marginBottom_xxsmall_mobile__iv7so5dc {
+  margin-bottom: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_marginBottom_xsmall_mobile__iv7so5dg {
+  margin-bottom: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_marginBottom_small_mobile__iv7so5dk {
+  margin-bottom: var(--space-small__xorl4v3);
+}
+.sprinkles_marginBottom_medium_mobile__iv7so5do {
+  margin-bottom: var(--space-medium__xorl4v4);
+}
+.sprinkles_marginBottom_large_mobile__iv7so5ds {
+  margin-bottom: var(--space-large__xorl4v5);
+}
+.sprinkles_marginBottom_xlarge_mobile__iv7so5dw {
+  margin-bottom: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_marginBottom_xxlarge_mobile__iv7so5e0 {
+  margin-bottom: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_marginBottom_xxxlarge_mobile__iv7so5e4 {
+  margin-bottom: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_marginBottom_none_mobile__iv7so5e8 {
+  margin-bottom: 0;
+}
+.sprinkles_marginRight_gutter_mobile__iv7so5ec {
+  margin-right: var(--space-gutter__xorl4v0);
+}
+.sprinkles_marginRight_xxsmall_mobile__iv7so5eg {
+  margin-right: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_marginRight_xsmall_mobile__iv7so5ek {
+  margin-right: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_marginRight_small_mobile__iv7so5eo {
+  margin-right: var(--space-small__xorl4v3);
+}
+.sprinkles_marginRight_medium_mobile__iv7so5es {
+  margin-right: var(--space-medium__xorl4v4);
+}
+.sprinkles_marginRight_large_mobile__iv7so5ew {
+  margin-right: var(--space-large__xorl4v5);
+}
+.sprinkles_marginRight_xlarge_mobile__iv7so5f0 {
+  margin-right: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_marginRight_xxlarge_mobile__iv7so5f4 {
+  margin-right: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_marginRight_xxxlarge_mobile__iv7so5f8 {
+  margin-right: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_marginRight_none_mobile__iv7so5fc {
+  margin-right: 0;
+}
+.sprinkles_marginLeft_gutter_mobile__iv7so5fg {
+  margin-left: var(--space-gutter__xorl4v0);
+}
+.sprinkles_marginLeft_xxsmall_mobile__iv7so5fk {
+  margin-left: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_marginLeft_xsmall_mobile__iv7so5fo {
+  margin-left: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_marginLeft_small_mobile__iv7so5fs {
+  margin-left: var(--space-small__xorl4v3);
+}
+.sprinkles_marginLeft_medium_mobile__iv7so5fw {
+  margin-left: var(--space-medium__xorl4v4);
+}
+.sprinkles_marginLeft_large_mobile__iv7so5g0 {
+  margin-left: var(--space-large__xorl4v5);
+}
+.sprinkles_marginLeft_xlarge_mobile__iv7so5g4 {
+  margin-left: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_marginLeft_xxlarge_mobile__iv7so5g8 {
+  margin-left: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_marginLeft_xxxlarge_mobile__iv7so5gc {
+  margin-left: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_marginLeft_none_mobile__iv7so5gg {
+  margin-left: 0;
+}
+.sprinkles_alignItems_flexStart_mobile__iv7so5gk {
+  align-items: flex-start;
+}
+.sprinkles_alignItems_center_mobile__iv7so5go {
+  align-items: center;
+}
+.sprinkles_alignItems_flexEnd_mobile__iv7so5gs {
+  align-items: flex-end;
+}
+.sprinkles_justifyContent_flexStart_mobile__iv7so5gw {
+  justify-content: flex-start;
+}
+.sprinkles_justifyContent_center_mobile__iv7so5h0 {
+  justify-content: center;
+}
+.sprinkles_justifyContent_flexEnd_mobile__iv7so5h4 {
+  justify-content: flex-end;
+}
+.sprinkles_justifyContent_spaceBetween_mobile__iv7so5h8 {
+  justify-content: space-between;
+}
+.sprinkles_flexDirection_row_mobile__iv7so5hc {
+  flex-direction: row;
+}
+.sprinkles_flexDirection_rowReverse_mobile__iv7so5hg {
+  flex-direction: row-reverse;
+}
+.sprinkles_flexDirection_column_mobile__iv7so5hk {
+  flex-direction: column;
+}
+.sprinkles_flexDirection_columnReverse_mobile__iv7so5ho {
+  flex-direction: column-reverse;
+}
+.sprinkles_flexWrap_wrap_mobile__iv7so5hs {
+  flex-wrap: wrap;
+}
+.sprinkles_flexWrap_nowrap_mobile__iv7so5hw {
+  flex-wrap: nowrap;
+}
+.sprinkles_flexShrink_0_mobile__iv7so5i0 {
+  flex-shrink: 0;
+}
+.sprinkles_flexGrow_0_mobile__iv7so5i4 {
+  flex-grow: 0;
+}
+.sprinkles_flexGrow_1_mobile__iv7so5i8 {
+  flex-grow: 1;
+}
+.sprinkles_textAlign_left_mobile__iv7so5ic {
+  text-align: left;
+}
+.sprinkles_textAlign_center_mobile__iv7so5ig {
+  text-align: center;
+}
+.sprinkles_textAlign_right_mobile__iv7so5ik {
+  text-align: right;
+}
+@media screen and (min-width: 740px) {
+  .sprinkles_display_none_tablet__iv7so54x {
+    display: none;
+  }
+  .sprinkles_display_block_tablet__iv7so551 {
+    display: block;
+  }
+  .sprinkles_display_inline_tablet__iv7so555 {
+    display: inline;
+  }
+  .sprinkles_display_inlineBlock_tablet__iv7so559 {
+    display: inline-block;
+  }
+  .sprinkles_display_flex_tablet__iv7so55d {
+    display: flex;
+  }
+  .sprinkles_position_relative_tablet__iv7so55h {
+    position: relative;
+  }
+  .sprinkles_position_absolute_tablet__iv7so55l {
+    position: absolute;
+  }
+  .sprinkles_position_fixed_tablet__iv7so55p {
+    position: fixed;
+  }
+  .sprinkles_position_sticky_tablet__iv7so55t {
+    position: sticky;
+  }
+  .sprinkles_borderRadius_none_tablet__iv7so55x {
+    border-radius: 0px;
+  }
+  .sprinkles_borderRadius_full_tablet__iv7so561 {
+    border-radius: 9999px;
+  }
+  .sprinkles_borderRadius_small_tablet__iv7so565 {
+    border-radius: var(--borderRadius-small__xorl4vb);
+  }
+  .sprinkles_borderRadius_standard_tablet__iv7so569 {
+    border-radius: var(--borderRadius-standard__xorl4vc);
+  }
+  .sprinkles_borderRadius_large_tablet__iv7so56d {
+    border-radius: var(--borderRadius-large__xorl4vd);
+  }
+  .sprinkles_borderRadius_xlarge_tablet__iv7so56h {
+    border-radius: var(--borderRadius-xlarge__xorl4ve);
+  }
+  .sprinkles_gap_gutter_tablet__iv7so56l {
+    gap: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_gap_xxsmall_tablet__iv7so56p {
+    gap: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_gap_xsmall_tablet__iv7so56t {
+    gap: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_gap_small_tablet__iv7so56x {
+    gap: var(--space-small__xorl4v3);
+  }
+  .sprinkles_gap_medium_tablet__iv7so571 {
+    gap: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_gap_large_tablet__iv7so575 {
+    gap: var(--space-large__xorl4v5);
+  }
+  .sprinkles_gap_xlarge_tablet__iv7so579 {
+    gap: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_gap_xxlarge_tablet__iv7so57d {
+    gap: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_gap_xxxlarge_tablet__iv7so57h {
+    gap: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_gap_none_tablet__iv7so57l {
+    gap: 0;
+  }
+  .sprinkles_paddingTop_gutter_tablet__iv7so57p {
+    padding-top: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingTop_xxsmall_tablet__iv7so57t {
+    padding-top: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingTop_xsmall_tablet__iv7so57x {
+    padding-top: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingTop_small_tablet__iv7so581 {
+    padding-top: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingTop_medium_tablet__iv7so585 {
+    padding-top: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingTop_large_tablet__iv7so589 {
+    padding-top: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingTop_xlarge_tablet__iv7so58d {
+    padding-top: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingTop_xxlarge_tablet__iv7so58h {
+    padding-top: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingTop_xxxlarge_tablet__iv7so58l {
+    padding-top: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingTop_none_tablet__iv7so58p {
+    padding-top: 0;
+  }
+  .sprinkles_paddingBottom_gutter_tablet__iv7so58t {
+    padding-bottom: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingBottom_xxsmall_tablet__iv7so58x {
+    padding-bottom: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingBottom_xsmall_tablet__iv7so591 {
+    padding-bottom: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingBottom_small_tablet__iv7so595 {
+    padding-bottom: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingBottom_medium_tablet__iv7so599 {
+    padding-bottom: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingBottom_large_tablet__iv7so59d {
+    padding-bottom: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingBottom_xlarge_tablet__iv7so59h {
+    padding-bottom: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingBottom_xxlarge_tablet__iv7so59l {
+    padding-bottom: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingBottom_xxxlarge_tablet__iv7so59p {
+    padding-bottom: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingBottom_none_tablet__iv7so59t {
+    padding-bottom: 0;
+  }
+  .sprinkles_paddingRight_gutter_tablet__iv7so59x {
+    padding-right: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingRight_xxsmall_tablet__iv7so5a1 {
+    padding-right: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingRight_xsmall_tablet__iv7so5a5 {
+    padding-right: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingRight_small_tablet__iv7so5a9 {
+    padding-right: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingRight_medium_tablet__iv7so5ad {
+    padding-right: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingRight_large_tablet__iv7so5ah {
+    padding-right: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingRight_xlarge_tablet__iv7so5al {
+    padding-right: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingRight_xxlarge_tablet__iv7so5ap {
+    padding-right: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingRight_xxxlarge_tablet__iv7so5at {
+    padding-right: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingRight_none_tablet__iv7so5ax {
+    padding-right: 0;
+  }
+  .sprinkles_paddingLeft_gutter_tablet__iv7so5b1 {
+    padding-left: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingLeft_xxsmall_tablet__iv7so5b5 {
+    padding-left: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingLeft_xsmall_tablet__iv7so5b9 {
+    padding-left: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingLeft_small_tablet__iv7so5bd {
+    padding-left: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingLeft_medium_tablet__iv7so5bh {
+    padding-left: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingLeft_large_tablet__iv7so5bl {
+    padding-left: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingLeft_xlarge_tablet__iv7so5bp {
+    padding-left: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingLeft_xxlarge_tablet__iv7so5bt {
+    padding-left: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingLeft_xxxlarge_tablet__iv7so5bx {
+    padding-left: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingLeft_none_tablet__iv7so5c1 {
+    padding-left: 0;
+  }
+  .sprinkles_marginTop_gutter_tablet__iv7so5c5 {
+    margin-top: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginTop_xxsmall_tablet__iv7so5c9 {
+    margin-top: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginTop_xsmall_tablet__iv7so5cd {
+    margin-top: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginTop_small_tablet__iv7so5ch {
+    margin-top: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginTop_medium_tablet__iv7so5cl {
+    margin-top: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginTop_large_tablet__iv7so5cp {
+    margin-top: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginTop_xlarge_tablet__iv7so5ct {
+    margin-top: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginTop_xxlarge_tablet__iv7so5cx {
+    margin-top: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginTop_xxxlarge_tablet__iv7so5d1 {
+    margin-top: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginTop_none_tablet__iv7so5d5 {
+    margin-top: 0;
+  }
+  .sprinkles_marginBottom_gutter_tablet__iv7so5d9 {
+    margin-bottom: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginBottom_xxsmall_tablet__iv7so5dd {
+    margin-bottom: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginBottom_xsmall_tablet__iv7so5dh {
+    margin-bottom: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginBottom_small_tablet__iv7so5dl {
+    margin-bottom: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginBottom_medium_tablet__iv7so5dp {
+    margin-bottom: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginBottom_large_tablet__iv7so5dt {
+    margin-bottom: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginBottom_xlarge_tablet__iv7so5dx {
+    margin-bottom: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginBottom_xxlarge_tablet__iv7so5e1 {
+    margin-bottom: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginBottom_xxxlarge_tablet__iv7so5e5 {
+    margin-bottom: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginBottom_none_tablet__iv7so5e9 {
+    margin-bottom: 0;
+  }
+  .sprinkles_marginRight_gutter_tablet__iv7so5ed {
+    margin-right: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginRight_xxsmall_tablet__iv7so5eh {
+    margin-right: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginRight_xsmall_tablet__iv7so5el {
+    margin-right: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginRight_small_tablet__iv7so5ep {
+    margin-right: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginRight_medium_tablet__iv7so5et {
+    margin-right: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginRight_large_tablet__iv7so5ex {
+    margin-right: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginRight_xlarge_tablet__iv7so5f1 {
+    margin-right: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginRight_xxlarge_tablet__iv7so5f5 {
+    margin-right: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginRight_xxxlarge_tablet__iv7so5f9 {
+    margin-right: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginRight_none_tablet__iv7so5fd {
+    margin-right: 0;
+  }
+  .sprinkles_marginLeft_gutter_tablet__iv7so5fh {
+    margin-left: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginLeft_xxsmall_tablet__iv7so5fl {
+    margin-left: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginLeft_xsmall_tablet__iv7so5fp {
+    margin-left: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginLeft_small_tablet__iv7so5ft {
+    margin-left: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginLeft_medium_tablet__iv7so5fx {
+    margin-left: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginLeft_large_tablet__iv7so5g1 {
+    margin-left: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginLeft_xlarge_tablet__iv7so5g5 {
+    margin-left: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginLeft_xxlarge_tablet__iv7so5g9 {
+    margin-left: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginLeft_xxxlarge_tablet__iv7so5gd {
+    margin-left: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginLeft_none_tablet__iv7so5gh {
+    margin-left: 0;
+  }
+  .sprinkles_alignItems_flexStart_tablet__iv7so5gl {
+    align-items: flex-start;
+  }
+  .sprinkles_alignItems_center_tablet__iv7so5gp {
+    align-items: center;
+  }
+  .sprinkles_alignItems_flexEnd_tablet__iv7so5gt {
+    align-items: flex-end;
+  }
+  .sprinkles_justifyContent_flexStart_tablet__iv7so5gx {
+    justify-content: flex-start;
+  }
+  .sprinkles_justifyContent_center_tablet__iv7so5h1 {
+    justify-content: center;
+  }
+  .sprinkles_justifyContent_flexEnd_tablet__iv7so5h5 {
+    justify-content: flex-end;
+  }
+  .sprinkles_justifyContent_spaceBetween_tablet__iv7so5h9 {
+    justify-content: space-between;
+  }
+  .sprinkles_flexDirection_row_tablet__iv7so5hd {
+    flex-direction: row;
+  }
+  .sprinkles_flexDirection_rowReverse_tablet__iv7so5hh {
+    flex-direction: row-reverse;
+  }
+  .sprinkles_flexDirection_column_tablet__iv7so5hl {
+    flex-direction: column;
+  }
+  .sprinkles_flexDirection_columnReverse_tablet__iv7so5hp {
+    flex-direction: column-reverse;
+  }
+  .sprinkles_flexWrap_wrap_tablet__iv7so5ht {
+    flex-wrap: wrap;
+  }
+  .sprinkles_flexWrap_nowrap_tablet__iv7so5hx {
+    flex-wrap: nowrap;
+  }
+  .sprinkles_flexShrink_0_tablet__iv7so5i1 {
+    flex-shrink: 0;
+  }
+  .sprinkles_flexGrow_0_tablet__iv7so5i5 {
+    flex-grow: 0;
+  }
+  .sprinkles_flexGrow_1_tablet__iv7so5i9 {
+    flex-grow: 1;
+  }
+  .sprinkles_textAlign_left_tablet__iv7so5id {
+    text-align: left;
+  }
+  .sprinkles_textAlign_center_tablet__iv7so5ih {
+    text-align: center;
+  }
+  .sprinkles_textAlign_right_tablet__iv7so5il {
+    text-align: right;
+  }
+}
+@media screen and (min-width: 992px) {
+  .sprinkles_display_none_desktop__iv7so54y {
+    display: none;
+  }
+  .sprinkles_display_block_desktop__iv7so552 {
+    display: block;
+  }
+  .sprinkles_display_inline_desktop__iv7so556 {
+    display: inline;
+  }
+  .sprinkles_display_inlineBlock_desktop__iv7so55a {
+    display: inline-block;
+  }
+  .sprinkles_display_flex_desktop__iv7so55e {
+    display: flex;
+  }
+  .sprinkles_position_relative_desktop__iv7so55i {
+    position: relative;
+  }
+  .sprinkles_position_absolute_desktop__iv7so55m {
+    position: absolute;
+  }
+  .sprinkles_position_fixed_desktop__iv7so55q {
+    position: fixed;
+  }
+  .sprinkles_position_sticky_desktop__iv7so55u {
+    position: sticky;
+  }
+  .sprinkles_borderRadius_none_desktop__iv7so55y {
+    border-radius: 0px;
+  }
+  .sprinkles_borderRadius_full_desktop__iv7so562 {
+    border-radius: 9999px;
+  }
+  .sprinkles_borderRadius_small_desktop__iv7so566 {
+    border-radius: var(--borderRadius-small__xorl4vb);
+  }
+  .sprinkles_borderRadius_standard_desktop__iv7so56a {
+    border-radius: var(--borderRadius-standard__xorl4vc);
+  }
+  .sprinkles_borderRadius_large_desktop__iv7so56e {
+    border-radius: var(--borderRadius-large__xorl4vd);
+  }
+  .sprinkles_borderRadius_xlarge_desktop__iv7so56i {
+    border-radius: var(--borderRadius-xlarge__xorl4ve);
+  }
+  .sprinkles_gap_gutter_desktop__iv7so56m {
+    gap: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_gap_xxsmall_desktop__iv7so56q {
+    gap: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_gap_xsmall_desktop__iv7so56u {
+    gap: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_gap_small_desktop__iv7so56y {
+    gap: var(--space-small__xorl4v3);
+  }
+  .sprinkles_gap_medium_desktop__iv7so572 {
+    gap: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_gap_large_desktop__iv7so576 {
+    gap: var(--space-large__xorl4v5);
+  }
+  .sprinkles_gap_xlarge_desktop__iv7so57a {
+    gap: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_gap_xxlarge_desktop__iv7so57e {
+    gap: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_gap_xxxlarge_desktop__iv7so57i {
+    gap: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_gap_none_desktop__iv7so57m {
+    gap: 0;
+  }
+  .sprinkles_paddingTop_gutter_desktop__iv7so57q {
+    padding-top: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingTop_xxsmall_desktop__iv7so57u {
+    padding-top: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingTop_xsmall_desktop__iv7so57y {
+    padding-top: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingTop_small_desktop__iv7so582 {
+    padding-top: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingTop_medium_desktop__iv7so586 {
+    padding-top: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingTop_large_desktop__iv7so58a {
+    padding-top: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingTop_xlarge_desktop__iv7so58e {
+    padding-top: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingTop_xxlarge_desktop__iv7so58i {
+    padding-top: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingTop_xxxlarge_desktop__iv7so58m {
+    padding-top: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingTop_none_desktop__iv7so58q {
+    padding-top: 0;
+  }
+  .sprinkles_paddingBottom_gutter_desktop__iv7so58u {
+    padding-bottom: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingBottom_xxsmall_desktop__iv7so58y {
+    padding-bottom: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingBottom_xsmall_desktop__iv7so592 {
+    padding-bottom: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingBottom_small_desktop__iv7so596 {
+    padding-bottom: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingBottom_medium_desktop__iv7so59a {
+    padding-bottom: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingBottom_large_desktop__iv7so59e {
+    padding-bottom: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingBottom_xlarge_desktop__iv7so59i {
+    padding-bottom: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingBottom_xxlarge_desktop__iv7so59m {
+    padding-bottom: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingBottom_xxxlarge_desktop__iv7so59q {
+    padding-bottom: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingBottom_none_desktop__iv7so59u {
+    padding-bottom: 0;
+  }
+  .sprinkles_paddingRight_gutter_desktop__iv7so59y {
+    padding-right: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingRight_xxsmall_desktop__iv7so5a2 {
+    padding-right: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingRight_xsmall_desktop__iv7so5a6 {
+    padding-right: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingRight_small_desktop__iv7so5aa {
+    padding-right: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingRight_medium_desktop__iv7so5ae {
+    padding-right: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingRight_large_desktop__iv7so5ai {
+    padding-right: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingRight_xlarge_desktop__iv7so5am {
+    padding-right: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingRight_xxlarge_desktop__iv7so5aq {
+    padding-right: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingRight_xxxlarge_desktop__iv7so5au {
+    padding-right: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingRight_none_desktop__iv7so5ay {
+    padding-right: 0;
+  }
+  .sprinkles_paddingLeft_gutter_desktop__iv7so5b2 {
+    padding-left: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingLeft_xxsmall_desktop__iv7so5b6 {
+    padding-left: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingLeft_xsmall_desktop__iv7so5ba {
+    padding-left: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingLeft_small_desktop__iv7so5be {
+    padding-left: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingLeft_medium_desktop__iv7so5bi {
+    padding-left: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingLeft_large_desktop__iv7so5bm {
+    padding-left: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingLeft_xlarge_desktop__iv7so5bq {
+    padding-left: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingLeft_xxlarge_desktop__iv7so5bu {
+    padding-left: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingLeft_xxxlarge_desktop__iv7so5by {
+    padding-left: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingLeft_none_desktop__iv7so5c2 {
+    padding-left: 0;
+  }
+  .sprinkles_marginTop_gutter_desktop__iv7so5c6 {
+    margin-top: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginTop_xxsmall_desktop__iv7so5ca {
+    margin-top: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginTop_xsmall_desktop__iv7so5ce {
+    margin-top: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginTop_small_desktop__iv7so5ci {
+    margin-top: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginTop_medium_desktop__iv7so5cm {
+    margin-top: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginTop_large_desktop__iv7so5cq {
+    margin-top: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginTop_xlarge_desktop__iv7so5cu {
+    margin-top: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginTop_xxlarge_desktop__iv7so5cy {
+    margin-top: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginTop_xxxlarge_desktop__iv7so5d2 {
+    margin-top: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginTop_none_desktop__iv7so5d6 {
+    margin-top: 0;
+  }
+  .sprinkles_marginBottom_gutter_desktop__iv7so5da {
+    margin-bottom: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginBottom_xxsmall_desktop__iv7so5de {
+    margin-bottom: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginBottom_xsmall_desktop__iv7so5di {
+    margin-bottom: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginBottom_small_desktop__iv7so5dm {
+    margin-bottom: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginBottom_medium_desktop__iv7so5dq {
+    margin-bottom: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginBottom_large_desktop__iv7so5du {
+    margin-bottom: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginBottom_xlarge_desktop__iv7so5dy {
+    margin-bottom: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginBottom_xxlarge_desktop__iv7so5e2 {
+    margin-bottom: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginBottom_xxxlarge_desktop__iv7so5e6 {
+    margin-bottom: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginBottom_none_desktop__iv7so5ea {
+    margin-bottom: 0;
+  }
+  .sprinkles_marginRight_gutter_desktop__iv7so5ee {
+    margin-right: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginRight_xxsmall_desktop__iv7so5ei {
+    margin-right: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginRight_xsmall_desktop__iv7so5em {
+    margin-right: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginRight_small_desktop__iv7so5eq {
+    margin-right: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginRight_medium_desktop__iv7so5eu {
+    margin-right: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginRight_large_desktop__iv7so5ey {
+    margin-right: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginRight_xlarge_desktop__iv7so5f2 {
+    margin-right: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginRight_xxlarge_desktop__iv7so5f6 {
+    margin-right: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginRight_xxxlarge_desktop__iv7so5fa {
+    margin-right: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginRight_none_desktop__iv7so5fe {
+    margin-right: 0;
+  }
+  .sprinkles_marginLeft_gutter_desktop__iv7so5fi {
+    margin-left: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginLeft_xxsmall_desktop__iv7so5fm {
+    margin-left: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginLeft_xsmall_desktop__iv7so5fq {
+    margin-left: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginLeft_small_desktop__iv7so5fu {
+    margin-left: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginLeft_medium_desktop__iv7so5fy {
+    margin-left: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginLeft_large_desktop__iv7so5g2 {
+    margin-left: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginLeft_xlarge_desktop__iv7so5g6 {
+    margin-left: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginLeft_xxlarge_desktop__iv7so5ga {
+    margin-left: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginLeft_xxxlarge_desktop__iv7so5ge {
+    margin-left: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginLeft_none_desktop__iv7so5gi {
+    margin-left: 0;
+  }
+  .sprinkles_alignItems_flexStart_desktop__iv7so5gm {
+    align-items: flex-start;
+  }
+  .sprinkles_alignItems_center_desktop__iv7so5gq {
+    align-items: center;
+  }
+  .sprinkles_alignItems_flexEnd_desktop__iv7so5gu {
+    align-items: flex-end;
+  }
+  .sprinkles_justifyContent_flexStart_desktop__iv7so5gy {
+    justify-content: flex-start;
+  }
+  .sprinkles_justifyContent_center_desktop__iv7so5h2 {
+    justify-content: center;
+  }
+  .sprinkles_justifyContent_flexEnd_desktop__iv7so5h6 {
+    justify-content: flex-end;
+  }
+  .sprinkles_justifyContent_spaceBetween_desktop__iv7so5ha {
+    justify-content: space-between;
+  }
+  .sprinkles_flexDirection_row_desktop__iv7so5he {
+    flex-direction: row;
+  }
+  .sprinkles_flexDirection_rowReverse_desktop__iv7so5hi {
+    flex-direction: row-reverse;
+  }
+  .sprinkles_flexDirection_column_desktop__iv7so5hm {
+    flex-direction: column;
+  }
+  .sprinkles_flexDirection_columnReverse_desktop__iv7so5hq {
+    flex-direction: column-reverse;
+  }
+  .sprinkles_flexWrap_wrap_desktop__iv7so5hu {
+    flex-wrap: wrap;
+  }
+  .sprinkles_flexWrap_nowrap_desktop__iv7so5hy {
+    flex-wrap: nowrap;
+  }
+  .sprinkles_flexShrink_0_desktop__iv7so5i2 {
+    flex-shrink: 0;
+  }
+  .sprinkles_flexGrow_0_desktop__iv7so5i6 {
+    flex-grow: 0;
+  }
+  .sprinkles_flexGrow_1_desktop__iv7so5ia {
+    flex-grow: 1;
+  }
+  .sprinkles_textAlign_left_desktop__iv7so5ie {
+    text-align: left;
+  }
+  .sprinkles_textAlign_center_desktop__iv7so5ii {
+    text-align: center;
+  }
+  .sprinkles_textAlign_right_desktop__iv7so5im {
+    text-align: right;
+  }
+}
+@media screen and (min-width: 1200px) {
+  .sprinkles_display_none_wide__iv7so54z {
+    display: none;
+  }
+  .sprinkles_display_block_wide__iv7so553 {
+    display: block;
+  }
+  .sprinkles_display_inline_wide__iv7so557 {
+    display: inline;
+  }
+  .sprinkles_display_inlineBlock_wide__iv7so55b {
+    display: inline-block;
+  }
+  .sprinkles_display_flex_wide__iv7so55f {
+    display: flex;
+  }
+  .sprinkles_position_relative_wide__iv7so55j {
+    position: relative;
+  }
+  .sprinkles_position_absolute_wide__iv7so55n {
+    position: absolute;
+  }
+  .sprinkles_position_fixed_wide__iv7so55r {
+    position: fixed;
+  }
+  .sprinkles_position_sticky_wide__iv7so55v {
+    position: sticky;
+  }
+  .sprinkles_borderRadius_none_wide__iv7so55z {
+    border-radius: 0px;
+  }
+  .sprinkles_borderRadius_full_wide__iv7so563 {
+    border-radius: 9999px;
+  }
+  .sprinkles_borderRadius_small_wide__iv7so567 {
+    border-radius: var(--borderRadius-small__xorl4vb);
+  }
+  .sprinkles_borderRadius_standard_wide__iv7so56b {
+    border-radius: var(--borderRadius-standard__xorl4vc);
+  }
+  .sprinkles_borderRadius_large_wide__iv7so56f {
+    border-radius: var(--borderRadius-large__xorl4vd);
+  }
+  .sprinkles_borderRadius_xlarge_wide__iv7so56j {
+    border-radius: var(--borderRadius-xlarge__xorl4ve);
+  }
+  .sprinkles_gap_gutter_wide__iv7so56n {
+    gap: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_gap_xxsmall_wide__iv7so56r {
+    gap: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_gap_xsmall_wide__iv7so56v {
+    gap: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_gap_small_wide__iv7so56z {
+    gap: var(--space-small__xorl4v3);
+  }
+  .sprinkles_gap_medium_wide__iv7so573 {
+    gap: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_gap_large_wide__iv7so577 {
+    gap: var(--space-large__xorl4v5);
+  }
+  .sprinkles_gap_xlarge_wide__iv7so57b {
+    gap: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_gap_xxlarge_wide__iv7so57f {
+    gap: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_gap_xxxlarge_wide__iv7so57j {
+    gap: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_gap_none_wide__iv7so57n {
+    gap: 0;
+  }
+  .sprinkles_paddingTop_gutter_wide__iv7so57r {
+    padding-top: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingTop_xxsmall_wide__iv7so57v {
+    padding-top: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingTop_xsmall_wide__iv7so57z {
+    padding-top: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingTop_small_wide__iv7so583 {
+    padding-top: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingTop_medium_wide__iv7so587 {
+    padding-top: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingTop_large_wide__iv7so58b {
+    padding-top: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingTop_xlarge_wide__iv7so58f {
+    padding-top: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingTop_xxlarge_wide__iv7so58j {
+    padding-top: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingTop_xxxlarge_wide__iv7so58n {
+    padding-top: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingTop_none_wide__iv7so58r {
+    padding-top: 0;
+  }
+  .sprinkles_paddingBottom_gutter_wide__iv7so58v {
+    padding-bottom: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingBottom_xxsmall_wide__iv7so58z {
+    padding-bottom: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingBottom_xsmall_wide__iv7so593 {
+    padding-bottom: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingBottom_small_wide__iv7so597 {
+    padding-bottom: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingBottom_medium_wide__iv7so59b {
+    padding-bottom: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingBottom_large_wide__iv7so59f {
+    padding-bottom: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingBottom_xlarge_wide__iv7so59j {
+    padding-bottom: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingBottom_xxlarge_wide__iv7so59n {
+    padding-bottom: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingBottom_xxxlarge_wide__iv7so59r {
+    padding-bottom: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingBottom_none_wide__iv7so59v {
+    padding-bottom: 0;
+  }
+  .sprinkles_paddingRight_gutter_wide__iv7so59z {
+    padding-right: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingRight_xxsmall_wide__iv7so5a3 {
+    padding-right: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingRight_xsmall_wide__iv7so5a7 {
+    padding-right: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingRight_small_wide__iv7so5ab {
+    padding-right: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingRight_medium_wide__iv7so5af {
+    padding-right: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingRight_large_wide__iv7so5aj {
+    padding-right: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingRight_xlarge_wide__iv7so5an {
+    padding-right: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingRight_xxlarge_wide__iv7so5ar {
+    padding-right: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingRight_xxxlarge_wide__iv7so5av {
+    padding-right: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingRight_none_wide__iv7so5az {
+    padding-right: 0;
+  }
+  .sprinkles_paddingLeft_gutter_wide__iv7so5b3 {
+    padding-left: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingLeft_xxsmall_wide__iv7so5b7 {
+    padding-left: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingLeft_xsmall_wide__iv7so5bb {
+    padding-left: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingLeft_small_wide__iv7so5bf {
+    padding-left: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingLeft_medium_wide__iv7so5bj {
+    padding-left: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingLeft_large_wide__iv7so5bn {
+    padding-left: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingLeft_xlarge_wide__iv7so5br {
+    padding-left: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingLeft_xxlarge_wide__iv7so5bv {
+    padding-left: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingLeft_xxxlarge_wide__iv7so5bz {
+    padding-left: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingLeft_none_wide__iv7so5c3 {
+    padding-left: 0;
+  }
+  .sprinkles_marginTop_gutter_wide__iv7so5c7 {
+    margin-top: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginTop_xxsmall_wide__iv7so5cb {
+    margin-top: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginTop_xsmall_wide__iv7so5cf {
+    margin-top: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginTop_small_wide__iv7so5cj {
+    margin-top: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginTop_medium_wide__iv7so5cn {
+    margin-top: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginTop_large_wide__iv7so5cr {
+    margin-top: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginTop_xlarge_wide__iv7so5cv {
+    margin-top: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginTop_xxlarge_wide__iv7so5cz {
+    margin-top: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginTop_xxxlarge_wide__iv7so5d3 {
+    margin-top: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginTop_none_wide__iv7so5d7 {
+    margin-top: 0;
+  }
+  .sprinkles_marginBottom_gutter_wide__iv7so5db {
+    margin-bottom: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginBottom_xxsmall_wide__iv7so5df {
+    margin-bottom: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginBottom_xsmall_wide__iv7so5dj {
+    margin-bottom: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginBottom_small_wide__iv7so5dn {
+    margin-bottom: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginBottom_medium_wide__iv7so5dr {
+    margin-bottom: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginBottom_large_wide__iv7so5dv {
+    margin-bottom: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginBottom_xlarge_wide__iv7so5dz {
+    margin-bottom: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginBottom_xxlarge_wide__iv7so5e3 {
+    margin-bottom: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginBottom_xxxlarge_wide__iv7so5e7 {
+    margin-bottom: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginBottom_none_wide__iv7so5eb {
+    margin-bottom: 0;
+  }
+  .sprinkles_marginRight_gutter_wide__iv7so5ef {
+    margin-right: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginRight_xxsmall_wide__iv7so5ej {
+    margin-right: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginRight_xsmall_wide__iv7so5en {
+    margin-right: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginRight_small_wide__iv7so5er {
+    margin-right: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginRight_medium_wide__iv7so5ev {
+    margin-right: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginRight_large_wide__iv7so5ez {
+    margin-right: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginRight_xlarge_wide__iv7so5f3 {
+    margin-right: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginRight_xxlarge_wide__iv7so5f7 {
+    margin-right: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginRight_xxxlarge_wide__iv7so5fb {
+    margin-right: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginRight_none_wide__iv7so5ff {
+    margin-right: 0;
+  }
+  .sprinkles_marginLeft_gutter_wide__iv7so5fj {
+    margin-left: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginLeft_xxsmall_wide__iv7so5fn {
+    margin-left: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginLeft_xsmall_wide__iv7so5fr {
+    margin-left: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginLeft_small_wide__iv7so5fv {
+    margin-left: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginLeft_medium_wide__iv7so5fz {
+    margin-left: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginLeft_large_wide__iv7so5g3 {
+    margin-left: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginLeft_xlarge_wide__iv7so5g7 {
+    margin-left: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginLeft_xxlarge_wide__iv7so5gb {
+    margin-left: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginLeft_xxxlarge_wide__iv7so5gf {
+    margin-left: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginLeft_none_wide__iv7so5gj {
+    margin-left: 0;
+  }
+  .sprinkles_alignItems_flexStart_wide__iv7so5gn {
+    align-items: flex-start;
+  }
+  .sprinkles_alignItems_center_wide__iv7so5gr {
+    align-items: center;
+  }
+  .sprinkles_alignItems_flexEnd_wide__iv7so5gv {
+    align-items: flex-end;
+  }
+  .sprinkles_justifyContent_flexStart_wide__iv7so5gz {
+    justify-content: flex-start;
+  }
+  .sprinkles_justifyContent_center_wide__iv7so5h3 {
+    justify-content: center;
+  }
+  .sprinkles_justifyContent_flexEnd_wide__iv7so5h7 {
+    justify-content: flex-end;
+  }
+  .sprinkles_justifyContent_spaceBetween_wide__iv7so5hb {
+    justify-content: space-between;
+  }
+  .sprinkles_flexDirection_row_wide__iv7so5hf {
+    flex-direction: row;
+  }
+  .sprinkles_flexDirection_rowReverse_wide__iv7so5hj {
+    flex-direction: row-reverse;
+  }
+  .sprinkles_flexDirection_column_wide__iv7so5hn {
+    flex-direction: column;
+  }
+  .sprinkles_flexDirection_columnReverse_wide__iv7so5hr {
+    flex-direction: column-reverse;
+  }
+  .sprinkles_flexWrap_wrap_wide__iv7so5hv {
+    flex-wrap: wrap;
+  }
+  .sprinkles_flexWrap_nowrap_wide__iv7so5hz {
+    flex-wrap: nowrap;
+  }
+  .sprinkles_flexShrink_0_wide__iv7so5i3 {
+    flex-shrink: 0;
+  }
+  .sprinkles_flexGrow_0_wide__iv7so5i7 {
+    flex-grow: 0;
+  }
+  .sprinkles_flexGrow_1_wide__iv7so5ib {
+    flex-grow: 1;
+  }
+  .sprinkles_textAlign_left_wide__iv7so5if {
+    text-align: left;
+  }
+  .sprinkles_textAlign_center_wide__iv7so5ij {
+    text-align: center;
+  }
+  .sprinkles_textAlign_right_wide__iv7so5in {
+    text-align: right;
+  }
+}
+.capsize_capsizeStyle__1lwixuj4 {
+  font-size: var(--fontSize__1lwixuj0);
+  line-height: var(--lineHeight__1lwixuj1);
+}
+.capsize_capsizeStyle__1lwixuj4::before {
+  content: '';
+  margin-bottom: var(--capHeightTrim__1lwixuj2);
+  display: table;
+}
+.capsize_capsizeStyle__1lwixuj4::after {
+  content: '';
+  margin-top: var(--baselineTrim__1lwixuj3);
+  display: table;
+}
+.typography_fontFamily__9al9wa0 {
+  font-family: var(--fontFamily__xorl4v2w);
+}
+.typography_fontWeight_regular__9al9wa1 {
+  font-weight: var(--textWeight-regular__xorl4v46);
+}
+.typography_fontWeight_medium__9al9wa2 {
+  font-weight: var(--textWeight-medium__xorl4v47);
+}
+.typography_fontWeight_strong__9al9wa3 {
+  font-weight: var(--textWeight-strong__xorl4v48);
+}
+.typography_textSize_xsmall__9al9wa4 {
+  --fontSize__1lwixuj0: var(--textSize-xsmall-mobile-fontSize__xorl4v32);
+  --lineHeight__1lwixuj1: var(--textSize-xsmall-mobile-lineHeight__xorl4v33);
+  --capHeightTrim__1lwixuj2: var(--textSize-xsmall-mobile-capsizeTrims-capHeightTrim__xorl4v35);
+  --baselineTrim__1lwixuj3: var(--textSize-xsmall-mobile-capsizeTrims-baselineTrim__xorl4v36);
+}
+.typography_textSize_small__9al9wa6 {
+  --fontSize__1lwixuj0: var(--textSize-small-mobile-fontSize__xorl4v3c);
+  --lineHeight__1lwixuj1: var(--textSize-small-mobile-lineHeight__xorl4v3d);
+  --capHeightTrim__1lwixuj2: var(--textSize-small-mobile-capsizeTrims-capHeightTrim__xorl4v3f);
+  --baselineTrim__1lwixuj3: var(--textSize-small-mobile-capsizeTrims-baselineTrim__xorl4v3g);
+}
+.typography_textSize_standard__9al9wa8 {
+  --fontSize__1lwixuj0: var(--textSize-standard-mobile-fontSize__xorl4v3m);
+  --lineHeight__1lwixuj1: var(--textSize-standard-mobile-lineHeight__xorl4v3n);
+  --capHeightTrim__1lwixuj2: var(--textSize-standard-mobile-capsizeTrims-capHeightTrim__xorl4v3p);
+  --baselineTrim__1lwixuj3: var(--textSize-standard-mobile-capsizeTrims-baselineTrim__xorl4v3q);
+}
+.typography_textSize_large__9al9waa {
+  --fontSize__1lwixuj0: var(--textSize-large-mobile-fontSize__xorl4v3w);
+  --lineHeight__1lwixuj1: var(--textSize-large-mobile-lineHeight__xorl4v3x);
+  --capHeightTrim__1lwixuj2: var(--textSize-large-mobile-capsizeTrims-capHeightTrim__xorl4v3z);
+  --baselineTrim__1lwixuj3: var(--textSize-large-mobile-capsizeTrims-baselineTrim__xorl4v40);
+}
+.typography_textSizeUntrimmed_xsmall__9al9wac {
+  font-size: var(--textSize-xsmall-mobile-fontSize__xorl4v32);
+  line-height: var(--textSize-xsmall-mobile-lineHeight__xorl4v33);
+}
+.typography_textSizeUntrimmed_small__9al9wad {
+  font-size: var(--textSize-small-mobile-fontSize__xorl4v3c);
+  line-height: var(--textSize-small-mobile-lineHeight__xorl4v3d);
+}
+.typography_textSizeUntrimmed_standard__9al9wae {
+  font-size: var(--textSize-standard-mobile-fontSize__xorl4v3m);
+  line-height: var(--textSize-standard-mobile-lineHeight__xorl4v3n);
+}
+.typography_textSizeUntrimmed_large__9al9waf {
+  font-size: var(--textSize-large-mobile-fontSize__xorl4v3w);
+  line-height: var(--textSize-large-mobile-lineHeight__xorl4v3x);
+}
+.typography_headingWeight_weak__9al9wag {
+  font-weight: var(--headingWeight-weak__xorl4v5d);
+}
+.typography_headingWeight_regular__9al9wah {
+  font-weight: var(--headingWeight-regular__xorl4v5e);
+}
+.typography_heading_1__9al9wai {
+  --fontSize__1lwixuj0: var(--headingLevel-1-mobile-fontSize__xorl4v49);
+  --lineHeight__1lwixuj1: var(--headingLevel-1-mobile-lineHeight__xorl4v4a);
+  --capHeightTrim__1lwixuj2: var(--headingLevel-1-mobile-capsizeTrims-capHeightTrim__xorl4v4c);
+  --baselineTrim__1lwixuj3: var(--headingLevel-1-mobile-capsizeTrims-baselineTrim__xorl4v4d);
+}
+.typography_heading_2__9al9wak {
+  --fontSize__1lwixuj0: var(--headingLevel-2-mobile-fontSize__xorl4v4j);
+  --lineHeight__1lwixuj1: var(--headingLevel-2-mobile-lineHeight__xorl4v4k);
+  --capHeightTrim__1lwixuj2: var(--headingLevel-2-mobile-capsizeTrims-capHeightTrim__xorl4v4m);
+  --baselineTrim__1lwixuj3: var(--headingLevel-2-mobile-capsizeTrims-baselineTrim__xorl4v4n);
+}
+.typography_heading_3__9al9wam {
+  --fontSize__1lwixuj0: var(--headingLevel-3-mobile-fontSize__xorl4v4t);
+  --lineHeight__1lwixuj1: var(--headingLevel-3-mobile-lineHeight__xorl4v4u);
+  --capHeightTrim__1lwixuj2: var(--headingLevel-3-mobile-capsizeTrims-capHeightTrim__xorl4v4w);
+  --baselineTrim__1lwixuj3: var(--headingLevel-3-mobile-capsizeTrims-baselineTrim__xorl4v4x);
+}
+.typography_heading_4__9al9wao {
+  --fontSize__1lwixuj0: var(--headingLevel-4-mobile-fontSize__xorl4v53);
+  --lineHeight__1lwixuj1: var(--headingLevel-4-mobile-lineHeight__xorl4v54);
+  --capHeightTrim__1lwixuj2: var(--headingLevel-4-mobile-capsizeTrims-capHeightTrim__xorl4v56);
+  --baselineTrim__1lwixuj3: var(--headingLevel-4-mobile-capsizeTrims-baselineTrim__xorl4v57);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeTone_light__9al9wa10 {
+  --critical__9al9waq: var(--foregroundColor-critical__xorl4v19);
+  --caution__9al9war: var(--foregroundColor-caution__xorl4v17);
+  --info__9al9was: var(--foregroundColor-info__xorl4v1d);
+  --promote__9al9wat: var(--foregroundColor-promote__xorl4v1o);
+  --positive__9al9wau: var(--foregroundColor-positive__xorl4v1m);
+  --brandAccent__9al9wav: var(--foregroundColor-brandAccent__xorl4v15);
+  --formAccent__9al9waw: var(--foregroundColor-formAccent__xorl4v1b);
+  --neutral__9al9wax: var(--foregroundColor-neutral__xorl4v1k);
+  --secondary__9al9way: var(--foregroundColor-secondary__xorl4v1r);
+  --link__9al9waz: var(--foregroundColor-link__xorl4v1f);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeTone_dark__9al9wa11 {
+  --critical__9al9waq: var(--foregroundColor-criticalLight__xorl4v1a);
+  --caution__9al9war: var(--foregroundColor-cautionLight__xorl4v18);
+  --info__9al9was: var(--foregroundColor-infoLight__xorl4v1e);
+  --promote__9al9wat: var(--foregroundColor-promoteLight__xorl4v1p);
+  --positive__9al9wau: var(--foregroundColor-positiveLight__xorl4v1n);
+  --brandAccent__9al9wav: var(--foregroundColor-brandAccentLight__xorl4v16);
+  --formAccent__9al9waw: var(--foregroundColor-formAccentLight__xorl4v1c);
+  --neutral__9al9wax: var(--foregroundColor-neutralInverted__xorl4v1l);
+  --secondary__9al9way: var(--foregroundColor-secondaryInverted__xorl4v1s);
+  --link__9al9waz: var(--foregroundColor-linkLight__xorl4v1h);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeTone_light__9al9wa12 {
+  --critical__9al9waq: var(--foregroundColor-critical__xorl4v19);
+  --caution__9al9war: var(--foregroundColor-caution__xorl4v17);
+  --info__9al9was: var(--foregroundColor-info__xorl4v1d);
+  --promote__9al9wat: var(--foregroundColor-promote__xorl4v1o);
+  --positive__9al9wau: var(--foregroundColor-positive__xorl4v1m);
+  --brandAccent__9al9wav: var(--foregroundColor-brandAccent__xorl4v15);
+  --formAccent__9al9waw: var(--foregroundColor-formAccent__xorl4v1b);
+  --neutral__9al9wax: var(--foregroundColor-neutral__xorl4v1k);
+  --secondary__9al9way: var(--foregroundColor-secondary__xorl4v1r);
+  --link__9al9waz: var(--foregroundColor-link__xorl4v1f);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeTone_dark__9al9wa13 {
+  --critical__9al9waq: var(--foregroundColor-criticalLight__xorl4v1a);
+  --caution__9al9war: var(--foregroundColor-cautionLight__xorl4v18);
+  --info__9al9was: var(--foregroundColor-infoLight__xorl4v1e);
+  --promote__9al9wat: var(--foregroundColor-promoteLight__xorl4v1p);
+  --positive__9al9wau: var(--foregroundColor-positiveLight__xorl4v1n);
+  --brandAccent__9al9wav: var(--foregroundColor-brandAccentLight__xorl4v16);
+  --formAccent__9al9waw: var(--foregroundColor-formAccentLight__xorl4v1c);
+  --neutral__9al9wax: var(--foregroundColor-neutralInverted__xorl4v1l);
+  --secondary__9al9way: var(--foregroundColor-secondaryInverted__xorl4v1s);
+  --link__9al9waz: var(--foregroundColor-linkLight__xorl4v1h);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_criticalLight__9al9wa14 {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_criticalSoft__9al9wa15 {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_criticalSoftActive__9al9wa16 {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_criticalSoftHover__9al9wa17 {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_caution__9al9wa18 {
+  --neutral__9al9wax: var(--caution__9al9war);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_cautionLight__9al9wa19 {
+  --neutral__9al9wax: var(--caution__9al9war);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_positiveLight__9al9wa1a {
+  --neutral__9al9wax: var(--positive__9al9wau);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_infoLight__9al9wa1b {
+  --neutral__9al9wax: var(--info__9al9was);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_promoteLight__9al9wa1c {
+  --neutral__9al9wax: var(--promote__9al9wat);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_criticalLight__9al9wa1d {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_criticalSoft__9al9wa1e {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_criticalSoftActive__9al9wa1f {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_criticalSoftHover__9al9wa1g {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_caution__9al9wa1h {
+  --neutral__9al9wax: var(--caution__9al9war);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_cautionLight__9al9wa1i {
+  --neutral__9al9wax: var(--caution__9al9war);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_positiveLight__9al9wa1j {
+  --neutral__9al9wax: var(--positive__9al9wau);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_infoLight__9al9wa1k {
+  --neutral__9al9wax: var(--info__9al9was);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_promoteLight__9al9wa1l {
+  --neutral__9al9wax: var(--promote__9al9wat);
+}
+.typography_tone_critical__9al9wa1m {
+  color: var(--critical__9al9waq);
+}
+.typography_tone_caution__9al9wa1n {
+  color: var(--caution__9al9war);
+}
+.typography_tone_info__9al9wa1o {
+  color: var(--info__9al9was);
+}
+.typography_tone_promote__9al9wa1p {
+  color: var(--promote__9al9wat);
+}
+.typography_tone_positive__9al9wa1q {
+  color: var(--positive__9al9wau);
+}
+.typography_tone_brandAccent__9al9wa1r {
+  color: var(--brandAccent__9al9wav);
+}
+.typography_tone_formAccent__9al9wa1s {
+  color: var(--formAccent__9al9waw);
+}
+.typography_tone_neutral__9al9wa1t {
+  color: var(--neutral__9al9wax);
+}
+.typography_tone_secondary__9al9wa1u {
+  color: var(--secondary__9al9way);
+}
+.typography_tone_link__9al9wa1v {
+  color: var(--link__9al9waz);
+}
+.typography_touchableText_xsmall__9al9wa1w {
+  padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-xsmall-mobile-lineHeight__xorl4v33)) / 2);
+  padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-xsmall-mobile-lineHeight__xorl4v33)) / 2);
+}
+.typography_touchableText_small__9al9wa1x {
+  padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-small-mobile-lineHeight__xorl4v3d)) / 2);
+  padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-small-mobile-lineHeight__xorl4v3d)) / 2);
+}
+.typography_touchableText_standard__9al9wa1y {
+  padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-standard-mobile-lineHeight__xorl4v3n)) / 2);
+  padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-standard-mobile-lineHeight__xorl4v3n)) / 2);
+}
+.typography_touchableText_large__9al9wa1z {
+  padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-large-mobile-lineHeight__xorl4v3x)) / 2);
+  padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-large-mobile-lineHeight__xorl4v3x)) / 2);
+}
+@media screen and (min-width: 740px) {
+  .typography_textSize_xsmall__9al9wa4 {
+    --fontSize__1lwixuj0: var(--textSize-xsmall-tablet-fontSize__xorl4v37);
+    --lineHeight__1lwixuj1: var(--textSize-xsmall-tablet-lineHeight__xorl4v38);
+    --capHeightTrim__1lwixuj2: var(--textSize-xsmall-tablet-capsizeTrims-capHeightTrim__xorl4v3a);
+    --baselineTrim__1lwixuj3: var(--textSize-xsmall-tablet-capsizeTrims-baselineTrim__xorl4v3b);
+  }
+  .typography_textSize_small__9al9wa6 {
+    --fontSize__1lwixuj0: var(--textSize-small-tablet-fontSize__xorl4v3h);
+    --lineHeight__1lwixuj1: var(--textSize-small-tablet-lineHeight__xorl4v3i);
+    --capHeightTrim__1lwixuj2: var(--textSize-small-tablet-capsizeTrims-capHeightTrim__xorl4v3k);
+    --baselineTrim__1lwixuj3: var(--textSize-small-tablet-capsizeTrims-baselineTrim__xorl4v3l);
+  }
+  .typography_textSize_standard__9al9wa8 {
+    --fontSize__1lwixuj0: var(--textSize-standard-tablet-fontSize__xorl4v3r);
+    --lineHeight__1lwixuj1: var(--textSize-standard-tablet-lineHeight__xorl4v3s);
+    --capHeightTrim__1lwixuj2: var(--textSize-standard-tablet-capsizeTrims-capHeightTrim__xorl4v3u);
+    --baselineTrim__1lwixuj3: var(--textSize-standard-tablet-capsizeTrims-baselineTrim__xorl4v3v);
+  }
+  .typography_textSize_large__9al9waa {
+    --fontSize__1lwixuj0: var(--textSize-large-tablet-fontSize__xorl4v41);
+    --lineHeight__1lwixuj1: var(--textSize-large-tablet-lineHeight__xorl4v42);
+    --capHeightTrim__1lwixuj2: var(--textSize-large-tablet-capsizeTrims-capHeightTrim__xorl4v44);
+    --baselineTrim__1lwixuj3: var(--textSize-large-tablet-capsizeTrims-baselineTrim__xorl4v45);
+  }
+  .typography_textSizeUntrimmed_xsmall__9al9wac {
+    font-size: var(--textSize-xsmall-tablet-fontSize__xorl4v37);
+    line-height: var(--textSize-xsmall-tablet-lineHeight__xorl4v38);
+  }
+  .typography_textSizeUntrimmed_small__9al9wad {
+    font-size: var(--textSize-small-tablet-fontSize__xorl4v3h);
+    line-height: var(--textSize-small-tablet-lineHeight__xorl4v3i);
+  }
+  .typography_textSizeUntrimmed_standard__9al9wae {
+    font-size: var(--textSize-standard-tablet-fontSize__xorl4v3r);
+    line-height: var(--textSize-standard-tablet-lineHeight__xorl4v3s);
+  }
+  .typography_textSizeUntrimmed_large__9al9waf {
+    font-size: var(--textSize-large-tablet-fontSize__xorl4v41);
+    line-height: var(--textSize-large-tablet-lineHeight__xorl4v42);
+  }
+  .typography_heading_1__9al9wai {
+    --fontSize__1lwixuj0: var(--headingLevel-1-tablet-fontSize__xorl4v4e);
+    --lineHeight__1lwixuj1: var(--headingLevel-1-tablet-lineHeight__xorl4v4f);
+    --capHeightTrim__1lwixuj2: var(--headingLevel-1-tablet-capsizeTrims-capHeightTrim__xorl4v4h);
+    --baselineTrim__1lwixuj3: var(--headingLevel-1-tablet-capsizeTrims-baselineTrim__xorl4v4i);
+  }
+  .typography_heading_2__9al9wak {
+    --fontSize__1lwixuj0: var(--headingLevel-2-tablet-fontSize__xorl4v4o);
+    --lineHeight__1lwixuj1: var(--headingLevel-2-tablet-lineHeight__xorl4v4p);
+    --capHeightTrim__1lwixuj2: var(--headingLevel-2-tablet-capsizeTrims-capHeightTrim__xorl4v4r);
+    --baselineTrim__1lwixuj3: var(--headingLevel-2-tablet-capsizeTrims-baselineTrim__xorl4v4s);
+  }
+  .typography_heading_3__9al9wam {
+    --fontSize__1lwixuj0: var(--headingLevel-3-tablet-fontSize__xorl4v4y);
+    --lineHeight__1lwixuj1: var(--headingLevel-3-tablet-lineHeight__xorl4v4z);
+    --capHeightTrim__1lwixuj2: var(--headingLevel-3-tablet-capsizeTrims-capHeightTrim__xorl4v51);
+    --baselineTrim__1lwixuj3: var(--headingLevel-3-tablet-capsizeTrims-baselineTrim__xorl4v52);
+  }
+  .typography_heading_4__9al9wao {
+    --fontSize__1lwixuj0: var(--headingLevel-4-tablet-fontSize__xorl4v58);
+    --lineHeight__1lwixuj1: var(--headingLevel-4-tablet-lineHeight__xorl4v59);
+    --capHeightTrim__1lwixuj2: var(--headingLevel-4-tablet-capsizeTrims-capHeightTrim__xorl4v5b);
+    --baselineTrim__1lwixuj3: var(--headingLevel-4-tablet-capsizeTrims-baselineTrim__xorl4v5c);
+  }
+  .typography_touchableText_xsmall__9al9wa1w {
+    padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-xsmall-tablet-lineHeight__xorl4v38)) / 2);
+    padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-xsmall-tablet-lineHeight__xorl4v38)) / 2);
+  }
+  .typography_touchableText_small__9al9wa1x {
+    padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-small-tablet-lineHeight__xorl4v3i)) / 2);
+    padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-small-tablet-lineHeight__xorl4v3i)) / 2);
+  }
+  .typography_touchableText_standard__9al9wa1y {
+    padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-standard-tablet-lineHeight__xorl4v3s)) / 2);
+    padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-standard-tablet-lineHeight__xorl4v3s)) / 2);
+  }
+  .typography_touchableText_large__9al9wa1z {
+    padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-large-tablet-lineHeight__xorl4v42)) / 2);
+    padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-large-tablet-lineHeight__xorl4v42)) / 2);
+  }
+}
+.Divider_base__wnnofa0 {
+  height: var(--borderWidth-standard__xorl4vy);
+}
+.Divider_regular__wnnofa3 {
+  background: var(--regular__wnnofa1);
+}
+.Divider_strong__wnnofa4 {
+  background: var(--strong__wnnofa2);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Divider_lightModeWeight_light__wnnofa5 {
+  --regular__wnnofa1: var(--borderColor-neutralLight__xorl4vt);
+  --strong__wnnofa2: var(--borderColor-neutral__xorl4vr);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Divider_lightModeWeight_dark__wnnofa6 {
+  --regular__wnnofa1: var(--borderColor-neutral__xorl4vr);
+  --strong__wnnofa2: var(--borderColor-neutralLight__xorl4vt);
+}
+html.sprinkles_darkMode__iv7so511 .Divider_darkModeWeight_light__wnnofa7 {
+  --regular__wnnofa1: var(--borderColor-neutralLight__xorl4vt);
+  --strong__wnnofa2: var(--borderColor-neutral__xorl4vr);
+}
+html.sprinkles_darkMode__iv7so511 .Divider_darkModeWeight_dark__wnnofa8 {
+  --regular__wnnofa1: var(--borderColor-neutral__xorl4vr);
+  --strong__wnnofa2: var(--borderColor-neutralLight__xorl4vt);
+}
+.Spread_fitContent__1otnb9q0 > * {
+  flex-basis: auto;
+  width: auto;
+}
+.Spread_maxWidth__1otnb9q1 > * {
+  max-width: 100%;
+}
+.MaxLines_descenderCropFixForWebkitBox__13p4shw0 {
+  margin-bottom: -0.1em;
+}
+.MaxLines_base__13p4shw2 {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow-wrap: break-word;
+}
+.MaxLines_descenderCropFixForWebkitBox__13p4shw0 .MaxLines_base__13p4shw2 {
+  padding-bottom: 0.1em;
+}
+@supports (display: -webkit-box) and (-webkit-line-clamp: 1) {
+  .MaxLines_multiLine__13p4shw4 {
+    white-space: initial;
+    display: -webkit-box;
+    -webkit-line-clamp: var(--lineLimit__13p4shw3);
+    -webkit-box-orient: vertical;
+  }
+}
+.virtualTouchable_virtualTouchable__1gayioq0 {
+  position: relative;
+}
+.virtualTouchable_virtualTouchable__1gayioq0::after {
+  content: "";
+  position: absolute;
+  min-height: 44px;
+  min-width: 44px;
+  height: 100%;
+  width: 100%;
+  transform: translate(-50%, -50%);
+  top: 50%;
+  left: 50%;
+}
+[data-braid-debug] .virtualTouchable_virtualTouchable__1gayioq0::after {
+  background: red;
+  opacity: 0.2;
+}
+.AccordionItem_focusRing__f5gff52 {
+  outline-offset: var(--space-xxsmall__xorl4v1);
+}
+.icon_size__1aiudid0 {
+  width: 1.2em;
+  height: 1.2em;
+}
+.icon_cropToTextSize__1aiudid1 {
+  margin: -0.1em;
+}
+.icon_inlineCrop__1aiudid2 {
+  margin-top: -0.2em;
+  margin-bottom: -0.2em;
+}
+.icon_inline__1aiudid3 {
+  vertical-align: middle;
+}
+.icon_alignY_uppercase_none__1aiudid4 {
+  top: -0.105em;
+}
+.icon_alignY_uppercase_up__1aiudid5 {
+  top: -0.16499999999999998em;
+}
+.icon_alignY_uppercase_down__1aiudid6 {
+  top: -0.045em;
+}
+.icon_alignY_lowercase_none__1aiudid7 {
+  top: -0.065em;
+}
+.icon_alignY_lowercase_up__1aiudid8 {
+  top: -0.125em;
+}
+.icon_alignY_lowercase_down__1aiudid9 {
+  top: -0.0050000000000000044em;
+}
+.icon_blockWidths_xsmall__1aiudida {
+  width: var(--textSize-xsmall-mobile-lineHeight__xorl4v33);
+}
+.icon_blockWidths_small__1aiudidb {
+  width: var(--textSize-small-mobile-lineHeight__xorl4v3d);
+}
+.icon_blockWidths_standard__1aiudidc {
+  width: var(--textSize-standard-mobile-lineHeight__xorl4v3n);
+}
+.icon_blockWidths_large__1aiudidd {
+  width: var(--textSize-large-mobile-lineHeight__xorl4v3x);
+}
+@media screen and (min-width: 740px) {
+  .icon_blockWidths_xsmall__1aiudida {
+    width: var(--textSize-xsmall-tablet-lineHeight__xorl4v38);
+  }
+  .icon_blockWidths_small__1aiudidb {
+    width: var(--textSize-small-tablet-lineHeight__xorl4v3i);
+  }
+  .icon_blockWidths_standard__1aiudidc {
+    width: var(--textSize-standard-tablet-lineHeight__xorl4v3s);
+  }
+  .icon_blockWidths_large__1aiudidd {
+    width: var(--textSize-large-tablet-lineHeight__xorl4v42);
+  }
+}
+.lineHeightContainer_lineHeightContainer_xsmall__6x1soo0 {
+  height: var(--textSize-xsmall-mobile-lineHeight__xorl4v33);
+}
+.lineHeightContainer_lineHeightContainer_small__6x1soo1 {
+  height: var(--textSize-small-mobile-lineHeight__xorl4v3d);
+}
+.lineHeightContainer_lineHeightContainer_standard__6x1soo2 {
+  height: var(--textSize-standard-mobile-lineHeight__xorl4v3n);
+}
+.lineHeightContainer_lineHeightContainer_large__6x1soo3 {
+  height: var(--textSize-large-mobile-lineHeight__xorl4v3x);
+}
+@media screen and (min-width: 740px) {
+  .lineHeightContainer_lineHeightContainer_xsmall__6x1soo0 {
+    height: var(--textSize-xsmall-tablet-lineHeight__xorl4v38);
+  }
+  .lineHeightContainer_lineHeightContainer_small__6x1soo1 {
+    height: var(--textSize-small-tablet-lineHeight__xorl4v3i);
+  }
+  .lineHeightContainer_lineHeightContainer_standard__6x1soo2 {
+    height: var(--textSize-standard-tablet-lineHeight__xorl4v3s);
+  }
+  .lineHeightContainer_lineHeightContainer_large__6x1soo3 {
+    height: var(--textSize-large-tablet-lineHeight__xorl4v42);
+  }
+}
+.IconChevron_root__1jqzlhx0 {
+  transition: transform 0.3s ease;
+  transform-origin: 50% 50%;
+}
+.IconChevron_left__1jqzlhx1 {
+  transform: rotate(90deg);
+}
+.IconChevron_up__1jqzlhx2 {
+  transform: rotate(180deg);
+}
+.IconChevron_right__1jqzlhx3 {
+  transform: rotate(270deg);
+}
+.Inline_fitContentMobile__1k33bv70 > * {
+  flex-basis: auto;
+  width: auto;
+  min-width: 0;
+}
+@media screen and (min-width: 740px) {
+  .Inline_fitContentTablet__1k33bv71 > * {
+    flex-basis: auto;
+    width: auto;
+    min-width: 0;
+  }
+}
+@media screen and (min-width: 992px) {
+  .Inline_fitContentDesktop__1k33bv72 > * {
+    flex-basis: auto;
+    width: auto;
+    min-width: 0;
+  }
+}
+@media screen and (min-width: 1200px) {
+  .Inline_fitContentWide__1k33bv73 > * {
+    flex-basis: auto;
+    width: auto;
+    min-width: 0;
+  }
+}
+.Column_noSpaceBeforeFirstWhenCollapsed__pvevjr0:first-child {
+  padding-top: 0;
+}
+.Column_width_1\\/2__pvevjr1 {
+  flex-basis: 50%;
+}
+.Column_width_1\\/3__pvevjr2 {
+  flex-basis: 33.33333333333333%;
+}
+.Column_width_2\\/3__pvevjr3 {
+  flex-basis: 66.66666666666666%;
+}
+.Column_width_1\\/4__pvevjr4 {
+  flex-basis: 25%;
+}
+.Column_width_3\\/4__pvevjr5 {
+  flex-basis: 75%;
+}
+.Column_width_1\\/5__pvevjr6 {
+  flex-basis: 20%;
+}
+.Column_width_2\\/5__pvevjr7 {
+  flex-basis: 40%;
+}
+.Column_width_3\\/5__pvevjr8 {
+  flex-basis: 60%;
+}
+.Column_width_4\\/5__pvevjr9 {
+  flex-basis: 80%;
+}
+.negativeMargin_preventCollapsePseudo_top__1559g980::before {
+  content: "";
+  display: table;
+}
+.negativeMargin_preventCollapsePseudo_bottom__1559g981::after {
+  content: "";
+  display: table;
+}
+.negativeMargin_stylesForBreakpoint_gutter__1559g982::before {
+  margin-bottom: calc(var(--space-gutter__xorl4v0) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxsmall__1559g983::before {
+  margin-bottom: calc(var(--space-xxsmall__xorl4v1) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xsmall__1559g984::before {
+  margin-bottom: calc(var(--space-xsmall__xorl4v2) * -1);
+}
+.negativeMargin_stylesForBreakpoint_small__1559g985::before {
+  margin-bottom: calc(var(--space-small__xorl4v3) * -1);
+}
+.negativeMargin_stylesForBreakpoint_medium__1559g986::before {
+  margin-bottom: calc(var(--space-medium__xorl4v4) * -1);
+}
+.negativeMargin_stylesForBreakpoint_large__1559g987::before {
+  margin-bottom: calc(var(--space-large__xorl4v5) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xlarge__1559g988::before {
+  margin-bottom: calc(var(--space-xlarge__xorl4v6) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxlarge__1559g989::before {
+  margin-bottom: calc(var(--space-xxlarge__xorl4v7) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxxlarge__1559g98a::before {
+  margin-bottom: calc(var(--space-xxxlarge__xorl4v8) * -1);
+}
+.negativeMargin_stylesForBreakpoint_none__1559g98b::before {
+  margin-bottom: 0;
+}
+.negativeMargin_stylesForBreakpoint_gutter__1559g9816::after {
+  margin-top: calc(var(--space-gutter__xorl4v0) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxsmall__1559g9817::after {
+  margin-top: calc(var(--space-xxsmall__xorl4v1) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xsmall__1559g9818::after {
+  margin-top: calc(var(--space-xsmall__xorl4v2) * -1);
+}
+.negativeMargin_stylesForBreakpoint_small__1559g9819::after {
+  margin-top: calc(var(--space-small__xorl4v3) * -1);
+}
+.negativeMargin_stylesForBreakpoint_medium__1559g981a::after {
+  margin-top: calc(var(--space-medium__xorl4v4) * -1);
+}
+.negativeMargin_stylesForBreakpoint_large__1559g981b::after {
+  margin-top: calc(var(--space-large__xorl4v5) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xlarge__1559g981c::after {
+  margin-top: calc(var(--space-xlarge__xorl4v6) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxlarge__1559g981d::after {
+  margin-top: calc(var(--space-xxlarge__xorl4v7) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxxlarge__1559g981e::after {
+  margin-top: calc(var(--space-xxxlarge__xorl4v8) * -1);
+}
+.negativeMargin_stylesForBreakpoint_none__1559g981f::after {
+  margin-top: 0;
+}
+.negativeMargin_stylesForBreakpoint_gutter__1559g982a {
+  margin-left: calc(var(--space-gutter__xorl4v0) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxsmall__1559g982b {
+  margin-left: calc(var(--space-xxsmall__xorl4v1) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xsmall__1559g982c {
+  margin-left: calc(var(--space-xsmall__xorl4v2) * -1);
+}
+.negativeMargin_stylesForBreakpoint_small__1559g982d {
+  margin-left: calc(var(--space-small__xorl4v3) * -1);
+}
+.negativeMargin_stylesForBreakpoint_medium__1559g982e {
+  margin-left: calc(var(--space-medium__xorl4v4) * -1);
+}
+.negativeMargin_stylesForBreakpoint_large__1559g982f {
+  margin-left: calc(var(--space-large__xorl4v5) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xlarge__1559g982g {
+  margin-left: calc(var(--space-xlarge__xorl4v6) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxlarge__1559g982h {
+  margin-left: calc(var(--space-xxlarge__xorl4v7) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxxlarge__1559g982i {
+  margin-left: calc(var(--space-xxxlarge__xorl4v8) * -1);
+}
+.negativeMargin_stylesForBreakpoint_none__1559g982j {
+  margin-left: 0;
+}
+.negativeMargin_stylesForBreakpoint_gutter__1559g983e {
+  margin-right: calc(var(--space-gutter__xorl4v0) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxsmall__1559g983f {
+  margin-right: calc(var(--space-xxsmall__xorl4v1) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xsmall__1559g983g {
+  margin-right: calc(var(--space-xsmall__xorl4v2) * -1);
+}
+.negativeMargin_stylesForBreakpoint_small__1559g983h {
+  margin-right: calc(var(--space-small__xorl4v3) * -1);
+}
+.negativeMargin_stylesForBreakpoint_medium__1559g983i {
+  margin-right: calc(var(--space-medium__xorl4v4) * -1);
+}
+.negativeMargin_stylesForBreakpoint_large__1559g983j {
+  margin-right: calc(var(--space-large__xorl4v5) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xlarge__1559g983k {
+  margin-right: calc(var(--space-xlarge__xorl4v6) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxlarge__1559g983l {
+  margin-right: calc(var(--space-xxlarge__xorl4v7) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxxlarge__1559g983m {
+  margin-right: calc(var(--space-xxxlarge__xorl4v8) * -1);
+}
+.negativeMargin_stylesForBreakpoint_none__1559g983n {
+  margin-right: 0;
+}
+@media screen and (min-width: 740px) {
+  .negativeMargin_stylesForBreakpoint_gutter__1559g98c::before {
+    margin-bottom: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g98d::before {
+    margin-bottom: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g98e::before {
+    margin-bottom: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g98f::before {
+    margin-bottom: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g98g::before {
+    margin-bottom: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g98h::before {
+    margin-bottom: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g98i::before {
+    margin-bottom: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g98j::before {
+    margin-bottom: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g98k::before {
+    margin-bottom: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g98l::before {
+    margin-bottom: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g981g::after {
+    margin-top: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g981h::after {
+    margin-top: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g981i::after {
+    margin-top: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g981j::after {
+    margin-top: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g981k::after {
+    margin-top: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g981l::after {
+    margin-top: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g981m::after {
+    margin-top: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g981n::after {
+    margin-top: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g981o::after {
+    margin-top: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g981p::after {
+    margin-top: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g982k {
+    margin-left: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g982l {
+    margin-left: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g982m {
+    margin-left: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g982n {
+    margin-left: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g982o {
+    margin-left: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g982p {
+    margin-left: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g982q {
+    margin-left: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g982r {
+    margin-left: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g982s {
+    margin-left: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g982t {
+    margin-left: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g983o {
+    margin-right: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g983p {
+    margin-right: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g983q {
+    margin-right: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g983r {
+    margin-right: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g983s {
+    margin-right: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g983t {
+    margin-right: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g983u {
+    margin-right: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g983v {
+    margin-right: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g983w {
+    margin-right: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g983x {
+    margin-right: 0;
+  }
+}
+@media screen and (min-width: 992px) {
+  .negativeMargin_stylesForBreakpoint_gutter__1559g98m::before {
+    margin-bottom: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g98n::before {
+    margin-bottom: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g98o::before {
+    margin-bottom: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g98p::before {
+    margin-bottom: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g98q::before {
+    margin-bottom: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g98r::before {
+    margin-bottom: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g98s::before {
+    margin-bottom: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g98t::before {
+    margin-bottom: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g98u::before {
+    margin-bottom: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g98v::before {
+    margin-bottom: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g981q::after {
+    margin-top: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g981r::after {
+    margin-top: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g981s::after {
+    margin-top: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g981t::after {
+    margin-top: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g981u::after {
+    margin-top: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g981v::after {
+    margin-top: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g981w::after {
+    margin-top: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g981x::after {
+    margin-top: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g981y::after {
+    margin-top: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g981z::after {
+    margin-top: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g982u {
+    margin-left: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g982v {
+    margin-left: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g982w {
+    margin-left: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g982x {
+    margin-left: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g982y {
+    margin-left: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g982z {
+    margin-left: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g9830 {
+    margin-left: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g9831 {
+    margin-left: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g9832 {
+    margin-left: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g9833 {
+    margin-left: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g983y {
+    margin-right: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g983z {
+    margin-right: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g9840 {
+    margin-right: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g9841 {
+    margin-right: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g9842 {
+    margin-right: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g9843 {
+    margin-right: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g9844 {
+    margin-right: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g9845 {
+    margin-right: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g9846 {
+    margin-right: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g9847 {
+    margin-right: 0;
+  }
+}
+@media screen and (min-width: 1200px) {
+  .negativeMargin_stylesForBreakpoint_gutter__1559g98w::before {
+    margin-bottom: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g98x::before {
+    margin-bottom: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g98y::before {
+    margin-bottom: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g98z::before {
+    margin-bottom: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g9810::before {
+    margin-bottom: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g9811::before {
+    margin-bottom: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g9812::before {
+    margin-bottom: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g9813::before {
+    margin-bottom: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g9814::before {
+    margin-bottom: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g9815::before {
+    margin-bottom: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g9820::after {
+    margin-top: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g9821::after {
+    margin-top: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g9822::after {
+    margin-top: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g9823::after {
+    margin-top: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g9824::after {
+    margin-top: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g9825::after {
+    margin-top: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g9826::after {
+    margin-top: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g9827::after {
+    margin-top: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g9828::after {
+    margin-top: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g9829::after {
+    margin-top: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g9834 {
+    margin-left: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g9835 {
+    margin-left: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g9836 {
+    margin-left: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g9837 {
+    margin-left: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g9838 {
+    margin-left: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g9839 {
+    margin-left: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g983a {
+    margin-left: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g983b {
+    margin-left: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g983c {
+    margin-left: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g983d {
+    margin-left: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g9848 {
+    margin-right: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g9849 {
+    margin-right: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g984a {
+    margin-right: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g984b {
+    margin-right: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g984c {
+    margin-right: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g984d {
+    margin-right: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g984e {
+    margin-right: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g984f {
+    margin-right: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g984g {
+    margin-right: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g984h {
+    margin-right: 0;
+  }
+}
+.Alert_closeButton__x2s9z00:focus .Alert_closeButtonHover__x2s9z01, .Alert_closeButton__x2s9z00:hover .Alert_closeButtonHover__x2s9z01 {
+  opacity: 1;
+}
+.textAlignedToIcon_textAlignedToIcon_standard__1pa6ue70 {
+  padding-top: calc((var(--textSize-standard-mobile-lineHeight__xorl4v3n) - var(--textSize-standard-mobile-capHeight__xorl4v3o)) / 2);
+  padding-bottom: calc((var(--textSize-standard-mobile-lineHeight__xorl4v3n) - var(--textSize-standard-mobile-capHeight__xorl4v3o)) / 2);
+}
+@media screen and (min-width: 740px) {
+  .textAlignedToIcon_textAlignedToIcon_standard__1pa6ue70 {
+    padding-top: calc((var(--textSize-standard-tablet-lineHeight__xorl4v3s) - var(--textSize-standard-tablet-capHeight__xorl4v3t)) / 2);
+    padding-bottom: calc((var(--textSize-standard-tablet-lineHeight__xorl4v3s) - var(--textSize-standard-tablet-capHeight__xorl4v3t)) / 2);
+  }
+}
+.AvoidWidowIcon_nowrap__onmis40 {
+  white-space: nowrap;
+}
+@keyframes Button_dot1__7j49xea {
+  14% {
+    opacity: 0;
+  }
+  15%,100% {
+    opacity: 1;
+  }
+}
+@keyframes Button_dot2__7j49xeb {
+  29% {
+    opacity: 0;
+  }
+  30%,100% {
+    opacity: 1;
+  }
+}
+@keyframes Button_dot3__7j49xec {
+  44% {
+    opacity: 0;
+  }
+  45%,100% {
+    opacity: 1;
+  }
+}
+.Button_root__7j49xe0 {
+  text-decoration: none;
+  align-items: stretch;
+}
+.Button_root__7j49xe0:active .Button_activeAnimation__7j49xe2, .Button_forceActive__7j49xe1.Button_activeAnimation__7j49xe2 {
+  transform: var(--transform-touchable__xorl4v5k);
+}
+.Button_root__7j49xe0:active .Button_activeOverlay__7j49xe3, .Button_forceActive__7j49xe1.Button_activeOverlay__7j49xe3 {
+  opacity: 1;
+}
+.Button_root__7j49xe0:hover:not(:disabled) .Button_hoverOverlay__7j49xe4 {
+  opacity: 1;
+}
+.Button_standard__7j49xe6 {
+  --capHeightToMinHeight__7j49xe5: calc((var(--touchableSize__xorl4v9) - var(--textSize-standard-mobile-capHeight__xorl4v3o)) / 2);
+}
+.Button_small__7j49xe7 {
+  --capHeightToMinHeight__7j49xe5: calc(((var(--touchableSize__xorl4v9) * 0.8) - var(--textSize-small-mobile-capHeight__xorl4v3e)) / 2);
+}
+.Button_bleedVerticallyToCapHeight__7j49xe8 {
+  margin-top: calc(var(--capHeightToMinHeight__7j49xe5) * -1);
+  margin-bottom: calc(var(--capHeightToMinHeight__7j49xe5) * -1);
+}
+.Button_padToMinHeight__7j49xe9 {
+  padding-top: var(--capHeightToMinHeight__7j49xe5);
+  padding-bottom: var(--capHeightToMinHeight__7j49xe5);
+}
+.Button_loadingDot__7j49xed {
+  animation-duration: 1s;
+  animation-iteration-count: infinite;
+  opacity: 0;
+}
+.Button_loadingDot__7j49xed:nth-child(1) {
+  animation-name: Button_dot1__7j49xea;
+}
+.Button_loadingDot__7j49xed:nth-child(2) {
+  animation-name: Button_dot2__7j49xeb;
+}
+.Button_loadingDot__7j49xed:nth-child(3) {
+  animation-name: Button_dot3__7j49xec;
+}
+html:not(.sprinkles_darkMode__iv7so511) .Button_invertedBackgroundsLightMode_soft__7j49xee {
+  background: rgba(255,255,255,0.1);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Button_invertedBackgroundsLightMode_hover__7j49xef {
+  background: rgba(255,255,255,0.15);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Button_invertedBackgroundsLightMode_active__7j49xeg {
+  background: rgba(255,255,255,0.15);
+}
+html.sprinkles_darkMode__iv7so511 .Button_invertedBackgroundsDarkMode_soft__7j49xeh {
+  background: rgba(255,255,255,0.1);
+}
+html.sprinkles_darkMode__iv7so511 .Button_invertedBackgroundsDarkMode_hover__7j49xei {
+  background: rgba(255,255,255,0.15);
+}
+html.sprinkles_darkMode__iv7so511 .Button_invertedBackgroundsDarkMode_active__7j49xej {
+  background: rgba(255,255,255,0.15);
+}
+@media screen and (min-width: 740px) {
+  .Button_standard__7j49xe6 {
+    --capHeightToMinHeight__7j49xe5: calc((var(--touchableSize__xorl4v9) - var(--textSize-standard-tablet-capHeight__xorl4v3t)) / 2);
+  }
+  .Button_small__7j49xe7 {
+    --capHeightToMinHeight__7j49xe5: calc(((var(--touchableSize__xorl4v9) * 0.8) - var(--textSize-small-tablet-capHeight__xorl4v3j)) / 2);
+  }
+}
+@keyframes Popover_popupAnimation__48p46ba {
+  from {
+    opacity: 0;
+    transform: translateY(calc(var(--space-xxsmall__xorl4v1) * var(--placementModifier__48p46b8, 1)));
+  }
+}
+.Popover_backdrop__48p46b0 {
+  width: 100vw;
+  height: 100vh;
+}
+.Popover_popoverPosition__48p46b7 {
+  --dynamicHeight__48p46b6: 100svh;
+  top: calc(var(--triggerVars_bottom__48p46b3) * 1px);
+  bottom: calc(var(--dynamicHeight__48p46b6, 100vh) - (var(--triggerVars_top__48p46b1) * 1px));
+  left: calc((var(--triggerVars_left__48p46b2) + var(--horizontalOffset__48p46b5)) * 1px);
+  right: calc((var(--triggerVars_right__48p46b4) + var(--horizontalOffset__48p46b5)) * 1px);
+}
+.Popover_invertPlacement__48p46b9 {
+  --placementModifier__48p46b8: -1;
+}
+.Popover_animation__48p46bb {
+  animation-name: Popover_popupAnimation__48p46ba;
+  animation-fill-mode: both;
+  animation-timing-function: ease;
+  animation-duration: 0.125s;
+  animation-delay: 15ms;
+}
+.Popover_delayVisibility__48p46bc {
+  animation-delay: 250ms;
+}
+.TooltipRenderer_maxWidth__1e2u52l0 {
+  max-width: 260px;
+}
+.TooltipRenderer_overflowWrap__1e2u52l1 {
+  overflow-wrap: break-word;
+}
+.TooltipRenderer_translateZ0__1e2u52l2 {
+  transform: translateZ(0);
+}
+.TooltipRenderer_baseArrow__1e2u52l4 {
+  left: clamp(var(--space-medium__xorl4v4), var(--horizontalOffset__1e2u52l3), calc(100% - var(--space-medium__xorl4v4)));
+  transform: translateX(-50%);
+  visibility: hidden;
+}
+.TooltipRenderer_baseArrow__1e2u52l4:before {
+  content: '';
+  visibility: visible;
+  transform: rotate(45deg);
+}
+.TooltipRenderer_baseArrow__1e2u52l4, .TooltipRenderer_baseArrow__1e2u52l4::before {
+  width: calc(12px + (var(--borderRadius-small__xorl4vb) * 2));
+  height: calc(12px + (var(--borderRadius-small__xorl4vb) * 2));
+  position: absolute;
+  background: inherit;
+  border-radius: var(--borderRadius-small__xorl4vb);
+}
+.TooltipRenderer_arrow_top__1e2u52l5 {
+  bottom: calc((12px / 2) * -1);
+}
+.TooltipRenderer_arrow_bottom__1e2u52l6 {
+  top: calc((12px / 2) * -1);
+}
+.ButtonIcon_button__9txf2k0:hover {
+  z-index: 1;
+}
+.ButtonIcon_button__9txf2k0::-moz-focus-inner {
+  border: 0;
+}
+.HiddenVisually_root__d29nt60 {
+  width: 1px;
+  height: 1px;
+  clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap;
+}
+.Field_placeholderColor__1tg1eg61::placeholder {
+  color: var(--foregroundColor-secondary__xorl4v1r);
+}
+.Field_secondaryIconSpace__1tg1eg62 {
+  padding-right: var(--touchableSize__xorl4v9);
+}
+.Field_iconSpace__1tg1eg63 {
+  padding-left: calc(var(--touchableSize__xorl4v9) - 2px);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Field_hideBorderOnDarkBackgroundInLightMode__1tg1eg64 {
+  opacity: 0;
+}
+.Field_field__1tg1eg60:hover:not(:disabled) ~ .Field_hoverOverlay__1tg1eg65, .Field_field__1tg1eg60:focus ~ .Field_hoverOverlay__1tg1eg65 {
+  opacity: 1;
+}
+.Field_verticalDivider__1tg1eg66 {
+  width: var(--borderWidth-standard__xorl4vy);
+  background: var(--borderColor-field__xorl4vl);
+  opacity: 0.4;
+}
+.Autosuggest_backdrop__2r47kq0 {
+  width: 100vw;
+  height: 100vh;
+  background: black;
+}
+.Autosuggest_backdropVisible__2r47kq1 {
+  opacity: 0.4;
+}
+.Autosuggest_menu__2r47kq2 {
+  max-height: calc((var(--touchableSize__xorl4v9) * 6) + var(--space-xxsmall__xorl4v1));
+  overflow-y: auto;
+}
+@media screen and (min-width: 740px) {
+  .Autosuggest_menu__2r47kq2 {
+    max-height: calc((var(--touchableSize__xorl4v9) * 8) + var(--space-xxsmall__xorl4v1));
+  }
+}
+.Badge_inline__ueqx8p0 {
+  display: inline-flex;
+  vertical-align: middle;
+  margin-bottom: calc(var(--space-xxsmall__xorl4v1) * -1);
+  margin-top: calc((var(--space-xxsmall__xorl4v1) + .2em) * -1);
+}
+.Keyline_tone_promote__uik19x6 {
+  background: var(--promote__uik19x0);
+}
+.Keyline_tone_info__uik19x7 {
+  background: var(--info__uik19x1);
+}
+.Keyline_tone_positive__uik19x8 {
+  background: var(--positive__uik19x2);
+}
+.Keyline_tone_caution__uik19x9 {
+  background: var(--caution__uik19x3);
+}
+.Keyline_tone_critical__uik19xa {
+  background: var(--critical__uik19x4);
+}
+.Keyline_tone_formAccent__uik19xb {
+  background: var(--formAccent__uik19x5);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Keyline_lightMode_light__uik19xc {
+  --promote__uik19x0: var(--borderColor-promote__xorl4vw);
+  --info__uik19x1: var(--borderColor-info__xorl4vp);
+  --positive__uik19x2: var(--borderColor-positive__xorl4vu);
+  --caution__uik19x3: var(--borderColor-caution__xorl4vh);
+  --critical__uik19x4: var(--borderColor-critical__xorl4vj);
+  --formAccent__uik19x5: var(--borderColor-formAccent__xorl4vn);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Keyline_lightMode_dark__uik19xd {
+  --promote__uik19x0: var(--borderColor-promoteLight__xorl4vx);
+  --info__uik19x1: var(--borderColor-infoLight__xorl4vq);
+  --positive__uik19x2: var(--borderColor-positiveLight__xorl4vv);
+  --caution__uik19x3: var(--borderColor-cautionLight__xorl4vi);
+  --critical__uik19x4: var(--borderColor-criticalLight__xorl4vk);
+  --formAccent__uik19x5: var(--borderColor-formAccentLight__xorl4vo);
+}
+html.sprinkles_darkMode__iv7so511 .Keyline_darkMode_light__uik19xe {
+  --promote__uik19x0: var(--borderColor-promote__xorl4vw);
+  --info__uik19x1: var(--borderColor-info__xorl4vp);
+  --positive__uik19x2: var(--borderColor-positive__xorl4vu);
+  --caution__uik19x3: var(--borderColor-caution__xorl4vh);
+  --critical__uik19x4: var(--borderColor-critical__xorl4vj);
+  --formAccent__uik19x5: var(--borderColor-formAccent__xorl4vn);
+}
+html.sprinkles_darkMode__iv7so511 .Keyline_darkMode_dark__uik19xf {
+  --promote__uik19x0: var(--borderColor-promoteLight__xorl4vx);
+  --info__uik19x1: var(--borderColor-infoLight__xorl4vq);
+  --positive__uik19x2: var(--borderColor-positiveLight__xorl4vv);
+  --caution__uik19x3: var(--borderColor-cautionLight__xorl4vi);
+  --critical__uik19x4: var(--borderColor-criticalLight__xorl4vk);
+  --formAccent__uik19x5: var(--borderColor-formAccentLight__xorl4vo);
+}
+.Keyline_noRadiusOnRight__uik19xg {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+.Keyline_largestWidth__uik19xh {
+  width: var(--borderRadius-xlarge__xorl4ve);
+}
+.Keyline_width__uik19xi {
+  width: var(--grid__xorl4va);
+}
+.InlineField_sizeVars_standard__3b9mfp2 {
+  --fieldSize__3b9mfp0: var(--inlineFieldSize-standard__xorl4v5g);
+  --labelCapHeight__3b9mfp1: var(--textSize-standard-mobile-capHeight__xorl4v3o);
+}
+.InlineField_sizeVars_small__3b9mfp3 {
+  --fieldSize__3b9mfp0: var(--inlineFieldSize-small__xorl4v5h);
+  --labelCapHeight__3b9mfp1: var(--textSize-small-mobile-capHeight__xorl4v3e);
+}
+.InlineField_realField__3b9mfp4 {
+  width: 44px;
+  height: 44px;
+  top: calc(((44px - var(--fieldSize__3b9mfp0)) / 2) * -1);
+  left: calc(((44px - var(--fieldSize__3b9mfp0)) / 2) * -1);
+}
+[data-braid-debug] .InlineField_realField__3b9mfp4 {
+  background: red;
+  opacity: 0.2;
+}
+.InlineField_fakeField__3b9mfp5 {
+  height: var(--fieldSize__3b9mfp0);
+  width: var(--fieldSize__3b9mfp0);
+  outline: var(--focusRingSize__xorl4v10) solid transparent;
+  transition: outline-color .125s ease;
+}
+.InlineField_realField__3b9mfp4[type="checkbox"]:checked ~ .InlineField_fakeField__3b9mfp5 {
+  background: transparent;
+}
+.InlineField_realField__3b9mfp4:focus-visible ~ .InlineField_fakeField__3b9mfp5 {
+  outline-color: var(--borderColor-focus__xorl4vm);
+}
+.InlineField_labelOffset__3b9mfp6 {
+  padding-top: calc((var(--fieldSize__3b9mfp0) - var(--labelCapHeight__3b9mfp1)) / 2);
+}
+.InlineField_realField__3b9mfp4:checked ~ * .InlineField_children__3b9mfp8,
+  .InlineField_realField__3b9mfp4.InlineField_isMixed__3b9mfp7 ~ * .InlineField_children__3b9mfp8 {
+  display: block;
+  z-index: 1;
+}
+.InlineField_realField__3b9mfp4:checked + .InlineField_fakeField__3b9mfp5 > .InlineField_selected__3b9mfp9,
+  .InlineField_realField__3b9mfp4.InlineField_isMixed__3b9mfp7 + .InlineField_fakeField__3b9mfp5 > .InlineField_selected__3b9mfp9 {
+  opacity: 1;
+}
+html:not(.sprinkles_darkMode__iv7so511) .InlineField_hideBorderOnDarkBackgroundInLightMode__3b9mfpa {
+  opacity: 0;
+}
+.InlineField_realField__3b9mfp4:hover:not(:checked):not(.InlineField_isMixed__3b9mfp7):not(:disabled) + .InlineField_fakeField__3b9mfp5 > .InlineField_hoverOverlay__3b9mfpb,
+  .InlineField_realField__3b9mfp4:focus:not(.InlineField_isMixed__3b9mfp7) + .InlineField_fakeField__3b9mfp5 > .InlineField_hoverOverlay__3b9mfpb {
+  opacity: 1;
+}
+.InlineField_hoverOverlay__3b9mfpb > .InlineField_indicator__3b9mfpc {
+  opacity: 0.2;
+}
+.InlineField_disabledRadioIndicator__3b9mfpd {
+  opacity: 0.3;
+}
+html:not(.sprinkles_darkMode__iv7so511) .InlineField_disabledRadioIndicator__3b9mfpd {
+  background-color: var(--foregroundColor-secondary__xorl4v1r);
+}
+html.sprinkles_darkMode__iv7so511 .InlineField_disabledRadioIndicator__3b9mfpd {
+  background-color: var(--foregroundColor-secondaryInverted__xorl4v1s);
+}
+.InlineField_checkboxScale__3b9mfpe {
+  transform: scale(0.85);
+}
+.InlineField_realField__3b9mfp4:active + .InlineField_fakeField__3b9mfp5 > * > .InlineField_checkboxScale__3b9mfpe {
+  transform: scale(0.75);
+}
+.InlineField_radioScale__3b9mfpf {
+  transform: scale(0.6);
+}
+.InlineField_realField__3b9mfp4:active + .InlineField_fakeField__3b9mfp5 > * > .InlineField_radioScale__3b9mfpf {
+  transform: scale(0.5);
+}
+@media screen and (min-width: 740px) {
+  .InlineField_sizeVars_standard__3b9mfp2 {
+    --labelCapHeight__3b9mfp1: var(--textSize-standard-tablet-capHeight__xorl4v3t);
+  }
+  .InlineField_sizeVars_small__3b9mfp3 {
+    --labelCapHeight__3b9mfp1: var(--textSize-small-tablet-capHeight__xorl4v3j);
+  }
+}
+.ContentBlock_marginAuto__7i4une0 {
+  margin: 0 auto;
+}
+html:not(.sprinkles_darkMode__iv7so511) .Modal_backdrop__1wjkaea2 {
+  background: rgba(0, 0, 0, 0.4);
+}
+html.sprinkles_darkMode__iv7so511 .Modal_backdrop__1wjkaea2 {
+  background: rgba(0, 0, 0, 0.6);
+}
+.Modal_rightAnimation__1wjkaea4 {
+  opacity: 1;
+  transform: translateX(110%);
+}
+.Modal_leftAnimation__1wjkaea5 {
+  opacity: 1;
+  transform: translateX(-110%);
+}
+.Modal_centerAnimation__1wjkaea6 {
+  transform: scale(.8);
+}
+.Modal_horizontalTransition__1wjkaea7 {
+  transition: transform .3s cubic-bezier(0.4, 0, 0, 1), opacity .3s cubic-bezier(0.4, 0, 0, 1);
+}
+.Modal_pointerEventsAll__1wjkaea9 {
+  pointer-events: all;
+}
+.Modal_viewportHeight__1wjkaead {
+  max-height: var(--fullHeightVar__1wjkaeab);
+}
+.Modal_maxSize_center__1wjkaeae {
+  --gutterSizeVar__1wjkaeaa: var(--space-xsmall__xorl4v2);
+  max-height: calc(var(--fullHeightVar__1wjkaeab) - (var(--gutterSizeVar__1wjkaeaa) * 2));
+  max-width: calc(var(--fullWidthVar__1wjkaeac) - (var(--gutterSizeVar__1wjkaeaa) * 2));
+}
+.Modal_modalContainer__1wjkaeaf {
+  --fullHeightVar__1wjkaeab: 100vh;
+  --fullWidthVar__1wjkaeac: 100vw;
+  max-height: var(--fullHeightVar__1wjkaeab);
+  max-width: var(--fullWidthVar__1wjkaeac);
+}
+.Modal_headingRoot__1wjkaeag {
+  overflow-wrap: break-word;
+}
+.Modal_closeIconOffset__1wjkaeah {
+  top: -5px;
+  right: -5px;
+}
+@media screen and (prefers-reduced-motion) {
+  .Modal_reducedMotion__1wjkaea3 {
+    transform: none !important;
+  }
+}
+@media screen and (min-width: 740px) {
+  .Modal_rightAnimation__1wjkaea4 {
+    opacity: 0;
+    transform: translateX(40px);
+  }
+  .Modal_leftAnimation__1wjkaea5 {
+    opacity: 0;
+    transform: translateX(-40px);
+  }
+  .Modal_horizontalTransition__1wjkaea7 {
+    transition: transform .175s cubic-bezier(0.4, 0, 0, 1), opacity .175s cubic-bezier(0.4, 0, 0, 1);
+  }
+  .Modal_maxSize_center__1wjkaeae {
+    --gutterSizeVar__1wjkaeaa: var(--space-gutter__xorl4v0);
+  }
+}
+@media screen and (min-width: 992px) {
+  .Modal_maxSize_center__1wjkaeae {
+    --gutterSizeVar__1wjkaeaa: var(--space-xlarge__xorl4v6);
+  }
+}
+@supports (height: 1dvh) {
+  .Modal_modalContainer__1wjkaeaf {
+    --fullHeightVar__1wjkaeab: 100dvh;
+    --fullWidthVar__1wjkaeac: 100dvw;
+  }
+}
+.TextLink_base__1uhsi8q2 {
+  color: var(--color__1uhsi8q0);
+  text-decoration: var(--linkDecoration__xorl4v5f);
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 3px;
+  outline-offset: 0.2em;
+  border-radius: var(--borderRadius-small__xorl4vb);
+}
+.TextLink_base__1uhsi8q2:hover {
+  color: var(--colorHover__1uhsi8q1);
+  text-decoration: underline;
+  text-decoration-thickness: 0.08em;
+}
+.TextLink_base__1uhsi8q2:focus-visible {
+  color: var(--colorHover__1uhsi8q1);
+}
+.TextLink_weakLink__1uhsi8q3 {
+  --color__1uhsi8q0: inherit;
+  --colorHover__1uhsi8q1: inherit;
+  text-decoration: underline;
+  text-decoration-thickness: 0.08em;
+}
+html:not(.sprinkles_darkMode__iv7so511) .TextLink_regularLinkLightMode_light__1uhsi8q4 {
+  --color__1uhsi8q0: var(--foregroundColor-link__xorl4v1f);
+  --colorHover__1uhsi8q1: var(--foregroundColor-linkHover__xorl4v1g);
+}
+html:not(.sprinkles_darkMode__iv7so511) .TextLink_regularLinkLightMode_dark__1uhsi8q5 {
+  --color__1uhsi8q0: var(--foregroundColor-linkLight__xorl4v1h);
+  --colorHover__1uhsi8q1: var(--foregroundColor-linkLight__xorl4v1h);
+}
+html.sprinkles_darkMode__iv7so511 .TextLink_regularLinkDarkMode_light__1uhsi8q6 {
+  --color__1uhsi8q0: var(--foregroundColor-link__xorl4v1f);
+  --colorHover__1uhsi8q1: var(--foregroundColor-linkHover__xorl4v1g);
+}
+html.sprinkles_darkMode__iv7so511 .TextLink_regularLinkDarkMode_dark__1uhsi8q7 {
+  --color__1uhsi8q0: var(--foregroundColor-linkLight__xorl4v1h);
+  --colorHover__1uhsi8q1: var(--foregroundColor-linkLight__xorl4v1h);
+}
+html:not(.sprinkles_darkMode__iv7so511) .TextLink_visitedLightMode_light__1uhsi8q8:visited {
+  color: var(--foregroundColor-linkVisited__xorl4v1i);
+}
+html:not(.sprinkles_darkMode__iv7so511) .TextLink_visitedLightMode_dark__1uhsi8q9:visited {
+  color: var(--foregroundColor-linkLightVisited__xorl4v1j);
+}
+html.sprinkles_darkMode__iv7so511 .TextLink_visitedDarkMode_light__1uhsi8qa:visited {
+  color: var(--foregroundColor-linkVisited__xorl4v1i);
+}
+html.sprinkles_darkMode__iv7so511 .TextLink_visitedDarkMode_dark__1uhsi8qb:visited {
+  color: var(--foregroundColor-linkLightVisited__xorl4v1j);
+}
+.Dropdown_field__wzgpgf0 {
+  padding-right: var(--touchableSize__xorl4v9);
+}
+@media print {
+  .Hidden_hiddenOnPrint__1ul19h20 {
+    display: none !important;
+  }
+}
+.List_currentColor__1c4y3150 {
+  background: currentColor;
+}
+.List_large__1c4y3151 {
+  width: 5px;
+  height: 5px;
+}
+.List_standard__1c4y3152 {
+  width: 4px;
+  height: 4px;
+}
+.List_xsmall__1c4y3153 {
+  width: 3px;
+  height: 3px;
+}
+.List_minCharacterWidth__1c4y3154 {
+  min-width: 1.4ch;
+}
+.List_minCharacterWidth__1c4y3155 {
+  min-width: 2.4ch;
+}
+.List_trimGutter__1c4y3156 {
+  margin-right: -0.4ch;
+}
+@keyframes Loader_bounce__jv8rqo9 {
+  33% {
+    transform: translateY(-1.4em);
+  }
+  66% {
+    transform: translateY(1.4em);
+  }
+}
+@keyframes Loader_fade__jv8rqod {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.Loader_rootSize_xsmall__jv8rqo0 {
+  height: var(--textSize-xsmall-mobile-capHeight__xorl4v34);
+}
+.Loader_rootSize_small__jv8rqo1 {
+  height: var(--textSize-small-mobile-capHeight__xorl4v3e);
+}
+.Loader_rootSize_standard__jv8rqo2 {
+  height: var(--textSize-standard-mobile-capHeight__xorl4v3o);
+}
+.Loader_rootSize_large__jv8rqo3 {
+  height: var(--textSize-large-mobile-capHeight__xorl4v3y);
+}
+.Loader_size_xsmall__jv8rqo4 {
+  height: var(--textSize-xsmall-mobile-fontSize__xorl4v32);
+}
+.Loader_size_small__jv8rqo5 {
+  height: var(--textSize-small-mobile-fontSize__xorl4v3c);
+}
+.Loader_size_standard__jv8rqo6 {
+  height: var(--textSize-standard-mobile-fontSize__xorl4v3m);
+}
+.Loader_size_large__jv8rqo7 {
+  height: var(--textSize-large-mobile-fontSize__xorl4v3w);
+}
+.Loader_currentColor__jv8rqo8 {
+  fill: currentcolor;
+}
+.Loader_bounceAnimation__jv8rqoa {
+  animation-name: Loader_bounce__jv8rqo9;
+  animation-fill-mode: both;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-duration: 0.6s;
+}
+.Loader_circle__jv8rqob {
+  transform: translateY(1.4em);
+}
+.Loader_circle__jv8rqob:nth-child(1) {
+  animation-delay: 140ms;
+}
+.Loader_circle__jv8rqob:nth-child(2) {
+  animation-delay: 70ms;
+}
+.Loader_delay__jv8rqoe {
+  opacity: 0;
+  animation-name: Loader_fade__jv8rqod;
+  animation-iteration-count: 1;
+  animation-fill-mode: forwards;
+  animation-timing-function: ease-in;
+  animation-duration: 0.25s;
+  animation-delay: 800ms;
+}
+@media screen and (min-width: 740px) {
+  .Loader_rootSize_xsmall__jv8rqo0 {
+    height: var(--textSize-xsmall-tablet-capHeight__xorl4v39);
+  }
+  .Loader_rootSize_small__jv8rqo1 {
+    height: var(--textSize-small-tablet-capHeight__xorl4v3j);
+  }
+  .Loader_rootSize_standard__jv8rqo2 {
+    height: var(--textSize-standard-tablet-capHeight__xorl4v3t);
+  }
+  .Loader_rootSize_large__jv8rqo3 {
+    height: var(--textSize-large-tablet-capHeight__xorl4v43);
+  }
+  .Loader_size_xsmall__jv8rqo4 {
+    height: var(--textSize-xsmall-tablet-fontSize__xorl4v37);
+  }
+  .Loader_size_small__jv8rqo5 {
+    height: var(--textSize-small-tablet-fontSize__xorl4v3h);
+  }
+  .Loader_size_standard__jv8rqo6 {
+    height: var(--textSize-standard-tablet-fontSize__xorl4v3r);
+  }
+  .Loader_size_large__jv8rqo7 {
+    height: var(--textSize-large-tablet-fontSize__xorl4v41);
+  }
+}
+.ScrollContainer_container__17ondx40 {
+  -webkit-overflow-scrolling: touch;
+  -webkit-mask-composite: destination-in;
+  mask-composite: intersect;
+}
+.ScrollContainer_hideScrollbar__17ondx41 {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.ScrollContainer_hideScrollbar__17ondx41::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+.ScrollContainer_fadeSize_small__17ondx43 {
+  --scrollOverlaySize__17ondx42: 40px;
+}
+.ScrollContainer_fadeSize_medium__17ondx44 {
+  --scrollOverlaySize__17ondx42: 60px;
+}
+.ScrollContainer_fadeSize_large__17ondx45 {
+  --scrollOverlaySize__17ondx42: 80px;
+}
+.ScrollContainer_direction_horizontal__17ondx46 {
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: fit-content;
+}
+.ScrollContainer_direction_vertical__17ondx47 {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+.ScrollContainer_direction_all__17ondx48 {
+  overflow: auto;
+}
+.ScrollContainer_mask__17ondx4d {
+  mask-image: linear-gradient(to bottom, transparent 0, black var(--top__17ondx4b, 0)),linear-gradient(to right, transparent 0, black var(--left__17ondx49, 0)),linear-gradient(to left, transparent 0, black var(--right__17ondx4a, 0)),linear-gradient(to top, transparent 0, black var(--bottom__17ondx4c, 0));
+}
+.ScrollContainer_maskLeft__17ondx4e {
+  --left__17ondx49: var(--scrollOverlaySize__17ondx42);
+}
+.ScrollContainer_maskRight__17ondx4f {
+  --right__17ondx4a: var(--scrollOverlaySize__17ondx42);
+}
+.ScrollContainer_maskTop__17ondx4g {
+  --top__17ondx4b: var(--scrollOverlaySize__17ondx42);
+}
+.ScrollContainer_maskBottom__17ondx4h {
+  --bottom__17ondx4c: var(--scrollOverlaySize__17ondx42);
+}
+.MenuRenderer_backdrop__gxm1hx1 {
+  width: 100vw;
+  height: 100vh;
+}
+.MenuRenderer_menuPosition__gxm1hx6 {
+  top: var(--triggerVars_bottom__gxm1hx4);
+  bottom: var(--triggerVars_top__gxm1hx2);
+  left: var(--triggerVars_left__gxm1hx3);
+  right: var(--triggerVars_right__gxm1hx5);
+}
+.MenuRenderer_baseWidth__gxm1hx8 {
+  width: calc(var(--widthVar__gxm1hx7) / 4);
+}
+.MenuRenderer_width_small__gxm1hx9 {
+  --widthVar__gxm1hx7: var(--contentWidth-small__xorl4v12);
+}
+.MenuRenderer_width_medium__gxm1hxa {
+  --widthVar__gxm1hx7: var(--contentWidth-medium__xorl4v13);
+}
+.MenuRenderer_width_large__gxm1hxb {
+  --widthVar__gxm1hx7: var(--contentWidth-large__xorl4v14);
+}
+.MenuRenderer_menuHeightLimit__gxm1hxc {
+  max-height: calc((var(--touchableSize__xorl4v9) * 9.5) + (var(--menuYPadding__gxm1hx0) * 2));
+}
+.useMenuItem_menuItem__1158u5f0::-moz-focus-inner {
+  border: 0;
+}
+.useMenuItem_menuItemLeftSlot__1158u5f1 {
+  height: 0px;
+}
+.MenuItemCheckbox_checkboxSize__1d2z2hd2 {
+  --menuItemCapHeight__1d2z2hd0: var(--textSize-standard-mobile-capHeight__xorl4v3o);
+  --crop__1d2z2hd1: calc(((var(--inlineFieldSize-small__xorl4v5h) - var(--menuItemCapHeight__1d2z2hd0)) / 2) * -1);
+  height: var(--inlineFieldSize-small__xorl4v5h);
+  width: var(--inlineFieldSize-small__xorl4v5h);
+  margin-top: var(--crop__1d2z2hd1);
+  margin-bottom: var(--crop__1d2z2hd1);
+}
+@media screen and (min-width: 740px) {
+  .MenuItemCheckbox_checkboxSize__1d2z2hd2 {
+    --menuItemCapHeight__1d2z2hd0: var(--textSize-standard-tablet-capHeight__xorl4v3t);
+  }
+}
+.OverflowMenu_wrapperPositioning__ycsyyc0 {
+  margin: -1px -6px;
+}
+.MonthPicker_nativeInput__1uimft00::-webkit-inner-spin-button, .MonthPicker_nativeInput__1uimft00::-webkit-calendar-picker-indicator, .MonthPicker_nativeInput__1uimft00::-webkit-clear-button {
+  display: none;
+  -webkit-appearance: none;
+}
+.Page_fullHeight__1lh04yl1 {
+  min-height: var(--heightLimit__1lh04yl0, 100vh);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Pagination_lightModeCurrentKeyline__bn82bg1 {
+  opacity: 0.3;
+}
+html.sprinkles_darkMode__iv7so511 .Pagination_darkModeCurrentKeyline__bn82bg2 {
+  opacity: 0.3;
+}
+.Pagination_current__bn82bg3 {
+  opacity: 0.075;
+}
+.Pagination_hover__bn82bg0:hover .Pagination_background__bn82bg4:not(.Pagination_current__bn82bg3) {
+  opacity: 0.5;
+}
+.Rating_inlineFlex__tlnpno0 {
+  display: inline-flex;
+  gap: 1px;
+}
+html:not(.sprinkles_darkMode__iv7so511) .Stepper_tone_formAccent__19bg0vv2 {
+  --highlightVar__19bg0vv1: var(--borderColor-formAccent__xorl4vn);
+}
+html.sprinkles_darkMode__iv7so511 .Stepper_tone_formAccent__19bg0vv2 {
+  --highlightVar__19bg0vv1: var(--borderColor-formAccentLight__xorl4vo);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Stepper_tone_neutral__19bg0vv3 {
+  --highlightVar__19bg0vv1: var(--borderColor-neutral__xorl4vr);
+}
+html.sprinkles_darkMode__iv7so511 .Stepper_tone_neutral__19bg0vv3 {
+  --highlightVar__19bg0vv1: var(--borderColor-neutralLight__xorl4vt);
+}
+.Stepper_step__19bg0vv4 {
+  outline: none;
+  text-align: left;
+}
+html:not(.sprinkles_darkMode__iv7so511) .Stepper_step__19bg0vv4 {
+  --baseColourVar__19bg0vv0: var(--borderColor-neutralLight__xorl4vt);
+}
+html.sprinkles_darkMode__iv7so511 .Stepper_step__19bg0vv4 {
+  --baseColourVar__19bg0vv0: var(--borderColor-neutral__xorl4vr);
+}
+.Stepper_indicator__19bg0vv6 {
+  height: var(--inlineFieldSize-small__xorl4v5h);
+  width: var(--inlineFieldSize-small__xorl4v5h);
+  color: var(--baseColourVar__19bg0vv0);
+}
+.Stepper_stretch__19bg0vv7 {
+  flex: 1;
+}
+.Stepper_highlight__19bg0vv9 {
+  color: var(--highlightVar__19bg0vv1);
+}
+.Stepper_inner__19bg0vvd {
+  fill: currentcolor;
+  transform-origin: 50% 50%;
+  transform: scale(0);
+}
+.Stepper_active__19bg0vvb > .Stepper_inner__19bg0vvd {
+  transform: scale(1);
+  opacity: 1;
+}
+.Stepper_complete__19bg0vva > .Stepper_inner__19bg0vvd {
+  transform: scale(2.1);
+  opacity: 1;
+}
+.Stepper_tick__19bg0vvf {
+  transition-delay: .1s;
+  transform-origin: 50% 50%;
+}
+:not(.Stepper_complete__19bg0vva) > .Stepper_tick__19bg0vvf {
+  opacity: 0;
+  transition-delay: 0s;
+  transform: scale(.5) rotate(50deg);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Stepper_tick__19bg0vvf {
+  fill: var(--foregroundColor-neutralInverted__xorl4v1l);
+}
+html.sprinkles_darkMode__iv7so511 .Stepper_tick__19bg0vvf {
+  fill: var(--foregroundColor-neutral__xorl4v1k);
+}
+.Stepper_progressTrack__19bg0vvg {
+  background: repeating-linear-gradient(90deg, var(--baseColourVar__19bg0vv0), var(--baseColourVar__19bg0vv0) 2px, transparent 2px, transparent 4px);
+  height: var(--borderWidth-large__xorl4vz);
+  width: calc((100% - var(--inlineFieldSize-small__xorl4v5h)) - (var(--space-xxsmall__xorl4v1) * 2));
+  top: calc((var(--inlineFieldSize-small__xorl4v5h) - var(--borderWidth-large__xorl4vz)) / 2);
+  left: calc(var(--inlineFieldSize-small__xorl4v5h) + var(--space-xxsmall__xorl4v1));
+}
+.Stepper_progressLine__19bg0vvi {
+  background: var(--highlightVar__19bg0vv1);
+  transition: transform .2s ease;
+}
+.Stepper_progressUnfilled__19bg0vvj {
+  transform: translateX(-101%);
+}
+.Stepper_indicatorContainer__19bg0vvk {
+  outline: var(--focusRingSize__xorl4v10) solid transparent;
+  width: var(--inlineFieldSize-small__xorl4v5h);
+  transition: var(--transition-fast__xorl4v5i), outline-color .125s ease;
+}
+.Stepper_step__19bg0vv4:focus-visible .Stepper_indicatorContainer__19bg0vvk {
+  outline-color: var(--borderColor-focus__xorl4vm);
+  transform: scale(1.2);
+}
+.Stepper_step__19bg0vv4:active .Stepper_indicatorContainer__19bg0vvk {
+  transform: var(--transform-touchable__xorl4v5k);
+}
+@media screen and (min-width: 740px) {
+  .Stepper_stretchLastAboveTablet__19bg0vv8 {
+    flex: 1;
+  }
+  .Stepper_progressTrackCentered__19bg0vvh {
+    left: calc((50% + (var(--inlineFieldSize-small__xorl4v5h) / 2)) + var(--space-xxsmall__xorl4v1));
+  }
+}
+.Table_table__1gzljjr1 {
+  border-collapse: separate;
+  border: var(--borderWidth-standard__xorl4vy) solid var(--borderColor__1gzljjr0);
+  font-variant-numeric: tabular-nums;
+  word-break: break-word;
+}
+html:not(.sprinkles_darkMode__iv7so511) .Table_table__1gzljjr1 {
+  --borderColor__1gzljjr0: var(--borderColor-neutralLight__xorl4vt);
+}
+html.sprinkles_darkMode__iv7so511 .Table_table__1gzljjr1 {
+  --borderColor__1gzljjr0: var(--borderColor-neutral__xorl4vr);
+}
+.Table_row__1gzljjr4:not(:last-child) > .Table_cell__1gzljjr5 {
+  border-bottom: 1px solid var(--borderColor__1gzljjr0);
+}
+.Table_tableSection__1gzljjr3:not(.Table_tableHeader__1gzljjr2) > .Table_row__1gzljjr4 > .Table_headCell__1gzljjr6:not(:first-child) {
+  border-left: 1px solid var(--borderColor__1gzljjr0);
+}
+.Table_tableSection__1gzljjr3:not(.Table_tableHeader__1gzljjr2) > .Table_row__1gzljjr4 > .Table_headCell__1gzljjr6:not(:last-child) {
+  border-right: 1px solid var(--borderColor__1gzljjr0);
+}
+.Table_tableSection__1gzljjr3:not(:first-child) > .Table_row__1gzljjr4:first-child > .Table_cell__1gzljjr5 {
+  border-top: var(--borderWidth-standard__xorl4vy) solid var(--borderColor__1gzljjr0);
+}
+.Table_alignYCenter__1gzljjr7 {
+  vertical-align: middle;
+}
+.Table_nowrap__1gzljjr8 {
+  white-space: nowrap;
+}
+.Table_softWidth__1gzljjra {
+  width: var(--softWidthVar__1gzljjr9);
+}
+.Table_minWidth__1gzljjrc {
+  min-width: var(--minWidthVar__1gzljjrb);
+}
+.Table_maxWidth__1gzljjre {
+  max-width: var(--maxWidthVar__1gzljjrd);
+}
+@media screen and (min-width: 740px) {
+  .Table_showOnTablet__1gzljjrf {
+    display: table-cell;
+  }
+}
+@media screen and (min-width: 992px) {
+  .Table_showOnDesktop__1gzljjrg {
+    display: table-cell;
+  }
+}
+@media screen and (min-width: 1200px) {
+  .Table_showOnWide__1gzljjrh {
+    display: table-cell;
+  }
+}
+.Tabs_tab__168cu0s0::-moz-focus-inner {
+  border: 0;
+}
+.Tabs_tab__168cu0s0:hover .Tabs_hoveredTab__168cu0s1 {
+  opacity: 1;
+}
+.Tabs_nowrap__168cu0s2 {
+  white-space: nowrap;
+}
+.Tabs_scroll__168cu0s3 {
+  -webkit-overflow-scrolling: touch;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.Tabs_scroll__168cu0s3::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+.Tabs_mask__168cu0s4 {
+  mask-image: linear-gradient(90deg, rgba(0,0,0,1) 0, rgba(0,0,0,1) calc(100% - 80px), rgba(0,0,0,0) 100%);
+}
+.Tabs_marginAuto__168cu0s5 {
+  margin-left: auto;
+  margin-right: auto;
+}
+.Tabs_tabFocusRing__168cu0s6 {
+  outline-offset: calc(var(--focusRingSize__xorl4v10) * -1);
+}
+.Tabs_tabUnderline__168cu0sb {
+  --underlineRadius__168cu0s9: calc(var(--borderRadius-small__xorl4vb) / var(--underlineScale__168cu0sa));
+  --underlineScale__168cu0sa: calc(var(--underlineWidth__168cu0s8) / 100);
+  height: var(--borderWidth-large__xorl4vz);
+  border-top-left-radius: var(--underlineRadius__168cu0s9);
+  border-top-right-radius: var(--underlineRadius__168cu0s9);
+  width: 100px;
+  transform-origin: 0 0;
+  transition: transform .3s ease;
+  transform: translateZ(0) translateX(calc(var(--underlineLeft__168cu0s7) * 1px)) scaleX(var(--underlineScale__168cu0sa));
+}
+html.sprinkles_darkMode__iv7so511 .Tabs_tabUnderlineActiveDarkMode__168cu0sc {
+  background: var(--borderColor-formAccentLight__xorl4vo);
+}
+.Tabs_divider__168cu0se {
+  height: var(--borderWidth-standard__xorl4vy);
+}
+.Tag_clearGutter__7vya150 {
+  padding-left: 1px;
+}
+.Highlight_root__1mad43z1 {
+  padding: 0 2px;
+  margin: 0 -2px;
+  text-decoration: underline;
+  text-decoration-style: wavy;
+  text-decoration-skip-ink: none;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 2px;
+}
+html:not(.sprinkles_darkMode__iv7so511) .Highlight_critical__1mad43z2 {
+  text-decoration-color: var(--borderColor-critical__xorl4vj);
+  background: var(--backgroundColor-criticalLight__xorl4v27);
+}
+html.sprinkles_darkMode__iv7so511 .Highlight_critical__1mad43z2 {
+  text-decoration-color: var(--borderColor-criticalLight__xorl4vk);
+}
+.Highlight_caution__1mad43z3 {
+  text-decoration-color: var(--borderColor-caution__xorl4vh);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Highlight_caution__1mad43z3 {
+  background: var(--backgroundColor-cautionLight__xorl4v23);
+}
+.Textarea_field__drx6sk0 {
+  resize: vertical;
+  background: transparent;
+  min-height: calc(var(--grid__xorl4va) * 15);
+}
+.Textarea_highlights__drx6sk1 {
+  color: transparent !important;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+.Textarea_highlights__drx6sk1:after {
+  content: "\\A";
+}
+.TextDropdown_select__196u93m0 {
+  min-height: 44px;
+  min-width: 44px;
+  height: 100%;
+  width: 100%;
+  transform: translate(-50%, -50%);
+  top: 50%;
+  left: 50%;
+}
+[data-braid-debug] .TextDropdown_select__196u93m0 {
+  background: red;
+  opacity: 0.2;
+}
+.TextDropdown_focusRing__196u93m2 {
+  outline: var(--focusRingSize__xorl4v10) solid transparent;
+  transition: outline-color .125s ease;
+  outline-offset: var(--space-xxsmall__xorl4v1);
+}
+.TextDropdown_select__196u93m0:focus-visible ~ .TextDropdown_focusRing__196u93m2 {
+  outline-color: var(--borderColor-focus__xorl4vm);
+}
+.Tiles_tiles__jxnmqs5 {
+  --columns__jxnmqs0: var(--mobileColumnsVar__jxnmqs1);
+  display: grid;
+  grid-template-columns: repeat(var(--columns__jxnmqs0), 1fr);
+}
+.Tiles_tiles__jxnmqs5 > * {
+  min-width: 0;
+}
+@media screen and (min-width: 740px) {
+  .Tiles_tiles__jxnmqs5 {
+    --columns__jxnmqs0: var(--tabletColumnsVar__jxnmqs2);
+  }
+}
+@media screen and (min-width: 992px) {
+  .Tiles_tiles__jxnmqs5 {
+    --columns__jxnmqs0: var(--desktopColumnsVar__jxnmqs3);
+  }
+}
+@media screen and (min-width: 1200px) {
+  .Tiles_tiles__jxnmqs5 {
+    --columns__jxnmqs0: var(--wideColumnsVar__jxnmqs4);
+  }
+}
+.Toggle_bleedToCapHeight_standard__18ov2xx0 {
+  height: var(--textSize-standard-mobile-capHeight__xorl4v3o);
+}
+.Toggle_bleedToCapHeight_small__18ov2xx1 {
+  height: var(--textSize-small-mobile-capHeight__xorl4v3e);
+}
+.Toggle_root__18ov2xx2:hover {
+  z-index: 1;
+}
+.Toggle_realField__18ov2xx3 {
+  height: 44px;
+}
+[data-braid-debug] .Toggle_realField__18ov2xx3 {
+  background: red;
+  opacity: 0.2;
+}
+.Toggle_realFieldPosition_standard__18ov2xx4 {
+  top: calc(((44px - var(--inlineFieldSize-standard__xorl4v5g)) / 2) * -1);
+}
+.Toggle_realFieldPosition_small__18ov2xx5 {
+  top: calc(((44px - var(--inlineFieldSize-small__xorl4v5h)) / 2) * -1);
+}
+.Toggle_fieldSize_standard__18ov2xx6 {
+  width: calc(var(--inlineFieldSize-standard__xorl4v5g) * 1.6);
+}
+.Toggle_fieldSize_small__18ov2xx7 {
+  width: calc(var(--inlineFieldSize-small__xorl4v5h) * 1.6);
+}
+.Toggle_slideContainerSize_standard__18ov2xx9 {
+  height: var(--inlineFieldSize-standard__xorl4v5g);
+}
+.Toggle_slideContainerSize_small__18ov2xxa {
+  height: var(--inlineFieldSize-small__xorl4v5h);
+}
+.Toggle_slideTrack_standard__18ov2xxb {
+  height: calc(var(--inlineFieldSize-standard__xorl4v5g) - var(--grid__xorl4va));
+}
+.Toggle_slideTrack_small__18ov2xxc {
+  height: calc(var(--inlineFieldSize-small__xorl4v5h) - var(--grid__xorl4va));
+}
+html:not(.sprinkles_darkMode__iv7so511) .Toggle_slideTrackBgLightMode_light__18ov2xxd {
+  background: rgba(0,0,0,0.08);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Toggle_slideTrackBgLightMode_dark__18ov2xxe {
+  background: rgba(255,255,255,0.12);
+}
+html.sprinkles_darkMode__iv7so511 .Toggle_slideTrackBgDarkMode_light__18ov2xxf {
+  background: rgba(0,0,0,0.08);
+}
+html.sprinkles_darkMode__iv7so511 .Toggle_slideTrackBgDarkMode_dark__18ov2xxg {
+  background: rgba(255,255,255,0.12);
+}
+.Toggle_slideTrackMask__18ov2xxh {
+  -webkit-mask-image: -webkit-radial-gradient(white, black);
+}
+.Toggle_realField__18ov2xx3:not(:checked) + .Toggle_slideContainer__18ov2xx8 .Toggle_slideTrackSelected__18ov2xxi {
+  transform: translateX(calc(var(--touchableSize__xorl4v9) * -1));
+}
+.Toggle_slider_standard__18ov2xxj {
+  outline: var(--focusRingSize__xorl4v10) solid transparent;
+  height: var(--inlineFieldSize-standard__xorl4v5g);
+  width: var(--inlineFieldSize-standard__xorl4v5g);
+  transition: var(--transition-fast__xorl4v5i), outline-color .125s ease;
+}
+.Toggle_realField__18ov2xx3:focus-visible + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_standard__18ov2xxj {
+  outline-color: var(--borderColor-focus__xorl4vm);
+}
+.Toggle_realField__18ov2xx3:active + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_standard__18ov2xxj {
+  transform: translateX(calc((var(--inlineFieldSize-standard__xorl4v5g) * 0.12) * -1));
+}
+.Toggle_realField__18ov2xx3:checked + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_standard__18ov2xxj {
+  transform: translateX(calc((var(--inlineFieldSize-standard__xorl4v5g) * 1.6) - var(--inlineFieldSize-standard__xorl4v5g)));
+}
+.Toggle_realField__18ov2xx3:active:checked + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_standard__18ov2xxj {
+  transform: translateX(calc(((var(--inlineFieldSize-standard__xorl4v5g) * 1.6) - var(--inlineFieldSize-standard__xorl4v5g)) + (var(--inlineFieldSize-standard__xorl4v5g) * 0.12)));
+}
+.Toggle_slider_small__18ov2xxk {
+  outline: var(--focusRingSize__xorl4v10) solid transparent;
+  height: var(--inlineFieldSize-small__xorl4v5h);
+  width: var(--inlineFieldSize-small__xorl4v5h);
+  transition: var(--transition-fast__xorl4v5i), outline-color .125s ease;
+}
+.Toggle_realField__18ov2xx3:focus-visible + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_small__18ov2xxk {
+  outline-color: var(--borderColor-focus__xorl4vm);
+}
+.Toggle_realField__18ov2xx3:active + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_small__18ov2xxk {
+  transform: translateX(calc((var(--inlineFieldSize-small__xorl4v5h) * 0.12) * -1));
+}
+.Toggle_realField__18ov2xx3:checked + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_small__18ov2xxk {
+  transform: translateX(calc((var(--inlineFieldSize-small__xorl4v5h) * 1.6) - var(--inlineFieldSize-small__xorl4v5h)));
+}
+.Toggle_realField__18ov2xx3:active:checked + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_small__18ov2xxk {
+  transform: translateX(calc(((var(--inlineFieldSize-small__xorl4v5h) * 1.6) - var(--inlineFieldSize-small__xorl4v5h)) + (var(--inlineFieldSize-small__xorl4v5h) * 0.12)));
+}
+.Toggle_sliderThumbOutlineFix__18ov2xxl {
+  transform: scale(1.04);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Toggle_hideBorderOnDarkBackgroundInLightMode__18ov2xxm {
+  opacity: 0;
+}
+.Toggle_realField__18ov2xx3:hover:not(:disabled) + .Toggle_slideContainer__18ov2xx8 .Toggle_hoverOverlay__18ov2xxn,
+  .Toggle_realField__18ov2xx3:focus + .Toggle_slideContainer__18ov2xx8 .Toggle_hoverOverlay__18ov2xxn {
+  opacity: 1;
+}
+@media screen and (min-width: 740px) {
+  .Toggle_bleedToCapHeight_standard__18ov2xx0 {
+    height: var(--textSize-standard-tablet-capHeight__xorl4v3t);
+  }
+  .Toggle_bleedToCapHeight_small__18ov2xx1 {
+    height: var(--textSize-small-tablet-capHeight__xorl4v3j);
+  }
+}
+.Toast_toast__yjs4y70 {
+  pointer-events: all;
+}
+.IconArrow_root__yd90er0 {
+  transition: transform 0.3s ease;
+  transform-origin: 50% 50%;
+}
+.IconArrow_flip__yd90er1 {
+  transform: rotateX(180deg);
+}
+.IconArrow_rotate__yd90er3 {
+  transform: scaleX(var(--mirrorVar__yd90er2, 1)) rotate(90deg);
+}
+.IconArrow_mirror__yd90er4 {
+  --mirrorVar__yd90er2: -1;
+}
+.IconThumb_root__1no4uw80 {
+  transition: transform 0.3s ease;
+  transform-origin: 50% 50%;
+}
+.IconThumb_down__1no4uw81 {
+  transform: rotate(180deg);
+}
+.seekJobs_seekJobs__17eom0l0 {
+  --space-gutter__xorl4v0: 24px;
+  --space-xxsmall__xorl4v1: 8px;
+  --space-xsmall__xorl4v2: 12px;
+  --space-small__xorl4v3: 16px;
+  --space-medium__xorl4v4: 24px;
+  --space-large__xorl4v5: 32px;
+  --space-xlarge__xorl4v6: 48px;
+  --space-xxlarge__xorl4v7: 64px;
+  --space-xxxlarge__xorl4v8: 96px;
+  --touchableSize__xorl4v9: 48px;
+  --grid__xorl4va: 4px;
+  --borderRadius-small__xorl4vb: 4px;
+  --borderRadius-standard__xorl4vc: 8px;
+  --borderRadius-large__xorl4vd: 16px;
+  --borderRadius-xlarge__xorl4ve: 24px;
+  --borderColor-brandAccent__xorl4vf: #E60278;
+  --borderColor-brandAccentLight__xorl4vg: #F8B1DC;
+  --borderColor-caution__xorl4vh: #FDC221;
+  --borderColor-cautionLight__xorl4vi: #FEE384;
+  --borderColor-critical__xorl4vj: #B91E1E;
+  --borderColor-criticalLight__xorl4vk: #FB999A;
+  --borderColor-field__xorl4vl: #838FA5;
+  --borderColor-focus__xorl4vm: rgba(153,191,247,0.7);
+  --borderColor-formAccent__xorl4vn: #1E47A9;
+  --borderColor-formAccentLight__xorl4vo: #99BFF7;
+  --borderColor-info__xorl4vp: #1D559D;
+  --borderColor-infoLight__xorl4vq: #98C9F1;
+  --borderColor-neutral__xorl4vr: #2E3849;
+  --borderColor-neutralLight__xorl4vt: #EAECF1;
+  --borderColor-neutralInverted__xorl4vs: #fff;
+  --borderColor-positive__xorl4vu: #12784F;
+  --borderColor-positiveLight__xorl4vv: #8BDEC5;
+  --borderColor-promote__xorl4vw: #7F35A9;
+  --borderColor-promoteLight__xorl4vx: #E1B2F5;
+  --borderWidth-standard__xorl4vy: 2px;
+  --borderWidth-large__xorl4vz: 4px;
+  --focusRingSize__xorl4v10: 6px;
+  --contentWidth-xsmall__xorl4v11: 400px;
+  --contentWidth-small__xorl4v12: 660px;
+  --contentWidth-medium__xorl4v13: 940px;
+  --contentWidth-large__xorl4v14: 1280px;
+  --foregroundColor-brandAccent__xorl4v15: #E60278;
+  --foregroundColor-brandAccentLight__xorl4v16: #F8B1DC;
+  --foregroundColor-caution__xorl4v17: #723D02;
+  --foregroundColor-cautionLight__xorl4v18: #FEE384;
+  --foregroundColor-critical__xorl4v19: #B91E1E;
+  --foregroundColor-criticalLight__xorl4v1a: #FB999A;
+  --foregroundColor-formAccent__xorl4v1b: #1E47A9;
+  --foregroundColor-formAccentLight__xorl4v1c: #99BFF7;
+  --foregroundColor-info__xorl4v1d: #1D559D;
+  --foregroundColor-infoLight__xorl4v1e: #98C9F1;
+  --foregroundColor-link__xorl4v1f: #2E3849;
+  --foregroundColor-linkLight__xorl4v1h: #fff;
+  --foregroundColor-linkHover__xorl4v1g: #2E3849;
+  --foregroundColor-linkVisited__xorl4v1i: #5B2084;
+  --foregroundColor-linkLightVisited__xorl4v1j: #F0D6FA;
+  --foregroundColor-neutral__xorl4v1k: #2E3849;
+  --foregroundColor-neutralInverted__xorl4v1l: #fff;
+  --foregroundColor-positive__xorl4v1m: #12784F;
+  --foregroundColor-positiveLight__xorl4v1n: #8BDEC5;
+  --foregroundColor-promote__xorl4v1o: #7F35A9;
+  --foregroundColor-promoteLight__xorl4v1p: #E1B2F5;
+  --foregroundColor-rating__xorl4v1q: #E60278;
+  --foregroundColor-secondary__xorl4v1r: #5A6881;
+  --foregroundColor-secondaryInverted__xorl4v1s: rgba(255,255,255,0.65);
+  --backgroundColor-body__xorl4v1t: #fff;
+  --backgroundColor-bodyDark__xorl4v1u: #1C2330;
+  --backgroundColor-brand__xorl4v1v: #051A49;
+  --backgroundColor-brandAccent__xorl4v1w: #E60278;
+  --backgroundColor-brandAccentActive__xorl4v1x: #cd026b;
+  --backgroundColor-brandAccentHover__xorl4v1y: #fd0585;
+  --backgroundColor-brandAccentSoft__xorl4v1z: #FEEFFA;
+  --backgroundColor-brandAccentSoftActive__xorl4v20: #fdd7f3;
+  --backgroundColor-brandAccentSoftHover__xorl4v21: #fde3f6;
+  --backgroundColor-caution__xorl4v22: #FDC221;
+  --backgroundColor-cautionLight__xorl4v23: #FEF8DE;
+  --backgroundColor-critical__xorl4v24: #B91E1E;
+  --backgroundColor-criticalActive__xorl4v25: #a31a1a;
+  --backgroundColor-criticalHover__xorl4v26: #db1616;
+  --backgroundColor-criticalLight__xorl4v27: #FFE3E2;
+  --backgroundColor-criticalSoft__xorl4v28: #FEF3F3;
+  --backgroundColor-criticalSoftActive__xorl4v29: #fcdbdb;
+  --backgroundColor-criticalSoftHover__xorl4v2a: #fde7e7;
+  --backgroundColor-formAccent__xorl4v2b: #1E47A9;
+  --backgroundColor-formAccentActive__xorl4v2c: #1a3e93;
+  --backgroundColor-formAccentHover__xorl4v2d: #2455c9;
+  --backgroundColor-formAccentSoft__xorl4v2e: #F0F7FE;
+  --backgroundColor-formAccentSoftActive__xorl4v2f: #d8eafc;
+  --backgroundColor-formAccentSoftHover__xorl4v2g: #e4f1fd;
+  --backgroundColor-info__xorl4v2h: #1D559D;
+  --backgroundColor-infoLight__xorl4v2i: #E3F2FB;
+  --backgroundColor-neutral__xorl4v2j: #2E3849;
+  --backgroundColor-neutralActive__xorl4v2k: #242c39;
+  --backgroundColor-neutralHover__xorl4v2l: #384459;
+  --backgroundColor-neutralLight__xorl4v2m: #F3F5F7;
+  --backgroundColor-neutralSoft__xorl4v2n: #F3F5F7;
+  --backgroundColor-neutralSoftActive__xorl4v2o: #e4e8ed;
+  --backgroundColor-neutralSoftHover__xorl4v2p: #ebeff2;
+  --backgroundColor-positive__xorl4v2q: #12784F;
+  --backgroundColor-positiveLight__xorl4v2r: #E2F7F1;
+  --backgroundColor-promote__xorl4v2s: #7F35A9;
+  --backgroundColor-promoteLight__xorl4v2t: #F9EBFD;
+  --backgroundColor-surface__xorl4v2u: #fff;
+  --backgroundColor-surfaceDark__xorl4v2v: #1C2330;
+  --fontFamily__xorl4v2w: SeekSans, "SeekSans Fallback", Arial, Tahoma, sans-serif;
+  --fontMetrics-capHeight__xorl4v2x: 783;
+  --fontMetrics-ascent__xorl4v2y: 1057;
+  --fontMetrics-descent__xorl4v2z: -274;
+  --fontMetrics-lineGap__xorl4v30: 0;
+  --fontMetrics-unitsPerEm__xorl4v31: 1000;
+  --textSize-large-mobile-fontSize__xorl4v3w: 18px;
+  --textSize-large-mobile-lineHeight__xorl4v3x: 27.094px;
+  --textSize-large-mobile-capHeight__xorl4v3y: 14.094px;
+  --textSize-large-mobile-capsizeTrims-capHeightTrim__xorl4v3z: -0.3611em;
+  --textSize-large-mobile-capsizeTrims-baselineTrim__xorl4v40: -0.3611em;
+  --textSize-large-tablet-fontSize__xorl4v41: 18px;
+  --textSize-large-tablet-lineHeight__xorl4v42: 27.094px;
+  --textSize-large-tablet-capHeight__xorl4v43: 14.094px;
+  --textSize-large-tablet-capsizeTrims-capHeightTrim__xorl4v44: -0.3611em;
+  --textSize-large-tablet-capsizeTrims-baselineTrim__xorl4v45: -0.3611em;
+  --textSize-standard-mobile-fontSize__xorl4v3m: 16px;
+  --textSize-standard-mobile-lineHeight__xorl4v3n: 24.528px;
+  --textSize-standard-mobile-capHeight__xorl4v3o: 12.528px;
+  --textSize-standard-mobile-capsizeTrims-capHeightTrim__xorl4v3p: -0.375em;
+  --textSize-standard-mobile-capsizeTrims-baselineTrim__xorl4v3q: -0.375em;
+  --textSize-standard-tablet-fontSize__xorl4v3r: 16px;
+  --textSize-standard-tablet-lineHeight__xorl4v3s: 24.528px;
+  --textSize-standard-tablet-capHeight__xorl4v3t: 12.528px;
+  --textSize-standard-tablet-capsizeTrims-capHeightTrim__xorl4v3u: -0.375em;
+  --textSize-standard-tablet-capsizeTrims-baselineTrim__xorl4v3v: -0.375em;
+  --textSize-small-mobile-fontSize__xorl4v3c: 14px;
+  --textSize-small-mobile-lineHeight__xorl4v3d: 20.962px;
+  --textSize-small-mobile-capHeight__xorl4v3e: 10.962px;
+  --textSize-small-mobile-capsizeTrims-capHeightTrim__xorl4v3f: -0.3571em;
+  --textSize-small-mobile-capsizeTrims-baselineTrim__xorl4v3g: -0.3571em;
+  --textSize-small-tablet-fontSize__xorl4v3h: 14px;
+  --textSize-small-tablet-lineHeight__xorl4v3i: 20.962px;
+  --textSize-small-tablet-capHeight__xorl4v3j: 10.962px;
+  --textSize-small-tablet-capsizeTrims-capHeightTrim__xorl4v3k: -0.3571em;
+  --textSize-small-tablet-capsizeTrims-baselineTrim__xorl4v3l: -0.3571em;
+  --textSize-xsmall-mobile-fontSize__xorl4v32: 12px;
+  --textSize-xsmall-mobile-lineHeight__xorl4v33: 18.396px;
+  --textSize-xsmall-mobile-capHeight__xorl4v34: 9.396px;
+  --textSize-xsmall-mobile-capsizeTrims-capHeightTrim__xorl4v35: -0.375em;
+  --textSize-xsmall-mobile-capsizeTrims-baselineTrim__xorl4v36: -0.375em;
+  --textSize-xsmall-tablet-fontSize__xorl4v37: 12px;
+  --textSize-xsmall-tablet-lineHeight__xorl4v38: 18.396px;
+  --textSize-xsmall-tablet-capHeight__xorl4v39: 9.396px;
+  --textSize-xsmall-tablet-capsizeTrims-capHeightTrim__xorl4v3a: -0.375em;
+  --textSize-xsmall-tablet-capsizeTrims-baselineTrim__xorl4v3b: -0.375em;
+  --textWeight-regular__xorl4v46: 400;
+  --textWeight-medium__xorl4v47: 500;
+  --textWeight-strong__xorl4v48: 700;
+  --headingLevel-1-mobile-fontSize__xorl4v49: 28px;
+  --headingLevel-1-mobile-lineHeight__xorl4v4a: 32.924px;
+  --headingLevel-1-mobile-capHeight__xorl4v4b: 21.924px;
+  --headingLevel-1-mobile-capsizeTrims-capHeightTrim__xorl4v4c: -0.1964em;
+  --headingLevel-1-mobile-capsizeTrims-baselineTrim__xorl4v4d: -0.1964em;
+  --headingLevel-1-tablet-fontSize__xorl4v4e: 36px;
+  --headingLevel-1-tablet-lineHeight__xorl4v4f: 42.188px;
+  --headingLevel-1-tablet-capHeight__xorl4v4g: 28.188px;
+  --headingLevel-1-tablet-capsizeTrims-capHeightTrim__xorl4v4h: -0.1944em;
+  --headingLevel-1-tablet-capsizeTrims-baselineTrim__xorl4v4i: -0.1944em;
+  --headingLevel-2-mobile-fontSize__xorl4v4j: 24px;
+  --headingLevel-2-mobile-lineHeight__xorl4v4k: 29.792px;
+  --headingLevel-2-mobile-capHeight__xorl4v4l: 18.792px;
+  --headingLevel-2-mobile-capsizeTrims-capHeightTrim__xorl4v4m: -0.2292em;
+  --headingLevel-2-mobile-capsizeTrims-baselineTrim__xorl4v4n: -0.2292em;
+  --headingLevel-2-tablet-fontSize__xorl4v4o: 30px;
+  --headingLevel-2-tablet-lineHeight__xorl4v4p: 36.49px;
+  --headingLevel-2-tablet-capHeight__xorl4v4q: 23.49px;
+  --headingLevel-2-tablet-capsizeTrims-capHeightTrim__xorl4v4r: -0.2167em;
+  --headingLevel-2-tablet-capsizeTrims-baselineTrim__xorl4v4s: -0.2167em;
+  --headingLevel-3-mobile-fontSize__xorl4v4t: 22px;
+  --headingLevel-3-mobile-lineHeight__xorl4v4u: 27.226px;
+  --headingLevel-3-mobile-capHeight__xorl4v4v: 17.226px;
+  --headingLevel-3-mobile-capsizeTrims-capHeightTrim__xorl4v4w: -0.2273em;
+  --headingLevel-3-mobile-capsizeTrims-baselineTrim__xorl4v4x: -0.2273em;
+  --headingLevel-3-tablet-fontSize__xorl4v4y: 24px;
+  --headingLevel-3-tablet-lineHeight__xorl4v4z: 29.792px;
+  --headingLevel-3-tablet-capHeight__xorl4v50: 18.792px;
+  --headingLevel-3-tablet-capsizeTrims-capHeightTrim__xorl4v51: -0.2292em;
+  --headingLevel-3-tablet-capsizeTrims-baselineTrim__xorl4v52: -0.2292em;
+  --headingLevel-4-mobile-fontSize__xorl4v53: 20px;
+  --headingLevel-4-mobile-lineHeight__xorl4v54: 24.66px;
+  --headingLevel-4-mobile-capHeight__xorl4v55: 15.66px;
+  --headingLevel-4-mobile-capsizeTrims-capHeightTrim__xorl4v56: -0.225em;
+  --headingLevel-4-mobile-capsizeTrims-baselineTrim__xorl4v57: -0.225em;
+  --headingLevel-4-tablet-fontSize__xorl4v58: 20px;
+  --headingLevel-4-tablet-lineHeight__xorl4v59: 24.66px;
+  --headingLevel-4-tablet-capHeight__xorl4v5a: 15.66px;
+  --headingLevel-4-tablet-capsizeTrims-capHeightTrim__xorl4v5b: -0.225em;
+  --headingLevel-4-tablet-capsizeTrims-baselineTrim__xorl4v5c: -0.225em;
+  --headingWeight-weak__xorl4v5d: 400;
+  --headingWeight-regular__xorl4v5e: 500;
+  --linkDecoration__xorl4v5f: underline;
+  --inlineFieldSize-standard__xorl4v5g: 24px;
+  --inlineFieldSize-small__xorl4v5h: 20px;
+  --transition-fast__xorl4v5i: transform .125s ease, opacity .125s ease;
+  --transition-touchable__xorl4v5j: transform 0.2s cubic-bezier(0.02, 1.505, 0.745, 1.235);
+  --transform-touchable__xorl4v5k: scale(0.95);
+  --shadow-small__xorl4v5l: 0 2px 4px 0px rgba(28,35,48,0.1), 0 2px 2px -2px rgba(28,35,48,0.1), 0 4px 4px -4px rgba(28,35,48,0.2);
+  --shadow-medium__xorl4v5m: 0 2px 4px 0px rgba(28,35,48,0.1), 0 8px 8px -4px rgba(28,35,48,0.1), 0 12px 12px -8px rgba(28,35,48,0.2);
+  --shadow-large__xorl4v5n: 0 2px 4px 0px rgba(28,35,48,0.1), 0 12px 12px -4px rgba(28,35,48,0.1), 0 20px 20px -12px rgba(28,35,48,0.2);
+}
+.App_vanillaBox__inn18b0 {
+  --backgroundColor__zv7nmx0: blueviolet;
+  background-color: var(--backgroundColor__zv7nmx0);
+  color: white;
+  font-size: 20px;
+  padding: 100px;
+}
+    </style>
     <script type="module">
       import { injectIntoGlobalHook } from "/@react-refresh";
 injectIntoGlobalHook(window);
@@ -3550,7 +8056,7 @@ POST HYDRATE DIFFS:
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -25,14 +25,4815 @@
+@@ -4531,14 +4531,4815 @@
      </script>
      <script
        type="module"
@@ -8368,7 +12874,7 @@ POST HYDRATE DIFFS:
    </head>
    <body>
      <div id="app">
-@@ -69,6 +4870,7 @@
+@@ -4575,6 +9376,7 @@
                  type="checkbox"
                  id="id_1"
                  aria-checked="false"
@@ -8376,7 +12882,7 @@ POST HYDRATE DIFFS:
                >
                <div class="reset_base__1j8ojzz0 sprinkles_flexShrink_0_mobile__iv7so5i0 sprinkles_position_relative_mobile__iv7so55g sprinkles_borderRadius_standard_mobile__iv7so568 InlineField_fakeField__3b9mfp5 InlineField_sizeVars_standard__3b9mfp2 typography_lightModeTone_light__9al9wa10  sprinkles_background_surface_lightMode__iv7so534">
                  <span class="reset_base__1j8ojzz0 sprinkles_top_0__iv7so5k sprinkles_bottom_0__iv7so5l sprinkles_left_0__iv7so5m sprinkles_right_0__iv7so5n sprinkles_position_absolute_mobile__iv7so55k sprinkles_pointerEvents_none__iv7so5j sprinkles_borderRadius_standard_mobile__iv7so568 sprinkles_transition_fast__iv7so5y sprinkles_opacity_0__iv7so57 InlineField_selected__3b9mfp9 typography_lightModeTone_dark__9al9wa11 typography_darkModeTone_dark__9al9wa13 sprinkles_background_formAccent_lightMode__iv7so522 sprinkles_background_formAccent_darkMode__iv7so523">
-@@ -165,7 +4967,7 @@
+@@ -4671,7 +9473,7 @@
          </div>
          <div class="reset_base__1j8ojzz0 App_vanillaBox__inn18b0">
            🧁 Vanilla content
@@ -8391,6 +12897,4512 @@ exports[`braid-design-system > bundler vite > start > should return development 
 <!DOCTYPE html>
 <html>
   <head>
+    <style
+      type="text/css"
+      data-vanilla-extract-inline-dev-css
+    >
+      .reset_base__1j8ojzz0 {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+  -webkit-tap-highlight-color: transparent;
+}
+.reset_block__1j8ojzz1 {
+  display: block;
+}
+.reset_body__1j8ojzz2 {
+  line-height: 1;
+}
+.reset_list__1j8ojzz3 {
+  list-style: none;
+}
+.reset_quote__1j8ojzz4 {
+  quotes: none;
+}
+.reset_quote__1j8ojzz4:before, .reset_quote__1j8ojzz4:after {
+  content: '';
+}
+.reset_table__1j8ojzz5 {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+.reset_appearance__1j8ojzz6 {
+  appearance: none;
+}
+.reset_transparent__1j8ojzz7 {
+  background-color: transparent;
+}
+.reset_focusVisible__1j8ojzz8 {
+  outline: var(--focusRingSize__xorl4v10) solid transparent;
+  transition: outline-color .125s ease;
+}
+.reset_focusVisible__1j8ojzz8:focus-visible {
+  outline-color: var(--borderColor-focus__xorl4vm);
+}
+.reset_mark__1j8ojzza {
+  color: inherit;
+}
+.reset_select__1j8ojzzb:disabled {
+  opacity: 1;
+}
+.reset_select__1j8ojzzb::-ms-expand {
+  display: none;
+}
+.reset_input__1j8ojzzd[type="number"] {
+  -moz-appearance: textfield;
+}
+.reset_input__1j8ojzzd[type="number"]::-webkit-inner-spin-button,.reset_input__1j8ojzzd[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.reset_input__1j8ojzzd::-ms-clear {
+  display: none;
+}
+.reset_input__1j8ojzzd::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+}
+.reset_a__1j8ojzzg {
+  text-decoration: none;
+  color: inherit;
+}
+.sprinkles_overflow_hidden__iv7so50 {
+  overflow: hidden;
+}
+.sprinkles_overflow_scroll__iv7so51 {
+  overflow: scroll;
+}
+.sprinkles_overflow_visible__iv7so52 {
+  overflow: visible;
+}
+.sprinkles_overflow_auto__iv7so53 {
+  overflow: auto;
+}
+.sprinkles_userSelect_none__iv7so54 {
+  user-select: none;
+}
+.sprinkles_outline_none__iv7so55 {
+  outline: none;
+}
+.sprinkles_outline_focus__iv7so56 {
+  outline: var(--focusRingSize__xorl4v10) solid transparent;
+  transition: outline-color .125s ease;
+}
+.sprinkles_outline_focus__iv7so56:focus-visible {
+  outline-color: var(--borderColor-focus__xorl4vm);
+}
+.sprinkles_opacity_0__iv7so57 {
+  opacity: 0;
+}
+.sprinkles_zIndex_0__iv7so58 {
+  z-index: 0;
+}
+.sprinkles_zIndex_1__iv7so59 {
+  z-index: 1;
+}
+.sprinkles_zIndex_2__iv7so5a {
+  z-index: 2;
+}
+.sprinkles_zIndex_dropdownBackdrop__iv7so5b {
+  z-index: 90;
+}
+.sprinkles_zIndex_dropdown__iv7so5c {
+  z-index: 100;
+}
+.sprinkles_zIndex_sticky__iv7so5d {
+  z-index: 200;
+}
+.sprinkles_zIndex_modalBackdrop__iv7so5e {
+  z-index: 290;
+}
+.sprinkles_zIndex_modal__iv7so5f {
+  z-index: 300;
+}
+.sprinkles_zIndex_notification__iv7so5g {
+  z-index: 400;
+}
+.sprinkles_cursor_default__iv7so5h {
+  cursor: default;
+}
+.sprinkles_cursor_pointer__iv7so5i {
+  cursor: pointer;
+}
+.sprinkles_pointerEvents_none__iv7so5j {
+  pointer-events: none;
+}
+.sprinkles_top_0__iv7so5k {
+  top: 0;
+}
+.sprinkles_bottom_0__iv7so5l {
+  bottom: 0;
+}
+.sprinkles_left_0__iv7so5m {
+  left: 0;
+}
+.sprinkles_right_0__iv7so5n {
+  right: 0;
+}
+.sprinkles_height_full__iv7so5o {
+  height: 100%;
+}
+.sprinkles_height_touchable__iv7so5p {
+  height: var(--touchableSize__xorl4v9);
+}
+.sprinkles_width_full__iv7so5q {
+  width: 100%;
+}
+.sprinkles_width_touchable__iv7so5r {
+  width: var(--touchableSize__xorl4v9);
+}
+.sprinkles_minWidth_0__iv7so5s {
+  min-width: 0%;
+}
+.sprinkles_maxWidth_xsmall__iv7so5t {
+  max-width: var(--contentWidth-xsmall__xorl4v11);
+}
+.sprinkles_maxWidth_small__iv7so5u {
+  max-width: var(--contentWidth-small__xorl4v12);
+}
+.sprinkles_maxWidth_medium__iv7so5v {
+  max-width: var(--contentWidth-medium__xorl4v13);
+}
+.sprinkles_maxWidth_large__iv7so5w {
+  max-width: var(--contentWidth-large__xorl4v14);
+}
+.sprinkles_maxWidth_content__iv7so5x {
+  max-width: fit-content;
+}
+.sprinkles_transition_fast__iv7so5y {
+  transition: var(--transition-fast__xorl4v5i);
+}
+.sprinkles_transition_touchable__iv7so5z {
+  transition: var(--transition-touchable__xorl4v5j);
+}
+.sprinkles_transform_touchable_active__iv7so510:active {
+  transform: var(--transform-touchable__xorl4v5k);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_body_lightMode__iv7so512 {
+  background: var(--backgroundColor-body__xorl4v1t);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_body_darkMode__iv7so513 {
+  background: var(--backgroundColor-body__xorl4v1t);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_bodyDark_lightMode__iv7so514 {
+  background: var(--backgroundColor-bodyDark__xorl4v1u);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_bodyDark_darkMode__iv7so515 {
+  background: var(--backgroundColor-bodyDark__xorl4v1u);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_brand_lightMode__iv7so516 {
+  background: var(--backgroundColor-brand__xorl4v1v);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_brand_darkMode__iv7so517 {
+  background: var(--backgroundColor-brand__xorl4v1v);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_brandAccent_lightMode__iv7so518 {
+  background: var(--backgroundColor-brandAccent__xorl4v1w);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_brandAccent_darkMode__iv7so519 {
+  background: var(--backgroundColor-brandAccent__xorl4v1w);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_brandAccentActive_lightMode__iv7so51a {
+  background: var(--backgroundColor-brandAccentActive__xorl4v1x);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_brandAccentActive_darkMode__iv7so51b {
+  background: var(--backgroundColor-brandAccentActive__xorl4v1x);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_brandAccentHover_lightMode__iv7so51c {
+  background: var(--backgroundColor-brandAccentHover__xorl4v1y);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_brandAccentHover_darkMode__iv7so51d {
+  background: var(--backgroundColor-brandAccentHover__xorl4v1y);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_brandAccentSoft_lightMode__iv7so51e {
+  background: var(--backgroundColor-brandAccentSoft__xorl4v1z);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_brandAccentSoft_darkMode__iv7so51f {
+  background: var(--backgroundColor-brandAccentSoft__xorl4v1z);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_brandAccentSoftActive_lightMode__iv7so51g {
+  background: var(--backgroundColor-brandAccentSoftActive__xorl4v20);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_brandAccentSoftActive_darkMode__iv7so51h {
+  background: var(--backgroundColor-brandAccentSoftActive__xorl4v20);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_brandAccentSoftHover_lightMode__iv7so51i {
+  background: var(--backgroundColor-brandAccentSoftHover__xorl4v21);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_brandAccentSoftHover_darkMode__iv7so51j {
+  background: var(--backgroundColor-brandAccentSoftHover__xorl4v21);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_caution_lightMode__iv7so51k {
+  background: var(--backgroundColor-caution__xorl4v22);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_caution_darkMode__iv7so51l {
+  background: var(--backgroundColor-caution__xorl4v22);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_cautionLight_lightMode__iv7so51m {
+  background: var(--backgroundColor-cautionLight__xorl4v23);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_cautionLight_darkMode__iv7so51n {
+  background: var(--backgroundColor-cautionLight__xorl4v23);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_critical_lightMode__iv7so51o {
+  background: var(--backgroundColor-critical__xorl4v24);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_critical_darkMode__iv7so51p {
+  background: var(--backgroundColor-critical__xorl4v24);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_criticalActive_lightMode__iv7so51q {
+  background: var(--backgroundColor-criticalActive__xorl4v25);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_criticalActive_darkMode__iv7so51r {
+  background: var(--backgroundColor-criticalActive__xorl4v25);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_criticalHover_lightMode__iv7so51s {
+  background: var(--backgroundColor-criticalHover__xorl4v26);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_criticalHover_darkMode__iv7so51t {
+  background: var(--backgroundColor-criticalHover__xorl4v26);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_criticalLight_lightMode__iv7so51u {
+  background: var(--backgroundColor-criticalLight__xorl4v27);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_criticalLight_darkMode__iv7so51v {
+  background: var(--backgroundColor-criticalLight__xorl4v27);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_criticalSoft_lightMode__iv7so51w {
+  background: var(--backgroundColor-criticalSoft__xorl4v28);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_criticalSoft_darkMode__iv7so51x {
+  background: var(--backgroundColor-criticalSoft__xorl4v28);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_criticalSoftActive_lightMode__iv7so51y {
+  background: var(--backgroundColor-criticalSoftActive__xorl4v29);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_criticalSoftActive_darkMode__iv7so51z {
+  background: var(--backgroundColor-criticalSoftActive__xorl4v29);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_criticalSoftHover_lightMode__iv7so520 {
+  background: var(--backgroundColor-criticalSoftHover__xorl4v2a);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_criticalSoftHover_darkMode__iv7so521 {
+  background: var(--backgroundColor-criticalSoftHover__xorl4v2a);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_formAccent_lightMode__iv7so522 {
+  background: var(--backgroundColor-formAccent__xorl4v2b);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_formAccent_darkMode__iv7so523 {
+  background: var(--backgroundColor-formAccent__xorl4v2b);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_formAccentActive_lightMode__iv7so524 {
+  background: var(--backgroundColor-formAccentActive__xorl4v2c);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_formAccentActive_darkMode__iv7so525 {
+  background: var(--backgroundColor-formAccentActive__xorl4v2c);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_formAccentHover_lightMode__iv7so526 {
+  background: var(--backgroundColor-formAccentHover__xorl4v2d);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_formAccentHover_darkMode__iv7so527 {
+  background: var(--backgroundColor-formAccentHover__xorl4v2d);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_formAccentSoft_lightMode__iv7so528 {
+  background: var(--backgroundColor-formAccentSoft__xorl4v2e);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_formAccentSoft_darkMode__iv7so529 {
+  background: var(--backgroundColor-formAccentSoft__xorl4v2e);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_formAccentSoftActive_lightMode__iv7so52a {
+  background: var(--backgroundColor-formAccentSoftActive__xorl4v2f);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_formAccentSoftActive_darkMode__iv7so52b {
+  background: var(--backgroundColor-formAccentSoftActive__xorl4v2f);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_formAccentSoftHover_lightMode__iv7so52c {
+  background: var(--backgroundColor-formAccentSoftHover__xorl4v2g);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_formAccentSoftHover_darkMode__iv7so52d {
+  background: var(--backgroundColor-formAccentSoftHover__xorl4v2g);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_info_lightMode__iv7so52e {
+  background: var(--backgroundColor-info__xorl4v2h);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_info_darkMode__iv7so52f {
+  background: var(--backgroundColor-info__xorl4v2h);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_infoLight_lightMode__iv7so52g {
+  background: var(--backgroundColor-infoLight__xorl4v2i);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_infoLight_darkMode__iv7so52h {
+  background: var(--backgroundColor-infoLight__xorl4v2i);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_neutral_lightMode__iv7so52i {
+  background: var(--backgroundColor-neutral__xorl4v2j);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_neutral_darkMode__iv7so52j {
+  background: var(--backgroundColor-neutral__xorl4v2j);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_neutralActive_lightMode__iv7so52k {
+  background: var(--backgroundColor-neutralActive__xorl4v2k);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_neutralActive_darkMode__iv7so52l {
+  background: var(--backgroundColor-neutralActive__xorl4v2k);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_neutralHover_lightMode__iv7so52m {
+  background: var(--backgroundColor-neutralHover__xorl4v2l);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_neutralHover_darkMode__iv7so52n {
+  background: var(--backgroundColor-neutralHover__xorl4v2l);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_neutralLight_lightMode__iv7so52o {
+  background: var(--backgroundColor-neutralLight__xorl4v2m);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_neutralLight_darkMode__iv7so52p {
+  background: var(--backgroundColor-neutralLight__xorl4v2m);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_neutralSoft_lightMode__iv7so52q {
+  background: var(--backgroundColor-neutralSoft__xorl4v2n);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_neutralSoft_darkMode__iv7so52r {
+  background: var(--backgroundColor-neutralSoft__xorl4v2n);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_neutralSoftActive_lightMode__iv7so52s {
+  background: var(--backgroundColor-neutralSoftActive__xorl4v2o);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_neutralSoftActive_darkMode__iv7so52t {
+  background: var(--backgroundColor-neutralSoftActive__xorl4v2o);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_neutralSoftHover_lightMode__iv7so52u {
+  background: var(--backgroundColor-neutralSoftHover__xorl4v2p);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_neutralSoftHover_darkMode__iv7so52v {
+  background: var(--backgroundColor-neutralSoftHover__xorl4v2p);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_positive_lightMode__iv7so52w {
+  background: var(--backgroundColor-positive__xorl4v2q);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_positive_darkMode__iv7so52x {
+  background: var(--backgroundColor-positive__xorl4v2q);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_positiveLight_lightMode__iv7so52y {
+  background: var(--backgroundColor-positiveLight__xorl4v2r);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_positiveLight_darkMode__iv7so52z {
+  background: var(--backgroundColor-positiveLight__xorl4v2r);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_promote_lightMode__iv7so530 {
+  background: var(--backgroundColor-promote__xorl4v2s);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_promote_darkMode__iv7so531 {
+  background: var(--backgroundColor-promote__xorl4v2s);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_promoteLight_lightMode__iv7so532 {
+  background: var(--backgroundColor-promoteLight__xorl4v2t);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_promoteLight_darkMode__iv7so533 {
+  background: var(--backgroundColor-promoteLight__xorl4v2t);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_surface_lightMode__iv7so534 {
+  background: var(--backgroundColor-surface__xorl4v2u);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_surface_darkMode__iv7so535 {
+  background: var(--backgroundColor-surface__xorl4v2u);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_background_surfaceDark_lightMode__iv7so536 {
+  background: var(--backgroundColor-surfaceDark__xorl4v2v);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_background_surfaceDark_darkMode__iv7so537 {
+  background: var(--backgroundColor-surfaceDark__xorl4v2v);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_small_lightMode__iv7so538 {
+  box-shadow: var(--shadow-small__xorl4v5l);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_small_darkMode__iv7so539 {
+  box-shadow: var(--shadow-small__xorl4v5l);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_medium_lightMode__iv7so53a {
+  box-shadow: var(--shadow-medium__xorl4v5m);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_medium_darkMode__iv7so53b {
+  box-shadow: var(--shadow-medium__xorl4v5m);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_large_lightMode__iv7so53c {
+  box-shadow: var(--shadow-large__xorl4v5n);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_large_darkMode__iv7so53d {
+  box-shadow: var(--shadow-large__xorl4v5n);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderBrandAccent_lightMode__iv7so53e {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-brandAccent__xorl4vf);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderBrandAccent_darkMode__iv7so53f {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-brandAccent__xorl4vf);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderBrandAccentLight_lightMode__iv7so53g {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-brandAccentLight__xorl4vg);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderBrandAccentLight_darkMode__iv7so53h {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-brandAccentLight__xorl4vg);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderBrandAccentLarge_lightMode__iv7so53i {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-brandAccent__xorl4vf);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderBrandAccentLarge_darkMode__iv7so53j {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-brandAccent__xorl4vf);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderBrandAccentLightLarge_lightMode__iv7so53k {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-brandAccentLight__xorl4vg);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderBrandAccentLightLarge_darkMode__iv7so53l {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-brandAccentLight__xorl4vg);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderCaution_lightMode__iv7so53m {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-caution__xorl4vh);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderCaution_darkMode__iv7so53n {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-caution__xorl4vh);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderCautionLight_lightMode__iv7so53o {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-cautionLight__xorl4vi);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderCautionLight_darkMode__iv7so53p {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-cautionLight__xorl4vi);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderCritical_lightMode__iv7so53q {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-critical__xorl4vj);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderCritical_darkMode__iv7so53r {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-critical__xorl4vj);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderCriticalLarge_lightMode__iv7so53s {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-critical__xorl4vj);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderCriticalLarge_darkMode__iv7so53t {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-critical__xorl4vj);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderCriticalLight_lightMode__iv7so53u {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-criticalLight__xorl4vk);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderCriticalLight_darkMode__iv7so53v {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-criticalLight__xorl4vk);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderCriticalLightLarge_lightMode__iv7so53w {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-criticalLight__xorl4vk);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderCriticalLightLarge_darkMode__iv7so53x {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-criticalLight__xorl4vk);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderField_lightMode__iv7so53y {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-field__xorl4vl);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderField_darkMode__iv7so53z {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-field__xorl4vl);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderFormAccent_lightMode__iv7so540 {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-formAccent__xorl4vn);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderFormAccent_darkMode__iv7so541 {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-formAccent__xorl4vn);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderFormAccentLarge_lightMode__iv7so542 {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-formAccent__xorl4vn);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderFormAccentLarge_darkMode__iv7so543 {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-formAccent__xorl4vn);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderFormAccentLight_lightMode__iv7so544 {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-formAccentLight__xorl4vo);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderFormAccentLight_darkMode__iv7so545 {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-formAccentLight__xorl4vo);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderFormAccentLightLarge_lightMode__iv7so546 {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-formAccentLight__xorl4vo);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderFormAccentLightLarge_darkMode__iv7so547 {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-formAccentLight__xorl4vo);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderInfo_lightMode__iv7so548 {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-info__xorl4vp);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderInfo_darkMode__iv7so549 {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-info__xorl4vp);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderInfoLight_lightMode__iv7so54a {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-infoLight__xorl4vq);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderInfoLight_darkMode__iv7so54b {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-infoLight__xorl4vq);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderNeutral_lightMode__iv7so54c {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-neutral__xorl4vr);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderNeutral_darkMode__iv7so54d {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-neutral__xorl4vr);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderNeutralLarge_lightMode__iv7so54e {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-neutral__xorl4vr);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderNeutralLarge_darkMode__iv7so54f {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-neutral__xorl4vr);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderNeutralInverted_lightMode__iv7so54g {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-neutralInverted__xorl4vs);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderNeutralInverted_darkMode__iv7so54h {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-neutralInverted__xorl4vs);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderNeutralInvertedLarge_lightMode__iv7so54i {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-neutralInverted__xorl4vs);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderNeutralInvertedLarge_darkMode__iv7so54j {
+  box-shadow: inset 0 0 0 var(--borderWidth-large__xorl4vz) var(--borderColor-neutralInverted__xorl4vs);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderNeutralLight_lightMode__iv7so54k {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-neutralLight__xorl4vt);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderNeutralLight_darkMode__iv7so54l {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-neutralLight__xorl4vt);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderPositive_lightMode__iv7so54m {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-positive__xorl4vu);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderPositive_darkMode__iv7so54n {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-positive__xorl4vu);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderPositiveLight_lightMode__iv7so54o {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-positiveLight__xorl4vv);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderPositiveLight_darkMode__iv7so54p {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-positiveLight__xorl4vv);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderPromote_lightMode__iv7so54q {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-promote__xorl4vw);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderPromote_darkMode__iv7so54r {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-promote__xorl4vw);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_borderPromoteLight_lightMode__iv7so54s {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-promoteLight__xorl4vx);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_borderPromoteLight_darkMode__iv7so54t {
+  box-shadow: inset 0 0 0 var(--borderWidth-standard__xorl4vy) var(--borderColor-promoteLight__xorl4vx);
+}
+html:not(.sprinkles_darkMode__iv7so511) .sprinkles_boxShadow_outlineFocus_lightMode__iv7so54u {
+  box-shadow: 0 0 0 var(--focusRingSize__xorl4v10) var(--borderColor-focus__xorl4vm);
+}
+html.sprinkles_darkMode__iv7so511 .sprinkles_boxShadow_outlineFocus_darkMode__iv7so54v {
+  box-shadow: 0 0 0 var(--focusRingSize__xorl4v10) var(--borderColor-focus__xorl4vm);
+}
+.sprinkles_display_none_mobile__iv7so54w {
+  display: none;
+}
+.sprinkles_display_block_mobile__iv7so550 {
+  display: block;
+}
+.sprinkles_display_inline_mobile__iv7so554 {
+  display: inline;
+}
+.sprinkles_display_inlineBlock_mobile__iv7so558 {
+  display: inline-block;
+}
+.sprinkles_display_flex_mobile__iv7so55c {
+  display: flex;
+}
+.sprinkles_position_relative_mobile__iv7so55g {
+  position: relative;
+}
+.sprinkles_position_absolute_mobile__iv7so55k {
+  position: absolute;
+}
+.sprinkles_position_fixed_mobile__iv7so55o {
+  position: fixed;
+}
+.sprinkles_position_sticky_mobile__iv7so55s {
+  position: sticky;
+}
+.sprinkles_borderRadius_none_mobile__iv7so55w {
+  border-radius: 0px;
+}
+.sprinkles_borderRadius_full_mobile__iv7so560 {
+  border-radius: 9999px;
+}
+.sprinkles_borderRadius_small_mobile__iv7so564 {
+  border-radius: var(--borderRadius-small__xorl4vb);
+}
+.sprinkles_borderRadius_standard_mobile__iv7so568 {
+  border-radius: var(--borderRadius-standard__xorl4vc);
+}
+.sprinkles_borderRadius_large_mobile__iv7so56c {
+  border-radius: var(--borderRadius-large__xorl4vd);
+}
+.sprinkles_borderRadius_xlarge_mobile__iv7so56g {
+  border-radius: var(--borderRadius-xlarge__xorl4ve);
+}
+.sprinkles_gap_gutter_mobile__iv7so56k {
+  gap: var(--space-gutter__xorl4v0);
+}
+.sprinkles_gap_xxsmall_mobile__iv7so56o {
+  gap: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_gap_xsmall_mobile__iv7so56s {
+  gap: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_gap_small_mobile__iv7so56w {
+  gap: var(--space-small__xorl4v3);
+}
+.sprinkles_gap_medium_mobile__iv7so570 {
+  gap: var(--space-medium__xorl4v4);
+}
+.sprinkles_gap_large_mobile__iv7so574 {
+  gap: var(--space-large__xorl4v5);
+}
+.sprinkles_gap_xlarge_mobile__iv7so578 {
+  gap: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_gap_xxlarge_mobile__iv7so57c {
+  gap: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_gap_xxxlarge_mobile__iv7so57g {
+  gap: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_gap_none_mobile__iv7so57k {
+  gap: 0;
+}
+.sprinkles_paddingTop_gutter_mobile__iv7so57o {
+  padding-top: var(--space-gutter__xorl4v0);
+}
+.sprinkles_paddingTop_xxsmall_mobile__iv7so57s {
+  padding-top: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_paddingTop_xsmall_mobile__iv7so57w {
+  padding-top: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_paddingTop_small_mobile__iv7so580 {
+  padding-top: var(--space-small__xorl4v3);
+}
+.sprinkles_paddingTop_medium_mobile__iv7so584 {
+  padding-top: var(--space-medium__xorl4v4);
+}
+.sprinkles_paddingTop_large_mobile__iv7so588 {
+  padding-top: var(--space-large__xorl4v5);
+}
+.sprinkles_paddingTop_xlarge_mobile__iv7so58c {
+  padding-top: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_paddingTop_xxlarge_mobile__iv7so58g {
+  padding-top: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_paddingTop_xxxlarge_mobile__iv7so58k {
+  padding-top: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_paddingTop_none_mobile__iv7so58o {
+  padding-top: 0;
+}
+.sprinkles_paddingBottom_gutter_mobile__iv7so58s {
+  padding-bottom: var(--space-gutter__xorl4v0);
+}
+.sprinkles_paddingBottom_xxsmall_mobile__iv7so58w {
+  padding-bottom: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_paddingBottom_xsmall_mobile__iv7so590 {
+  padding-bottom: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_paddingBottom_small_mobile__iv7so594 {
+  padding-bottom: var(--space-small__xorl4v3);
+}
+.sprinkles_paddingBottom_medium_mobile__iv7so598 {
+  padding-bottom: var(--space-medium__xorl4v4);
+}
+.sprinkles_paddingBottom_large_mobile__iv7so59c {
+  padding-bottom: var(--space-large__xorl4v5);
+}
+.sprinkles_paddingBottom_xlarge_mobile__iv7so59g {
+  padding-bottom: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_paddingBottom_xxlarge_mobile__iv7so59k {
+  padding-bottom: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_paddingBottom_xxxlarge_mobile__iv7so59o {
+  padding-bottom: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_paddingBottom_none_mobile__iv7so59s {
+  padding-bottom: 0;
+}
+.sprinkles_paddingRight_gutter_mobile__iv7so59w {
+  padding-right: var(--space-gutter__xorl4v0);
+}
+.sprinkles_paddingRight_xxsmall_mobile__iv7so5a0 {
+  padding-right: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_paddingRight_xsmall_mobile__iv7so5a4 {
+  padding-right: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_paddingRight_small_mobile__iv7so5a8 {
+  padding-right: var(--space-small__xorl4v3);
+}
+.sprinkles_paddingRight_medium_mobile__iv7so5ac {
+  padding-right: var(--space-medium__xorl4v4);
+}
+.sprinkles_paddingRight_large_mobile__iv7so5ag {
+  padding-right: var(--space-large__xorl4v5);
+}
+.sprinkles_paddingRight_xlarge_mobile__iv7so5ak {
+  padding-right: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_paddingRight_xxlarge_mobile__iv7so5ao {
+  padding-right: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_paddingRight_xxxlarge_mobile__iv7so5as {
+  padding-right: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_paddingRight_none_mobile__iv7so5aw {
+  padding-right: 0;
+}
+.sprinkles_paddingLeft_gutter_mobile__iv7so5b0 {
+  padding-left: var(--space-gutter__xorl4v0);
+}
+.sprinkles_paddingLeft_xxsmall_mobile__iv7so5b4 {
+  padding-left: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_paddingLeft_xsmall_mobile__iv7so5b8 {
+  padding-left: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_paddingLeft_small_mobile__iv7so5bc {
+  padding-left: var(--space-small__xorl4v3);
+}
+.sprinkles_paddingLeft_medium_mobile__iv7so5bg {
+  padding-left: var(--space-medium__xorl4v4);
+}
+.sprinkles_paddingLeft_large_mobile__iv7so5bk {
+  padding-left: var(--space-large__xorl4v5);
+}
+.sprinkles_paddingLeft_xlarge_mobile__iv7so5bo {
+  padding-left: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_paddingLeft_xxlarge_mobile__iv7so5bs {
+  padding-left: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_paddingLeft_xxxlarge_mobile__iv7so5bw {
+  padding-left: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_paddingLeft_none_mobile__iv7so5c0 {
+  padding-left: 0;
+}
+.sprinkles_marginTop_gutter_mobile__iv7so5c4 {
+  margin-top: var(--space-gutter__xorl4v0);
+}
+.sprinkles_marginTop_xxsmall_mobile__iv7so5c8 {
+  margin-top: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_marginTop_xsmall_mobile__iv7so5cc {
+  margin-top: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_marginTop_small_mobile__iv7so5cg {
+  margin-top: var(--space-small__xorl4v3);
+}
+.sprinkles_marginTop_medium_mobile__iv7so5ck {
+  margin-top: var(--space-medium__xorl4v4);
+}
+.sprinkles_marginTop_large_mobile__iv7so5co {
+  margin-top: var(--space-large__xorl4v5);
+}
+.sprinkles_marginTop_xlarge_mobile__iv7so5cs {
+  margin-top: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_marginTop_xxlarge_mobile__iv7so5cw {
+  margin-top: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_marginTop_xxxlarge_mobile__iv7so5d0 {
+  margin-top: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_marginTop_none_mobile__iv7so5d4 {
+  margin-top: 0;
+}
+.sprinkles_marginBottom_gutter_mobile__iv7so5d8 {
+  margin-bottom: var(--space-gutter__xorl4v0);
+}
+.sprinkles_marginBottom_xxsmall_mobile__iv7so5dc {
+  margin-bottom: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_marginBottom_xsmall_mobile__iv7so5dg {
+  margin-bottom: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_marginBottom_small_mobile__iv7so5dk {
+  margin-bottom: var(--space-small__xorl4v3);
+}
+.sprinkles_marginBottom_medium_mobile__iv7so5do {
+  margin-bottom: var(--space-medium__xorl4v4);
+}
+.sprinkles_marginBottom_large_mobile__iv7so5ds {
+  margin-bottom: var(--space-large__xorl4v5);
+}
+.sprinkles_marginBottom_xlarge_mobile__iv7so5dw {
+  margin-bottom: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_marginBottom_xxlarge_mobile__iv7so5e0 {
+  margin-bottom: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_marginBottom_xxxlarge_mobile__iv7so5e4 {
+  margin-bottom: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_marginBottom_none_mobile__iv7so5e8 {
+  margin-bottom: 0;
+}
+.sprinkles_marginRight_gutter_mobile__iv7so5ec {
+  margin-right: var(--space-gutter__xorl4v0);
+}
+.sprinkles_marginRight_xxsmall_mobile__iv7so5eg {
+  margin-right: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_marginRight_xsmall_mobile__iv7so5ek {
+  margin-right: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_marginRight_small_mobile__iv7so5eo {
+  margin-right: var(--space-small__xorl4v3);
+}
+.sprinkles_marginRight_medium_mobile__iv7so5es {
+  margin-right: var(--space-medium__xorl4v4);
+}
+.sprinkles_marginRight_large_mobile__iv7so5ew {
+  margin-right: var(--space-large__xorl4v5);
+}
+.sprinkles_marginRight_xlarge_mobile__iv7so5f0 {
+  margin-right: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_marginRight_xxlarge_mobile__iv7so5f4 {
+  margin-right: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_marginRight_xxxlarge_mobile__iv7so5f8 {
+  margin-right: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_marginRight_none_mobile__iv7so5fc {
+  margin-right: 0;
+}
+.sprinkles_marginLeft_gutter_mobile__iv7so5fg {
+  margin-left: var(--space-gutter__xorl4v0);
+}
+.sprinkles_marginLeft_xxsmall_mobile__iv7so5fk {
+  margin-left: var(--space-xxsmall__xorl4v1);
+}
+.sprinkles_marginLeft_xsmall_mobile__iv7so5fo {
+  margin-left: var(--space-xsmall__xorl4v2);
+}
+.sprinkles_marginLeft_small_mobile__iv7so5fs {
+  margin-left: var(--space-small__xorl4v3);
+}
+.sprinkles_marginLeft_medium_mobile__iv7so5fw {
+  margin-left: var(--space-medium__xorl4v4);
+}
+.sprinkles_marginLeft_large_mobile__iv7so5g0 {
+  margin-left: var(--space-large__xorl4v5);
+}
+.sprinkles_marginLeft_xlarge_mobile__iv7so5g4 {
+  margin-left: var(--space-xlarge__xorl4v6);
+}
+.sprinkles_marginLeft_xxlarge_mobile__iv7so5g8 {
+  margin-left: var(--space-xxlarge__xorl4v7);
+}
+.sprinkles_marginLeft_xxxlarge_mobile__iv7so5gc {
+  margin-left: var(--space-xxxlarge__xorl4v8);
+}
+.sprinkles_marginLeft_none_mobile__iv7so5gg {
+  margin-left: 0;
+}
+.sprinkles_alignItems_flexStart_mobile__iv7so5gk {
+  align-items: flex-start;
+}
+.sprinkles_alignItems_center_mobile__iv7so5go {
+  align-items: center;
+}
+.sprinkles_alignItems_flexEnd_mobile__iv7so5gs {
+  align-items: flex-end;
+}
+.sprinkles_justifyContent_flexStart_mobile__iv7so5gw {
+  justify-content: flex-start;
+}
+.sprinkles_justifyContent_center_mobile__iv7so5h0 {
+  justify-content: center;
+}
+.sprinkles_justifyContent_flexEnd_mobile__iv7so5h4 {
+  justify-content: flex-end;
+}
+.sprinkles_justifyContent_spaceBetween_mobile__iv7so5h8 {
+  justify-content: space-between;
+}
+.sprinkles_flexDirection_row_mobile__iv7so5hc {
+  flex-direction: row;
+}
+.sprinkles_flexDirection_rowReverse_mobile__iv7so5hg {
+  flex-direction: row-reverse;
+}
+.sprinkles_flexDirection_column_mobile__iv7so5hk {
+  flex-direction: column;
+}
+.sprinkles_flexDirection_columnReverse_mobile__iv7so5ho {
+  flex-direction: column-reverse;
+}
+.sprinkles_flexWrap_wrap_mobile__iv7so5hs {
+  flex-wrap: wrap;
+}
+.sprinkles_flexWrap_nowrap_mobile__iv7so5hw {
+  flex-wrap: nowrap;
+}
+.sprinkles_flexShrink_0_mobile__iv7so5i0 {
+  flex-shrink: 0;
+}
+.sprinkles_flexGrow_0_mobile__iv7so5i4 {
+  flex-grow: 0;
+}
+.sprinkles_flexGrow_1_mobile__iv7so5i8 {
+  flex-grow: 1;
+}
+.sprinkles_textAlign_left_mobile__iv7so5ic {
+  text-align: left;
+}
+.sprinkles_textAlign_center_mobile__iv7so5ig {
+  text-align: center;
+}
+.sprinkles_textAlign_right_mobile__iv7so5ik {
+  text-align: right;
+}
+@media screen and (min-width: 740px) {
+  .sprinkles_display_none_tablet__iv7so54x {
+    display: none;
+  }
+  .sprinkles_display_block_tablet__iv7so551 {
+    display: block;
+  }
+  .sprinkles_display_inline_tablet__iv7so555 {
+    display: inline;
+  }
+  .sprinkles_display_inlineBlock_tablet__iv7so559 {
+    display: inline-block;
+  }
+  .sprinkles_display_flex_tablet__iv7so55d {
+    display: flex;
+  }
+  .sprinkles_position_relative_tablet__iv7so55h {
+    position: relative;
+  }
+  .sprinkles_position_absolute_tablet__iv7so55l {
+    position: absolute;
+  }
+  .sprinkles_position_fixed_tablet__iv7so55p {
+    position: fixed;
+  }
+  .sprinkles_position_sticky_tablet__iv7so55t {
+    position: sticky;
+  }
+  .sprinkles_borderRadius_none_tablet__iv7so55x {
+    border-radius: 0px;
+  }
+  .sprinkles_borderRadius_full_tablet__iv7so561 {
+    border-radius: 9999px;
+  }
+  .sprinkles_borderRadius_small_tablet__iv7so565 {
+    border-radius: var(--borderRadius-small__xorl4vb);
+  }
+  .sprinkles_borderRadius_standard_tablet__iv7so569 {
+    border-radius: var(--borderRadius-standard__xorl4vc);
+  }
+  .sprinkles_borderRadius_large_tablet__iv7so56d {
+    border-radius: var(--borderRadius-large__xorl4vd);
+  }
+  .sprinkles_borderRadius_xlarge_tablet__iv7so56h {
+    border-radius: var(--borderRadius-xlarge__xorl4ve);
+  }
+  .sprinkles_gap_gutter_tablet__iv7so56l {
+    gap: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_gap_xxsmall_tablet__iv7so56p {
+    gap: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_gap_xsmall_tablet__iv7so56t {
+    gap: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_gap_small_tablet__iv7so56x {
+    gap: var(--space-small__xorl4v3);
+  }
+  .sprinkles_gap_medium_tablet__iv7so571 {
+    gap: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_gap_large_tablet__iv7so575 {
+    gap: var(--space-large__xorl4v5);
+  }
+  .sprinkles_gap_xlarge_tablet__iv7so579 {
+    gap: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_gap_xxlarge_tablet__iv7so57d {
+    gap: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_gap_xxxlarge_tablet__iv7so57h {
+    gap: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_gap_none_tablet__iv7so57l {
+    gap: 0;
+  }
+  .sprinkles_paddingTop_gutter_tablet__iv7so57p {
+    padding-top: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingTop_xxsmall_tablet__iv7so57t {
+    padding-top: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingTop_xsmall_tablet__iv7so57x {
+    padding-top: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingTop_small_tablet__iv7so581 {
+    padding-top: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingTop_medium_tablet__iv7so585 {
+    padding-top: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingTop_large_tablet__iv7so589 {
+    padding-top: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingTop_xlarge_tablet__iv7so58d {
+    padding-top: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingTop_xxlarge_tablet__iv7so58h {
+    padding-top: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingTop_xxxlarge_tablet__iv7so58l {
+    padding-top: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingTop_none_tablet__iv7so58p {
+    padding-top: 0;
+  }
+  .sprinkles_paddingBottom_gutter_tablet__iv7so58t {
+    padding-bottom: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingBottom_xxsmall_tablet__iv7so58x {
+    padding-bottom: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingBottom_xsmall_tablet__iv7so591 {
+    padding-bottom: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingBottom_small_tablet__iv7so595 {
+    padding-bottom: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingBottom_medium_tablet__iv7so599 {
+    padding-bottom: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingBottom_large_tablet__iv7so59d {
+    padding-bottom: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingBottom_xlarge_tablet__iv7so59h {
+    padding-bottom: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingBottom_xxlarge_tablet__iv7so59l {
+    padding-bottom: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingBottom_xxxlarge_tablet__iv7so59p {
+    padding-bottom: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingBottom_none_tablet__iv7so59t {
+    padding-bottom: 0;
+  }
+  .sprinkles_paddingRight_gutter_tablet__iv7so59x {
+    padding-right: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingRight_xxsmall_tablet__iv7so5a1 {
+    padding-right: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingRight_xsmall_tablet__iv7so5a5 {
+    padding-right: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingRight_small_tablet__iv7so5a9 {
+    padding-right: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingRight_medium_tablet__iv7so5ad {
+    padding-right: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingRight_large_tablet__iv7so5ah {
+    padding-right: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingRight_xlarge_tablet__iv7so5al {
+    padding-right: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingRight_xxlarge_tablet__iv7so5ap {
+    padding-right: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingRight_xxxlarge_tablet__iv7so5at {
+    padding-right: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingRight_none_tablet__iv7so5ax {
+    padding-right: 0;
+  }
+  .sprinkles_paddingLeft_gutter_tablet__iv7so5b1 {
+    padding-left: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingLeft_xxsmall_tablet__iv7so5b5 {
+    padding-left: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingLeft_xsmall_tablet__iv7so5b9 {
+    padding-left: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingLeft_small_tablet__iv7so5bd {
+    padding-left: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingLeft_medium_tablet__iv7so5bh {
+    padding-left: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingLeft_large_tablet__iv7so5bl {
+    padding-left: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingLeft_xlarge_tablet__iv7so5bp {
+    padding-left: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingLeft_xxlarge_tablet__iv7so5bt {
+    padding-left: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingLeft_xxxlarge_tablet__iv7so5bx {
+    padding-left: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingLeft_none_tablet__iv7so5c1 {
+    padding-left: 0;
+  }
+  .sprinkles_marginTop_gutter_tablet__iv7so5c5 {
+    margin-top: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginTop_xxsmall_tablet__iv7so5c9 {
+    margin-top: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginTop_xsmall_tablet__iv7so5cd {
+    margin-top: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginTop_small_tablet__iv7so5ch {
+    margin-top: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginTop_medium_tablet__iv7so5cl {
+    margin-top: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginTop_large_tablet__iv7so5cp {
+    margin-top: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginTop_xlarge_tablet__iv7so5ct {
+    margin-top: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginTop_xxlarge_tablet__iv7so5cx {
+    margin-top: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginTop_xxxlarge_tablet__iv7so5d1 {
+    margin-top: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginTop_none_tablet__iv7so5d5 {
+    margin-top: 0;
+  }
+  .sprinkles_marginBottom_gutter_tablet__iv7so5d9 {
+    margin-bottom: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginBottom_xxsmall_tablet__iv7so5dd {
+    margin-bottom: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginBottom_xsmall_tablet__iv7so5dh {
+    margin-bottom: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginBottom_small_tablet__iv7so5dl {
+    margin-bottom: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginBottom_medium_tablet__iv7so5dp {
+    margin-bottom: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginBottom_large_tablet__iv7so5dt {
+    margin-bottom: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginBottom_xlarge_tablet__iv7so5dx {
+    margin-bottom: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginBottom_xxlarge_tablet__iv7so5e1 {
+    margin-bottom: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginBottom_xxxlarge_tablet__iv7so5e5 {
+    margin-bottom: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginBottom_none_tablet__iv7so5e9 {
+    margin-bottom: 0;
+  }
+  .sprinkles_marginRight_gutter_tablet__iv7so5ed {
+    margin-right: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginRight_xxsmall_tablet__iv7so5eh {
+    margin-right: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginRight_xsmall_tablet__iv7so5el {
+    margin-right: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginRight_small_tablet__iv7so5ep {
+    margin-right: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginRight_medium_tablet__iv7so5et {
+    margin-right: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginRight_large_tablet__iv7so5ex {
+    margin-right: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginRight_xlarge_tablet__iv7so5f1 {
+    margin-right: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginRight_xxlarge_tablet__iv7so5f5 {
+    margin-right: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginRight_xxxlarge_tablet__iv7so5f9 {
+    margin-right: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginRight_none_tablet__iv7so5fd {
+    margin-right: 0;
+  }
+  .sprinkles_marginLeft_gutter_tablet__iv7so5fh {
+    margin-left: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginLeft_xxsmall_tablet__iv7so5fl {
+    margin-left: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginLeft_xsmall_tablet__iv7so5fp {
+    margin-left: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginLeft_small_tablet__iv7so5ft {
+    margin-left: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginLeft_medium_tablet__iv7so5fx {
+    margin-left: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginLeft_large_tablet__iv7so5g1 {
+    margin-left: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginLeft_xlarge_tablet__iv7so5g5 {
+    margin-left: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginLeft_xxlarge_tablet__iv7so5g9 {
+    margin-left: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginLeft_xxxlarge_tablet__iv7so5gd {
+    margin-left: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginLeft_none_tablet__iv7so5gh {
+    margin-left: 0;
+  }
+  .sprinkles_alignItems_flexStart_tablet__iv7so5gl {
+    align-items: flex-start;
+  }
+  .sprinkles_alignItems_center_tablet__iv7so5gp {
+    align-items: center;
+  }
+  .sprinkles_alignItems_flexEnd_tablet__iv7so5gt {
+    align-items: flex-end;
+  }
+  .sprinkles_justifyContent_flexStart_tablet__iv7so5gx {
+    justify-content: flex-start;
+  }
+  .sprinkles_justifyContent_center_tablet__iv7so5h1 {
+    justify-content: center;
+  }
+  .sprinkles_justifyContent_flexEnd_tablet__iv7so5h5 {
+    justify-content: flex-end;
+  }
+  .sprinkles_justifyContent_spaceBetween_tablet__iv7so5h9 {
+    justify-content: space-between;
+  }
+  .sprinkles_flexDirection_row_tablet__iv7so5hd {
+    flex-direction: row;
+  }
+  .sprinkles_flexDirection_rowReverse_tablet__iv7so5hh {
+    flex-direction: row-reverse;
+  }
+  .sprinkles_flexDirection_column_tablet__iv7so5hl {
+    flex-direction: column;
+  }
+  .sprinkles_flexDirection_columnReverse_tablet__iv7so5hp {
+    flex-direction: column-reverse;
+  }
+  .sprinkles_flexWrap_wrap_tablet__iv7so5ht {
+    flex-wrap: wrap;
+  }
+  .sprinkles_flexWrap_nowrap_tablet__iv7so5hx {
+    flex-wrap: nowrap;
+  }
+  .sprinkles_flexShrink_0_tablet__iv7so5i1 {
+    flex-shrink: 0;
+  }
+  .sprinkles_flexGrow_0_tablet__iv7so5i5 {
+    flex-grow: 0;
+  }
+  .sprinkles_flexGrow_1_tablet__iv7so5i9 {
+    flex-grow: 1;
+  }
+  .sprinkles_textAlign_left_tablet__iv7so5id {
+    text-align: left;
+  }
+  .sprinkles_textAlign_center_tablet__iv7so5ih {
+    text-align: center;
+  }
+  .sprinkles_textAlign_right_tablet__iv7so5il {
+    text-align: right;
+  }
+}
+@media screen and (min-width: 992px) {
+  .sprinkles_display_none_desktop__iv7so54y {
+    display: none;
+  }
+  .sprinkles_display_block_desktop__iv7so552 {
+    display: block;
+  }
+  .sprinkles_display_inline_desktop__iv7so556 {
+    display: inline;
+  }
+  .sprinkles_display_inlineBlock_desktop__iv7so55a {
+    display: inline-block;
+  }
+  .sprinkles_display_flex_desktop__iv7so55e {
+    display: flex;
+  }
+  .sprinkles_position_relative_desktop__iv7so55i {
+    position: relative;
+  }
+  .sprinkles_position_absolute_desktop__iv7so55m {
+    position: absolute;
+  }
+  .sprinkles_position_fixed_desktop__iv7so55q {
+    position: fixed;
+  }
+  .sprinkles_position_sticky_desktop__iv7so55u {
+    position: sticky;
+  }
+  .sprinkles_borderRadius_none_desktop__iv7so55y {
+    border-radius: 0px;
+  }
+  .sprinkles_borderRadius_full_desktop__iv7so562 {
+    border-radius: 9999px;
+  }
+  .sprinkles_borderRadius_small_desktop__iv7so566 {
+    border-radius: var(--borderRadius-small__xorl4vb);
+  }
+  .sprinkles_borderRadius_standard_desktop__iv7so56a {
+    border-radius: var(--borderRadius-standard__xorl4vc);
+  }
+  .sprinkles_borderRadius_large_desktop__iv7so56e {
+    border-radius: var(--borderRadius-large__xorl4vd);
+  }
+  .sprinkles_borderRadius_xlarge_desktop__iv7so56i {
+    border-radius: var(--borderRadius-xlarge__xorl4ve);
+  }
+  .sprinkles_gap_gutter_desktop__iv7so56m {
+    gap: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_gap_xxsmall_desktop__iv7so56q {
+    gap: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_gap_xsmall_desktop__iv7so56u {
+    gap: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_gap_small_desktop__iv7so56y {
+    gap: var(--space-small__xorl4v3);
+  }
+  .sprinkles_gap_medium_desktop__iv7so572 {
+    gap: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_gap_large_desktop__iv7so576 {
+    gap: var(--space-large__xorl4v5);
+  }
+  .sprinkles_gap_xlarge_desktop__iv7so57a {
+    gap: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_gap_xxlarge_desktop__iv7so57e {
+    gap: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_gap_xxxlarge_desktop__iv7so57i {
+    gap: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_gap_none_desktop__iv7so57m {
+    gap: 0;
+  }
+  .sprinkles_paddingTop_gutter_desktop__iv7so57q {
+    padding-top: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingTop_xxsmall_desktop__iv7so57u {
+    padding-top: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingTop_xsmall_desktop__iv7so57y {
+    padding-top: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingTop_small_desktop__iv7so582 {
+    padding-top: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingTop_medium_desktop__iv7so586 {
+    padding-top: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingTop_large_desktop__iv7so58a {
+    padding-top: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingTop_xlarge_desktop__iv7so58e {
+    padding-top: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingTop_xxlarge_desktop__iv7so58i {
+    padding-top: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingTop_xxxlarge_desktop__iv7so58m {
+    padding-top: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingTop_none_desktop__iv7so58q {
+    padding-top: 0;
+  }
+  .sprinkles_paddingBottom_gutter_desktop__iv7so58u {
+    padding-bottom: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingBottom_xxsmall_desktop__iv7so58y {
+    padding-bottom: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingBottom_xsmall_desktop__iv7so592 {
+    padding-bottom: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingBottom_small_desktop__iv7so596 {
+    padding-bottom: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingBottom_medium_desktop__iv7so59a {
+    padding-bottom: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingBottom_large_desktop__iv7so59e {
+    padding-bottom: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingBottom_xlarge_desktop__iv7so59i {
+    padding-bottom: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingBottom_xxlarge_desktop__iv7so59m {
+    padding-bottom: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingBottom_xxxlarge_desktop__iv7so59q {
+    padding-bottom: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingBottom_none_desktop__iv7so59u {
+    padding-bottom: 0;
+  }
+  .sprinkles_paddingRight_gutter_desktop__iv7so59y {
+    padding-right: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingRight_xxsmall_desktop__iv7so5a2 {
+    padding-right: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingRight_xsmall_desktop__iv7so5a6 {
+    padding-right: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingRight_small_desktop__iv7so5aa {
+    padding-right: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingRight_medium_desktop__iv7so5ae {
+    padding-right: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingRight_large_desktop__iv7so5ai {
+    padding-right: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingRight_xlarge_desktop__iv7so5am {
+    padding-right: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingRight_xxlarge_desktop__iv7so5aq {
+    padding-right: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingRight_xxxlarge_desktop__iv7so5au {
+    padding-right: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingRight_none_desktop__iv7so5ay {
+    padding-right: 0;
+  }
+  .sprinkles_paddingLeft_gutter_desktop__iv7so5b2 {
+    padding-left: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingLeft_xxsmall_desktop__iv7so5b6 {
+    padding-left: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingLeft_xsmall_desktop__iv7so5ba {
+    padding-left: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingLeft_small_desktop__iv7so5be {
+    padding-left: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingLeft_medium_desktop__iv7so5bi {
+    padding-left: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingLeft_large_desktop__iv7so5bm {
+    padding-left: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingLeft_xlarge_desktop__iv7so5bq {
+    padding-left: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingLeft_xxlarge_desktop__iv7so5bu {
+    padding-left: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingLeft_xxxlarge_desktop__iv7so5by {
+    padding-left: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingLeft_none_desktop__iv7so5c2 {
+    padding-left: 0;
+  }
+  .sprinkles_marginTop_gutter_desktop__iv7so5c6 {
+    margin-top: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginTop_xxsmall_desktop__iv7so5ca {
+    margin-top: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginTop_xsmall_desktop__iv7so5ce {
+    margin-top: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginTop_small_desktop__iv7so5ci {
+    margin-top: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginTop_medium_desktop__iv7so5cm {
+    margin-top: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginTop_large_desktop__iv7so5cq {
+    margin-top: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginTop_xlarge_desktop__iv7so5cu {
+    margin-top: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginTop_xxlarge_desktop__iv7so5cy {
+    margin-top: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginTop_xxxlarge_desktop__iv7so5d2 {
+    margin-top: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginTop_none_desktop__iv7so5d6 {
+    margin-top: 0;
+  }
+  .sprinkles_marginBottom_gutter_desktop__iv7so5da {
+    margin-bottom: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginBottom_xxsmall_desktop__iv7so5de {
+    margin-bottom: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginBottom_xsmall_desktop__iv7so5di {
+    margin-bottom: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginBottom_small_desktop__iv7so5dm {
+    margin-bottom: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginBottom_medium_desktop__iv7so5dq {
+    margin-bottom: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginBottom_large_desktop__iv7so5du {
+    margin-bottom: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginBottom_xlarge_desktop__iv7so5dy {
+    margin-bottom: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginBottom_xxlarge_desktop__iv7so5e2 {
+    margin-bottom: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginBottom_xxxlarge_desktop__iv7so5e6 {
+    margin-bottom: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginBottom_none_desktop__iv7so5ea {
+    margin-bottom: 0;
+  }
+  .sprinkles_marginRight_gutter_desktop__iv7so5ee {
+    margin-right: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginRight_xxsmall_desktop__iv7so5ei {
+    margin-right: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginRight_xsmall_desktop__iv7so5em {
+    margin-right: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginRight_small_desktop__iv7so5eq {
+    margin-right: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginRight_medium_desktop__iv7so5eu {
+    margin-right: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginRight_large_desktop__iv7so5ey {
+    margin-right: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginRight_xlarge_desktop__iv7so5f2 {
+    margin-right: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginRight_xxlarge_desktop__iv7so5f6 {
+    margin-right: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginRight_xxxlarge_desktop__iv7so5fa {
+    margin-right: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginRight_none_desktop__iv7so5fe {
+    margin-right: 0;
+  }
+  .sprinkles_marginLeft_gutter_desktop__iv7so5fi {
+    margin-left: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginLeft_xxsmall_desktop__iv7so5fm {
+    margin-left: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginLeft_xsmall_desktop__iv7so5fq {
+    margin-left: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginLeft_small_desktop__iv7so5fu {
+    margin-left: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginLeft_medium_desktop__iv7so5fy {
+    margin-left: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginLeft_large_desktop__iv7so5g2 {
+    margin-left: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginLeft_xlarge_desktop__iv7so5g6 {
+    margin-left: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginLeft_xxlarge_desktop__iv7so5ga {
+    margin-left: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginLeft_xxxlarge_desktop__iv7so5ge {
+    margin-left: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginLeft_none_desktop__iv7so5gi {
+    margin-left: 0;
+  }
+  .sprinkles_alignItems_flexStart_desktop__iv7so5gm {
+    align-items: flex-start;
+  }
+  .sprinkles_alignItems_center_desktop__iv7so5gq {
+    align-items: center;
+  }
+  .sprinkles_alignItems_flexEnd_desktop__iv7so5gu {
+    align-items: flex-end;
+  }
+  .sprinkles_justifyContent_flexStart_desktop__iv7so5gy {
+    justify-content: flex-start;
+  }
+  .sprinkles_justifyContent_center_desktop__iv7so5h2 {
+    justify-content: center;
+  }
+  .sprinkles_justifyContent_flexEnd_desktop__iv7so5h6 {
+    justify-content: flex-end;
+  }
+  .sprinkles_justifyContent_spaceBetween_desktop__iv7so5ha {
+    justify-content: space-between;
+  }
+  .sprinkles_flexDirection_row_desktop__iv7so5he {
+    flex-direction: row;
+  }
+  .sprinkles_flexDirection_rowReverse_desktop__iv7so5hi {
+    flex-direction: row-reverse;
+  }
+  .sprinkles_flexDirection_column_desktop__iv7so5hm {
+    flex-direction: column;
+  }
+  .sprinkles_flexDirection_columnReverse_desktop__iv7so5hq {
+    flex-direction: column-reverse;
+  }
+  .sprinkles_flexWrap_wrap_desktop__iv7so5hu {
+    flex-wrap: wrap;
+  }
+  .sprinkles_flexWrap_nowrap_desktop__iv7so5hy {
+    flex-wrap: nowrap;
+  }
+  .sprinkles_flexShrink_0_desktop__iv7so5i2 {
+    flex-shrink: 0;
+  }
+  .sprinkles_flexGrow_0_desktop__iv7so5i6 {
+    flex-grow: 0;
+  }
+  .sprinkles_flexGrow_1_desktop__iv7so5ia {
+    flex-grow: 1;
+  }
+  .sprinkles_textAlign_left_desktop__iv7so5ie {
+    text-align: left;
+  }
+  .sprinkles_textAlign_center_desktop__iv7so5ii {
+    text-align: center;
+  }
+  .sprinkles_textAlign_right_desktop__iv7so5im {
+    text-align: right;
+  }
+}
+@media screen and (min-width: 1200px) {
+  .sprinkles_display_none_wide__iv7so54z {
+    display: none;
+  }
+  .sprinkles_display_block_wide__iv7so553 {
+    display: block;
+  }
+  .sprinkles_display_inline_wide__iv7so557 {
+    display: inline;
+  }
+  .sprinkles_display_inlineBlock_wide__iv7so55b {
+    display: inline-block;
+  }
+  .sprinkles_display_flex_wide__iv7so55f {
+    display: flex;
+  }
+  .sprinkles_position_relative_wide__iv7so55j {
+    position: relative;
+  }
+  .sprinkles_position_absolute_wide__iv7so55n {
+    position: absolute;
+  }
+  .sprinkles_position_fixed_wide__iv7so55r {
+    position: fixed;
+  }
+  .sprinkles_position_sticky_wide__iv7so55v {
+    position: sticky;
+  }
+  .sprinkles_borderRadius_none_wide__iv7so55z {
+    border-radius: 0px;
+  }
+  .sprinkles_borderRadius_full_wide__iv7so563 {
+    border-radius: 9999px;
+  }
+  .sprinkles_borderRadius_small_wide__iv7so567 {
+    border-radius: var(--borderRadius-small__xorl4vb);
+  }
+  .sprinkles_borderRadius_standard_wide__iv7so56b {
+    border-radius: var(--borderRadius-standard__xorl4vc);
+  }
+  .sprinkles_borderRadius_large_wide__iv7so56f {
+    border-radius: var(--borderRadius-large__xorl4vd);
+  }
+  .sprinkles_borderRadius_xlarge_wide__iv7so56j {
+    border-radius: var(--borderRadius-xlarge__xorl4ve);
+  }
+  .sprinkles_gap_gutter_wide__iv7so56n {
+    gap: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_gap_xxsmall_wide__iv7so56r {
+    gap: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_gap_xsmall_wide__iv7so56v {
+    gap: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_gap_small_wide__iv7so56z {
+    gap: var(--space-small__xorl4v3);
+  }
+  .sprinkles_gap_medium_wide__iv7so573 {
+    gap: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_gap_large_wide__iv7so577 {
+    gap: var(--space-large__xorl4v5);
+  }
+  .sprinkles_gap_xlarge_wide__iv7so57b {
+    gap: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_gap_xxlarge_wide__iv7so57f {
+    gap: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_gap_xxxlarge_wide__iv7so57j {
+    gap: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_gap_none_wide__iv7so57n {
+    gap: 0;
+  }
+  .sprinkles_paddingTop_gutter_wide__iv7so57r {
+    padding-top: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingTop_xxsmall_wide__iv7so57v {
+    padding-top: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingTop_xsmall_wide__iv7so57z {
+    padding-top: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingTop_small_wide__iv7so583 {
+    padding-top: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingTop_medium_wide__iv7so587 {
+    padding-top: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingTop_large_wide__iv7so58b {
+    padding-top: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingTop_xlarge_wide__iv7so58f {
+    padding-top: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingTop_xxlarge_wide__iv7so58j {
+    padding-top: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingTop_xxxlarge_wide__iv7so58n {
+    padding-top: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingTop_none_wide__iv7so58r {
+    padding-top: 0;
+  }
+  .sprinkles_paddingBottom_gutter_wide__iv7so58v {
+    padding-bottom: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingBottom_xxsmall_wide__iv7so58z {
+    padding-bottom: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingBottom_xsmall_wide__iv7so593 {
+    padding-bottom: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingBottom_small_wide__iv7so597 {
+    padding-bottom: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingBottom_medium_wide__iv7so59b {
+    padding-bottom: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingBottom_large_wide__iv7so59f {
+    padding-bottom: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingBottom_xlarge_wide__iv7so59j {
+    padding-bottom: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingBottom_xxlarge_wide__iv7so59n {
+    padding-bottom: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingBottom_xxxlarge_wide__iv7so59r {
+    padding-bottom: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingBottom_none_wide__iv7so59v {
+    padding-bottom: 0;
+  }
+  .sprinkles_paddingRight_gutter_wide__iv7so59z {
+    padding-right: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingRight_xxsmall_wide__iv7so5a3 {
+    padding-right: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingRight_xsmall_wide__iv7so5a7 {
+    padding-right: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingRight_small_wide__iv7so5ab {
+    padding-right: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingRight_medium_wide__iv7so5af {
+    padding-right: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingRight_large_wide__iv7so5aj {
+    padding-right: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingRight_xlarge_wide__iv7so5an {
+    padding-right: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingRight_xxlarge_wide__iv7so5ar {
+    padding-right: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingRight_xxxlarge_wide__iv7so5av {
+    padding-right: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingRight_none_wide__iv7so5az {
+    padding-right: 0;
+  }
+  .sprinkles_paddingLeft_gutter_wide__iv7so5b3 {
+    padding-left: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_paddingLeft_xxsmall_wide__iv7so5b7 {
+    padding-left: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_paddingLeft_xsmall_wide__iv7so5bb {
+    padding-left: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_paddingLeft_small_wide__iv7so5bf {
+    padding-left: var(--space-small__xorl4v3);
+  }
+  .sprinkles_paddingLeft_medium_wide__iv7so5bj {
+    padding-left: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_paddingLeft_large_wide__iv7so5bn {
+    padding-left: var(--space-large__xorl4v5);
+  }
+  .sprinkles_paddingLeft_xlarge_wide__iv7so5br {
+    padding-left: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_paddingLeft_xxlarge_wide__iv7so5bv {
+    padding-left: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_paddingLeft_xxxlarge_wide__iv7so5bz {
+    padding-left: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_paddingLeft_none_wide__iv7so5c3 {
+    padding-left: 0;
+  }
+  .sprinkles_marginTop_gutter_wide__iv7so5c7 {
+    margin-top: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginTop_xxsmall_wide__iv7so5cb {
+    margin-top: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginTop_xsmall_wide__iv7so5cf {
+    margin-top: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginTop_small_wide__iv7so5cj {
+    margin-top: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginTop_medium_wide__iv7so5cn {
+    margin-top: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginTop_large_wide__iv7so5cr {
+    margin-top: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginTop_xlarge_wide__iv7so5cv {
+    margin-top: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginTop_xxlarge_wide__iv7so5cz {
+    margin-top: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginTop_xxxlarge_wide__iv7so5d3 {
+    margin-top: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginTop_none_wide__iv7so5d7 {
+    margin-top: 0;
+  }
+  .sprinkles_marginBottom_gutter_wide__iv7so5db {
+    margin-bottom: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginBottom_xxsmall_wide__iv7so5df {
+    margin-bottom: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginBottom_xsmall_wide__iv7so5dj {
+    margin-bottom: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginBottom_small_wide__iv7so5dn {
+    margin-bottom: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginBottom_medium_wide__iv7so5dr {
+    margin-bottom: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginBottom_large_wide__iv7so5dv {
+    margin-bottom: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginBottom_xlarge_wide__iv7so5dz {
+    margin-bottom: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginBottom_xxlarge_wide__iv7so5e3 {
+    margin-bottom: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginBottom_xxxlarge_wide__iv7so5e7 {
+    margin-bottom: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginBottom_none_wide__iv7so5eb {
+    margin-bottom: 0;
+  }
+  .sprinkles_marginRight_gutter_wide__iv7so5ef {
+    margin-right: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginRight_xxsmall_wide__iv7so5ej {
+    margin-right: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginRight_xsmall_wide__iv7so5en {
+    margin-right: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginRight_small_wide__iv7so5er {
+    margin-right: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginRight_medium_wide__iv7so5ev {
+    margin-right: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginRight_large_wide__iv7so5ez {
+    margin-right: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginRight_xlarge_wide__iv7so5f3 {
+    margin-right: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginRight_xxlarge_wide__iv7so5f7 {
+    margin-right: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginRight_xxxlarge_wide__iv7so5fb {
+    margin-right: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginRight_none_wide__iv7so5ff {
+    margin-right: 0;
+  }
+  .sprinkles_marginLeft_gutter_wide__iv7so5fj {
+    margin-left: var(--space-gutter__xorl4v0);
+  }
+  .sprinkles_marginLeft_xxsmall_wide__iv7so5fn {
+    margin-left: var(--space-xxsmall__xorl4v1);
+  }
+  .sprinkles_marginLeft_xsmall_wide__iv7so5fr {
+    margin-left: var(--space-xsmall__xorl4v2);
+  }
+  .sprinkles_marginLeft_small_wide__iv7so5fv {
+    margin-left: var(--space-small__xorl4v3);
+  }
+  .sprinkles_marginLeft_medium_wide__iv7so5fz {
+    margin-left: var(--space-medium__xorl4v4);
+  }
+  .sprinkles_marginLeft_large_wide__iv7so5g3 {
+    margin-left: var(--space-large__xorl4v5);
+  }
+  .sprinkles_marginLeft_xlarge_wide__iv7so5g7 {
+    margin-left: var(--space-xlarge__xorl4v6);
+  }
+  .sprinkles_marginLeft_xxlarge_wide__iv7so5gb {
+    margin-left: var(--space-xxlarge__xorl4v7);
+  }
+  .sprinkles_marginLeft_xxxlarge_wide__iv7so5gf {
+    margin-left: var(--space-xxxlarge__xorl4v8);
+  }
+  .sprinkles_marginLeft_none_wide__iv7so5gj {
+    margin-left: 0;
+  }
+  .sprinkles_alignItems_flexStart_wide__iv7so5gn {
+    align-items: flex-start;
+  }
+  .sprinkles_alignItems_center_wide__iv7so5gr {
+    align-items: center;
+  }
+  .sprinkles_alignItems_flexEnd_wide__iv7so5gv {
+    align-items: flex-end;
+  }
+  .sprinkles_justifyContent_flexStart_wide__iv7so5gz {
+    justify-content: flex-start;
+  }
+  .sprinkles_justifyContent_center_wide__iv7so5h3 {
+    justify-content: center;
+  }
+  .sprinkles_justifyContent_flexEnd_wide__iv7so5h7 {
+    justify-content: flex-end;
+  }
+  .sprinkles_justifyContent_spaceBetween_wide__iv7so5hb {
+    justify-content: space-between;
+  }
+  .sprinkles_flexDirection_row_wide__iv7so5hf {
+    flex-direction: row;
+  }
+  .sprinkles_flexDirection_rowReverse_wide__iv7so5hj {
+    flex-direction: row-reverse;
+  }
+  .sprinkles_flexDirection_column_wide__iv7so5hn {
+    flex-direction: column;
+  }
+  .sprinkles_flexDirection_columnReverse_wide__iv7so5hr {
+    flex-direction: column-reverse;
+  }
+  .sprinkles_flexWrap_wrap_wide__iv7so5hv {
+    flex-wrap: wrap;
+  }
+  .sprinkles_flexWrap_nowrap_wide__iv7so5hz {
+    flex-wrap: nowrap;
+  }
+  .sprinkles_flexShrink_0_wide__iv7so5i3 {
+    flex-shrink: 0;
+  }
+  .sprinkles_flexGrow_0_wide__iv7so5i7 {
+    flex-grow: 0;
+  }
+  .sprinkles_flexGrow_1_wide__iv7so5ib {
+    flex-grow: 1;
+  }
+  .sprinkles_textAlign_left_wide__iv7so5if {
+    text-align: left;
+  }
+  .sprinkles_textAlign_center_wide__iv7so5ij {
+    text-align: center;
+  }
+  .sprinkles_textAlign_right_wide__iv7so5in {
+    text-align: right;
+  }
+}
+.capsize_capsizeStyle__1lwixuj4 {
+  font-size: var(--fontSize__1lwixuj0);
+  line-height: var(--lineHeight__1lwixuj1);
+}
+.capsize_capsizeStyle__1lwixuj4::before {
+  content: '';
+  margin-bottom: var(--capHeightTrim__1lwixuj2);
+  display: table;
+}
+.capsize_capsizeStyle__1lwixuj4::after {
+  content: '';
+  margin-top: var(--baselineTrim__1lwixuj3);
+  display: table;
+}
+.typography_fontFamily__9al9wa0 {
+  font-family: var(--fontFamily__xorl4v2w);
+}
+.typography_fontWeight_regular__9al9wa1 {
+  font-weight: var(--textWeight-regular__xorl4v46);
+}
+.typography_fontWeight_medium__9al9wa2 {
+  font-weight: var(--textWeight-medium__xorl4v47);
+}
+.typography_fontWeight_strong__9al9wa3 {
+  font-weight: var(--textWeight-strong__xorl4v48);
+}
+.typography_textSize_xsmall__9al9wa4 {
+  --fontSize__1lwixuj0: var(--textSize-xsmall-mobile-fontSize__xorl4v32);
+  --lineHeight__1lwixuj1: var(--textSize-xsmall-mobile-lineHeight__xorl4v33);
+  --capHeightTrim__1lwixuj2: var(--textSize-xsmall-mobile-capsizeTrims-capHeightTrim__xorl4v35);
+  --baselineTrim__1lwixuj3: var(--textSize-xsmall-mobile-capsizeTrims-baselineTrim__xorl4v36);
+}
+.typography_textSize_small__9al9wa6 {
+  --fontSize__1lwixuj0: var(--textSize-small-mobile-fontSize__xorl4v3c);
+  --lineHeight__1lwixuj1: var(--textSize-small-mobile-lineHeight__xorl4v3d);
+  --capHeightTrim__1lwixuj2: var(--textSize-small-mobile-capsizeTrims-capHeightTrim__xorl4v3f);
+  --baselineTrim__1lwixuj3: var(--textSize-small-mobile-capsizeTrims-baselineTrim__xorl4v3g);
+}
+.typography_textSize_standard__9al9wa8 {
+  --fontSize__1lwixuj0: var(--textSize-standard-mobile-fontSize__xorl4v3m);
+  --lineHeight__1lwixuj1: var(--textSize-standard-mobile-lineHeight__xorl4v3n);
+  --capHeightTrim__1lwixuj2: var(--textSize-standard-mobile-capsizeTrims-capHeightTrim__xorl4v3p);
+  --baselineTrim__1lwixuj3: var(--textSize-standard-mobile-capsizeTrims-baselineTrim__xorl4v3q);
+}
+.typography_textSize_large__9al9waa {
+  --fontSize__1lwixuj0: var(--textSize-large-mobile-fontSize__xorl4v3w);
+  --lineHeight__1lwixuj1: var(--textSize-large-mobile-lineHeight__xorl4v3x);
+  --capHeightTrim__1lwixuj2: var(--textSize-large-mobile-capsizeTrims-capHeightTrim__xorl4v3z);
+  --baselineTrim__1lwixuj3: var(--textSize-large-mobile-capsizeTrims-baselineTrim__xorl4v40);
+}
+.typography_textSizeUntrimmed_xsmall__9al9wac {
+  font-size: var(--textSize-xsmall-mobile-fontSize__xorl4v32);
+  line-height: var(--textSize-xsmall-mobile-lineHeight__xorl4v33);
+}
+.typography_textSizeUntrimmed_small__9al9wad {
+  font-size: var(--textSize-small-mobile-fontSize__xorl4v3c);
+  line-height: var(--textSize-small-mobile-lineHeight__xorl4v3d);
+}
+.typography_textSizeUntrimmed_standard__9al9wae {
+  font-size: var(--textSize-standard-mobile-fontSize__xorl4v3m);
+  line-height: var(--textSize-standard-mobile-lineHeight__xorl4v3n);
+}
+.typography_textSizeUntrimmed_large__9al9waf {
+  font-size: var(--textSize-large-mobile-fontSize__xorl4v3w);
+  line-height: var(--textSize-large-mobile-lineHeight__xorl4v3x);
+}
+.typography_headingWeight_weak__9al9wag {
+  font-weight: var(--headingWeight-weak__xorl4v5d);
+}
+.typography_headingWeight_regular__9al9wah {
+  font-weight: var(--headingWeight-regular__xorl4v5e);
+}
+.typography_heading_1__9al9wai {
+  --fontSize__1lwixuj0: var(--headingLevel-1-mobile-fontSize__xorl4v49);
+  --lineHeight__1lwixuj1: var(--headingLevel-1-mobile-lineHeight__xorl4v4a);
+  --capHeightTrim__1lwixuj2: var(--headingLevel-1-mobile-capsizeTrims-capHeightTrim__xorl4v4c);
+  --baselineTrim__1lwixuj3: var(--headingLevel-1-mobile-capsizeTrims-baselineTrim__xorl4v4d);
+}
+.typography_heading_2__9al9wak {
+  --fontSize__1lwixuj0: var(--headingLevel-2-mobile-fontSize__xorl4v4j);
+  --lineHeight__1lwixuj1: var(--headingLevel-2-mobile-lineHeight__xorl4v4k);
+  --capHeightTrim__1lwixuj2: var(--headingLevel-2-mobile-capsizeTrims-capHeightTrim__xorl4v4m);
+  --baselineTrim__1lwixuj3: var(--headingLevel-2-mobile-capsizeTrims-baselineTrim__xorl4v4n);
+}
+.typography_heading_3__9al9wam {
+  --fontSize__1lwixuj0: var(--headingLevel-3-mobile-fontSize__xorl4v4t);
+  --lineHeight__1lwixuj1: var(--headingLevel-3-mobile-lineHeight__xorl4v4u);
+  --capHeightTrim__1lwixuj2: var(--headingLevel-3-mobile-capsizeTrims-capHeightTrim__xorl4v4w);
+  --baselineTrim__1lwixuj3: var(--headingLevel-3-mobile-capsizeTrims-baselineTrim__xorl4v4x);
+}
+.typography_heading_4__9al9wao {
+  --fontSize__1lwixuj0: var(--headingLevel-4-mobile-fontSize__xorl4v53);
+  --lineHeight__1lwixuj1: var(--headingLevel-4-mobile-lineHeight__xorl4v54);
+  --capHeightTrim__1lwixuj2: var(--headingLevel-4-mobile-capsizeTrims-capHeightTrim__xorl4v56);
+  --baselineTrim__1lwixuj3: var(--headingLevel-4-mobile-capsizeTrims-baselineTrim__xorl4v57);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeTone_light__9al9wa10 {
+  --critical__9al9waq: var(--foregroundColor-critical__xorl4v19);
+  --caution__9al9war: var(--foregroundColor-caution__xorl4v17);
+  --info__9al9was: var(--foregroundColor-info__xorl4v1d);
+  --promote__9al9wat: var(--foregroundColor-promote__xorl4v1o);
+  --positive__9al9wau: var(--foregroundColor-positive__xorl4v1m);
+  --brandAccent__9al9wav: var(--foregroundColor-brandAccent__xorl4v15);
+  --formAccent__9al9waw: var(--foregroundColor-formAccent__xorl4v1b);
+  --neutral__9al9wax: var(--foregroundColor-neutral__xorl4v1k);
+  --secondary__9al9way: var(--foregroundColor-secondary__xorl4v1r);
+  --link__9al9waz: var(--foregroundColor-link__xorl4v1f);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeTone_dark__9al9wa11 {
+  --critical__9al9waq: var(--foregroundColor-criticalLight__xorl4v1a);
+  --caution__9al9war: var(--foregroundColor-cautionLight__xorl4v18);
+  --info__9al9was: var(--foregroundColor-infoLight__xorl4v1e);
+  --promote__9al9wat: var(--foregroundColor-promoteLight__xorl4v1p);
+  --positive__9al9wau: var(--foregroundColor-positiveLight__xorl4v1n);
+  --brandAccent__9al9wav: var(--foregroundColor-brandAccentLight__xorl4v16);
+  --formAccent__9al9waw: var(--foregroundColor-formAccentLight__xorl4v1c);
+  --neutral__9al9wax: var(--foregroundColor-neutralInverted__xorl4v1l);
+  --secondary__9al9way: var(--foregroundColor-secondaryInverted__xorl4v1s);
+  --link__9al9waz: var(--foregroundColor-linkLight__xorl4v1h);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeTone_light__9al9wa12 {
+  --critical__9al9waq: var(--foregroundColor-critical__xorl4v19);
+  --caution__9al9war: var(--foregroundColor-caution__xorl4v17);
+  --info__9al9was: var(--foregroundColor-info__xorl4v1d);
+  --promote__9al9wat: var(--foregroundColor-promote__xorl4v1o);
+  --positive__9al9wau: var(--foregroundColor-positive__xorl4v1m);
+  --brandAccent__9al9wav: var(--foregroundColor-brandAccent__xorl4v15);
+  --formAccent__9al9waw: var(--foregroundColor-formAccent__xorl4v1b);
+  --neutral__9al9wax: var(--foregroundColor-neutral__xorl4v1k);
+  --secondary__9al9way: var(--foregroundColor-secondary__xorl4v1r);
+  --link__9al9waz: var(--foregroundColor-link__xorl4v1f);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeTone_dark__9al9wa13 {
+  --critical__9al9waq: var(--foregroundColor-criticalLight__xorl4v1a);
+  --caution__9al9war: var(--foregroundColor-cautionLight__xorl4v18);
+  --info__9al9was: var(--foregroundColor-infoLight__xorl4v1e);
+  --promote__9al9wat: var(--foregroundColor-promoteLight__xorl4v1p);
+  --positive__9al9wau: var(--foregroundColor-positiveLight__xorl4v1n);
+  --brandAccent__9al9wav: var(--foregroundColor-brandAccentLight__xorl4v16);
+  --formAccent__9al9waw: var(--foregroundColor-formAccentLight__xorl4v1c);
+  --neutral__9al9wax: var(--foregroundColor-neutralInverted__xorl4v1l);
+  --secondary__9al9way: var(--foregroundColor-secondaryInverted__xorl4v1s);
+  --link__9al9waz: var(--foregroundColor-linkLight__xorl4v1h);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_criticalLight__9al9wa14 {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_criticalSoft__9al9wa15 {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_criticalSoftActive__9al9wa16 {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_criticalSoftHover__9al9wa17 {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_caution__9al9wa18 {
+  --neutral__9al9wax: var(--caution__9al9war);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_cautionLight__9al9wa19 {
+  --neutral__9al9wax: var(--caution__9al9war);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_positiveLight__9al9wa1a {
+  --neutral__9al9wax: var(--positive__9al9wau);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_infoLight__9al9wa1b {
+  --neutral__9al9wax: var(--info__9al9was);
+}
+html:not(.sprinkles_darkMode__iv7so511) .typography_lightModeNeutralOverride_promoteLight__9al9wa1c {
+  --neutral__9al9wax: var(--promote__9al9wat);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_criticalLight__9al9wa1d {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_criticalSoft__9al9wa1e {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_criticalSoftActive__9al9wa1f {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_criticalSoftHover__9al9wa1g {
+  --neutral__9al9wax: var(--critical__9al9waq);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_caution__9al9wa1h {
+  --neutral__9al9wax: var(--caution__9al9war);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_cautionLight__9al9wa1i {
+  --neutral__9al9wax: var(--caution__9al9war);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_positiveLight__9al9wa1j {
+  --neutral__9al9wax: var(--positive__9al9wau);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_infoLight__9al9wa1k {
+  --neutral__9al9wax: var(--info__9al9was);
+}
+html.sprinkles_darkMode__iv7so511 .typography_darkModeNeutralOverride_promoteLight__9al9wa1l {
+  --neutral__9al9wax: var(--promote__9al9wat);
+}
+.typography_tone_critical__9al9wa1m {
+  color: var(--critical__9al9waq);
+}
+.typography_tone_caution__9al9wa1n {
+  color: var(--caution__9al9war);
+}
+.typography_tone_info__9al9wa1o {
+  color: var(--info__9al9was);
+}
+.typography_tone_promote__9al9wa1p {
+  color: var(--promote__9al9wat);
+}
+.typography_tone_positive__9al9wa1q {
+  color: var(--positive__9al9wau);
+}
+.typography_tone_brandAccent__9al9wa1r {
+  color: var(--brandAccent__9al9wav);
+}
+.typography_tone_formAccent__9al9wa1s {
+  color: var(--formAccent__9al9waw);
+}
+.typography_tone_neutral__9al9wa1t {
+  color: var(--neutral__9al9wax);
+}
+.typography_tone_secondary__9al9wa1u {
+  color: var(--secondary__9al9way);
+}
+.typography_tone_link__9al9wa1v {
+  color: var(--link__9al9waz);
+}
+.typography_touchableText_xsmall__9al9wa1w {
+  padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-xsmall-mobile-lineHeight__xorl4v33)) / 2);
+  padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-xsmall-mobile-lineHeight__xorl4v33)) / 2);
+}
+.typography_touchableText_small__9al9wa1x {
+  padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-small-mobile-lineHeight__xorl4v3d)) / 2);
+  padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-small-mobile-lineHeight__xorl4v3d)) / 2);
+}
+.typography_touchableText_standard__9al9wa1y {
+  padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-standard-mobile-lineHeight__xorl4v3n)) / 2);
+  padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-standard-mobile-lineHeight__xorl4v3n)) / 2);
+}
+.typography_touchableText_large__9al9wa1z {
+  padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-large-mobile-lineHeight__xorl4v3x)) / 2);
+  padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-large-mobile-lineHeight__xorl4v3x)) / 2);
+}
+@media screen and (min-width: 740px) {
+  .typography_textSize_xsmall__9al9wa4 {
+    --fontSize__1lwixuj0: var(--textSize-xsmall-tablet-fontSize__xorl4v37);
+    --lineHeight__1lwixuj1: var(--textSize-xsmall-tablet-lineHeight__xorl4v38);
+    --capHeightTrim__1lwixuj2: var(--textSize-xsmall-tablet-capsizeTrims-capHeightTrim__xorl4v3a);
+    --baselineTrim__1lwixuj3: var(--textSize-xsmall-tablet-capsizeTrims-baselineTrim__xorl4v3b);
+  }
+  .typography_textSize_small__9al9wa6 {
+    --fontSize__1lwixuj0: var(--textSize-small-tablet-fontSize__xorl4v3h);
+    --lineHeight__1lwixuj1: var(--textSize-small-tablet-lineHeight__xorl4v3i);
+    --capHeightTrim__1lwixuj2: var(--textSize-small-tablet-capsizeTrims-capHeightTrim__xorl4v3k);
+    --baselineTrim__1lwixuj3: var(--textSize-small-tablet-capsizeTrims-baselineTrim__xorl4v3l);
+  }
+  .typography_textSize_standard__9al9wa8 {
+    --fontSize__1lwixuj0: var(--textSize-standard-tablet-fontSize__xorl4v3r);
+    --lineHeight__1lwixuj1: var(--textSize-standard-tablet-lineHeight__xorl4v3s);
+    --capHeightTrim__1lwixuj2: var(--textSize-standard-tablet-capsizeTrims-capHeightTrim__xorl4v3u);
+    --baselineTrim__1lwixuj3: var(--textSize-standard-tablet-capsizeTrims-baselineTrim__xorl4v3v);
+  }
+  .typography_textSize_large__9al9waa {
+    --fontSize__1lwixuj0: var(--textSize-large-tablet-fontSize__xorl4v41);
+    --lineHeight__1lwixuj1: var(--textSize-large-tablet-lineHeight__xorl4v42);
+    --capHeightTrim__1lwixuj2: var(--textSize-large-tablet-capsizeTrims-capHeightTrim__xorl4v44);
+    --baselineTrim__1lwixuj3: var(--textSize-large-tablet-capsizeTrims-baselineTrim__xorl4v45);
+  }
+  .typography_textSizeUntrimmed_xsmall__9al9wac {
+    font-size: var(--textSize-xsmall-tablet-fontSize__xorl4v37);
+    line-height: var(--textSize-xsmall-tablet-lineHeight__xorl4v38);
+  }
+  .typography_textSizeUntrimmed_small__9al9wad {
+    font-size: var(--textSize-small-tablet-fontSize__xorl4v3h);
+    line-height: var(--textSize-small-tablet-lineHeight__xorl4v3i);
+  }
+  .typography_textSizeUntrimmed_standard__9al9wae {
+    font-size: var(--textSize-standard-tablet-fontSize__xorl4v3r);
+    line-height: var(--textSize-standard-tablet-lineHeight__xorl4v3s);
+  }
+  .typography_textSizeUntrimmed_large__9al9waf {
+    font-size: var(--textSize-large-tablet-fontSize__xorl4v41);
+    line-height: var(--textSize-large-tablet-lineHeight__xorl4v42);
+  }
+  .typography_heading_1__9al9wai {
+    --fontSize__1lwixuj0: var(--headingLevel-1-tablet-fontSize__xorl4v4e);
+    --lineHeight__1lwixuj1: var(--headingLevel-1-tablet-lineHeight__xorl4v4f);
+    --capHeightTrim__1lwixuj2: var(--headingLevel-1-tablet-capsizeTrims-capHeightTrim__xorl4v4h);
+    --baselineTrim__1lwixuj3: var(--headingLevel-1-tablet-capsizeTrims-baselineTrim__xorl4v4i);
+  }
+  .typography_heading_2__9al9wak {
+    --fontSize__1lwixuj0: var(--headingLevel-2-tablet-fontSize__xorl4v4o);
+    --lineHeight__1lwixuj1: var(--headingLevel-2-tablet-lineHeight__xorl4v4p);
+    --capHeightTrim__1lwixuj2: var(--headingLevel-2-tablet-capsizeTrims-capHeightTrim__xorl4v4r);
+    --baselineTrim__1lwixuj3: var(--headingLevel-2-tablet-capsizeTrims-baselineTrim__xorl4v4s);
+  }
+  .typography_heading_3__9al9wam {
+    --fontSize__1lwixuj0: var(--headingLevel-3-tablet-fontSize__xorl4v4y);
+    --lineHeight__1lwixuj1: var(--headingLevel-3-tablet-lineHeight__xorl4v4z);
+    --capHeightTrim__1lwixuj2: var(--headingLevel-3-tablet-capsizeTrims-capHeightTrim__xorl4v51);
+    --baselineTrim__1lwixuj3: var(--headingLevel-3-tablet-capsizeTrims-baselineTrim__xorl4v52);
+  }
+  .typography_heading_4__9al9wao {
+    --fontSize__1lwixuj0: var(--headingLevel-4-tablet-fontSize__xorl4v58);
+    --lineHeight__1lwixuj1: var(--headingLevel-4-tablet-lineHeight__xorl4v59);
+    --capHeightTrim__1lwixuj2: var(--headingLevel-4-tablet-capsizeTrims-capHeightTrim__xorl4v5b);
+    --baselineTrim__1lwixuj3: var(--headingLevel-4-tablet-capsizeTrims-baselineTrim__xorl4v5c);
+  }
+  .typography_touchableText_xsmall__9al9wa1w {
+    padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-xsmall-tablet-lineHeight__xorl4v38)) / 2);
+    padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-xsmall-tablet-lineHeight__xorl4v38)) / 2);
+  }
+  .typography_touchableText_small__9al9wa1x {
+    padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-small-tablet-lineHeight__xorl4v3i)) / 2);
+    padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-small-tablet-lineHeight__xorl4v3i)) / 2);
+  }
+  .typography_touchableText_standard__9al9wa1y {
+    padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-standard-tablet-lineHeight__xorl4v3s)) / 2);
+    padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-standard-tablet-lineHeight__xorl4v3s)) / 2);
+  }
+  .typography_touchableText_large__9al9wa1z {
+    padding-top: calc((var(--touchableSize__xorl4v9) - var(--textSize-large-tablet-lineHeight__xorl4v42)) / 2);
+    padding-bottom: calc((var(--touchableSize__xorl4v9) - var(--textSize-large-tablet-lineHeight__xorl4v42)) / 2);
+  }
+}
+.Divider_base__wnnofa0 {
+  height: var(--borderWidth-standard__xorl4vy);
+}
+.Divider_regular__wnnofa3 {
+  background: var(--regular__wnnofa1);
+}
+.Divider_strong__wnnofa4 {
+  background: var(--strong__wnnofa2);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Divider_lightModeWeight_light__wnnofa5 {
+  --regular__wnnofa1: var(--borderColor-neutralLight__xorl4vt);
+  --strong__wnnofa2: var(--borderColor-neutral__xorl4vr);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Divider_lightModeWeight_dark__wnnofa6 {
+  --regular__wnnofa1: var(--borderColor-neutral__xorl4vr);
+  --strong__wnnofa2: var(--borderColor-neutralLight__xorl4vt);
+}
+html.sprinkles_darkMode__iv7so511 .Divider_darkModeWeight_light__wnnofa7 {
+  --regular__wnnofa1: var(--borderColor-neutralLight__xorl4vt);
+  --strong__wnnofa2: var(--borderColor-neutral__xorl4vr);
+}
+html.sprinkles_darkMode__iv7so511 .Divider_darkModeWeight_dark__wnnofa8 {
+  --regular__wnnofa1: var(--borderColor-neutral__xorl4vr);
+  --strong__wnnofa2: var(--borderColor-neutralLight__xorl4vt);
+}
+.Spread_fitContent__1otnb9q0 > * {
+  flex-basis: auto;
+  width: auto;
+}
+.Spread_maxWidth__1otnb9q1 > * {
+  max-width: 100%;
+}
+.MaxLines_descenderCropFixForWebkitBox__13p4shw0 {
+  margin-bottom: -0.1em;
+}
+.MaxLines_base__13p4shw2 {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow-wrap: break-word;
+}
+.MaxLines_descenderCropFixForWebkitBox__13p4shw0 .MaxLines_base__13p4shw2 {
+  padding-bottom: 0.1em;
+}
+@supports (display: -webkit-box) and (-webkit-line-clamp: 1) {
+  .MaxLines_multiLine__13p4shw4 {
+    white-space: initial;
+    display: -webkit-box;
+    -webkit-line-clamp: var(--lineLimit__13p4shw3);
+    -webkit-box-orient: vertical;
+  }
+}
+.virtualTouchable_virtualTouchable__1gayioq0 {
+  position: relative;
+}
+.virtualTouchable_virtualTouchable__1gayioq0::after {
+  content: "";
+  position: absolute;
+  min-height: 44px;
+  min-width: 44px;
+  height: 100%;
+  width: 100%;
+  transform: translate(-50%, -50%);
+  top: 50%;
+  left: 50%;
+}
+[data-braid-debug] .virtualTouchable_virtualTouchable__1gayioq0::after {
+  background: red;
+  opacity: 0.2;
+}
+.AccordionItem_focusRing__f5gff52 {
+  outline-offset: var(--space-xxsmall__xorl4v1);
+}
+.icon_size__1aiudid0 {
+  width: 1.2em;
+  height: 1.2em;
+}
+.icon_cropToTextSize__1aiudid1 {
+  margin: -0.1em;
+}
+.icon_inlineCrop__1aiudid2 {
+  margin-top: -0.2em;
+  margin-bottom: -0.2em;
+}
+.icon_inline__1aiudid3 {
+  vertical-align: middle;
+}
+.icon_alignY_uppercase_none__1aiudid4 {
+  top: -0.105em;
+}
+.icon_alignY_uppercase_up__1aiudid5 {
+  top: -0.16499999999999998em;
+}
+.icon_alignY_uppercase_down__1aiudid6 {
+  top: -0.045em;
+}
+.icon_alignY_lowercase_none__1aiudid7 {
+  top: -0.065em;
+}
+.icon_alignY_lowercase_up__1aiudid8 {
+  top: -0.125em;
+}
+.icon_alignY_lowercase_down__1aiudid9 {
+  top: -0.0050000000000000044em;
+}
+.icon_blockWidths_xsmall__1aiudida {
+  width: var(--textSize-xsmall-mobile-lineHeight__xorl4v33);
+}
+.icon_blockWidths_small__1aiudidb {
+  width: var(--textSize-small-mobile-lineHeight__xorl4v3d);
+}
+.icon_blockWidths_standard__1aiudidc {
+  width: var(--textSize-standard-mobile-lineHeight__xorl4v3n);
+}
+.icon_blockWidths_large__1aiudidd {
+  width: var(--textSize-large-mobile-lineHeight__xorl4v3x);
+}
+@media screen and (min-width: 740px) {
+  .icon_blockWidths_xsmall__1aiudida {
+    width: var(--textSize-xsmall-tablet-lineHeight__xorl4v38);
+  }
+  .icon_blockWidths_small__1aiudidb {
+    width: var(--textSize-small-tablet-lineHeight__xorl4v3i);
+  }
+  .icon_blockWidths_standard__1aiudidc {
+    width: var(--textSize-standard-tablet-lineHeight__xorl4v3s);
+  }
+  .icon_blockWidths_large__1aiudidd {
+    width: var(--textSize-large-tablet-lineHeight__xorl4v42);
+  }
+}
+.lineHeightContainer_lineHeightContainer_xsmall__6x1soo0 {
+  height: var(--textSize-xsmall-mobile-lineHeight__xorl4v33);
+}
+.lineHeightContainer_lineHeightContainer_small__6x1soo1 {
+  height: var(--textSize-small-mobile-lineHeight__xorl4v3d);
+}
+.lineHeightContainer_lineHeightContainer_standard__6x1soo2 {
+  height: var(--textSize-standard-mobile-lineHeight__xorl4v3n);
+}
+.lineHeightContainer_lineHeightContainer_large__6x1soo3 {
+  height: var(--textSize-large-mobile-lineHeight__xorl4v3x);
+}
+@media screen and (min-width: 740px) {
+  .lineHeightContainer_lineHeightContainer_xsmall__6x1soo0 {
+    height: var(--textSize-xsmall-tablet-lineHeight__xorl4v38);
+  }
+  .lineHeightContainer_lineHeightContainer_small__6x1soo1 {
+    height: var(--textSize-small-tablet-lineHeight__xorl4v3i);
+  }
+  .lineHeightContainer_lineHeightContainer_standard__6x1soo2 {
+    height: var(--textSize-standard-tablet-lineHeight__xorl4v3s);
+  }
+  .lineHeightContainer_lineHeightContainer_large__6x1soo3 {
+    height: var(--textSize-large-tablet-lineHeight__xorl4v42);
+  }
+}
+.IconChevron_root__1jqzlhx0 {
+  transition: transform 0.3s ease;
+  transform-origin: 50% 50%;
+}
+.IconChevron_left__1jqzlhx1 {
+  transform: rotate(90deg);
+}
+.IconChevron_up__1jqzlhx2 {
+  transform: rotate(180deg);
+}
+.IconChevron_right__1jqzlhx3 {
+  transform: rotate(270deg);
+}
+.Inline_fitContentMobile__1k33bv70 > * {
+  flex-basis: auto;
+  width: auto;
+  min-width: 0;
+}
+@media screen and (min-width: 740px) {
+  .Inline_fitContentTablet__1k33bv71 > * {
+    flex-basis: auto;
+    width: auto;
+    min-width: 0;
+  }
+}
+@media screen and (min-width: 992px) {
+  .Inline_fitContentDesktop__1k33bv72 > * {
+    flex-basis: auto;
+    width: auto;
+    min-width: 0;
+  }
+}
+@media screen and (min-width: 1200px) {
+  .Inline_fitContentWide__1k33bv73 > * {
+    flex-basis: auto;
+    width: auto;
+    min-width: 0;
+  }
+}
+.Column_noSpaceBeforeFirstWhenCollapsed__pvevjr0:first-child {
+  padding-top: 0;
+}
+.Column_width_1\\/2__pvevjr1 {
+  flex-basis: 50%;
+}
+.Column_width_1\\/3__pvevjr2 {
+  flex-basis: 33.33333333333333%;
+}
+.Column_width_2\\/3__pvevjr3 {
+  flex-basis: 66.66666666666666%;
+}
+.Column_width_1\\/4__pvevjr4 {
+  flex-basis: 25%;
+}
+.Column_width_3\\/4__pvevjr5 {
+  flex-basis: 75%;
+}
+.Column_width_1\\/5__pvevjr6 {
+  flex-basis: 20%;
+}
+.Column_width_2\\/5__pvevjr7 {
+  flex-basis: 40%;
+}
+.Column_width_3\\/5__pvevjr8 {
+  flex-basis: 60%;
+}
+.Column_width_4\\/5__pvevjr9 {
+  flex-basis: 80%;
+}
+.negativeMargin_preventCollapsePseudo_top__1559g980::before {
+  content: "";
+  display: table;
+}
+.negativeMargin_preventCollapsePseudo_bottom__1559g981::after {
+  content: "";
+  display: table;
+}
+.negativeMargin_stylesForBreakpoint_gutter__1559g982::before {
+  margin-bottom: calc(var(--space-gutter__xorl4v0) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxsmall__1559g983::before {
+  margin-bottom: calc(var(--space-xxsmall__xorl4v1) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xsmall__1559g984::before {
+  margin-bottom: calc(var(--space-xsmall__xorl4v2) * -1);
+}
+.negativeMargin_stylesForBreakpoint_small__1559g985::before {
+  margin-bottom: calc(var(--space-small__xorl4v3) * -1);
+}
+.negativeMargin_stylesForBreakpoint_medium__1559g986::before {
+  margin-bottom: calc(var(--space-medium__xorl4v4) * -1);
+}
+.negativeMargin_stylesForBreakpoint_large__1559g987::before {
+  margin-bottom: calc(var(--space-large__xorl4v5) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xlarge__1559g988::before {
+  margin-bottom: calc(var(--space-xlarge__xorl4v6) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxlarge__1559g989::before {
+  margin-bottom: calc(var(--space-xxlarge__xorl4v7) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxxlarge__1559g98a::before {
+  margin-bottom: calc(var(--space-xxxlarge__xorl4v8) * -1);
+}
+.negativeMargin_stylesForBreakpoint_none__1559g98b::before {
+  margin-bottom: 0;
+}
+.negativeMargin_stylesForBreakpoint_gutter__1559g9816::after {
+  margin-top: calc(var(--space-gutter__xorl4v0) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxsmall__1559g9817::after {
+  margin-top: calc(var(--space-xxsmall__xorl4v1) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xsmall__1559g9818::after {
+  margin-top: calc(var(--space-xsmall__xorl4v2) * -1);
+}
+.negativeMargin_stylesForBreakpoint_small__1559g9819::after {
+  margin-top: calc(var(--space-small__xorl4v3) * -1);
+}
+.negativeMargin_stylesForBreakpoint_medium__1559g981a::after {
+  margin-top: calc(var(--space-medium__xorl4v4) * -1);
+}
+.negativeMargin_stylesForBreakpoint_large__1559g981b::after {
+  margin-top: calc(var(--space-large__xorl4v5) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xlarge__1559g981c::after {
+  margin-top: calc(var(--space-xlarge__xorl4v6) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxlarge__1559g981d::after {
+  margin-top: calc(var(--space-xxlarge__xorl4v7) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxxlarge__1559g981e::after {
+  margin-top: calc(var(--space-xxxlarge__xorl4v8) * -1);
+}
+.negativeMargin_stylesForBreakpoint_none__1559g981f::after {
+  margin-top: 0;
+}
+.negativeMargin_stylesForBreakpoint_gutter__1559g982a {
+  margin-left: calc(var(--space-gutter__xorl4v0) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxsmall__1559g982b {
+  margin-left: calc(var(--space-xxsmall__xorl4v1) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xsmall__1559g982c {
+  margin-left: calc(var(--space-xsmall__xorl4v2) * -1);
+}
+.negativeMargin_stylesForBreakpoint_small__1559g982d {
+  margin-left: calc(var(--space-small__xorl4v3) * -1);
+}
+.negativeMargin_stylesForBreakpoint_medium__1559g982e {
+  margin-left: calc(var(--space-medium__xorl4v4) * -1);
+}
+.negativeMargin_stylesForBreakpoint_large__1559g982f {
+  margin-left: calc(var(--space-large__xorl4v5) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xlarge__1559g982g {
+  margin-left: calc(var(--space-xlarge__xorl4v6) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxlarge__1559g982h {
+  margin-left: calc(var(--space-xxlarge__xorl4v7) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxxlarge__1559g982i {
+  margin-left: calc(var(--space-xxxlarge__xorl4v8) * -1);
+}
+.negativeMargin_stylesForBreakpoint_none__1559g982j {
+  margin-left: 0;
+}
+.negativeMargin_stylesForBreakpoint_gutter__1559g983e {
+  margin-right: calc(var(--space-gutter__xorl4v0) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxsmall__1559g983f {
+  margin-right: calc(var(--space-xxsmall__xorl4v1) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xsmall__1559g983g {
+  margin-right: calc(var(--space-xsmall__xorl4v2) * -1);
+}
+.negativeMargin_stylesForBreakpoint_small__1559g983h {
+  margin-right: calc(var(--space-small__xorl4v3) * -1);
+}
+.negativeMargin_stylesForBreakpoint_medium__1559g983i {
+  margin-right: calc(var(--space-medium__xorl4v4) * -1);
+}
+.negativeMargin_stylesForBreakpoint_large__1559g983j {
+  margin-right: calc(var(--space-large__xorl4v5) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xlarge__1559g983k {
+  margin-right: calc(var(--space-xlarge__xorl4v6) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxlarge__1559g983l {
+  margin-right: calc(var(--space-xxlarge__xorl4v7) * -1);
+}
+.negativeMargin_stylesForBreakpoint_xxxlarge__1559g983m {
+  margin-right: calc(var(--space-xxxlarge__xorl4v8) * -1);
+}
+.negativeMargin_stylesForBreakpoint_none__1559g983n {
+  margin-right: 0;
+}
+@media screen and (min-width: 740px) {
+  .negativeMargin_stylesForBreakpoint_gutter__1559g98c::before {
+    margin-bottom: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g98d::before {
+    margin-bottom: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g98e::before {
+    margin-bottom: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g98f::before {
+    margin-bottom: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g98g::before {
+    margin-bottom: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g98h::before {
+    margin-bottom: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g98i::before {
+    margin-bottom: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g98j::before {
+    margin-bottom: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g98k::before {
+    margin-bottom: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g98l::before {
+    margin-bottom: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g981g::after {
+    margin-top: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g981h::after {
+    margin-top: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g981i::after {
+    margin-top: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g981j::after {
+    margin-top: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g981k::after {
+    margin-top: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g981l::after {
+    margin-top: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g981m::after {
+    margin-top: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g981n::after {
+    margin-top: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g981o::after {
+    margin-top: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g981p::after {
+    margin-top: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g982k {
+    margin-left: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g982l {
+    margin-left: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g982m {
+    margin-left: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g982n {
+    margin-left: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g982o {
+    margin-left: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g982p {
+    margin-left: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g982q {
+    margin-left: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g982r {
+    margin-left: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g982s {
+    margin-left: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g982t {
+    margin-left: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g983o {
+    margin-right: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g983p {
+    margin-right: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g983q {
+    margin-right: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g983r {
+    margin-right: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g983s {
+    margin-right: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g983t {
+    margin-right: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g983u {
+    margin-right: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g983v {
+    margin-right: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g983w {
+    margin-right: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g983x {
+    margin-right: 0;
+  }
+}
+@media screen and (min-width: 992px) {
+  .negativeMargin_stylesForBreakpoint_gutter__1559g98m::before {
+    margin-bottom: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g98n::before {
+    margin-bottom: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g98o::before {
+    margin-bottom: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g98p::before {
+    margin-bottom: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g98q::before {
+    margin-bottom: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g98r::before {
+    margin-bottom: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g98s::before {
+    margin-bottom: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g98t::before {
+    margin-bottom: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g98u::before {
+    margin-bottom: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g98v::before {
+    margin-bottom: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g981q::after {
+    margin-top: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g981r::after {
+    margin-top: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g981s::after {
+    margin-top: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g981t::after {
+    margin-top: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g981u::after {
+    margin-top: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g981v::after {
+    margin-top: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g981w::after {
+    margin-top: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g981x::after {
+    margin-top: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g981y::after {
+    margin-top: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g981z::after {
+    margin-top: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g982u {
+    margin-left: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g982v {
+    margin-left: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g982w {
+    margin-left: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g982x {
+    margin-left: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g982y {
+    margin-left: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g982z {
+    margin-left: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g9830 {
+    margin-left: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g9831 {
+    margin-left: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g9832 {
+    margin-left: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g9833 {
+    margin-left: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g983y {
+    margin-right: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g983z {
+    margin-right: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g9840 {
+    margin-right: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g9841 {
+    margin-right: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g9842 {
+    margin-right: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g9843 {
+    margin-right: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g9844 {
+    margin-right: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g9845 {
+    margin-right: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g9846 {
+    margin-right: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g9847 {
+    margin-right: 0;
+  }
+}
+@media screen and (min-width: 1200px) {
+  .negativeMargin_stylesForBreakpoint_gutter__1559g98w::before {
+    margin-bottom: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g98x::before {
+    margin-bottom: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g98y::before {
+    margin-bottom: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g98z::before {
+    margin-bottom: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g9810::before {
+    margin-bottom: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g9811::before {
+    margin-bottom: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g9812::before {
+    margin-bottom: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g9813::before {
+    margin-bottom: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g9814::before {
+    margin-bottom: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g9815::before {
+    margin-bottom: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g9820::after {
+    margin-top: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g9821::after {
+    margin-top: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g9822::after {
+    margin-top: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g9823::after {
+    margin-top: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g9824::after {
+    margin-top: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g9825::after {
+    margin-top: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g9826::after {
+    margin-top: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g9827::after {
+    margin-top: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g9828::after {
+    margin-top: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g9829::after {
+    margin-top: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g9834 {
+    margin-left: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g9835 {
+    margin-left: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g9836 {
+    margin-left: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g9837 {
+    margin-left: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g9838 {
+    margin-left: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g9839 {
+    margin-left: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g983a {
+    margin-left: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g983b {
+    margin-left: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g983c {
+    margin-left: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g983d {
+    margin-left: 0;
+  }
+  .negativeMargin_stylesForBreakpoint_gutter__1559g9848 {
+    margin-right: calc(var(--space-gutter__xorl4v0) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxsmall__1559g9849 {
+    margin-right: calc(var(--space-xxsmall__xorl4v1) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xsmall__1559g984a {
+    margin-right: calc(var(--space-xsmall__xorl4v2) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_small__1559g984b {
+    margin-right: calc(var(--space-small__xorl4v3) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_medium__1559g984c {
+    margin-right: calc(var(--space-medium__xorl4v4) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_large__1559g984d {
+    margin-right: calc(var(--space-large__xorl4v5) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xlarge__1559g984e {
+    margin-right: calc(var(--space-xlarge__xorl4v6) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxlarge__1559g984f {
+    margin-right: calc(var(--space-xxlarge__xorl4v7) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_xxxlarge__1559g984g {
+    margin-right: calc(var(--space-xxxlarge__xorl4v8) * -1);
+  }
+  .negativeMargin_stylesForBreakpoint_none__1559g984h {
+    margin-right: 0;
+  }
+}
+.Alert_closeButton__x2s9z00:focus .Alert_closeButtonHover__x2s9z01, .Alert_closeButton__x2s9z00:hover .Alert_closeButtonHover__x2s9z01 {
+  opacity: 1;
+}
+.textAlignedToIcon_textAlignedToIcon_standard__1pa6ue70 {
+  padding-top: calc((var(--textSize-standard-mobile-lineHeight__xorl4v3n) - var(--textSize-standard-mobile-capHeight__xorl4v3o)) / 2);
+  padding-bottom: calc((var(--textSize-standard-mobile-lineHeight__xorl4v3n) - var(--textSize-standard-mobile-capHeight__xorl4v3o)) / 2);
+}
+@media screen and (min-width: 740px) {
+  .textAlignedToIcon_textAlignedToIcon_standard__1pa6ue70 {
+    padding-top: calc((var(--textSize-standard-tablet-lineHeight__xorl4v3s) - var(--textSize-standard-tablet-capHeight__xorl4v3t)) / 2);
+    padding-bottom: calc((var(--textSize-standard-tablet-lineHeight__xorl4v3s) - var(--textSize-standard-tablet-capHeight__xorl4v3t)) / 2);
+  }
+}
+.AvoidWidowIcon_nowrap__onmis40 {
+  white-space: nowrap;
+}
+@keyframes Button_dot1__7j49xea {
+  14% {
+    opacity: 0;
+  }
+  15%,100% {
+    opacity: 1;
+  }
+}
+@keyframes Button_dot2__7j49xeb {
+  29% {
+    opacity: 0;
+  }
+  30%,100% {
+    opacity: 1;
+  }
+}
+@keyframes Button_dot3__7j49xec {
+  44% {
+    opacity: 0;
+  }
+  45%,100% {
+    opacity: 1;
+  }
+}
+.Button_root__7j49xe0 {
+  text-decoration: none;
+  align-items: stretch;
+}
+.Button_root__7j49xe0:active .Button_activeAnimation__7j49xe2, .Button_forceActive__7j49xe1.Button_activeAnimation__7j49xe2 {
+  transform: var(--transform-touchable__xorl4v5k);
+}
+.Button_root__7j49xe0:active .Button_activeOverlay__7j49xe3, .Button_forceActive__7j49xe1.Button_activeOverlay__7j49xe3 {
+  opacity: 1;
+}
+.Button_root__7j49xe0:hover:not(:disabled) .Button_hoverOverlay__7j49xe4 {
+  opacity: 1;
+}
+.Button_standard__7j49xe6 {
+  --capHeightToMinHeight__7j49xe5: calc((var(--touchableSize__xorl4v9) - var(--textSize-standard-mobile-capHeight__xorl4v3o)) / 2);
+}
+.Button_small__7j49xe7 {
+  --capHeightToMinHeight__7j49xe5: calc(((var(--touchableSize__xorl4v9) * 0.8) - var(--textSize-small-mobile-capHeight__xorl4v3e)) / 2);
+}
+.Button_bleedVerticallyToCapHeight__7j49xe8 {
+  margin-top: calc(var(--capHeightToMinHeight__7j49xe5) * -1);
+  margin-bottom: calc(var(--capHeightToMinHeight__7j49xe5) * -1);
+}
+.Button_padToMinHeight__7j49xe9 {
+  padding-top: var(--capHeightToMinHeight__7j49xe5);
+  padding-bottom: var(--capHeightToMinHeight__7j49xe5);
+}
+.Button_loadingDot__7j49xed {
+  animation-duration: 1s;
+  animation-iteration-count: infinite;
+  opacity: 0;
+}
+.Button_loadingDot__7j49xed:nth-child(1) {
+  animation-name: Button_dot1__7j49xea;
+}
+.Button_loadingDot__7j49xed:nth-child(2) {
+  animation-name: Button_dot2__7j49xeb;
+}
+.Button_loadingDot__7j49xed:nth-child(3) {
+  animation-name: Button_dot3__7j49xec;
+}
+html:not(.sprinkles_darkMode__iv7so511) .Button_invertedBackgroundsLightMode_soft__7j49xee {
+  background: rgba(255,255,255,0.1);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Button_invertedBackgroundsLightMode_hover__7j49xef {
+  background: rgba(255,255,255,0.15);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Button_invertedBackgroundsLightMode_active__7j49xeg {
+  background: rgba(255,255,255,0.15);
+}
+html.sprinkles_darkMode__iv7so511 .Button_invertedBackgroundsDarkMode_soft__7j49xeh {
+  background: rgba(255,255,255,0.1);
+}
+html.sprinkles_darkMode__iv7so511 .Button_invertedBackgroundsDarkMode_hover__7j49xei {
+  background: rgba(255,255,255,0.15);
+}
+html.sprinkles_darkMode__iv7so511 .Button_invertedBackgroundsDarkMode_active__7j49xej {
+  background: rgba(255,255,255,0.15);
+}
+@media screen and (min-width: 740px) {
+  .Button_standard__7j49xe6 {
+    --capHeightToMinHeight__7j49xe5: calc((var(--touchableSize__xorl4v9) - var(--textSize-standard-tablet-capHeight__xorl4v3t)) / 2);
+  }
+  .Button_small__7j49xe7 {
+    --capHeightToMinHeight__7j49xe5: calc(((var(--touchableSize__xorl4v9) * 0.8) - var(--textSize-small-tablet-capHeight__xorl4v3j)) / 2);
+  }
+}
+@keyframes Popover_popupAnimation__48p46ba {
+  from {
+    opacity: 0;
+    transform: translateY(calc(var(--space-xxsmall__xorl4v1) * var(--placementModifier__48p46b8, 1)));
+  }
+}
+.Popover_backdrop__48p46b0 {
+  width: 100vw;
+  height: 100vh;
+}
+.Popover_popoverPosition__48p46b7 {
+  --dynamicHeight__48p46b6: 100svh;
+  top: calc(var(--triggerVars_bottom__48p46b3) * 1px);
+  bottom: calc(var(--dynamicHeight__48p46b6, 100vh) - (var(--triggerVars_top__48p46b1) * 1px));
+  left: calc((var(--triggerVars_left__48p46b2) + var(--horizontalOffset__48p46b5)) * 1px);
+  right: calc((var(--triggerVars_right__48p46b4) + var(--horizontalOffset__48p46b5)) * 1px);
+}
+.Popover_invertPlacement__48p46b9 {
+  --placementModifier__48p46b8: -1;
+}
+.Popover_animation__48p46bb {
+  animation-name: Popover_popupAnimation__48p46ba;
+  animation-fill-mode: both;
+  animation-timing-function: ease;
+  animation-duration: 0.125s;
+  animation-delay: 15ms;
+}
+.Popover_delayVisibility__48p46bc {
+  animation-delay: 250ms;
+}
+.TooltipRenderer_maxWidth__1e2u52l0 {
+  max-width: 260px;
+}
+.TooltipRenderer_overflowWrap__1e2u52l1 {
+  overflow-wrap: break-word;
+}
+.TooltipRenderer_translateZ0__1e2u52l2 {
+  transform: translateZ(0);
+}
+.TooltipRenderer_baseArrow__1e2u52l4 {
+  left: clamp(var(--space-medium__xorl4v4), var(--horizontalOffset__1e2u52l3), calc(100% - var(--space-medium__xorl4v4)));
+  transform: translateX(-50%);
+  visibility: hidden;
+}
+.TooltipRenderer_baseArrow__1e2u52l4:before {
+  content: '';
+  visibility: visible;
+  transform: rotate(45deg);
+}
+.TooltipRenderer_baseArrow__1e2u52l4, .TooltipRenderer_baseArrow__1e2u52l4::before {
+  width: calc(12px + (var(--borderRadius-small__xorl4vb) * 2));
+  height: calc(12px + (var(--borderRadius-small__xorl4vb) * 2));
+  position: absolute;
+  background: inherit;
+  border-radius: var(--borderRadius-small__xorl4vb);
+}
+.TooltipRenderer_arrow_top__1e2u52l5 {
+  bottom: calc((12px / 2) * -1);
+}
+.TooltipRenderer_arrow_bottom__1e2u52l6 {
+  top: calc((12px / 2) * -1);
+}
+.ButtonIcon_button__9txf2k0:hover {
+  z-index: 1;
+}
+.ButtonIcon_button__9txf2k0::-moz-focus-inner {
+  border: 0;
+}
+.HiddenVisually_root__d29nt60 {
+  width: 1px;
+  height: 1px;
+  clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap;
+}
+.Field_placeholderColor__1tg1eg61::placeholder {
+  color: var(--foregroundColor-secondary__xorl4v1r);
+}
+.Field_secondaryIconSpace__1tg1eg62 {
+  padding-right: var(--touchableSize__xorl4v9);
+}
+.Field_iconSpace__1tg1eg63 {
+  padding-left: calc(var(--touchableSize__xorl4v9) - 2px);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Field_hideBorderOnDarkBackgroundInLightMode__1tg1eg64 {
+  opacity: 0;
+}
+.Field_field__1tg1eg60:hover:not(:disabled) ~ .Field_hoverOverlay__1tg1eg65, .Field_field__1tg1eg60:focus ~ .Field_hoverOverlay__1tg1eg65 {
+  opacity: 1;
+}
+.Field_verticalDivider__1tg1eg66 {
+  width: var(--borderWidth-standard__xorl4vy);
+  background: var(--borderColor-field__xorl4vl);
+  opacity: 0.4;
+}
+.Autosuggest_backdrop__2r47kq0 {
+  width: 100vw;
+  height: 100vh;
+  background: black;
+}
+.Autosuggest_backdropVisible__2r47kq1 {
+  opacity: 0.4;
+}
+.Autosuggest_menu__2r47kq2 {
+  max-height: calc((var(--touchableSize__xorl4v9) * 6) + var(--space-xxsmall__xorl4v1));
+  overflow-y: auto;
+}
+@media screen and (min-width: 740px) {
+  .Autosuggest_menu__2r47kq2 {
+    max-height: calc((var(--touchableSize__xorl4v9) * 8) + var(--space-xxsmall__xorl4v1));
+  }
+}
+.Badge_inline__ueqx8p0 {
+  display: inline-flex;
+  vertical-align: middle;
+  margin-bottom: calc(var(--space-xxsmall__xorl4v1) * -1);
+  margin-top: calc((var(--space-xxsmall__xorl4v1) + .2em) * -1);
+}
+.Keyline_tone_promote__uik19x6 {
+  background: var(--promote__uik19x0);
+}
+.Keyline_tone_info__uik19x7 {
+  background: var(--info__uik19x1);
+}
+.Keyline_tone_positive__uik19x8 {
+  background: var(--positive__uik19x2);
+}
+.Keyline_tone_caution__uik19x9 {
+  background: var(--caution__uik19x3);
+}
+.Keyline_tone_critical__uik19xa {
+  background: var(--critical__uik19x4);
+}
+.Keyline_tone_formAccent__uik19xb {
+  background: var(--formAccent__uik19x5);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Keyline_lightMode_light__uik19xc {
+  --promote__uik19x0: var(--borderColor-promote__xorl4vw);
+  --info__uik19x1: var(--borderColor-info__xorl4vp);
+  --positive__uik19x2: var(--borderColor-positive__xorl4vu);
+  --caution__uik19x3: var(--borderColor-caution__xorl4vh);
+  --critical__uik19x4: var(--borderColor-critical__xorl4vj);
+  --formAccent__uik19x5: var(--borderColor-formAccent__xorl4vn);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Keyline_lightMode_dark__uik19xd {
+  --promote__uik19x0: var(--borderColor-promoteLight__xorl4vx);
+  --info__uik19x1: var(--borderColor-infoLight__xorl4vq);
+  --positive__uik19x2: var(--borderColor-positiveLight__xorl4vv);
+  --caution__uik19x3: var(--borderColor-cautionLight__xorl4vi);
+  --critical__uik19x4: var(--borderColor-criticalLight__xorl4vk);
+  --formAccent__uik19x5: var(--borderColor-formAccentLight__xorl4vo);
+}
+html.sprinkles_darkMode__iv7so511 .Keyline_darkMode_light__uik19xe {
+  --promote__uik19x0: var(--borderColor-promote__xorl4vw);
+  --info__uik19x1: var(--borderColor-info__xorl4vp);
+  --positive__uik19x2: var(--borderColor-positive__xorl4vu);
+  --caution__uik19x3: var(--borderColor-caution__xorl4vh);
+  --critical__uik19x4: var(--borderColor-critical__xorl4vj);
+  --formAccent__uik19x5: var(--borderColor-formAccent__xorl4vn);
+}
+html.sprinkles_darkMode__iv7so511 .Keyline_darkMode_dark__uik19xf {
+  --promote__uik19x0: var(--borderColor-promoteLight__xorl4vx);
+  --info__uik19x1: var(--borderColor-infoLight__xorl4vq);
+  --positive__uik19x2: var(--borderColor-positiveLight__xorl4vv);
+  --caution__uik19x3: var(--borderColor-cautionLight__xorl4vi);
+  --critical__uik19x4: var(--borderColor-criticalLight__xorl4vk);
+  --formAccent__uik19x5: var(--borderColor-formAccentLight__xorl4vo);
+}
+.Keyline_noRadiusOnRight__uik19xg {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+.Keyline_largestWidth__uik19xh {
+  width: var(--borderRadius-xlarge__xorl4ve);
+}
+.Keyline_width__uik19xi {
+  width: var(--grid__xorl4va);
+}
+.InlineField_sizeVars_standard__3b9mfp2 {
+  --fieldSize__3b9mfp0: var(--inlineFieldSize-standard__xorl4v5g);
+  --labelCapHeight__3b9mfp1: var(--textSize-standard-mobile-capHeight__xorl4v3o);
+}
+.InlineField_sizeVars_small__3b9mfp3 {
+  --fieldSize__3b9mfp0: var(--inlineFieldSize-small__xorl4v5h);
+  --labelCapHeight__3b9mfp1: var(--textSize-small-mobile-capHeight__xorl4v3e);
+}
+.InlineField_realField__3b9mfp4 {
+  width: 44px;
+  height: 44px;
+  top: calc(((44px - var(--fieldSize__3b9mfp0)) / 2) * -1);
+  left: calc(((44px - var(--fieldSize__3b9mfp0)) / 2) * -1);
+}
+[data-braid-debug] .InlineField_realField__3b9mfp4 {
+  background: red;
+  opacity: 0.2;
+}
+.InlineField_fakeField__3b9mfp5 {
+  height: var(--fieldSize__3b9mfp0);
+  width: var(--fieldSize__3b9mfp0);
+  outline: var(--focusRingSize__xorl4v10) solid transparent;
+  transition: outline-color .125s ease;
+}
+.InlineField_realField__3b9mfp4[type="checkbox"]:checked ~ .InlineField_fakeField__3b9mfp5 {
+  background: transparent;
+}
+.InlineField_realField__3b9mfp4:focus-visible ~ .InlineField_fakeField__3b9mfp5 {
+  outline-color: var(--borderColor-focus__xorl4vm);
+}
+.InlineField_labelOffset__3b9mfp6 {
+  padding-top: calc((var(--fieldSize__3b9mfp0) - var(--labelCapHeight__3b9mfp1)) / 2);
+}
+.InlineField_realField__3b9mfp4:checked ~ * .InlineField_children__3b9mfp8,
+  .InlineField_realField__3b9mfp4.InlineField_isMixed__3b9mfp7 ~ * .InlineField_children__3b9mfp8 {
+  display: block;
+  z-index: 1;
+}
+.InlineField_realField__3b9mfp4:checked + .InlineField_fakeField__3b9mfp5 > .InlineField_selected__3b9mfp9,
+  .InlineField_realField__3b9mfp4.InlineField_isMixed__3b9mfp7 + .InlineField_fakeField__3b9mfp5 > .InlineField_selected__3b9mfp9 {
+  opacity: 1;
+}
+html:not(.sprinkles_darkMode__iv7so511) .InlineField_hideBorderOnDarkBackgroundInLightMode__3b9mfpa {
+  opacity: 0;
+}
+.InlineField_realField__3b9mfp4:hover:not(:checked):not(.InlineField_isMixed__3b9mfp7):not(:disabled) + .InlineField_fakeField__3b9mfp5 > .InlineField_hoverOverlay__3b9mfpb,
+  .InlineField_realField__3b9mfp4:focus:not(.InlineField_isMixed__3b9mfp7) + .InlineField_fakeField__3b9mfp5 > .InlineField_hoverOverlay__3b9mfpb {
+  opacity: 1;
+}
+.InlineField_hoverOverlay__3b9mfpb > .InlineField_indicator__3b9mfpc {
+  opacity: 0.2;
+}
+.InlineField_disabledRadioIndicator__3b9mfpd {
+  opacity: 0.3;
+}
+html:not(.sprinkles_darkMode__iv7so511) .InlineField_disabledRadioIndicator__3b9mfpd {
+  background-color: var(--foregroundColor-secondary__xorl4v1r);
+}
+html.sprinkles_darkMode__iv7so511 .InlineField_disabledRadioIndicator__3b9mfpd {
+  background-color: var(--foregroundColor-secondaryInverted__xorl4v1s);
+}
+.InlineField_checkboxScale__3b9mfpe {
+  transform: scale(0.85);
+}
+.InlineField_realField__3b9mfp4:active + .InlineField_fakeField__3b9mfp5 > * > .InlineField_checkboxScale__3b9mfpe {
+  transform: scale(0.75);
+}
+.InlineField_radioScale__3b9mfpf {
+  transform: scale(0.6);
+}
+.InlineField_realField__3b9mfp4:active + .InlineField_fakeField__3b9mfp5 > * > .InlineField_radioScale__3b9mfpf {
+  transform: scale(0.5);
+}
+@media screen and (min-width: 740px) {
+  .InlineField_sizeVars_standard__3b9mfp2 {
+    --labelCapHeight__3b9mfp1: var(--textSize-standard-tablet-capHeight__xorl4v3t);
+  }
+  .InlineField_sizeVars_small__3b9mfp3 {
+    --labelCapHeight__3b9mfp1: var(--textSize-small-tablet-capHeight__xorl4v3j);
+  }
+}
+.ContentBlock_marginAuto__7i4une0 {
+  margin: 0 auto;
+}
+html:not(.sprinkles_darkMode__iv7so511) .Modal_backdrop__1wjkaea2 {
+  background: rgba(0, 0, 0, 0.4);
+}
+html.sprinkles_darkMode__iv7so511 .Modal_backdrop__1wjkaea2 {
+  background: rgba(0, 0, 0, 0.6);
+}
+.Modal_rightAnimation__1wjkaea4 {
+  opacity: 1;
+  transform: translateX(110%);
+}
+.Modal_leftAnimation__1wjkaea5 {
+  opacity: 1;
+  transform: translateX(-110%);
+}
+.Modal_centerAnimation__1wjkaea6 {
+  transform: scale(.8);
+}
+.Modal_horizontalTransition__1wjkaea7 {
+  transition: transform .3s cubic-bezier(0.4, 0, 0, 1), opacity .3s cubic-bezier(0.4, 0, 0, 1);
+}
+.Modal_pointerEventsAll__1wjkaea9 {
+  pointer-events: all;
+}
+.Modal_viewportHeight__1wjkaead {
+  max-height: var(--fullHeightVar__1wjkaeab);
+}
+.Modal_maxSize_center__1wjkaeae {
+  --gutterSizeVar__1wjkaeaa: var(--space-xsmall__xorl4v2);
+  max-height: calc(var(--fullHeightVar__1wjkaeab) - (var(--gutterSizeVar__1wjkaeaa) * 2));
+  max-width: calc(var(--fullWidthVar__1wjkaeac) - (var(--gutterSizeVar__1wjkaeaa) * 2));
+}
+.Modal_modalContainer__1wjkaeaf {
+  --fullHeightVar__1wjkaeab: 100vh;
+  --fullWidthVar__1wjkaeac: 100vw;
+  max-height: var(--fullHeightVar__1wjkaeab);
+  max-width: var(--fullWidthVar__1wjkaeac);
+}
+.Modal_headingRoot__1wjkaeag {
+  overflow-wrap: break-word;
+}
+.Modal_closeIconOffset__1wjkaeah {
+  top: -5px;
+  right: -5px;
+}
+@media screen and (prefers-reduced-motion) {
+  .Modal_reducedMotion__1wjkaea3 {
+    transform: none !important;
+  }
+}
+@media screen and (min-width: 740px) {
+  .Modal_rightAnimation__1wjkaea4 {
+    opacity: 0;
+    transform: translateX(40px);
+  }
+  .Modal_leftAnimation__1wjkaea5 {
+    opacity: 0;
+    transform: translateX(-40px);
+  }
+  .Modal_horizontalTransition__1wjkaea7 {
+    transition: transform .175s cubic-bezier(0.4, 0, 0, 1), opacity .175s cubic-bezier(0.4, 0, 0, 1);
+  }
+  .Modal_maxSize_center__1wjkaeae {
+    --gutterSizeVar__1wjkaeaa: var(--space-gutter__xorl4v0);
+  }
+}
+@media screen and (min-width: 992px) {
+  .Modal_maxSize_center__1wjkaeae {
+    --gutterSizeVar__1wjkaeaa: var(--space-xlarge__xorl4v6);
+  }
+}
+@supports (height: 1dvh) {
+  .Modal_modalContainer__1wjkaeaf {
+    --fullHeightVar__1wjkaeab: 100dvh;
+    --fullWidthVar__1wjkaeac: 100dvw;
+  }
+}
+.TextLink_base__1uhsi8q2 {
+  color: var(--color__1uhsi8q0);
+  text-decoration: var(--linkDecoration__xorl4v5f);
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 3px;
+  outline-offset: 0.2em;
+  border-radius: var(--borderRadius-small__xorl4vb);
+}
+.TextLink_base__1uhsi8q2:hover {
+  color: var(--colorHover__1uhsi8q1);
+  text-decoration: underline;
+  text-decoration-thickness: 0.08em;
+}
+.TextLink_base__1uhsi8q2:focus-visible {
+  color: var(--colorHover__1uhsi8q1);
+}
+.TextLink_weakLink__1uhsi8q3 {
+  --color__1uhsi8q0: inherit;
+  --colorHover__1uhsi8q1: inherit;
+  text-decoration: underline;
+  text-decoration-thickness: 0.08em;
+}
+html:not(.sprinkles_darkMode__iv7so511) .TextLink_regularLinkLightMode_light__1uhsi8q4 {
+  --color__1uhsi8q0: var(--foregroundColor-link__xorl4v1f);
+  --colorHover__1uhsi8q1: var(--foregroundColor-linkHover__xorl4v1g);
+}
+html:not(.sprinkles_darkMode__iv7so511) .TextLink_regularLinkLightMode_dark__1uhsi8q5 {
+  --color__1uhsi8q0: var(--foregroundColor-linkLight__xorl4v1h);
+  --colorHover__1uhsi8q1: var(--foregroundColor-linkLight__xorl4v1h);
+}
+html.sprinkles_darkMode__iv7so511 .TextLink_regularLinkDarkMode_light__1uhsi8q6 {
+  --color__1uhsi8q0: var(--foregroundColor-link__xorl4v1f);
+  --colorHover__1uhsi8q1: var(--foregroundColor-linkHover__xorl4v1g);
+}
+html.sprinkles_darkMode__iv7so511 .TextLink_regularLinkDarkMode_dark__1uhsi8q7 {
+  --color__1uhsi8q0: var(--foregroundColor-linkLight__xorl4v1h);
+  --colorHover__1uhsi8q1: var(--foregroundColor-linkLight__xorl4v1h);
+}
+html:not(.sprinkles_darkMode__iv7so511) .TextLink_visitedLightMode_light__1uhsi8q8:visited {
+  color: var(--foregroundColor-linkVisited__xorl4v1i);
+}
+html:not(.sprinkles_darkMode__iv7so511) .TextLink_visitedLightMode_dark__1uhsi8q9:visited {
+  color: var(--foregroundColor-linkLightVisited__xorl4v1j);
+}
+html.sprinkles_darkMode__iv7so511 .TextLink_visitedDarkMode_light__1uhsi8qa:visited {
+  color: var(--foregroundColor-linkVisited__xorl4v1i);
+}
+html.sprinkles_darkMode__iv7so511 .TextLink_visitedDarkMode_dark__1uhsi8qb:visited {
+  color: var(--foregroundColor-linkLightVisited__xorl4v1j);
+}
+.Dropdown_field__wzgpgf0 {
+  padding-right: var(--touchableSize__xorl4v9);
+}
+@media print {
+  .Hidden_hiddenOnPrint__1ul19h20 {
+    display: none !important;
+  }
+}
+.List_currentColor__1c4y3150 {
+  background: currentColor;
+}
+.List_large__1c4y3151 {
+  width: 5px;
+  height: 5px;
+}
+.List_standard__1c4y3152 {
+  width: 4px;
+  height: 4px;
+}
+.List_xsmall__1c4y3153 {
+  width: 3px;
+  height: 3px;
+}
+.List_minCharacterWidth__1c4y3154 {
+  min-width: 1.4ch;
+}
+.List_minCharacterWidth__1c4y3155 {
+  min-width: 2.4ch;
+}
+.List_trimGutter__1c4y3156 {
+  margin-right: -0.4ch;
+}
+@keyframes Loader_bounce__jv8rqo9 {
+  33% {
+    transform: translateY(-1.4em);
+  }
+  66% {
+    transform: translateY(1.4em);
+  }
+}
+@keyframes Loader_fade__jv8rqod {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.Loader_rootSize_xsmall__jv8rqo0 {
+  height: var(--textSize-xsmall-mobile-capHeight__xorl4v34);
+}
+.Loader_rootSize_small__jv8rqo1 {
+  height: var(--textSize-small-mobile-capHeight__xorl4v3e);
+}
+.Loader_rootSize_standard__jv8rqo2 {
+  height: var(--textSize-standard-mobile-capHeight__xorl4v3o);
+}
+.Loader_rootSize_large__jv8rqo3 {
+  height: var(--textSize-large-mobile-capHeight__xorl4v3y);
+}
+.Loader_size_xsmall__jv8rqo4 {
+  height: var(--textSize-xsmall-mobile-fontSize__xorl4v32);
+}
+.Loader_size_small__jv8rqo5 {
+  height: var(--textSize-small-mobile-fontSize__xorl4v3c);
+}
+.Loader_size_standard__jv8rqo6 {
+  height: var(--textSize-standard-mobile-fontSize__xorl4v3m);
+}
+.Loader_size_large__jv8rqo7 {
+  height: var(--textSize-large-mobile-fontSize__xorl4v3w);
+}
+.Loader_currentColor__jv8rqo8 {
+  fill: currentcolor;
+}
+.Loader_bounceAnimation__jv8rqoa {
+  animation-name: Loader_bounce__jv8rqo9;
+  animation-fill-mode: both;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-duration: 0.6s;
+}
+.Loader_circle__jv8rqob {
+  transform: translateY(1.4em);
+}
+.Loader_circle__jv8rqob:nth-child(1) {
+  animation-delay: 140ms;
+}
+.Loader_circle__jv8rqob:nth-child(2) {
+  animation-delay: 70ms;
+}
+.Loader_delay__jv8rqoe {
+  opacity: 0;
+  animation-name: Loader_fade__jv8rqod;
+  animation-iteration-count: 1;
+  animation-fill-mode: forwards;
+  animation-timing-function: ease-in;
+  animation-duration: 0.25s;
+  animation-delay: 800ms;
+}
+@media screen and (min-width: 740px) {
+  .Loader_rootSize_xsmall__jv8rqo0 {
+    height: var(--textSize-xsmall-tablet-capHeight__xorl4v39);
+  }
+  .Loader_rootSize_small__jv8rqo1 {
+    height: var(--textSize-small-tablet-capHeight__xorl4v3j);
+  }
+  .Loader_rootSize_standard__jv8rqo2 {
+    height: var(--textSize-standard-tablet-capHeight__xorl4v3t);
+  }
+  .Loader_rootSize_large__jv8rqo3 {
+    height: var(--textSize-large-tablet-capHeight__xorl4v43);
+  }
+  .Loader_size_xsmall__jv8rqo4 {
+    height: var(--textSize-xsmall-tablet-fontSize__xorl4v37);
+  }
+  .Loader_size_small__jv8rqo5 {
+    height: var(--textSize-small-tablet-fontSize__xorl4v3h);
+  }
+  .Loader_size_standard__jv8rqo6 {
+    height: var(--textSize-standard-tablet-fontSize__xorl4v3r);
+  }
+  .Loader_size_large__jv8rqo7 {
+    height: var(--textSize-large-tablet-fontSize__xorl4v41);
+  }
+}
+.ScrollContainer_container__17ondx40 {
+  -webkit-overflow-scrolling: touch;
+  -webkit-mask-composite: destination-in;
+  mask-composite: intersect;
+}
+.ScrollContainer_hideScrollbar__17ondx41 {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.ScrollContainer_hideScrollbar__17ondx41::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+.ScrollContainer_fadeSize_small__17ondx43 {
+  --scrollOverlaySize__17ondx42: 40px;
+}
+.ScrollContainer_fadeSize_medium__17ondx44 {
+  --scrollOverlaySize__17ondx42: 60px;
+}
+.ScrollContainer_fadeSize_large__17ondx45 {
+  --scrollOverlaySize__17ondx42: 80px;
+}
+.ScrollContainer_direction_horizontal__17ondx46 {
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: fit-content;
+}
+.ScrollContainer_direction_vertical__17ondx47 {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+.ScrollContainer_direction_all__17ondx48 {
+  overflow: auto;
+}
+.ScrollContainer_mask__17ondx4d {
+  mask-image: linear-gradient(to bottom, transparent 0, black var(--top__17ondx4b, 0)),linear-gradient(to right, transparent 0, black var(--left__17ondx49, 0)),linear-gradient(to left, transparent 0, black var(--right__17ondx4a, 0)),linear-gradient(to top, transparent 0, black var(--bottom__17ondx4c, 0));
+}
+.ScrollContainer_maskLeft__17ondx4e {
+  --left__17ondx49: var(--scrollOverlaySize__17ondx42);
+}
+.ScrollContainer_maskRight__17ondx4f {
+  --right__17ondx4a: var(--scrollOverlaySize__17ondx42);
+}
+.ScrollContainer_maskTop__17ondx4g {
+  --top__17ondx4b: var(--scrollOverlaySize__17ondx42);
+}
+.ScrollContainer_maskBottom__17ondx4h {
+  --bottom__17ondx4c: var(--scrollOverlaySize__17ondx42);
+}
+.MenuRenderer_backdrop__gxm1hx1 {
+  width: 100vw;
+  height: 100vh;
+}
+.MenuRenderer_menuPosition__gxm1hx6 {
+  top: var(--triggerVars_bottom__gxm1hx4);
+  bottom: var(--triggerVars_top__gxm1hx2);
+  left: var(--triggerVars_left__gxm1hx3);
+  right: var(--triggerVars_right__gxm1hx5);
+}
+.MenuRenderer_baseWidth__gxm1hx8 {
+  width: calc(var(--widthVar__gxm1hx7) / 4);
+}
+.MenuRenderer_width_small__gxm1hx9 {
+  --widthVar__gxm1hx7: var(--contentWidth-small__xorl4v12);
+}
+.MenuRenderer_width_medium__gxm1hxa {
+  --widthVar__gxm1hx7: var(--contentWidth-medium__xorl4v13);
+}
+.MenuRenderer_width_large__gxm1hxb {
+  --widthVar__gxm1hx7: var(--contentWidth-large__xorl4v14);
+}
+.MenuRenderer_menuHeightLimit__gxm1hxc {
+  max-height: calc((var(--touchableSize__xorl4v9) * 9.5) + (var(--menuYPadding__gxm1hx0) * 2));
+}
+.useMenuItem_menuItem__1158u5f0::-moz-focus-inner {
+  border: 0;
+}
+.useMenuItem_menuItemLeftSlot__1158u5f1 {
+  height: 0px;
+}
+.MenuItemCheckbox_checkboxSize__1d2z2hd2 {
+  --menuItemCapHeight__1d2z2hd0: var(--textSize-standard-mobile-capHeight__xorl4v3o);
+  --crop__1d2z2hd1: calc(((var(--inlineFieldSize-small__xorl4v5h) - var(--menuItemCapHeight__1d2z2hd0)) / 2) * -1);
+  height: var(--inlineFieldSize-small__xorl4v5h);
+  width: var(--inlineFieldSize-small__xorl4v5h);
+  margin-top: var(--crop__1d2z2hd1);
+  margin-bottom: var(--crop__1d2z2hd1);
+}
+@media screen and (min-width: 740px) {
+  .MenuItemCheckbox_checkboxSize__1d2z2hd2 {
+    --menuItemCapHeight__1d2z2hd0: var(--textSize-standard-tablet-capHeight__xorl4v3t);
+  }
+}
+.OverflowMenu_wrapperPositioning__ycsyyc0 {
+  margin: -1px -6px;
+}
+.MonthPicker_nativeInput__1uimft00::-webkit-inner-spin-button, .MonthPicker_nativeInput__1uimft00::-webkit-calendar-picker-indicator, .MonthPicker_nativeInput__1uimft00::-webkit-clear-button {
+  display: none;
+  -webkit-appearance: none;
+}
+.Page_fullHeight__1lh04yl1 {
+  min-height: var(--heightLimit__1lh04yl0, 100vh);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Pagination_lightModeCurrentKeyline__bn82bg1 {
+  opacity: 0.3;
+}
+html.sprinkles_darkMode__iv7so511 .Pagination_darkModeCurrentKeyline__bn82bg2 {
+  opacity: 0.3;
+}
+.Pagination_current__bn82bg3 {
+  opacity: 0.075;
+}
+.Pagination_hover__bn82bg0:hover .Pagination_background__bn82bg4:not(.Pagination_current__bn82bg3) {
+  opacity: 0.5;
+}
+.Rating_inlineFlex__tlnpno0 {
+  display: inline-flex;
+  gap: 1px;
+}
+html:not(.sprinkles_darkMode__iv7so511) .Stepper_tone_formAccent__19bg0vv2 {
+  --highlightVar__19bg0vv1: var(--borderColor-formAccent__xorl4vn);
+}
+html.sprinkles_darkMode__iv7so511 .Stepper_tone_formAccent__19bg0vv2 {
+  --highlightVar__19bg0vv1: var(--borderColor-formAccentLight__xorl4vo);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Stepper_tone_neutral__19bg0vv3 {
+  --highlightVar__19bg0vv1: var(--borderColor-neutral__xorl4vr);
+}
+html.sprinkles_darkMode__iv7so511 .Stepper_tone_neutral__19bg0vv3 {
+  --highlightVar__19bg0vv1: var(--borderColor-neutralLight__xorl4vt);
+}
+.Stepper_step__19bg0vv4 {
+  outline: none;
+  text-align: left;
+}
+html:not(.sprinkles_darkMode__iv7so511) .Stepper_step__19bg0vv4 {
+  --baseColourVar__19bg0vv0: var(--borderColor-neutralLight__xorl4vt);
+}
+html.sprinkles_darkMode__iv7so511 .Stepper_step__19bg0vv4 {
+  --baseColourVar__19bg0vv0: var(--borderColor-neutral__xorl4vr);
+}
+.Stepper_indicator__19bg0vv6 {
+  height: var(--inlineFieldSize-small__xorl4v5h);
+  width: var(--inlineFieldSize-small__xorl4v5h);
+  color: var(--baseColourVar__19bg0vv0);
+}
+.Stepper_stretch__19bg0vv7 {
+  flex: 1;
+}
+.Stepper_highlight__19bg0vv9 {
+  color: var(--highlightVar__19bg0vv1);
+}
+.Stepper_inner__19bg0vvd {
+  fill: currentcolor;
+  transform-origin: 50% 50%;
+  transform: scale(0);
+}
+.Stepper_active__19bg0vvb > .Stepper_inner__19bg0vvd {
+  transform: scale(1);
+  opacity: 1;
+}
+.Stepper_complete__19bg0vva > .Stepper_inner__19bg0vvd {
+  transform: scale(2.1);
+  opacity: 1;
+}
+.Stepper_tick__19bg0vvf {
+  transition-delay: .1s;
+  transform-origin: 50% 50%;
+}
+:not(.Stepper_complete__19bg0vva) > .Stepper_tick__19bg0vvf {
+  opacity: 0;
+  transition-delay: 0s;
+  transform: scale(.5) rotate(50deg);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Stepper_tick__19bg0vvf {
+  fill: var(--foregroundColor-neutralInverted__xorl4v1l);
+}
+html.sprinkles_darkMode__iv7so511 .Stepper_tick__19bg0vvf {
+  fill: var(--foregroundColor-neutral__xorl4v1k);
+}
+.Stepper_progressTrack__19bg0vvg {
+  background: repeating-linear-gradient(90deg, var(--baseColourVar__19bg0vv0), var(--baseColourVar__19bg0vv0) 2px, transparent 2px, transparent 4px);
+  height: var(--borderWidth-large__xorl4vz);
+  width: calc((100% - var(--inlineFieldSize-small__xorl4v5h)) - (var(--space-xxsmall__xorl4v1) * 2));
+  top: calc((var(--inlineFieldSize-small__xorl4v5h) - var(--borderWidth-large__xorl4vz)) / 2);
+  left: calc(var(--inlineFieldSize-small__xorl4v5h) + var(--space-xxsmall__xorl4v1));
+}
+.Stepper_progressLine__19bg0vvi {
+  background: var(--highlightVar__19bg0vv1);
+  transition: transform .2s ease;
+}
+.Stepper_progressUnfilled__19bg0vvj {
+  transform: translateX(-101%);
+}
+.Stepper_indicatorContainer__19bg0vvk {
+  outline: var(--focusRingSize__xorl4v10) solid transparent;
+  width: var(--inlineFieldSize-small__xorl4v5h);
+  transition: var(--transition-fast__xorl4v5i), outline-color .125s ease;
+}
+.Stepper_step__19bg0vv4:focus-visible .Stepper_indicatorContainer__19bg0vvk {
+  outline-color: var(--borderColor-focus__xorl4vm);
+  transform: scale(1.2);
+}
+.Stepper_step__19bg0vv4:active .Stepper_indicatorContainer__19bg0vvk {
+  transform: var(--transform-touchable__xorl4v5k);
+}
+@media screen and (min-width: 740px) {
+  .Stepper_stretchLastAboveTablet__19bg0vv8 {
+    flex: 1;
+  }
+  .Stepper_progressTrackCentered__19bg0vvh {
+    left: calc((50% + (var(--inlineFieldSize-small__xorl4v5h) / 2)) + var(--space-xxsmall__xorl4v1));
+  }
+}
+.Table_table__1gzljjr1 {
+  border-collapse: separate;
+  border: var(--borderWidth-standard__xorl4vy) solid var(--borderColor__1gzljjr0);
+  font-variant-numeric: tabular-nums;
+  word-break: break-word;
+}
+html:not(.sprinkles_darkMode__iv7so511) .Table_table__1gzljjr1 {
+  --borderColor__1gzljjr0: var(--borderColor-neutralLight__xorl4vt);
+}
+html.sprinkles_darkMode__iv7so511 .Table_table__1gzljjr1 {
+  --borderColor__1gzljjr0: var(--borderColor-neutral__xorl4vr);
+}
+.Table_row__1gzljjr4:not(:last-child) > .Table_cell__1gzljjr5 {
+  border-bottom: 1px solid var(--borderColor__1gzljjr0);
+}
+.Table_tableSection__1gzljjr3:not(.Table_tableHeader__1gzljjr2) > .Table_row__1gzljjr4 > .Table_headCell__1gzljjr6:not(:first-child) {
+  border-left: 1px solid var(--borderColor__1gzljjr0);
+}
+.Table_tableSection__1gzljjr3:not(.Table_tableHeader__1gzljjr2) > .Table_row__1gzljjr4 > .Table_headCell__1gzljjr6:not(:last-child) {
+  border-right: 1px solid var(--borderColor__1gzljjr0);
+}
+.Table_tableSection__1gzljjr3:not(:first-child) > .Table_row__1gzljjr4:first-child > .Table_cell__1gzljjr5 {
+  border-top: var(--borderWidth-standard__xorl4vy) solid var(--borderColor__1gzljjr0);
+}
+.Table_alignYCenter__1gzljjr7 {
+  vertical-align: middle;
+}
+.Table_nowrap__1gzljjr8 {
+  white-space: nowrap;
+}
+.Table_softWidth__1gzljjra {
+  width: var(--softWidthVar__1gzljjr9);
+}
+.Table_minWidth__1gzljjrc {
+  min-width: var(--minWidthVar__1gzljjrb);
+}
+.Table_maxWidth__1gzljjre {
+  max-width: var(--maxWidthVar__1gzljjrd);
+}
+@media screen and (min-width: 740px) {
+  .Table_showOnTablet__1gzljjrf {
+    display: table-cell;
+  }
+}
+@media screen and (min-width: 992px) {
+  .Table_showOnDesktop__1gzljjrg {
+    display: table-cell;
+  }
+}
+@media screen and (min-width: 1200px) {
+  .Table_showOnWide__1gzljjrh {
+    display: table-cell;
+  }
+}
+.Tabs_tab__168cu0s0::-moz-focus-inner {
+  border: 0;
+}
+.Tabs_tab__168cu0s0:hover .Tabs_hoveredTab__168cu0s1 {
+  opacity: 1;
+}
+.Tabs_nowrap__168cu0s2 {
+  white-space: nowrap;
+}
+.Tabs_scroll__168cu0s3 {
+  -webkit-overflow-scrolling: touch;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.Tabs_scroll__168cu0s3::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+.Tabs_mask__168cu0s4 {
+  mask-image: linear-gradient(90deg, rgba(0,0,0,1) 0, rgba(0,0,0,1) calc(100% - 80px), rgba(0,0,0,0) 100%);
+}
+.Tabs_marginAuto__168cu0s5 {
+  margin-left: auto;
+  margin-right: auto;
+}
+.Tabs_tabFocusRing__168cu0s6 {
+  outline-offset: calc(var(--focusRingSize__xorl4v10) * -1);
+}
+.Tabs_tabUnderline__168cu0sb {
+  --underlineRadius__168cu0s9: calc(var(--borderRadius-small__xorl4vb) / var(--underlineScale__168cu0sa));
+  --underlineScale__168cu0sa: calc(var(--underlineWidth__168cu0s8) / 100);
+  height: var(--borderWidth-large__xorl4vz);
+  border-top-left-radius: var(--underlineRadius__168cu0s9);
+  border-top-right-radius: var(--underlineRadius__168cu0s9);
+  width: 100px;
+  transform-origin: 0 0;
+  transition: transform .3s ease;
+  transform: translateZ(0) translateX(calc(var(--underlineLeft__168cu0s7) * 1px)) scaleX(var(--underlineScale__168cu0sa));
+}
+html.sprinkles_darkMode__iv7so511 .Tabs_tabUnderlineActiveDarkMode__168cu0sc {
+  background: var(--borderColor-formAccentLight__xorl4vo);
+}
+.Tabs_divider__168cu0se {
+  height: var(--borderWidth-standard__xorl4vy);
+}
+.Tag_clearGutter__7vya150 {
+  padding-left: 1px;
+}
+.Highlight_root__1mad43z1 {
+  padding: 0 2px;
+  margin: 0 -2px;
+  text-decoration: underline;
+  text-decoration-style: wavy;
+  text-decoration-skip-ink: none;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 2px;
+}
+html:not(.sprinkles_darkMode__iv7so511) .Highlight_critical__1mad43z2 {
+  text-decoration-color: var(--borderColor-critical__xorl4vj);
+  background: var(--backgroundColor-criticalLight__xorl4v27);
+}
+html.sprinkles_darkMode__iv7so511 .Highlight_critical__1mad43z2 {
+  text-decoration-color: var(--borderColor-criticalLight__xorl4vk);
+}
+.Highlight_caution__1mad43z3 {
+  text-decoration-color: var(--borderColor-caution__xorl4vh);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Highlight_caution__1mad43z3 {
+  background: var(--backgroundColor-cautionLight__xorl4v23);
+}
+.Textarea_field__drx6sk0 {
+  resize: vertical;
+  background: transparent;
+  min-height: calc(var(--grid__xorl4va) * 15);
+}
+.Textarea_highlights__drx6sk1 {
+  color: transparent !important;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+.Textarea_highlights__drx6sk1:after {
+  content: "\\A";
+}
+.TextDropdown_select__196u93m0 {
+  min-height: 44px;
+  min-width: 44px;
+  height: 100%;
+  width: 100%;
+  transform: translate(-50%, -50%);
+  top: 50%;
+  left: 50%;
+}
+[data-braid-debug] .TextDropdown_select__196u93m0 {
+  background: red;
+  opacity: 0.2;
+}
+.TextDropdown_focusRing__196u93m2 {
+  outline: var(--focusRingSize__xorl4v10) solid transparent;
+  transition: outline-color .125s ease;
+  outline-offset: var(--space-xxsmall__xorl4v1);
+}
+.TextDropdown_select__196u93m0:focus-visible ~ .TextDropdown_focusRing__196u93m2 {
+  outline-color: var(--borderColor-focus__xorl4vm);
+}
+.Tiles_tiles__jxnmqs5 {
+  --columns__jxnmqs0: var(--mobileColumnsVar__jxnmqs1);
+  display: grid;
+  grid-template-columns: repeat(var(--columns__jxnmqs0), 1fr);
+}
+.Tiles_tiles__jxnmqs5 > * {
+  min-width: 0;
+}
+@media screen and (min-width: 740px) {
+  .Tiles_tiles__jxnmqs5 {
+    --columns__jxnmqs0: var(--tabletColumnsVar__jxnmqs2);
+  }
+}
+@media screen and (min-width: 992px) {
+  .Tiles_tiles__jxnmqs5 {
+    --columns__jxnmqs0: var(--desktopColumnsVar__jxnmqs3);
+  }
+}
+@media screen and (min-width: 1200px) {
+  .Tiles_tiles__jxnmqs5 {
+    --columns__jxnmqs0: var(--wideColumnsVar__jxnmqs4);
+  }
+}
+.Toggle_bleedToCapHeight_standard__18ov2xx0 {
+  height: var(--textSize-standard-mobile-capHeight__xorl4v3o);
+}
+.Toggle_bleedToCapHeight_small__18ov2xx1 {
+  height: var(--textSize-small-mobile-capHeight__xorl4v3e);
+}
+.Toggle_root__18ov2xx2:hover {
+  z-index: 1;
+}
+.Toggle_realField__18ov2xx3 {
+  height: 44px;
+}
+[data-braid-debug] .Toggle_realField__18ov2xx3 {
+  background: red;
+  opacity: 0.2;
+}
+.Toggle_realFieldPosition_standard__18ov2xx4 {
+  top: calc(((44px - var(--inlineFieldSize-standard__xorl4v5g)) / 2) * -1);
+}
+.Toggle_realFieldPosition_small__18ov2xx5 {
+  top: calc(((44px - var(--inlineFieldSize-small__xorl4v5h)) / 2) * -1);
+}
+.Toggle_fieldSize_standard__18ov2xx6 {
+  width: calc(var(--inlineFieldSize-standard__xorl4v5g) * 1.6);
+}
+.Toggle_fieldSize_small__18ov2xx7 {
+  width: calc(var(--inlineFieldSize-small__xorl4v5h) * 1.6);
+}
+.Toggle_slideContainerSize_standard__18ov2xx9 {
+  height: var(--inlineFieldSize-standard__xorl4v5g);
+}
+.Toggle_slideContainerSize_small__18ov2xxa {
+  height: var(--inlineFieldSize-small__xorl4v5h);
+}
+.Toggle_slideTrack_standard__18ov2xxb {
+  height: calc(var(--inlineFieldSize-standard__xorl4v5g) - var(--grid__xorl4va));
+}
+.Toggle_slideTrack_small__18ov2xxc {
+  height: calc(var(--inlineFieldSize-small__xorl4v5h) - var(--grid__xorl4va));
+}
+html:not(.sprinkles_darkMode__iv7so511) .Toggle_slideTrackBgLightMode_light__18ov2xxd {
+  background: rgba(0,0,0,0.08);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Toggle_slideTrackBgLightMode_dark__18ov2xxe {
+  background: rgba(255,255,255,0.12);
+}
+html.sprinkles_darkMode__iv7so511 .Toggle_slideTrackBgDarkMode_light__18ov2xxf {
+  background: rgba(0,0,0,0.08);
+}
+html.sprinkles_darkMode__iv7so511 .Toggle_slideTrackBgDarkMode_dark__18ov2xxg {
+  background: rgba(255,255,255,0.12);
+}
+.Toggle_slideTrackMask__18ov2xxh {
+  -webkit-mask-image: -webkit-radial-gradient(white, black);
+}
+.Toggle_realField__18ov2xx3:not(:checked) + .Toggle_slideContainer__18ov2xx8 .Toggle_slideTrackSelected__18ov2xxi {
+  transform: translateX(calc(var(--touchableSize__xorl4v9) * -1));
+}
+.Toggle_slider_standard__18ov2xxj {
+  outline: var(--focusRingSize__xorl4v10) solid transparent;
+  height: var(--inlineFieldSize-standard__xorl4v5g);
+  width: var(--inlineFieldSize-standard__xorl4v5g);
+  transition: var(--transition-fast__xorl4v5i), outline-color .125s ease;
+}
+.Toggle_realField__18ov2xx3:focus-visible + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_standard__18ov2xxj {
+  outline-color: var(--borderColor-focus__xorl4vm);
+}
+.Toggle_realField__18ov2xx3:active + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_standard__18ov2xxj {
+  transform: translateX(calc((var(--inlineFieldSize-standard__xorl4v5g) * 0.12) * -1));
+}
+.Toggle_realField__18ov2xx3:checked + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_standard__18ov2xxj {
+  transform: translateX(calc((var(--inlineFieldSize-standard__xorl4v5g) * 1.6) - var(--inlineFieldSize-standard__xorl4v5g)));
+}
+.Toggle_realField__18ov2xx3:active:checked + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_standard__18ov2xxj {
+  transform: translateX(calc(((var(--inlineFieldSize-standard__xorl4v5g) * 1.6) - var(--inlineFieldSize-standard__xorl4v5g)) + (var(--inlineFieldSize-standard__xorl4v5g) * 0.12)));
+}
+.Toggle_slider_small__18ov2xxk {
+  outline: var(--focusRingSize__xorl4v10) solid transparent;
+  height: var(--inlineFieldSize-small__xorl4v5h);
+  width: var(--inlineFieldSize-small__xorl4v5h);
+  transition: var(--transition-fast__xorl4v5i), outline-color .125s ease;
+}
+.Toggle_realField__18ov2xx3:focus-visible + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_small__18ov2xxk {
+  outline-color: var(--borderColor-focus__xorl4vm);
+}
+.Toggle_realField__18ov2xx3:active + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_small__18ov2xxk {
+  transform: translateX(calc((var(--inlineFieldSize-small__xorl4v5h) * 0.12) * -1));
+}
+.Toggle_realField__18ov2xx3:checked + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_small__18ov2xxk {
+  transform: translateX(calc((var(--inlineFieldSize-small__xorl4v5h) * 1.6) - var(--inlineFieldSize-small__xorl4v5h)));
+}
+.Toggle_realField__18ov2xx3:active:checked + .Toggle_slideContainer__18ov2xx8 .Toggle_slider_small__18ov2xxk {
+  transform: translateX(calc(((var(--inlineFieldSize-small__xorl4v5h) * 1.6) - var(--inlineFieldSize-small__xorl4v5h)) + (var(--inlineFieldSize-small__xorl4v5h) * 0.12)));
+}
+.Toggle_sliderThumbOutlineFix__18ov2xxl {
+  transform: scale(1.04);
+}
+html:not(.sprinkles_darkMode__iv7so511) .Toggle_hideBorderOnDarkBackgroundInLightMode__18ov2xxm {
+  opacity: 0;
+}
+.Toggle_realField__18ov2xx3:hover:not(:disabled) + .Toggle_slideContainer__18ov2xx8 .Toggle_hoverOverlay__18ov2xxn,
+  .Toggle_realField__18ov2xx3:focus + .Toggle_slideContainer__18ov2xx8 .Toggle_hoverOverlay__18ov2xxn {
+  opacity: 1;
+}
+@media screen and (min-width: 740px) {
+  .Toggle_bleedToCapHeight_standard__18ov2xx0 {
+    height: var(--textSize-standard-tablet-capHeight__xorl4v3t);
+  }
+  .Toggle_bleedToCapHeight_small__18ov2xx1 {
+    height: var(--textSize-small-tablet-capHeight__xorl4v3j);
+  }
+}
+.Toast_toast__yjs4y70 {
+  pointer-events: all;
+}
+.IconArrow_root__yd90er0 {
+  transition: transform 0.3s ease;
+  transform-origin: 50% 50%;
+}
+.IconArrow_flip__yd90er1 {
+  transform: rotateX(180deg);
+}
+.IconArrow_rotate__yd90er3 {
+  transform: scaleX(var(--mirrorVar__yd90er2, 1)) rotate(90deg);
+}
+.IconArrow_mirror__yd90er4 {
+  --mirrorVar__yd90er2: -1;
+}
+.IconThumb_root__1no4uw80 {
+  transition: transform 0.3s ease;
+  transform-origin: 50% 50%;
+}
+.IconThumb_down__1no4uw81 {
+  transform: rotate(180deg);
+}
+.seekJobs_seekJobs__17eom0l0 {
+  --space-gutter__xorl4v0: 24px;
+  --space-xxsmall__xorl4v1: 8px;
+  --space-xsmall__xorl4v2: 12px;
+  --space-small__xorl4v3: 16px;
+  --space-medium__xorl4v4: 24px;
+  --space-large__xorl4v5: 32px;
+  --space-xlarge__xorl4v6: 48px;
+  --space-xxlarge__xorl4v7: 64px;
+  --space-xxxlarge__xorl4v8: 96px;
+  --touchableSize__xorl4v9: 48px;
+  --grid__xorl4va: 4px;
+  --borderRadius-small__xorl4vb: 4px;
+  --borderRadius-standard__xorl4vc: 8px;
+  --borderRadius-large__xorl4vd: 16px;
+  --borderRadius-xlarge__xorl4ve: 24px;
+  --borderColor-brandAccent__xorl4vf: #E60278;
+  --borderColor-brandAccentLight__xorl4vg: #F8B1DC;
+  --borderColor-caution__xorl4vh: #FDC221;
+  --borderColor-cautionLight__xorl4vi: #FEE384;
+  --borderColor-critical__xorl4vj: #B91E1E;
+  --borderColor-criticalLight__xorl4vk: #FB999A;
+  --borderColor-field__xorl4vl: #838FA5;
+  --borderColor-focus__xorl4vm: rgba(153,191,247,0.7);
+  --borderColor-formAccent__xorl4vn: #1E47A9;
+  --borderColor-formAccentLight__xorl4vo: #99BFF7;
+  --borderColor-info__xorl4vp: #1D559D;
+  --borderColor-infoLight__xorl4vq: #98C9F1;
+  --borderColor-neutral__xorl4vr: #2E3849;
+  --borderColor-neutralLight__xorl4vt: #EAECF1;
+  --borderColor-neutralInverted__xorl4vs: #fff;
+  --borderColor-positive__xorl4vu: #12784F;
+  --borderColor-positiveLight__xorl4vv: #8BDEC5;
+  --borderColor-promote__xorl4vw: #7F35A9;
+  --borderColor-promoteLight__xorl4vx: #E1B2F5;
+  --borderWidth-standard__xorl4vy: 2px;
+  --borderWidth-large__xorl4vz: 4px;
+  --focusRingSize__xorl4v10: 6px;
+  --contentWidth-xsmall__xorl4v11: 400px;
+  --contentWidth-small__xorl4v12: 660px;
+  --contentWidth-medium__xorl4v13: 940px;
+  --contentWidth-large__xorl4v14: 1280px;
+  --foregroundColor-brandAccent__xorl4v15: #E60278;
+  --foregroundColor-brandAccentLight__xorl4v16: #F8B1DC;
+  --foregroundColor-caution__xorl4v17: #723D02;
+  --foregroundColor-cautionLight__xorl4v18: #FEE384;
+  --foregroundColor-critical__xorl4v19: #B91E1E;
+  --foregroundColor-criticalLight__xorl4v1a: #FB999A;
+  --foregroundColor-formAccent__xorl4v1b: #1E47A9;
+  --foregroundColor-formAccentLight__xorl4v1c: #99BFF7;
+  --foregroundColor-info__xorl4v1d: #1D559D;
+  --foregroundColor-infoLight__xorl4v1e: #98C9F1;
+  --foregroundColor-link__xorl4v1f: #2E3849;
+  --foregroundColor-linkLight__xorl4v1h: #fff;
+  --foregroundColor-linkHover__xorl4v1g: #2E3849;
+  --foregroundColor-linkVisited__xorl4v1i: #5B2084;
+  --foregroundColor-linkLightVisited__xorl4v1j: #F0D6FA;
+  --foregroundColor-neutral__xorl4v1k: #2E3849;
+  --foregroundColor-neutralInverted__xorl4v1l: #fff;
+  --foregroundColor-positive__xorl4v1m: #12784F;
+  --foregroundColor-positiveLight__xorl4v1n: #8BDEC5;
+  --foregroundColor-promote__xorl4v1o: #7F35A9;
+  --foregroundColor-promoteLight__xorl4v1p: #E1B2F5;
+  --foregroundColor-rating__xorl4v1q: #E60278;
+  --foregroundColor-secondary__xorl4v1r: #5A6881;
+  --foregroundColor-secondaryInverted__xorl4v1s: rgba(255,255,255,0.65);
+  --backgroundColor-body__xorl4v1t: #fff;
+  --backgroundColor-bodyDark__xorl4v1u: #1C2330;
+  --backgroundColor-brand__xorl4v1v: #051A49;
+  --backgroundColor-brandAccent__xorl4v1w: #E60278;
+  --backgroundColor-brandAccentActive__xorl4v1x: #cd026b;
+  --backgroundColor-brandAccentHover__xorl4v1y: #fd0585;
+  --backgroundColor-brandAccentSoft__xorl4v1z: #FEEFFA;
+  --backgroundColor-brandAccentSoftActive__xorl4v20: #fdd7f3;
+  --backgroundColor-brandAccentSoftHover__xorl4v21: #fde3f6;
+  --backgroundColor-caution__xorl4v22: #FDC221;
+  --backgroundColor-cautionLight__xorl4v23: #FEF8DE;
+  --backgroundColor-critical__xorl4v24: #B91E1E;
+  --backgroundColor-criticalActive__xorl4v25: #a31a1a;
+  --backgroundColor-criticalHover__xorl4v26: #db1616;
+  --backgroundColor-criticalLight__xorl4v27: #FFE3E2;
+  --backgroundColor-criticalSoft__xorl4v28: #FEF3F3;
+  --backgroundColor-criticalSoftActive__xorl4v29: #fcdbdb;
+  --backgroundColor-criticalSoftHover__xorl4v2a: #fde7e7;
+  --backgroundColor-formAccent__xorl4v2b: #1E47A9;
+  --backgroundColor-formAccentActive__xorl4v2c: #1a3e93;
+  --backgroundColor-formAccentHover__xorl4v2d: #2455c9;
+  --backgroundColor-formAccentSoft__xorl4v2e: #F0F7FE;
+  --backgroundColor-formAccentSoftActive__xorl4v2f: #d8eafc;
+  --backgroundColor-formAccentSoftHover__xorl4v2g: #e4f1fd;
+  --backgroundColor-info__xorl4v2h: #1D559D;
+  --backgroundColor-infoLight__xorl4v2i: #E3F2FB;
+  --backgroundColor-neutral__xorl4v2j: #2E3849;
+  --backgroundColor-neutralActive__xorl4v2k: #242c39;
+  --backgroundColor-neutralHover__xorl4v2l: #384459;
+  --backgroundColor-neutralLight__xorl4v2m: #F3F5F7;
+  --backgroundColor-neutralSoft__xorl4v2n: #F3F5F7;
+  --backgroundColor-neutralSoftActive__xorl4v2o: #e4e8ed;
+  --backgroundColor-neutralSoftHover__xorl4v2p: #ebeff2;
+  --backgroundColor-positive__xorl4v2q: #12784F;
+  --backgroundColor-positiveLight__xorl4v2r: #E2F7F1;
+  --backgroundColor-promote__xorl4v2s: #7F35A9;
+  --backgroundColor-promoteLight__xorl4v2t: #F9EBFD;
+  --backgroundColor-surface__xorl4v2u: #fff;
+  --backgroundColor-surfaceDark__xorl4v2v: #1C2330;
+  --fontFamily__xorl4v2w: SeekSans, "SeekSans Fallback", Arial, Tahoma, sans-serif;
+  --fontMetrics-capHeight__xorl4v2x: 783;
+  --fontMetrics-ascent__xorl4v2y: 1057;
+  --fontMetrics-descent__xorl4v2z: -274;
+  --fontMetrics-lineGap__xorl4v30: 0;
+  --fontMetrics-unitsPerEm__xorl4v31: 1000;
+  --textSize-large-mobile-fontSize__xorl4v3w: 18px;
+  --textSize-large-mobile-lineHeight__xorl4v3x: 27.094px;
+  --textSize-large-mobile-capHeight__xorl4v3y: 14.094px;
+  --textSize-large-mobile-capsizeTrims-capHeightTrim__xorl4v3z: -0.3611em;
+  --textSize-large-mobile-capsizeTrims-baselineTrim__xorl4v40: -0.3611em;
+  --textSize-large-tablet-fontSize__xorl4v41: 18px;
+  --textSize-large-tablet-lineHeight__xorl4v42: 27.094px;
+  --textSize-large-tablet-capHeight__xorl4v43: 14.094px;
+  --textSize-large-tablet-capsizeTrims-capHeightTrim__xorl4v44: -0.3611em;
+  --textSize-large-tablet-capsizeTrims-baselineTrim__xorl4v45: -0.3611em;
+  --textSize-standard-mobile-fontSize__xorl4v3m: 16px;
+  --textSize-standard-mobile-lineHeight__xorl4v3n: 24.528px;
+  --textSize-standard-mobile-capHeight__xorl4v3o: 12.528px;
+  --textSize-standard-mobile-capsizeTrims-capHeightTrim__xorl4v3p: -0.375em;
+  --textSize-standard-mobile-capsizeTrims-baselineTrim__xorl4v3q: -0.375em;
+  --textSize-standard-tablet-fontSize__xorl4v3r: 16px;
+  --textSize-standard-tablet-lineHeight__xorl4v3s: 24.528px;
+  --textSize-standard-tablet-capHeight__xorl4v3t: 12.528px;
+  --textSize-standard-tablet-capsizeTrims-capHeightTrim__xorl4v3u: -0.375em;
+  --textSize-standard-tablet-capsizeTrims-baselineTrim__xorl4v3v: -0.375em;
+  --textSize-small-mobile-fontSize__xorl4v3c: 14px;
+  --textSize-small-mobile-lineHeight__xorl4v3d: 20.962px;
+  --textSize-small-mobile-capHeight__xorl4v3e: 10.962px;
+  --textSize-small-mobile-capsizeTrims-capHeightTrim__xorl4v3f: -0.3571em;
+  --textSize-small-mobile-capsizeTrims-baselineTrim__xorl4v3g: -0.3571em;
+  --textSize-small-tablet-fontSize__xorl4v3h: 14px;
+  --textSize-small-tablet-lineHeight__xorl4v3i: 20.962px;
+  --textSize-small-tablet-capHeight__xorl4v3j: 10.962px;
+  --textSize-small-tablet-capsizeTrims-capHeightTrim__xorl4v3k: -0.3571em;
+  --textSize-small-tablet-capsizeTrims-baselineTrim__xorl4v3l: -0.3571em;
+  --textSize-xsmall-mobile-fontSize__xorl4v32: 12px;
+  --textSize-xsmall-mobile-lineHeight__xorl4v33: 18.396px;
+  --textSize-xsmall-mobile-capHeight__xorl4v34: 9.396px;
+  --textSize-xsmall-mobile-capsizeTrims-capHeightTrim__xorl4v35: -0.375em;
+  --textSize-xsmall-mobile-capsizeTrims-baselineTrim__xorl4v36: -0.375em;
+  --textSize-xsmall-tablet-fontSize__xorl4v37: 12px;
+  --textSize-xsmall-tablet-lineHeight__xorl4v38: 18.396px;
+  --textSize-xsmall-tablet-capHeight__xorl4v39: 9.396px;
+  --textSize-xsmall-tablet-capsizeTrims-capHeightTrim__xorl4v3a: -0.375em;
+  --textSize-xsmall-tablet-capsizeTrims-baselineTrim__xorl4v3b: -0.375em;
+  --textWeight-regular__xorl4v46: 400;
+  --textWeight-medium__xorl4v47: 500;
+  --textWeight-strong__xorl4v48: 700;
+  --headingLevel-1-mobile-fontSize__xorl4v49: 28px;
+  --headingLevel-1-mobile-lineHeight__xorl4v4a: 32.924px;
+  --headingLevel-1-mobile-capHeight__xorl4v4b: 21.924px;
+  --headingLevel-1-mobile-capsizeTrims-capHeightTrim__xorl4v4c: -0.1964em;
+  --headingLevel-1-mobile-capsizeTrims-baselineTrim__xorl4v4d: -0.1964em;
+  --headingLevel-1-tablet-fontSize__xorl4v4e: 36px;
+  --headingLevel-1-tablet-lineHeight__xorl4v4f: 42.188px;
+  --headingLevel-1-tablet-capHeight__xorl4v4g: 28.188px;
+  --headingLevel-1-tablet-capsizeTrims-capHeightTrim__xorl4v4h: -0.1944em;
+  --headingLevel-1-tablet-capsizeTrims-baselineTrim__xorl4v4i: -0.1944em;
+  --headingLevel-2-mobile-fontSize__xorl4v4j: 24px;
+  --headingLevel-2-mobile-lineHeight__xorl4v4k: 29.792px;
+  --headingLevel-2-mobile-capHeight__xorl4v4l: 18.792px;
+  --headingLevel-2-mobile-capsizeTrims-capHeightTrim__xorl4v4m: -0.2292em;
+  --headingLevel-2-mobile-capsizeTrims-baselineTrim__xorl4v4n: -0.2292em;
+  --headingLevel-2-tablet-fontSize__xorl4v4o: 30px;
+  --headingLevel-2-tablet-lineHeight__xorl4v4p: 36.49px;
+  --headingLevel-2-tablet-capHeight__xorl4v4q: 23.49px;
+  --headingLevel-2-tablet-capsizeTrims-capHeightTrim__xorl4v4r: -0.2167em;
+  --headingLevel-2-tablet-capsizeTrims-baselineTrim__xorl4v4s: -0.2167em;
+  --headingLevel-3-mobile-fontSize__xorl4v4t: 22px;
+  --headingLevel-3-mobile-lineHeight__xorl4v4u: 27.226px;
+  --headingLevel-3-mobile-capHeight__xorl4v4v: 17.226px;
+  --headingLevel-3-mobile-capsizeTrims-capHeightTrim__xorl4v4w: -0.2273em;
+  --headingLevel-3-mobile-capsizeTrims-baselineTrim__xorl4v4x: -0.2273em;
+  --headingLevel-3-tablet-fontSize__xorl4v4y: 24px;
+  --headingLevel-3-tablet-lineHeight__xorl4v4z: 29.792px;
+  --headingLevel-3-tablet-capHeight__xorl4v50: 18.792px;
+  --headingLevel-3-tablet-capsizeTrims-capHeightTrim__xorl4v51: -0.2292em;
+  --headingLevel-3-tablet-capsizeTrims-baselineTrim__xorl4v52: -0.2292em;
+  --headingLevel-4-mobile-fontSize__xorl4v53: 20px;
+  --headingLevel-4-mobile-lineHeight__xorl4v54: 24.66px;
+  --headingLevel-4-mobile-capHeight__xorl4v55: 15.66px;
+  --headingLevel-4-mobile-capsizeTrims-capHeightTrim__xorl4v56: -0.225em;
+  --headingLevel-4-mobile-capsizeTrims-baselineTrim__xorl4v57: -0.225em;
+  --headingLevel-4-tablet-fontSize__xorl4v58: 20px;
+  --headingLevel-4-tablet-lineHeight__xorl4v59: 24.66px;
+  --headingLevel-4-tablet-capHeight__xorl4v5a: 15.66px;
+  --headingLevel-4-tablet-capsizeTrims-capHeightTrim__xorl4v5b: -0.225em;
+  --headingLevel-4-tablet-capsizeTrims-baselineTrim__xorl4v5c: -0.225em;
+  --headingWeight-weak__xorl4v5d: 400;
+  --headingWeight-regular__xorl4v5e: 500;
+  --linkDecoration__xorl4v5f: underline;
+  --inlineFieldSize-standard__xorl4v5g: 24px;
+  --inlineFieldSize-small__xorl4v5h: 20px;
+  --transition-fast__xorl4v5i: transform .125s ease, opacity .125s ease;
+  --transition-touchable__xorl4v5j: transform 0.2s cubic-bezier(0.02, 1.505, 0.745, 1.235);
+  --transform-touchable__xorl4v5k: scale(0.95);
+  --shadow-small__xorl4v5l: 0 2px 4px 0px rgba(28,35,48,0.1), 0 2px 2px -2px rgba(28,35,48,0.1), 0 4px 4px -4px rgba(28,35,48,0.2);
+  --shadow-medium__xorl4v5m: 0 2px 4px 0px rgba(28,35,48,0.1), 0 8px 8px -4px rgba(28,35,48,0.1), 0 12px 12px -8px rgba(28,35,48,0.2);
+  --shadow-large__xorl4v5n: 0 2px 4px 0px rgba(28,35,48,0.1), 0 12px 12px -4px rgba(28,35,48,0.1), 0 20px 20px -12px rgba(28,35,48,0.2);
+}
+.App_vanillaBox__inn18b0 {
+  --backgroundColor__zv7nmx0: blueviolet;
+  background-color: var(--backgroundColor__zv7nmx0);
+  color: white;
+  font-size: 20px;
+  padding: 100px;
+}
+    </style>
     <script type="module">
       import { injectIntoGlobalHook } from "/@react-refresh";
 injectIntoGlobalHook(window);
@@ -8576,7 +17588,7 @@ POST HYDRATE DIFFS:
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -25,14 +25,4815 @@
+@@ -4531,14 +4531,4815 @@
      </script>
      <script
        type="module"
@@ -13394,7 +22406,7 @@ POST HYDRATE DIFFS:
    </head>
    <body>
      <div id="app">
-@@ -69,6 +4870,7 @@
+@@ -4575,6 +9376,7 @@
                  type="checkbox"
                  id="id_1"
                  aria-checked="false"
@@ -13402,7 +22414,7 @@ POST HYDRATE DIFFS:
                >
                <div class="reset_base__1j8ojzz0 sprinkles_flexShrink_0_mobile__iv7so5i0 sprinkles_position_relative_mobile__iv7so55g sprinkles_borderRadius_standard_mobile__iv7so568 InlineField_fakeField__3b9mfp5 InlineField_sizeVars_standard__3b9mfp2 typography_lightModeTone_light__9al9wa10  sprinkles_background_surface_lightMode__iv7so534">
                  <span class="reset_base__1j8ojzz0 sprinkles_top_0__iv7so5k sprinkles_bottom_0__iv7so5l sprinkles_left_0__iv7so5m sprinkles_right_0__iv7so5n sprinkles_position_absolute_mobile__iv7so55k sprinkles_pointerEvents_none__iv7so5j sprinkles_borderRadius_standard_mobile__iv7so568 sprinkles_transition_fast__iv7so5y sprinkles_opacity_0__iv7so57 InlineField_selected__3b9mfp9 typography_lightModeTone_dark__9al9wa11 typography_darkModeTone_dark__9al9wa13 sprinkles_background_formAccent_lightMode__iv7so522 sprinkles_background_formAccent_darkMode__iv7so523">
-@@ -165,7 +4967,7 @@
+@@ -4671,7 +9473,7 @@
          </div>
          <div class="reset_base__1j8ojzz0 App_vanillaBox__inn18b0">
            🧁 Vanilla content

--- a/tests/browser/__snapshots__/multiple-routes.test.ts.snap
+++ b/tests/browser/__snapshots__/multiple-routes.test.ts.snap
@@ -512,6 +512,17 @@ exports[`multiple-routes > bundler: vite > start > should render details page co
       http-equiv="Content-Security-Policy"
       content="script-src 'self' https://error-tracking.com https://fb-tracking.com https://code.jquery.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' 'sha256-rGv16tw6EM5EMe4gsxdgzpqzrzd14bhfa2neQclOXDU=';"
     >
+    <style
+      type="text/css"
+      data-vanilla-extract-inline-dev-css
+    >
+      .Home_root__ms22la0 {
+  color: red;
+}
+.Details_root__1hpn1da0 {
+  color: blue;
+}
+    </style>
     <script type="module">
       import { injectIntoGlobalHook } from "/@react-refresh";
 injectIntoGlobalHook(window);
@@ -578,7 +589,7 @@ POST HYDRATE DIFFS:
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -36,19 +36,27 @@
+@@ -47,19 +47,27 @@
      </style>
      <script
        type="module"
@@ -619,6 +630,14 @@ exports[`multiple-routes > bundler: vite > start > should render home page corre
       http-equiv="Content-Security-Policy"
       content="script-src 'self' https://error-tracking.com https://fb-tracking.com https://code.jquery.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' 'sha256-rGv16tw6EM5EMe4gsxdgzpqzrzd14bhfa2neQclOXDU=';"
     >
+    <style
+      type="text/css"
+      data-vanilla-extract-inline-dev-css
+    >
+      .Home_root__ms22la0 {
+  color: red;
+}
+    </style>
     <script type="module">
       import { injectIntoGlobalHook } from "/@react-refresh";
 injectIntoGlobalHook(window);
@@ -682,7 +701,7 @@ POST HYDRATE DIFFS:
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -36,14 +36,22 @@
+@@ -44,14 +44,22 @@
      </style>
      <script
        type="module"

--- a/tests/browser/__snapshots__/sku-with-https.test.ts.snap
+++ b/tests/browser/__snapshots__/sku-with-https.test.ts.snap
@@ -8,6 +8,17 @@ exports[`sku-with-https > bundler: vite > start > should start a development ser
       http-equiv="Content-Security-Policy"
       content="script-src 'self' https://some-cdn.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=';"
     >
+    <style
+      type="text/css"
+      data-vanilla-extract-inline-dev-css
+    >
+      .styles_root__2vdre50 {
+  display: flex;
+}
+.styles_root__2vdre50 .styles_nested__2vdre51 {
+  font-size: 32px;
+}
+    </style>
     <script type="module">
       import { injectIntoGlobalHook } from "/@react-refresh";
 injectIntoGlobalHook(window);
@@ -58,7 +69,7 @@ POST HYDRATE DIFFS:
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -26,20 +26,31 @@
+@@ -37,20 +37,31 @@
      >
      <script
        type="module"


### PR DESCRIPTION
The primary change is adding [`unstable_mode: 'inlineCssInDev'`](https://github.com/vanilla-extract-css/vanilla-extract/pull/1614) to the VE Vite plugin. The rest of the changes are some slight refactors to the middleware plugin and snapshot updates.

I tried to implement critical style extraction with [`beasties`](https://github.com/danielroe/beasties), which _did_ work, but also caused hydration errors because it was removing [this inline style tag injected by braid](https://github.com/seek-oss/braid-design-system/blob/82c6441d4636e2db3e66d8c4ed97ab953735fe69/packages/braid-design-system/src/lib/components/BraidProvider/BraidProvider.tsx#L98-L101). My efforts to stop it from doing that failed, so I removed the change. If critical CSS during dev is something we really care about, we can look further into it, but at this point in time I don't see a reason to put any effort into it.

As a side note, this change results in duplicate CSS in the DOM: the inlined style tag from the VE Vite plugin, as well as the individual stylesheets injected when the Vite client loads the VE styles (again). We _can_ remove the inlined style tag after all DOM content has loaded, and in fact I got it to work with no issues in a simple fixture. However, once again I don't think it's worth doing this as these styles are only inlined at dev and otherwise don't affect anything.

