### PR TITLE
`vite`: Don't emit `sku start` telemetry when `OPEN_TAB=false` is set

### DIFF
--- a/.changeset/silly-pianos-win.md
+++ b/.changeset/silly-pianos-win.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Don't emit `sku start` telemetry when `OPEN_TAB=false` is set

--- a/packages/sku/src/services/telemetry/metricsMeasurers.ts
+++ b/packages/sku/src/services/telemetry/metricsMeasurers.ts
@@ -8,7 +8,7 @@ const skuStart = {
     performance.mark(skuStartMarkName);
   },
   measure: () => {
-    const result = performance.measure('skuStart', {}, skuStartMarkName);
+    const result = performance.measure('skuStart', { end: skuStartMarkName });
 
     log(`Sku dev server start took ${Math.round(result.duration)}ms`);
 
@@ -22,13 +22,13 @@ const initialPageLoad = {
     performance.mark(initialPageLoadMarkName);
   },
   isInitialPageLoad: true,
+  openTab: process.env.OPEN_TAB !== 'false',
   measure() {
     this.isInitialPageLoad = false;
 
-    const result = performance.measure(
-      'initialPageLoad',
-      initialPageLoadMarkName,
-    );
+    const result = performance.measure('initialPageLoad', {
+      start: initialPageLoadMarkName,
+    });
 
     log(`Initial page load took ${Math.round(result.duration)}ms`);
 

--- a/packages/sku/src/services/vite/plugins/middlewarePlugin.ts
+++ b/packages/sku/src/services/vite/plugins/middlewarePlugin.ts
@@ -21,7 +21,10 @@ const clientEntry = require.resolve('../entries/vite-client.js');
 export const middlewarePlugin = (skuContext: SkuContext): Plugin => ({
   name: 'vite-plugin-sku-server-middleware',
   async configureServer(server) {
-    if (metricsMeasurers.initialPageLoad.isInitialPageLoad) {
+    if (
+      metricsMeasurers.initialPageLoad.isInitialPageLoad &&
+      metricsMeasurers.initialPageLoad.openTab
+    ) {
       metricsMeasurers.initialPageLoad.mark();
     }
     // We need to start loading the devMiddleware before Vite's middleware runs.

--- a/packages/sku/src/services/vite/plugins/startTelemetry.ts
+++ b/packages/sku/src/services/vite/plugins/startTelemetry.ts
@@ -28,7 +28,10 @@ export const startTelemetryPlugin = ({
   },
   configureServer(server) {
     server.ws.on(initialPageLoadEventName, () => {
-      if (metricsMeasurers.initialPageLoad.isInitialPageLoad) {
+      if (
+        metricsMeasurers.initialPageLoad.isInitialPageLoad &&
+        metricsMeasurers.initialPageLoad.openTab
+      ) {
         const { duration: skuStartDuration } =
           metricsMeasurers.skuStart.measure();
 


### PR DESCRIPTION
Our Vite `start` telemetry is a combination of two values:
- The time it takes for the Vite dev server to be ready
- The time it takes for the dev server middleware to serve its first request and for the page to load

Specifically, the latter time starts as soon as the middleware is configured, so if a page takes a long time to load, e.g. `OPEN_TAB=false` is set and the user manually opens an app page 5 minutes after running `sku start`, then the overall metric timing will be significantly skewed.

There aren't many reasons to permanently set `OPEN_TAB=false`, and there isn't much usage of it anyway, so a simple solution to prevent this metric from being affected by this situation is to simply not send telemetry.

I was tempted to yak shave the metrics measurers - IMO they should probably be stateful singleton classes or something - but that can wait for when we properly refactor metrics.