### PR TITLE
Fix sku init snapshot versioning

### DIFF
--- a/tests/node/__snapshots__/sku-init.test.ts.snap
+++ b/tests/node/__snapshots__/sku-init.test.ts.snap
@@ -340,7 +340,12 @@ export function NextSteps({ environment }: NextStepsProps) {
 `;
 
 exports[`sku init > should update the pnpm-workspace.yaml 1`] = `
-"configDependencies:
+"packages:
+  - ../../packages/*
+
+configDependencies:
   pnpm-plugin-sku: VERSION_IGNORED
+
+linkWorkspacePackages: true
 "
 `;

--- a/tests/node/sku-init.test.ts
+++ b/tests/node/sku-init.test.ts
@@ -17,7 +17,15 @@ const projectDirectory = fixturePath(projectName);
 describe('sku init', () => {
   beforeAll(async () => {
     await fs.rm(projectDirectory, { recursive: true, force: true });
-    await fs.writeFile(fixturePath('pnpm-workspace.yaml'), '');
+    await fs.writeFile(
+      fixturePath('pnpm-workspace.yaml'),
+      `
+      packages:
+        - ../../packages/*
+
+      linkWorkspacePackages: true
+    `,
+    );
 
     const result = await sku('init', [projectName]);
     globalExpect(await result.findByText('Project created')).toBeInTheConsole();


### PR DESCRIPTION
Tests for sku-init fail on Version branches because the pnpm-workspace file added to the sku-init fixture makes the sku package unavailable in the workspace, making sku-init try to fetch an unpublished version of sku from the npm registry. This changes makes sku available in the fixtures workspace and turns on linking from a workspace when available (with `linkWorkspacePackages`)