### PR TITLE
Test custom output target in `vite`

### DIFF
--- a/tests/node/__snapshots__/custom-output-target.test.ts.snap
+++ b/tests/node/__snapshots__/custom-output-target.test.ts.snap
@@ -1,6 +1,47 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`custom-output-target > should generate an output directory with the value specified in sku.config 1`] = `
+exports[`bundler vite > custom-output-target > should generate an output directory with the value specified in sku.config 1`] = `
+{
+  "index.html": SCRIPTS: [
+    "/vite-client-DCgbtdoA.js",
+  ]
+CSS: []
+SOURCE HTML: <!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>
+      hello-world
+    </title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1"
+    >
+    <link
+      rel="modulepreload"
+      href="SCRIPTS[0]"
+      crossorigin
+    >
+  </head>
+  <body>
+    <div id="app">
+      <p>
+        Hello there!
+      </p>
+    </div>
+    <script
+      type="module"
+      src="SCRIPTS[0]"
+    >
+    </script>
+  </body>
+</html>,
+  "vite-client-DCgbtdoA.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "vite-client-DCgbtdoA.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
+}
+`;
+
+exports[`bundler webpack > custom-output-target > should generate an output directory with the value specified in sku.config 1`] = `
 {
   "2.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "2.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",

--- a/tests/node/custom-output-target.test.ts
+++ b/tests/node/custom-output-target.test.ts
@@ -1,20 +1,31 @@
 import { describe, it } from 'vitest';
 import { dirContentsToObject } from '@sku-private/test-utils';
-import { scopeToFixture } from '@sku-private/testing-library';
+import {
+  bundlers,
+  type BundlerValues,
+  scopeToFixture,
+} from '@sku-private/testing-library';
 
 const { sku, fixturePath } = scopeToFixture('custom-output-target');
 
-describe('custom-output-target', () => {
-  it('should generate an output directory with the value specified in sku.config', async ({
-    expect,
-  }) => {
-    const build = await sku('build');
+describe.sequential.each(bundlers)('bundler %s', (bundler) => {
+  const args: BundlerValues<string[]> = {
+    vite: ['--config', 'sku.config.vite.ts', '--experimental-bundler'],
+    webpack: [],
+  };
 
-    expect(await build.findByText('Build complete')).toBeInTheConsole();
+  describe('custom-output-target', () => {
+    it('should generate an output directory with the value specified in sku.config', async ({
+      expect,
+    }) => {
+      const build = await sku('build', args[bundler]);
 
-    const files = await dirContentsToObject(
-      fixturePath('custom-output-directory'),
-    );
-    expect(files).toMatchSnapshot();
+      expect(await build.findByText('Build complete')).toBeInTheConsole();
+
+      const files = await dirContentsToObject(
+        fixturePath('custom-output-directory'),
+      );
+      expect(files).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
Only webpack was being tested in #1314. This PR adds a test for Vite too.