### PR TITLE
Test changes

### DIFF
--- a/fixtures/braid-design-system/package.json
+++ b/fixtures/braid-design-system/package.json
@@ -9,7 +9,10 @@
   },
   "scripts": {
     "start": "sku start",
-    "start:vite": "sku start --config sku.config.vite.js --experimental-bundler"
+    "start:vite": "sku start --config sku.config.vite.js --experimental-bundler",
+    "build:vite": "sku build --config sku.config.vite.js --experimental-bundler",
+    "build": "sku build",
+    "serve": "sku serve"
   },
   "devDependencies": {
     "@sku-private/test-utils": "workspace:*",

--- a/fixtures/multiple-routes/package.json
+++ b/fixtures/multiple-routes/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "start:vite": "sku start --convert-loadable --experimental-bundler --config sku.config.vite.js",
-    "build:vite": "sku build --convert-loadable --experimental-bundler --config sku.config.vite.js"
+    "build:vite": "sku build --convert-loadable --experimental-bundler --config sku.config.vite.js",
+    "serve": "sku serve"
   },
   "dependencies": {
     "@vanilla-extract/css": "^1.17.1",

--- a/fixtures/ssr-hello-world/sku-build.config.ts
+++ b/fixtures/ssr-hello-world/sku-build.config.ts
@@ -2,7 +2,6 @@ import { makeStableHashes } from '@sku-private/test-utils';
 import type { SkuConfig } from 'sku';
 
 export default {
-  publicPath: 'http://localhost:4000',
   port: 8000,
   serverPort: 8001,
   target: 'dist-build',

--- a/packages/sku/src/services/webpack/config/cache.ts
+++ b/packages/sku/src/services/webpack/config/cache.ts
@@ -1,7 +1,7 @@
 import isCI from '../../../utils/isCI.js';
 import type { SkuContext } from '../../../context/createSkuContext.js';
 
-const disableCacheOverride = Boolean(process.env.SKU_DISABLE_CACHE);
+export const disableCacheOverride = Boolean(process.env.SKU_DISABLE_CACHE);
 
 function getWebpackCacheSettings({
   isDevServer,

--- a/packages/sku/src/services/webpack/config/webpack.config.ts
+++ b/packages/sku/src/services/webpack/config/webpack.config.ts
@@ -18,7 +18,7 @@ import { cwd } from '../../../utils/cwd.js';
 import { getVocabConfig } from '../../vocab/config/vocab.js';
 import getStatsConfig from './statsConfig.js';
 import getSourceMapSetting from './sourceMaps.js';
-import getCacheSettings from './cache.js';
+import getCacheSettings, { disableCacheOverride } from './cache.js';
 import modules from './resolveModules.js';
 import targets from '../../../config/targets.json' with { type: 'json' };
 import type { MakeWebpackConfigOptions } from './types.js';
@@ -195,7 +195,7 @@ const makeWebpackConfig = ({
                       loader: require.resolve('babel-loader'),
                       options: {
                         babelrc: false,
-                        cacheDirectory: true,
+                        cacheDirectory: !disableCacheOverride,
                         cacheCompression: false,
                         presets: [
                           [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1266,9 +1266,6 @@ importers:
       '@types/css':
         specifier: ^0.0.38
         version: 0.0.38
-      '@types/diff':
-        specifier: ^7.0.1
-        version: 7.0.2
       '@types/diffable-html':
         specifier: ^5.0.2
         version: 5.0.2
@@ -1276,11 +1273,11 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       diff:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^8.0.2
+        version: 8.0.2
       diffable-html:
-        specifier: ^5.0.0
-        version: 5.0.0
+        specifier: ^6.0.1
+        version: 6.0.1
 
   private/test-utils:
     devDependencies:
@@ -4787,8 +4784,12 @@ packages:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
     engines: {node: '>=0.3.1'}
 
-  diffable-html@5.0.0:
-    resolution: {integrity: sha512-BymfWdoIv53XDp/sINPyngxiyJr7ygmAoUN7nIlPC7E+jiLvPdVIZteG4btCaB5Nyf8CMyMxp8r4Vi2r1FtSsA==}
+  diff@8.0.2:
+    resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
+    engines: {node: '>=0.3.1'}
+
+  diffable-html@6.0.1:
+    resolution: {integrity: sha512-z/AuT6urMKzCl1oz+HalSjjPxPMNKfbnWwzLzx/qWfzTQ3kBL8EnLKSCr2IpOofIpV+BA1Zd+e2eSzxGEQojUw==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -4827,23 +4828,18 @@ packages:
   dom-converter@0.2.0:
     resolution: {integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==}
 
-  dom-serializer@0.2.2:
-    resolution: {integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==}
-
   dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
-  domelementtype@1.3.1:
-    resolution: {integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==}
-
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
 
-  domhandler@2.4.2:
-    resolution: {integrity: sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==}
+  domhandler@3.3.0:
+    resolution: {integrity: sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==}
+    engines: {node: '>= 4'}
 
   domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
@@ -4852,9 +4848,6 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
-
-  domutils@1.7.0:
-    resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -4932,9 +4925,6 @@ packages:
 
   ensure-gitignore@1.2.0:
     resolution: {integrity: sha512-CfkUKQsT1/2BdpF1XXGs8/8CZQK2JMAIsl3bHUwFS/fsBU58Mn+iZ6qd2vFxupWJTZA0Din0USWdu6UbojV3sQ==}
-
-  entities@1.1.2:
-    resolution: {integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==}
 
   entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
@@ -5787,8 +5777,8 @@ packages:
       webpack:
         optional: true
 
-  htmlparser2@3.10.1:
-    resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==}
+  htmlparser2@5.0.1:
+    resolution: {integrity: sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==}
 
   htmlparser2@6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
@@ -13433,9 +13423,11 @@ snapshots:
 
   diff@7.0.0: {}
 
-  diffable-html@5.0.0:
+  diff@8.0.2: {}
+
+  diffable-html@6.0.1:
     dependencies:
-      htmlparser2: 3.10.1
+      htmlparser2: 5.0.1
 
   dir-glob@3.0.1:
     dependencies:
@@ -13506,11 +13498,6 @@ snapshots:
     dependencies:
       utila: 0.4.0
 
-  dom-serializer@0.2.2:
-    dependencies:
-      domelementtype: 2.3.0
-      entities: 2.2.0
-
   dom-serializer@1.4.1:
     dependencies:
       domelementtype: 2.3.0
@@ -13523,13 +13510,11 @@ snapshots:
       domhandler: 5.0.3
       entities: 4.5.0
 
-  domelementtype@1.3.1: {}
-
   domelementtype@2.3.0: {}
 
-  domhandler@2.4.2:
+  domhandler@3.3.0:
     dependencies:
-      domelementtype: 1.3.1
+      domelementtype: 2.3.0
 
   domhandler@4.3.1:
     dependencies:
@@ -13538,11 +13523,6 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
-
-  domutils@1.7.0:
-    dependencies:
-      dom-serializer: 0.2.2
-      domelementtype: 1.3.1
 
   domutils@2.8.0:
     dependencies:
@@ -13618,8 +13598,6 @@ snapshots:
       strip-ansi: 6.0.1
 
   ensure-gitignore@1.2.0: {}
-
-  entities@1.1.2: {}
 
   entities@2.2.0: {}
 
@@ -14764,14 +14742,12 @@ snapshots:
     optionalDependencies:
       webpack: 5.100.0(@swc/core@1.12.11)(esbuild@0.25.6)(webpack-cli@5.1.4)
 
-  htmlparser2@3.10.1:
+  htmlparser2@5.0.1:
     dependencies:
-      domelementtype: 1.3.1
-      domhandler: 2.4.2
-      domutils: 1.7.0
-      entities: 1.1.2
-      inherits: 2.0.4
-      readable-stream: 3.6.2
+      domelementtype: 2.3.0
+      domhandler: 3.3.0
+      domutils: 2.8.0
+      entities: 2.2.0
 
   htmlparser2@6.1.0:
     dependencies:

--- a/private/puppeteer/appSnapshot.ts
+++ b/private/puppeteer/appSnapshot.ts
@@ -27,6 +27,9 @@ export const getAppSnapshot = async ({
   const errors: string[] = [];
 
   const appPage = await browser.newPage();
+  // Puppeteer, by default, respects standard HTTP caching rules. This can cause mismatches during snapshot testing so we disable it.
+  await appPage.setCacheEnabled(false);
+
   appPage.setDefaultNavigationTimeout(timeout);
 
   appPage.on('console', (msg) => {

--- a/private/puppeteer/appSnapshotSerializer.ts
+++ b/private/puppeteer/appSnapshotSerializer.ts
@@ -22,17 +22,13 @@ export const appSnapshotSerializer: SnapshotSerializer = {
       formattedClientHtml,
       undefined,
       undefined,
-      { ignoreNewlineAtEof: true, context: 3 },
+      { ignoreWhitespace: true, context: Infinity },
     ).trim();
 
-    const isEmptyDiff = htmlDiff === emptyDiff;
-
-    const snapshotItems = [
-      formattedSourceHtml,
-      `POST HYDRATE DIFFS: ${isEmptyDiff ? 'NO DIFF' : `\n${htmlDiff}`}`,
-    ];
-
-    return snapshotItems.join('\n');
+    // If there is no difference between the source and client html then we can just return the source html
+    return htmlDiff === emptyDiff
+      ? [emptyDiff, formattedSourceHtml].join('\n')
+      : htmlDiff;
   },
 
   test: (val) =>

--- a/private/puppeteer/package.json
+++ b/private/puppeteer/package.json
@@ -8,10 +8,9 @@
     "@sku-private/test-utils": "workspace:*",
     "@sku-private/testing-library": "workspace:*",
     "@types/css": "^0.0.38",
-    "@types/diff": "^7.0.1",
     "@types/diffable-html": "^5.0.2",
     "css": "^3.0.0",
-    "diff": "^7.0.0",
-    "diffable-html": "^5.0.0"
+    "diff": "^8.0.2",
+    "diffable-html": "^6.0.1"
   }
 }

--- a/tests/browser/__snapshots__/braid-design-system.test.ts.snap
+++ b/tests/browser/__snapshots__/braid-design-system.test.ts.snap
@@ -2965,184 +2965,163 @@ html._1hjdb9v11 ._1b4ltjxd {
 `;
 
 exports[`braid-design-system > bundler vite > build > should return built jobStreet site 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      rel="stylesheet"
-      href="/vite-client-UQg7MwHG.css"
-      crossorigin
-    >
-    <link
-      rel="modulepreload"
-      href="/vite-client-BevCe62w.js"
-      crossorigin
-    >
-    <script>
-      window.SKU_SITE = 'jobStreet';
-    </script>
-  </head>
-  <body>
-    <div id="app">
-      <style type="text/css">
-        html,body{margin:0;padding:0;background:#fff}
-            html._1hjdb9v11,html._1hjdb9v11 body{color-scheme:dark;background:#1C2330}
-      </style>
-      <div class="_1fmskxf0 co4djb10 co4djb13">
-        <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb9 co4djb8 _1lwixuj4">
-          Hello
-          jobStreet
-          <span class="yw2qws0 _1hjdb9v58">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewbox="0 0 24 24"
-              xml:space="preserve"
-              focusable="false"
-              fill="currentColor"
-              width="16"
-              height="16"
-              class="yw2qws0 v2pdba0 _1hjdb9v58 _1hjdb9v5g _1ltfiyk0 _1ltfiyk2 _1ltfiyk3 _1ltfiyk4"
-              aria-hidden="true"
-            >
-              <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
-              </path>
-            </svg>
-          </span>
-        </span>
-        <div class="yw2qws0 _1hjdb9v8s _1hjdb9v7o _1hjdb9vb0 _1hjdb9v9w _1hjdb9v5g _1hjdb9v6c _1hjdb9vic _1hjdb9v4k _1hjdb9v4d co4djb10 co4djb13 _1hjdb9v34 _1hjdb9v37">
-          <div class="yw2qws0 _1hjdb9v5g">
-            <div class="yw2qws0 _1hjdb9v5c _1hjdb9vic">
-              <input
-                class="yw2qws0 yw2qwse yw2qws9 yw2qws1 yw2qws6 yw2qws7 yw2qws8 yw2qwsd _1hjdb9v5k _1hjdb9v9 _1hjdb9vi _1hjdb9v7 _1b4ltjx4 _1b4ltjx2"
-                type="checkbox"
-                id="id_1"
-                aria-checked="false"
-              >
-              <div class="yw2qws0 _1hjdb9vi0 _1hjdb9v5g _1hjdb9v68 _1b4ltjx5 _1b4ltjx2 co4djb10  _1hjdb9v34">
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjx9 co4djb11 co4djb13 _1hjdb9v22 _1hjdb9v23">
-                  <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v3y _1hjdb9v3z">
-                </span>
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1hjdb9v3q _1hjdb9v3v">
-                </span>
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjxb _1hjdb9v40 _1hjdb9v45">
-                  <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-              </div>
-              <div class="yw2qws0 _1hjdb9vb8 _1hjdb9vi8">
-                <div class="yw2qws0 _1hjdb9v5c _1b4ltjx2 _1b4ltjx6">
-                  <label
-                    class="yw2qws0 _1hjdb9v4 _1hjdb9v50 _1hjdb9vi _9705do0"
-                    for="id_1"
-                  >
-                    <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb9 co4djb8 _1lwixuj4">
-                      This is a checkbox
-                    </span>
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="yw2qws0 inn18b0">
-          🧁 Vanilla content
-          Initial
-        </div>
-      </div>
-    </div>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"site":"jobStreet"}
-    </script>
-    <script
-      type="module"
-      src="/vite-client-BevCe62w.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -154,7 +154,7 @@
+@@ -1,173 +1,173 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       rel="stylesheet"
+       href="/vite-client-UQg7MwHG.css"
+       crossorigin
+     >
+     <link
+       rel="modulepreload"
+       href="/vite-client-BevCe62w.js"
+       crossorigin
+     >
+     <script>
+       window.SKU_SITE = 'jobStreet';
+     </script>
+   </head>
+   <body>
+     <div id="app">
+       <style type="text/css">
+         html,body{margin:0;padding:0;background:#fff}
+             html._1hjdb9v11,html._1hjdb9v11 body{color-scheme:dark;background:#1C2330}
+       </style>
+       <div class="_1fmskxf0 co4djb10 co4djb13">
+         <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb9 co4djb8 _1lwixuj4">
+           Hello
+           jobStreet
+           <span class="yw2qws0 _1hjdb9v58">
+             <svg
+               xmlns="http://www.w3.org/2000/svg"
+               viewbox="0 0 24 24"
+               xml:space="preserve"
+               focusable="false"
+               fill="currentColor"
+               width="16"
+               height="16"
+               class="yw2qws0 v2pdba0 _1hjdb9v58 _1hjdb9v5g _1ltfiyk0 _1ltfiyk2 _1ltfiyk3 _1ltfiyk4"
+               aria-hidden="true"
+             >
+               <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
+               </path>
+             </svg>
+           </span>
+         </span>
+         <div class="yw2qws0 _1hjdb9v8s _1hjdb9v7o _1hjdb9vb0 _1hjdb9v9w _1hjdb9v5g _1hjdb9v6c _1hjdb9vic _1hjdb9v4k _1hjdb9v4d co4djb10 co4djb13 _1hjdb9v34 _1hjdb9v37">
+           <div class="yw2qws0 _1hjdb9v5g">
+             <div class="yw2qws0 _1hjdb9v5c _1hjdb9vic">
+               <input
+                 class="yw2qws0 yw2qwse yw2qws9 yw2qws1 yw2qws6 yw2qws7 yw2qws8 yw2qwsd _1hjdb9v5k _1hjdb9v9 _1hjdb9vi _1hjdb9v7 _1b4ltjx4 _1b4ltjx2"
+                 type="checkbox"
+                 id="id_1"
+                 aria-checked="false"
+               >
+               <div class="yw2qws0 _1hjdb9vi0 _1hjdb9v5g _1hjdb9v68 _1b4ltjx5 _1b4ltjx2 co4djb10  _1hjdb9v34">
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjx9 co4djb11 co4djb13 _1hjdb9v22 _1hjdb9v23">
+                   <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v3y _1hjdb9v3z">
+                 </span>
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1hjdb9v3q _1hjdb9v3v">
+                 </span>
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjxb _1hjdb9v40 _1hjdb9v45">
+                   <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+               </div>
+               <div class="yw2qws0 _1hjdb9vb8 _1hjdb9vi8">
+                 <div class="yw2qws0 _1hjdb9v5c _1b4ltjx2 _1b4ltjx6">
+                   <label
+                     class="yw2qws0 _1hjdb9v4 _1hjdb9v50 _1hjdb9vi _9705do0"
+                     for="id_1"
+                   >
+                     <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb9 co4djb8 _1lwixuj4">
+                       This is a checkbox
+                     </span>
+                   </label>
+                 </div>
+               </div>
+             </div>
+           </div>
          </div>
          <div class="yw2qws0 inn18b0">
            🧁 Vanilla content
@@ -3151,187 +3130,180 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"site":"jobStreet"}
+     </script>
+     <script
+       type="module"
+       src="/vite-client-BevCe62w.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`braid-design-system > bundler vite > build > should return built seekAnz site 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      rel="stylesheet"
-      href="/vite-client-UQg7MwHG.css"
-      crossorigin
-    >
-    <link
-      rel="modulepreload"
-      href="/vite-client-BevCe62w.js"
-      crossorigin
-    >
-    <script>
-      window.SKU_SITE = 'seekAnz';
-    </script>
-  </head>
-  <body>
-    <div id="app">
-      <style type="text/css">
-        html,body{margin:0;padding:0;background:#fff}
-            html._1hjdb9v11,html._1hjdb9v11 body{color-scheme:dark;background:#1C2330}
-      </style>
-      <div class="_1fmskxf0 co4djb10 co4djb13">
-        <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb9 co4djb8 _1lwixuj4">
-          Hello
-          seekAnz
-          <span class="yw2qws0 _1hjdb9v58">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewbox="0 0 24 24"
-              xml:space="preserve"
-              focusable="false"
-              fill="currentColor"
-              width="16"
-              height="16"
-              class="yw2qws0 v2pdba0 _1hjdb9v58 _1hjdb9v5g _1ltfiyk0 _1ltfiyk2 _1ltfiyk3 _1ltfiyk4"
-              aria-hidden="true"
-            >
-              <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
-              </path>
-            </svg>
-          </span>
-        </span>
-        <div class="yw2qws0 _1hjdb9v8s _1hjdb9v7o _1hjdb9vb0 _1hjdb9v9w _1hjdb9v5g _1hjdb9v6c _1hjdb9vic _1hjdb9v4k _1hjdb9v4d co4djb10 co4djb13 _1hjdb9v34 _1hjdb9v37">
-          <div class="yw2qws0 _1hjdb9v5g">
-            <div class="yw2qws0 _1hjdb9v5c _1hjdb9vic">
-              <input
-                class="yw2qws0 yw2qwse yw2qws9 yw2qws1 yw2qws6 yw2qws7 yw2qws8 yw2qwsd _1hjdb9v5k _1hjdb9v9 _1hjdb9vi _1hjdb9v7 _1b4ltjx4 _1b4ltjx2"
-                type="checkbox"
-                id="id_1"
-                aria-checked="false"
-              >
-              <div class="yw2qws0 _1hjdb9vi0 _1hjdb9v5g _1hjdb9v68 _1b4ltjx5 _1b4ltjx2 co4djb10  _1hjdb9v34">
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjx9 co4djb11 co4djb13 _1hjdb9v22 _1hjdb9v23">
-                  <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v3y _1hjdb9v3z">
-                </span>
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1hjdb9v3q _1hjdb9v3v">
-                </span>
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjxb _1hjdb9v40 _1hjdb9v45">
-                  <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-              </div>
-              <div class="yw2qws0 _1hjdb9vb8 _1hjdb9vi8">
-                <div class="yw2qws0 _1hjdb9v5c _1b4ltjx2 _1b4ltjx6">
-                  <label
-                    class="yw2qws0 _1hjdb9v4 _1hjdb9v50 _1hjdb9vi _9705do0"
-                    for="id_1"
-                  >
-                    <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb9 co4djb8 _1lwixuj4">
-                      This is a checkbox
-                    </span>
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="yw2qws0 inn18b0">
-          🧁 Vanilla content
-          Initial
-        </div>
-      </div>
-    </div>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"site":"seekAnz"}
-    </script>
-    <script
-      type="module"
-      src="/vite-client-BevCe62w.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -154,7 +154,7 @@
+@@ -1,173 +1,173 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       rel="stylesheet"
+       href="/vite-client-UQg7MwHG.css"
+       crossorigin
+     >
+     <link
+       rel="modulepreload"
+       href="/vite-client-BevCe62w.js"
+       crossorigin
+     >
+     <script>
+       window.SKU_SITE = 'seekAnz';
+     </script>
+   </head>
+   <body>
+     <div id="app">
+       <style type="text/css">
+         html,body{margin:0;padding:0;background:#fff}
+             html._1hjdb9v11,html._1hjdb9v11 body{color-scheme:dark;background:#1C2330}
+       </style>
+       <div class="_1fmskxf0 co4djb10 co4djb13">
+         <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb9 co4djb8 _1lwixuj4">
+           Hello
+           seekAnz
+           <span class="yw2qws0 _1hjdb9v58">
+             <svg
+               xmlns="http://www.w3.org/2000/svg"
+               viewbox="0 0 24 24"
+               xml:space="preserve"
+               focusable="false"
+               fill="currentColor"
+               width="16"
+               height="16"
+               class="yw2qws0 v2pdba0 _1hjdb9v58 _1hjdb9v5g _1ltfiyk0 _1ltfiyk2 _1ltfiyk3 _1ltfiyk4"
+               aria-hidden="true"
+             >
+               <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
+               </path>
+             </svg>
+           </span>
+         </span>
+         <div class="yw2qws0 _1hjdb9v8s _1hjdb9v7o _1hjdb9vb0 _1hjdb9v9w _1hjdb9v5g _1hjdb9v6c _1hjdb9vic _1hjdb9v4k _1hjdb9v4d co4djb10 co4djb13 _1hjdb9v34 _1hjdb9v37">
+           <div class="yw2qws0 _1hjdb9v5g">
+             <div class="yw2qws0 _1hjdb9v5c _1hjdb9vic">
+               <input
+                 class="yw2qws0 yw2qwse yw2qws9 yw2qws1 yw2qws6 yw2qws7 yw2qws8 yw2qwsd _1hjdb9v5k _1hjdb9v9 _1hjdb9vi _1hjdb9v7 _1b4ltjx4 _1b4ltjx2"
+                 type="checkbox"
+                 id="id_1"
+                 aria-checked="false"
+               >
+               <div class="yw2qws0 _1hjdb9vi0 _1hjdb9v5g _1hjdb9v68 _1b4ltjx5 _1b4ltjx2 co4djb10  _1hjdb9v34">
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjx9 co4djb11 co4djb13 _1hjdb9v22 _1hjdb9v23">
+                   <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v3y _1hjdb9v3z">
+                 </span>
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1hjdb9v3q _1hjdb9v3v">
+                 </span>
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjxb _1hjdb9v40 _1hjdb9v45">
+                   <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+               </div>
+               <div class="yw2qws0 _1hjdb9vb8 _1hjdb9vi8">
+                 <div class="yw2qws0 _1hjdb9v5c _1b4ltjx2 _1b4ltjx6">
+                   <label
+                     class="yw2qws0 _1hjdb9v4 _1hjdb9v50 _1hjdb9vi _9705do0"
+                     for="id_1"
+                   >
+                     <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb9 co4djb8 _1lwixuj4">
+                       This is a checkbox
+                     </span>
+                   </label>
+                 </div>
+               </div>
+             </div>
+           </div>
          </div>
          <div class="yw2qws0 inn18b0">
            🧁 Vanilla content
@@ -3340,4721 +3312,4574 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"site":"seekAnz"}
+     </script>
+     <script
+       type="module"
+       src="/vite-client-BevCe62w.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`braid-design-system > bundler vite > start > should return development jobStreet site 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <style
-      type="text/css"
-      data-vanilla-extract-inline-dev-css
-    >
-      .reset_base__yw2qws0 {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
-  -webkit-tap-highlight-color: transparent;
-}
-.reset_block__yw2qws1 {
-  display: block;
-}
-.reset_body__yw2qws2 {
-  line-height: 1;
-}
-.reset_list__yw2qws3 {
-  list-style: none;
-}
-.reset_quote__yw2qws4 {
-  quotes: none;
-}
-.reset_quote__yw2qws4:before, .reset_quote__yw2qws4:after {
-  content: '';
-}
-.reset_table__yw2qws5 {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-.reset_appearance__yw2qws6 {
-  appearance: none;
-}
-.reset_transparent__yw2qws7 {
-  background-color: transparent;
-}
-.reset_focusVisible__yw2qws8 {
-  outline: var(--focusRingSize__qhrpjv10) solid transparent;
-  transition: outline-color .125s ease;
-}
-.reset_focusVisible__yw2qws8:focus-visible {
-  outline-color: var(--borderColor-focus__qhrpjvm);
-}
-.reset_mark__yw2qwsa {
-  color: inherit;
-}
-.reset_select__yw2qwsb:disabled {
-  opacity: 1;
-}
-.reset_select__yw2qwsb::-ms-expand {
-  display: none;
-}
-.reset_input__yw2qwsd[type="number"] {
-  -moz-appearance: textfield;
-}
-.reset_input__yw2qwsd[type="number"]::-webkit-inner-spin-button,.reset_input__yw2qwsd[type="number"]::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-.reset_input__yw2qwsd::-ms-clear {
-  display: none;
-}
-.reset_input__yw2qwsd::-webkit-search-cancel-button {
-  -webkit-appearance: none;
-}
-.reset_a__yw2qwsg {
-  text-decoration: none;
-  color: inherit;
-}
-.sprinkles_overflow_hidden__1hjdb9v0 {
-  overflow: hidden;
-}
-.sprinkles_overflow_scroll__1hjdb9v1 {
-  overflow: scroll;
-}
-.sprinkles_overflow_visible__1hjdb9v2 {
-  overflow: visible;
-}
-.sprinkles_overflow_auto__1hjdb9v3 {
-  overflow: auto;
-}
-.sprinkles_userSelect_none__1hjdb9v4 {
-  user-select: none;
-}
-.sprinkles_outline_none__1hjdb9v5 {
-  outline: none;
-}
-.sprinkles_outline_focus__1hjdb9v6 {
-  outline: var(--focusRingSize__qhrpjv10) solid transparent;
-  transition: outline-color .125s ease;
-}
-.sprinkles_outline_focus__1hjdb9v6:focus-visible {
-  outline-color: var(--borderColor-focus__qhrpjvm);
-}
-.sprinkles_opacity_0__1hjdb9v7 {
-  opacity: 0;
-}
-.sprinkles_zIndex_0__1hjdb9v8 {
-  z-index: 0;
-}
-.sprinkles_zIndex_1__1hjdb9v9 {
-  z-index: 1;
-}
-.sprinkles_zIndex_2__1hjdb9va {
-  z-index: 2;
-}
-.sprinkles_zIndex_dropdownBackdrop__1hjdb9vb {
-  z-index: 90;
-}
-.sprinkles_zIndex_dropdown__1hjdb9vc {
-  z-index: 100;
-}
-.sprinkles_zIndex_sticky__1hjdb9vd {
-  z-index: 200;
-}
-.sprinkles_zIndex_modalBackdrop__1hjdb9ve {
-  z-index: 290;
-}
-.sprinkles_zIndex_modal__1hjdb9vf {
-  z-index: 300;
-}
-.sprinkles_zIndex_notification__1hjdb9vg {
-  z-index: 400;
-}
-.sprinkles_cursor_default__1hjdb9vh {
-  cursor: default;
-}
-.sprinkles_cursor_pointer__1hjdb9vi {
-  cursor: pointer;
-}
-.sprinkles_pointerEvents_none__1hjdb9vj {
-  pointer-events: none;
-}
-.sprinkles_top_0__1hjdb9vk {
-  top: 0;
-}
-.sprinkles_bottom_0__1hjdb9vl {
-  bottom: 0;
-}
-.sprinkles_left_0__1hjdb9vm {
-  left: 0;
-}
-.sprinkles_right_0__1hjdb9vn {
-  right: 0;
-}
-.sprinkles_height_full__1hjdb9vo {
-  height: 100%;
-}
-.sprinkles_height_touchable__1hjdb9vp {
-  height: var(--touchableSize__qhrpjv9);
-}
-.sprinkles_width_full__1hjdb9vq {
-  width: 100%;
-}
-.sprinkles_width_touchable__1hjdb9vr {
-  width: var(--touchableSize__qhrpjv9);
-}
-.sprinkles_minWidth_0__1hjdb9vs {
-  min-width: 0%;
-}
-.sprinkles_maxWidth_xsmall__1hjdb9vt {
-  max-width: var(--contentWidth-xsmall__qhrpjv11);
-}
-.sprinkles_maxWidth_small__1hjdb9vu {
-  max-width: var(--contentWidth-small__qhrpjv12);
-}
-.sprinkles_maxWidth_medium__1hjdb9vv {
-  max-width: var(--contentWidth-medium__qhrpjv13);
-}
-.sprinkles_maxWidth_large__1hjdb9vw {
-  max-width: var(--contentWidth-large__qhrpjv14);
-}
-.sprinkles_maxWidth_content__1hjdb9vx {
-  max-width: fit-content;
-}
-.sprinkles_transition_fast__1hjdb9vy {
-  transition: var(--transition-fast__qhrpjv5i);
-}
-.sprinkles_transition_touchable__1hjdb9vz {
-  transition: var(--transition-touchable__qhrpjv5j);
-}
-.sprinkles_transform_touchable_active__1hjdb9v10:active {
-  transform: var(--transform-touchable__qhrpjv5k);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_body_lightMode__1hjdb9v12 {
-  background: var(--backgroundColor-body__qhrpjv1t);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_body_darkMode__1hjdb9v13 {
-  background: var(--backgroundColor-body__qhrpjv1t);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_bodyDark_lightMode__1hjdb9v14 {
-  background: var(--backgroundColor-bodyDark__qhrpjv1u);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_bodyDark_darkMode__1hjdb9v15 {
-  background: var(--backgroundColor-bodyDark__qhrpjv1u);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brand_lightMode__1hjdb9v16 {
-  background: var(--backgroundColor-brand__qhrpjv1v);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brand_darkMode__1hjdb9v17 {
-  background: var(--backgroundColor-brand__qhrpjv1v);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccent_lightMode__1hjdb9v18 {
-  background: var(--backgroundColor-brandAccent__qhrpjv1w);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccent_darkMode__1hjdb9v19 {
-  background: var(--backgroundColor-brandAccent__qhrpjv1w);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentActive_lightMode__1hjdb9v1a {
-  background: var(--backgroundColor-brandAccentActive__qhrpjv1x);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentActive_darkMode__1hjdb9v1b {
-  background: var(--backgroundColor-brandAccentActive__qhrpjv1x);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentHover_lightMode__1hjdb9v1c {
-  background: var(--backgroundColor-brandAccentHover__qhrpjv1y);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentHover_darkMode__1hjdb9v1d {
-  background: var(--backgroundColor-brandAccentHover__qhrpjv1y);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentSoft_lightMode__1hjdb9v1e {
-  background: var(--backgroundColor-brandAccentSoft__qhrpjv1z);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentSoft_darkMode__1hjdb9v1f {
-  background: var(--backgroundColor-brandAccentSoft__qhrpjv1z);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentSoftActive_lightMode__1hjdb9v1g {
-  background: var(--backgroundColor-brandAccentSoftActive__qhrpjv20);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentSoftActive_darkMode__1hjdb9v1h {
-  background: var(--backgroundColor-brandAccentSoftActive__qhrpjv20);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentSoftHover_lightMode__1hjdb9v1i {
-  background: var(--backgroundColor-brandAccentSoftHover__qhrpjv21);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentSoftHover_darkMode__1hjdb9v1j {
-  background: var(--backgroundColor-brandAccentSoftHover__qhrpjv21);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_caution_lightMode__1hjdb9v1k {
-  background: var(--backgroundColor-caution__qhrpjv22);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_caution_darkMode__1hjdb9v1l {
-  background: var(--backgroundColor-caution__qhrpjv22);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_cautionLight_lightMode__1hjdb9v1m {
-  background: var(--backgroundColor-cautionLight__qhrpjv23);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_cautionLight_darkMode__1hjdb9v1n {
-  background: var(--backgroundColor-cautionLight__qhrpjv23);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_critical_lightMode__1hjdb9v1o {
-  background: var(--backgroundColor-critical__qhrpjv24);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_critical_darkMode__1hjdb9v1p {
-  background: var(--backgroundColor-critical__qhrpjv24);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalActive_lightMode__1hjdb9v1q {
-  background: var(--backgroundColor-criticalActive__qhrpjv25);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalActive_darkMode__1hjdb9v1r {
-  background: var(--backgroundColor-criticalActive__qhrpjv25);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalHover_lightMode__1hjdb9v1s {
-  background: var(--backgroundColor-criticalHover__qhrpjv26);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalHover_darkMode__1hjdb9v1t {
-  background: var(--backgroundColor-criticalHover__qhrpjv26);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalLight_lightMode__1hjdb9v1u {
-  background: var(--backgroundColor-criticalLight__qhrpjv27);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalLight_darkMode__1hjdb9v1v {
-  background: var(--backgroundColor-criticalLight__qhrpjv27);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalSoft_lightMode__1hjdb9v1w {
-  background: var(--backgroundColor-criticalSoft__qhrpjv28);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalSoft_darkMode__1hjdb9v1x {
-  background: var(--backgroundColor-criticalSoft__qhrpjv28);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalSoftActive_lightMode__1hjdb9v1y {
-  background: var(--backgroundColor-criticalSoftActive__qhrpjv29);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalSoftActive_darkMode__1hjdb9v1z {
-  background: var(--backgroundColor-criticalSoftActive__qhrpjv29);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalSoftHover_lightMode__1hjdb9v20 {
-  background: var(--backgroundColor-criticalSoftHover__qhrpjv2a);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalSoftHover_darkMode__1hjdb9v21 {
-  background: var(--backgroundColor-criticalSoftHover__qhrpjv2a);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccent_lightMode__1hjdb9v22 {
-  background: var(--backgroundColor-formAccent__qhrpjv2b);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccent_darkMode__1hjdb9v23 {
-  background: var(--backgroundColor-formAccent__qhrpjv2b);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentActive_lightMode__1hjdb9v24 {
-  background: var(--backgroundColor-formAccentActive__qhrpjv2c);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentActive_darkMode__1hjdb9v25 {
-  background: var(--backgroundColor-formAccentActive__qhrpjv2c);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentHover_lightMode__1hjdb9v26 {
-  background: var(--backgroundColor-formAccentHover__qhrpjv2d);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentHover_darkMode__1hjdb9v27 {
-  background: var(--backgroundColor-formAccentHover__qhrpjv2d);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentSoft_lightMode__1hjdb9v28 {
-  background: var(--backgroundColor-formAccentSoft__qhrpjv2e);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentSoft_darkMode__1hjdb9v29 {
-  background: var(--backgroundColor-formAccentSoft__qhrpjv2e);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentSoftActive_lightMode__1hjdb9v2a {
-  background: var(--backgroundColor-formAccentSoftActive__qhrpjv2f);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentSoftActive_darkMode__1hjdb9v2b {
-  background: var(--backgroundColor-formAccentSoftActive__qhrpjv2f);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentSoftHover_lightMode__1hjdb9v2c {
-  background: var(--backgroundColor-formAccentSoftHover__qhrpjv2g);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentSoftHover_darkMode__1hjdb9v2d {
-  background: var(--backgroundColor-formAccentSoftHover__qhrpjv2g);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_info_lightMode__1hjdb9v2e {
-  background: var(--backgroundColor-info__qhrpjv2h);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_info_darkMode__1hjdb9v2f {
-  background: var(--backgroundColor-info__qhrpjv2h);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_infoLight_lightMode__1hjdb9v2g {
-  background: var(--backgroundColor-infoLight__qhrpjv2i);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_infoLight_darkMode__1hjdb9v2h {
-  background: var(--backgroundColor-infoLight__qhrpjv2i);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutral_lightMode__1hjdb9v2i {
-  background: var(--backgroundColor-neutral__qhrpjv2j);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutral_darkMode__1hjdb9v2j {
-  background: var(--backgroundColor-neutral__qhrpjv2j);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralActive_lightMode__1hjdb9v2k {
-  background: var(--backgroundColor-neutralActive__qhrpjv2k);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralActive_darkMode__1hjdb9v2l {
-  background: var(--backgroundColor-neutralActive__qhrpjv2k);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralHover_lightMode__1hjdb9v2m {
-  background: var(--backgroundColor-neutralHover__qhrpjv2l);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralHover_darkMode__1hjdb9v2n {
-  background: var(--backgroundColor-neutralHover__qhrpjv2l);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralLight_lightMode__1hjdb9v2o {
-  background: var(--backgroundColor-neutralLight__qhrpjv2m);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralLight_darkMode__1hjdb9v2p {
-  background: var(--backgroundColor-neutralLight__qhrpjv2m);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralSoft_lightMode__1hjdb9v2q {
-  background: var(--backgroundColor-neutralSoft__qhrpjv2n);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralSoft_darkMode__1hjdb9v2r {
-  background: var(--backgroundColor-neutralSoft__qhrpjv2n);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralSoftActive_lightMode__1hjdb9v2s {
-  background: var(--backgroundColor-neutralSoftActive__qhrpjv2o);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralSoftActive_darkMode__1hjdb9v2t {
-  background: var(--backgroundColor-neutralSoftActive__qhrpjv2o);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralSoftHover_lightMode__1hjdb9v2u {
-  background: var(--backgroundColor-neutralSoftHover__qhrpjv2p);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralSoftHover_darkMode__1hjdb9v2v {
-  background: var(--backgroundColor-neutralSoftHover__qhrpjv2p);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_positive_lightMode__1hjdb9v2w {
-  background: var(--backgroundColor-positive__qhrpjv2q);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_positive_darkMode__1hjdb9v2x {
-  background: var(--backgroundColor-positive__qhrpjv2q);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_positiveLight_lightMode__1hjdb9v2y {
-  background: var(--backgroundColor-positiveLight__qhrpjv2r);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_positiveLight_darkMode__1hjdb9v2z {
-  background: var(--backgroundColor-positiveLight__qhrpjv2r);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_promote_lightMode__1hjdb9v30 {
-  background: var(--backgroundColor-promote__qhrpjv2s);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_promote_darkMode__1hjdb9v31 {
-  background: var(--backgroundColor-promote__qhrpjv2s);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_promoteLight_lightMode__1hjdb9v32 {
-  background: var(--backgroundColor-promoteLight__qhrpjv2t);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_promoteLight_darkMode__1hjdb9v33 {
-  background: var(--backgroundColor-promoteLight__qhrpjv2t);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_surface_lightMode__1hjdb9v34 {
-  background: var(--backgroundColor-surface__qhrpjv2u);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_surface_darkMode__1hjdb9v35 {
-  background: var(--backgroundColor-surface__qhrpjv2u);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_surfaceDark_lightMode__1hjdb9v36 {
-  background: var(--backgroundColor-surfaceDark__qhrpjv2v);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_surfaceDark_darkMode__1hjdb9v37 {
-  background: var(--backgroundColor-surfaceDark__qhrpjv2v);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_small_lightMode__1hjdb9v38 {
-  box-shadow: var(--shadow-small__qhrpjv5l);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_small_darkMode__1hjdb9v39 {
-  box-shadow: var(--shadow-small__qhrpjv5l);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_medium_lightMode__1hjdb9v3a {
-  box-shadow: var(--shadow-medium__qhrpjv5m);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_medium_darkMode__1hjdb9v3b {
-  box-shadow: var(--shadow-medium__qhrpjv5m);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_large_lightMode__1hjdb9v3c {
-  box-shadow: var(--shadow-large__qhrpjv5n);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_large_darkMode__1hjdb9v3d {
-  box-shadow: var(--shadow-large__qhrpjv5n);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccent_lightMode__1hjdb9v3e {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccent__qhrpjvf);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccent_darkMode__1hjdb9v3f {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccent__qhrpjvf);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccentLight_lightMode__1hjdb9v3g {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccentLight__qhrpjvg);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccentLight_darkMode__1hjdb9v3h {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccentLight__qhrpjvg);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccentLarge_lightMode__1hjdb9v3i {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccent__qhrpjvf);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccentLarge_darkMode__1hjdb9v3j {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccent__qhrpjvf);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccentLightLarge_lightMode__1hjdb9v3k {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccentLight__qhrpjvg);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccentLightLarge_darkMode__1hjdb9v3l {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccentLight__qhrpjvg);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCaution_lightMode__1hjdb9v3m {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-caution__qhrpjvh);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCaution_darkMode__1hjdb9v3n {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-caution__qhrpjvh);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCautionLight_lightMode__1hjdb9v3o {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-cautionLight__qhrpjvi);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCautionLight_darkMode__1hjdb9v3p {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-cautionLight__qhrpjvi);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCritical_lightMode__1hjdb9v3q {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-critical__qhrpjvj);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCritical_darkMode__1hjdb9v3r {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-critical__qhrpjvj);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCriticalLarge_lightMode__1hjdb9v3s {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-critical__qhrpjvj);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCriticalLarge_darkMode__1hjdb9v3t {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-critical__qhrpjvj);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCriticalLight_lightMode__1hjdb9v3u {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-criticalLight__qhrpjvk);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCriticalLight_darkMode__1hjdb9v3v {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-criticalLight__qhrpjvk);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCriticalLightLarge_lightMode__1hjdb9v3w {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-criticalLight__qhrpjvk);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCriticalLightLarge_darkMode__1hjdb9v3x {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-criticalLight__qhrpjvk);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderField_lightMode__1hjdb9v3y {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-field__qhrpjvl);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderField_darkMode__1hjdb9v3z {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-field__qhrpjvl);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccent_lightMode__1hjdb9v40 {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccent__qhrpjvn);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccent_darkMode__1hjdb9v41 {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccent__qhrpjvn);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccentLarge_lightMode__1hjdb9v42 {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccent__qhrpjvn);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccentLarge_darkMode__1hjdb9v43 {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccent__qhrpjvn);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccentLight_lightMode__1hjdb9v44 {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccentLight__qhrpjvo);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccentLight_darkMode__1hjdb9v45 {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccentLight__qhrpjvo);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccentLightLarge_lightMode__1hjdb9v46 {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccentLight__qhrpjvo);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccentLightLarge_darkMode__1hjdb9v47 {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccentLight__qhrpjvo);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderInfo_lightMode__1hjdb9v48 {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-info__qhrpjvp);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderInfo_darkMode__1hjdb9v49 {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-info__qhrpjvp);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderInfoLight_lightMode__1hjdb9v4a {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-infoLight__qhrpjvq);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderInfoLight_darkMode__1hjdb9v4b {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-infoLight__qhrpjvq);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutral_lightMode__1hjdb9v4c {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutral__qhrpjvr);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutral_darkMode__1hjdb9v4d {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutral__qhrpjvr);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralLarge_lightMode__1hjdb9v4e {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutral__qhrpjvr);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralLarge_darkMode__1hjdb9v4f {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutral__qhrpjvr);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralInverted_lightMode__1hjdb9v4g {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralInverted__qhrpjvs);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralInverted_darkMode__1hjdb9v4h {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralInverted__qhrpjvs);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralInvertedLarge_lightMode__1hjdb9v4i {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutralInverted__qhrpjvs);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralInvertedLarge_darkMode__1hjdb9v4j {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutralInverted__qhrpjvs);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralLight_lightMode__1hjdb9v4k {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralLight__qhrpjvt);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralLight_darkMode__1hjdb9v4l {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralLight__qhrpjvt);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPositive_lightMode__1hjdb9v4m {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positive__qhrpjvu);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPositive_darkMode__1hjdb9v4n {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positive__qhrpjvu);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPositiveLight_lightMode__1hjdb9v4o {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positiveLight__qhrpjvv);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPositiveLight_darkMode__1hjdb9v4p {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positiveLight__qhrpjvv);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPromote_lightMode__1hjdb9v4q {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promote__qhrpjvw);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPromote_darkMode__1hjdb9v4r {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promote__qhrpjvw);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPromoteLight_lightMode__1hjdb9v4s {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promoteLight__qhrpjvx);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPromoteLight_darkMode__1hjdb9v4t {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promoteLight__qhrpjvx);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_outlineFocus_lightMode__1hjdb9v4u {
-  box-shadow: 0 0 0 var(--focusRingSize__qhrpjv10) var(--borderColor-focus__qhrpjvm);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_outlineFocus_darkMode__1hjdb9v4v {
-  box-shadow: 0 0 0 var(--focusRingSize__qhrpjv10) var(--borderColor-focus__qhrpjvm);
-}
-.sprinkles_display_none_mobile__1hjdb9v4w {
-  display: none;
-}
-.sprinkles_display_block_mobile__1hjdb9v50 {
-  display: block;
-}
-.sprinkles_display_inline_mobile__1hjdb9v54 {
-  display: inline;
-}
-.sprinkles_display_inlineBlock_mobile__1hjdb9v58 {
-  display: inline-block;
-}
-.sprinkles_display_flex_mobile__1hjdb9v5c {
-  display: flex;
-}
-.sprinkles_position_relative_mobile__1hjdb9v5g {
-  position: relative;
-}
-.sprinkles_position_absolute_mobile__1hjdb9v5k {
-  position: absolute;
-}
-.sprinkles_position_fixed_mobile__1hjdb9v5o {
-  position: fixed;
-}
-.sprinkles_position_sticky_mobile__1hjdb9v5s {
-  position: sticky;
-}
-.sprinkles_borderRadius_none_mobile__1hjdb9v5w {
-  border-radius: 0px;
-}
-.sprinkles_borderRadius_full_mobile__1hjdb9v60 {
-  border-radius: 9999px;
-}
-.sprinkles_borderRadius_small_mobile__1hjdb9v64 {
-  border-radius: var(--borderRadius-small__qhrpjvb);
-}
-.sprinkles_borderRadius_standard_mobile__1hjdb9v68 {
-  border-radius: var(--borderRadius-standard__qhrpjvc);
-}
-.sprinkles_borderRadius_large_mobile__1hjdb9v6c {
-  border-radius: var(--borderRadius-large__qhrpjvd);
-}
-.sprinkles_borderRadius_xlarge_mobile__1hjdb9v6g {
-  border-radius: var(--borderRadius-xlarge__qhrpjve);
-}
-.sprinkles_gap_gutter_mobile__1hjdb9v6k {
-  gap: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_gap_xxsmall_mobile__1hjdb9v6o {
-  gap: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_gap_xsmall_mobile__1hjdb9v6s {
-  gap: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_gap_small_mobile__1hjdb9v6w {
-  gap: var(--space-small__qhrpjv3);
-}
-.sprinkles_gap_medium_mobile__1hjdb9v70 {
-  gap: var(--space-medium__qhrpjv4);
-}
-.sprinkles_gap_large_mobile__1hjdb9v74 {
-  gap: var(--space-large__qhrpjv5);
-}
-.sprinkles_gap_xlarge_mobile__1hjdb9v78 {
-  gap: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_gap_xxlarge_mobile__1hjdb9v7c {
-  gap: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_gap_xxxlarge_mobile__1hjdb9v7g {
-  gap: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_gap_none_mobile__1hjdb9v7k {
-  gap: 0;
-}
-.sprinkles_paddingTop_gutter_mobile__1hjdb9v7o {
-  padding-top: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_paddingTop_xxsmall_mobile__1hjdb9v7s {
-  padding-top: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_paddingTop_xsmall_mobile__1hjdb9v7w {
-  padding-top: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_paddingTop_small_mobile__1hjdb9v80 {
-  padding-top: var(--space-small__qhrpjv3);
-}
-.sprinkles_paddingTop_medium_mobile__1hjdb9v84 {
-  padding-top: var(--space-medium__qhrpjv4);
-}
-.sprinkles_paddingTop_large_mobile__1hjdb9v88 {
-  padding-top: var(--space-large__qhrpjv5);
-}
-.sprinkles_paddingTop_xlarge_mobile__1hjdb9v8c {
-  padding-top: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_paddingTop_xxlarge_mobile__1hjdb9v8g {
-  padding-top: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_paddingTop_xxxlarge_mobile__1hjdb9v8k {
-  padding-top: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_paddingTop_none_mobile__1hjdb9v8o {
-  padding-top: 0;
-}
-.sprinkles_paddingBottom_gutter_mobile__1hjdb9v8s {
-  padding-bottom: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_paddingBottom_xxsmall_mobile__1hjdb9v8w {
-  padding-bottom: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_paddingBottom_xsmall_mobile__1hjdb9v90 {
-  padding-bottom: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_paddingBottom_small_mobile__1hjdb9v94 {
-  padding-bottom: var(--space-small__qhrpjv3);
-}
-.sprinkles_paddingBottom_medium_mobile__1hjdb9v98 {
-  padding-bottom: var(--space-medium__qhrpjv4);
-}
-.sprinkles_paddingBottom_large_mobile__1hjdb9v9c {
-  padding-bottom: var(--space-large__qhrpjv5);
-}
-.sprinkles_paddingBottom_xlarge_mobile__1hjdb9v9g {
-  padding-bottom: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_paddingBottom_xxlarge_mobile__1hjdb9v9k {
-  padding-bottom: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_paddingBottom_xxxlarge_mobile__1hjdb9v9o {
-  padding-bottom: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_paddingBottom_none_mobile__1hjdb9v9s {
-  padding-bottom: 0;
-}
-.sprinkles_paddingRight_gutter_mobile__1hjdb9v9w {
-  padding-right: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_paddingRight_xxsmall_mobile__1hjdb9va0 {
-  padding-right: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_paddingRight_xsmall_mobile__1hjdb9va4 {
-  padding-right: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_paddingRight_small_mobile__1hjdb9va8 {
-  padding-right: var(--space-small__qhrpjv3);
-}
-.sprinkles_paddingRight_medium_mobile__1hjdb9vac {
-  padding-right: var(--space-medium__qhrpjv4);
-}
-.sprinkles_paddingRight_large_mobile__1hjdb9vag {
-  padding-right: var(--space-large__qhrpjv5);
-}
-.sprinkles_paddingRight_xlarge_mobile__1hjdb9vak {
-  padding-right: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_paddingRight_xxlarge_mobile__1hjdb9vao {
-  padding-right: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_paddingRight_xxxlarge_mobile__1hjdb9vas {
-  padding-right: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_paddingRight_none_mobile__1hjdb9vaw {
-  padding-right: 0;
-}
-.sprinkles_paddingLeft_gutter_mobile__1hjdb9vb0 {
-  padding-left: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_paddingLeft_xxsmall_mobile__1hjdb9vb4 {
-  padding-left: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_paddingLeft_xsmall_mobile__1hjdb9vb8 {
-  padding-left: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_paddingLeft_small_mobile__1hjdb9vbc {
-  padding-left: var(--space-small__qhrpjv3);
-}
-.sprinkles_paddingLeft_medium_mobile__1hjdb9vbg {
-  padding-left: var(--space-medium__qhrpjv4);
-}
-.sprinkles_paddingLeft_large_mobile__1hjdb9vbk {
-  padding-left: var(--space-large__qhrpjv5);
-}
-.sprinkles_paddingLeft_xlarge_mobile__1hjdb9vbo {
-  padding-left: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_paddingLeft_xxlarge_mobile__1hjdb9vbs {
-  padding-left: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_paddingLeft_xxxlarge_mobile__1hjdb9vbw {
-  padding-left: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_paddingLeft_none_mobile__1hjdb9vc0 {
-  padding-left: 0;
-}
-.sprinkles_marginTop_gutter_mobile__1hjdb9vc4 {
-  margin-top: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_marginTop_xxsmall_mobile__1hjdb9vc8 {
-  margin-top: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_marginTop_xsmall_mobile__1hjdb9vcc {
-  margin-top: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_marginTop_small_mobile__1hjdb9vcg {
-  margin-top: var(--space-small__qhrpjv3);
-}
-.sprinkles_marginTop_medium_mobile__1hjdb9vck {
-  margin-top: var(--space-medium__qhrpjv4);
-}
-.sprinkles_marginTop_large_mobile__1hjdb9vco {
-  margin-top: var(--space-large__qhrpjv5);
-}
-.sprinkles_marginTop_xlarge_mobile__1hjdb9vcs {
-  margin-top: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_marginTop_xxlarge_mobile__1hjdb9vcw {
-  margin-top: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_marginTop_xxxlarge_mobile__1hjdb9vd0 {
-  margin-top: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_marginTop_none_mobile__1hjdb9vd4 {
-  margin-top: 0;
-}
-.sprinkles_marginBottom_gutter_mobile__1hjdb9vd8 {
-  margin-bottom: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_marginBottom_xxsmall_mobile__1hjdb9vdc {
-  margin-bottom: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_marginBottom_xsmall_mobile__1hjdb9vdg {
-  margin-bottom: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_marginBottom_small_mobile__1hjdb9vdk {
-  margin-bottom: var(--space-small__qhrpjv3);
-}
-.sprinkles_marginBottom_medium_mobile__1hjdb9vdo {
-  margin-bottom: var(--space-medium__qhrpjv4);
-}
-.sprinkles_marginBottom_large_mobile__1hjdb9vds {
-  margin-bottom: var(--space-large__qhrpjv5);
-}
-.sprinkles_marginBottom_xlarge_mobile__1hjdb9vdw {
-  margin-bottom: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_marginBottom_xxlarge_mobile__1hjdb9ve0 {
-  margin-bottom: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_marginBottom_xxxlarge_mobile__1hjdb9ve4 {
-  margin-bottom: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_marginBottom_none_mobile__1hjdb9ve8 {
-  margin-bottom: 0;
-}
-.sprinkles_marginRight_gutter_mobile__1hjdb9vec {
-  margin-right: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_marginRight_xxsmall_mobile__1hjdb9veg {
-  margin-right: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_marginRight_xsmall_mobile__1hjdb9vek {
-  margin-right: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_marginRight_small_mobile__1hjdb9veo {
-  margin-right: var(--space-small__qhrpjv3);
-}
-.sprinkles_marginRight_medium_mobile__1hjdb9ves {
-  margin-right: var(--space-medium__qhrpjv4);
-}
-.sprinkles_marginRight_large_mobile__1hjdb9vew {
-  margin-right: var(--space-large__qhrpjv5);
-}
-.sprinkles_marginRight_xlarge_mobile__1hjdb9vf0 {
-  margin-right: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_marginRight_xxlarge_mobile__1hjdb9vf4 {
-  margin-right: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_marginRight_xxxlarge_mobile__1hjdb9vf8 {
-  margin-right: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_marginRight_none_mobile__1hjdb9vfc {
-  margin-right: 0;
-}
-.sprinkles_marginLeft_gutter_mobile__1hjdb9vfg {
-  margin-left: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_marginLeft_xxsmall_mobile__1hjdb9vfk {
-  margin-left: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_marginLeft_xsmall_mobile__1hjdb9vfo {
-  margin-left: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_marginLeft_small_mobile__1hjdb9vfs {
-  margin-left: var(--space-small__qhrpjv3);
-}
-.sprinkles_marginLeft_medium_mobile__1hjdb9vfw {
-  margin-left: var(--space-medium__qhrpjv4);
-}
-.sprinkles_marginLeft_large_mobile__1hjdb9vg0 {
-  margin-left: var(--space-large__qhrpjv5);
-}
-.sprinkles_marginLeft_xlarge_mobile__1hjdb9vg4 {
-  margin-left: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_marginLeft_xxlarge_mobile__1hjdb9vg8 {
-  margin-left: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_marginLeft_xxxlarge_mobile__1hjdb9vgc {
-  margin-left: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_marginLeft_none_mobile__1hjdb9vgg {
-  margin-left: 0;
-}
-.sprinkles_alignItems_flexStart_mobile__1hjdb9vgk {
-  align-items: flex-start;
-}
-.sprinkles_alignItems_center_mobile__1hjdb9vgo {
-  align-items: center;
-}
-.sprinkles_alignItems_flexEnd_mobile__1hjdb9vgs {
-  align-items: flex-end;
-}
-.sprinkles_justifyContent_flexStart_mobile__1hjdb9vgw {
-  justify-content: flex-start;
-}
-.sprinkles_justifyContent_center_mobile__1hjdb9vh0 {
-  justify-content: center;
-}
-.sprinkles_justifyContent_flexEnd_mobile__1hjdb9vh4 {
-  justify-content: flex-end;
-}
-.sprinkles_justifyContent_spaceBetween_mobile__1hjdb9vh8 {
-  justify-content: space-between;
-}
-.sprinkles_flexDirection_row_mobile__1hjdb9vhc {
-  flex-direction: row;
-}
-.sprinkles_flexDirection_rowReverse_mobile__1hjdb9vhg {
-  flex-direction: row-reverse;
-}
-.sprinkles_flexDirection_column_mobile__1hjdb9vhk {
-  flex-direction: column;
-}
-.sprinkles_flexDirection_columnReverse_mobile__1hjdb9vho {
-  flex-direction: column-reverse;
-}
-.sprinkles_flexWrap_wrap_mobile__1hjdb9vhs {
-  flex-wrap: wrap;
-}
-.sprinkles_flexWrap_nowrap_mobile__1hjdb9vhw {
-  flex-wrap: nowrap;
-}
-.sprinkles_flexShrink_0_mobile__1hjdb9vi0 {
-  flex-shrink: 0;
-}
-.sprinkles_flexGrow_0_mobile__1hjdb9vi4 {
-  flex-grow: 0;
-}
-.sprinkles_flexGrow_1_mobile__1hjdb9vi8 {
-  flex-grow: 1;
-}
-.sprinkles_textAlign_left_mobile__1hjdb9vic {
-  text-align: left;
-}
-.sprinkles_textAlign_center_mobile__1hjdb9vig {
-  text-align: center;
-}
-.sprinkles_textAlign_right_mobile__1hjdb9vik {
-  text-align: right;
-}
-@media screen and (min-width: 740px) {
-  .sprinkles_display_none_tablet__1hjdb9v4x {
-    display: none;
-  }
-  .sprinkles_display_block_tablet__1hjdb9v51 {
-    display: block;
-  }
-  .sprinkles_display_inline_tablet__1hjdb9v55 {
-    display: inline;
-  }
-  .sprinkles_display_inlineBlock_tablet__1hjdb9v59 {
-    display: inline-block;
-  }
-  .sprinkles_display_flex_tablet__1hjdb9v5d {
-    display: flex;
-  }
-  .sprinkles_position_relative_tablet__1hjdb9v5h {
-    position: relative;
-  }
-  .sprinkles_position_absolute_tablet__1hjdb9v5l {
-    position: absolute;
-  }
-  .sprinkles_position_fixed_tablet__1hjdb9v5p {
-    position: fixed;
-  }
-  .sprinkles_position_sticky_tablet__1hjdb9v5t {
-    position: sticky;
-  }
-  .sprinkles_borderRadius_none_tablet__1hjdb9v5x {
-    border-radius: 0px;
-  }
-  .sprinkles_borderRadius_full_tablet__1hjdb9v61 {
-    border-radius: 9999px;
-  }
-  .sprinkles_borderRadius_small_tablet__1hjdb9v65 {
-    border-radius: var(--borderRadius-small__qhrpjvb);
-  }
-  .sprinkles_borderRadius_standard_tablet__1hjdb9v69 {
-    border-radius: var(--borderRadius-standard__qhrpjvc);
-  }
-  .sprinkles_borderRadius_large_tablet__1hjdb9v6d {
-    border-radius: var(--borderRadius-large__qhrpjvd);
-  }
-  .sprinkles_borderRadius_xlarge_tablet__1hjdb9v6h {
-    border-radius: var(--borderRadius-xlarge__qhrpjve);
-  }
-  .sprinkles_gap_gutter_tablet__1hjdb9v6l {
-    gap: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_gap_xxsmall_tablet__1hjdb9v6p {
-    gap: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_gap_xsmall_tablet__1hjdb9v6t {
-    gap: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_gap_small_tablet__1hjdb9v6x {
-    gap: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_gap_medium_tablet__1hjdb9v71 {
-    gap: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_gap_large_tablet__1hjdb9v75 {
-    gap: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_gap_xlarge_tablet__1hjdb9v79 {
-    gap: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_gap_xxlarge_tablet__1hjdb9v7d {
-    gap: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_gap_xxxlarge_tablet__1hjdb9v7h {
-    gap: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_gap_none_tablet__1hjdb9v7l {
-    gap: 0;
-  }
-  .sprinkles_paddingTop_gutter_tablet__1hjdb9v7p {
-    padding-top: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingTop_xxsmall_tablet__1hjdb9v7t {
-    padding-top: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingTop_xsmall_tablet__1hjdb9v7x {
-    padding-top: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingTop_small_tablet__1hjdb9v81 {
-    padding-top: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingTop_medium_tablet__1hjdb9v85 {
-    padding-top: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingTop_large_tablet__1hjdb9v89 {
-    padding-top: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingTop_xlarge_tablet__1hjdb9v8d {
-    padding-top: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingTop_xxlarge_tablet__1hjdb9v8h {
-    padding-top: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingTop_xxxlarge_tablet__1hjdb9v8l {
-    padding-top: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingTop_none_tablet__1hjdb9v8p {
-    padding-top: 0;
-  }
-  .sprinkles_paddingBottom_gutter_tablet__1hjdb9v8t {
-    padding-bottom: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingBottom_xxsmall_tablet__1hjdb9v8x {
-    padding-bottom: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingBottom_xsmall_tablet__1hjdb9v91 {
-    padding-bottom: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingBottom_small_tablet__1hjdb9v95 {
-    padding-bottom: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingBottom_medium_tablet__1hjdb9v99 {
-    padding-bottom: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingBottom_large_tablet__1hjdb9v9d {
-    padding-bottom: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingBottom_xlarge_tablet__1hjdb9v9h {
-    padding-bottom: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingBottom_xxlarge_tablet__1hjdb9v9l {
-    padding-bottom: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingBottom_xxxlarge_tablet__1hjdb9v9p {
-    padding-bottom: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingBottom_none_tablet__1hjdb9v9t {
-    padding-bottom: 0;
-  }
-  .sprinkles_paddingRight_gutter_tablet__1hjdb9v9x {
-    padding-right: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingRight_xxsmall_tablet__1hjdb9va1 {
-    padding-right: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingRight_xsmall_tablet__1hjdb9va5 {
-    padding-right: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingRight_small_tablet__1hjdb9va9 {
-    padding-right: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingRight_medium_tablet__1hjdb9vad {
-    padding-right: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingRight_large_tablet__1hjdb9vah {
-    padding-right: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingRight_xlarge_tablet__1hjdb9val {
-    padding-right: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingRight_xxlarge_tablet__1hjdb9vap {
-    padding-right: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingRight_xxxlarge_tablet__1hjdb9vat {
-    padding-right: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingRight_none_tablet__1hjdb9vax {
-    padding-right: 0;
-  }
-  .sprinkles_paddingLeft_gutter_tablet__1hjdb9vb1 {
-    padding-left: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingLeft_xxsmall_tablet__1hjdb9vb5 {
-    padding-left: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingLeft_xsmall_tablet__1hjdb9vb9 {
-    padding-left: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingLeft_small_tablet__1hjdb9vbd {
-    padding-left: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingLeft_medium_tablet__1hjdb9vbh {
-    padding-left: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingLeft_large_tablet__1hjdb9vbl {
-    padding-left: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingLeft_xlarge_tablet__1hjdb9vbp {
-    padding-left: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingLeft_xxlarge_tablet__1hjdb9vbt {
-    padding-left: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingLeft_xxxlarge_tablet__1hjdb9vbx {
-    padding-left: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingLeft_none_tablet__1hjdb9vc1 {
-    padding-left: 0;
-  }
-  .sprinkles_marginTop_gutter_tablet__1hjdb9vc5 {
-    margin-top: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginTop_xxsmall_tablet__1hjdb9vc9 {
-    margin-top: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginTop_xsmall_tablet__1hjdb9vcd {
-    margin-top: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginTop_small_tablet__1hjdb9vch {
-    margin-top: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginTop_medium_tablet__1hjdb9vcl {
-    margin-top: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginTop_large_tablet__1hjdb9vcp {
-    margin-top: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginTop_xlarge_tablet__1hjdb9vct {
-    margin-top: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginTop_xxlarge_tablet__1hjdb9vcx {
-    margin-top: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginTop_xxxlarge_tablet__1hjdb9vd1 {
-    margin-top: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginTop_none_tablet__1hjdb9vd5 {
-    margin-top: 0;
-  }
-  .sprinkles_marginBottom_gutter_tablet__1hjdb9vd9 {
-    margin-bottom: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginBottom_xxsmall_tablet__1hjdb9vdd {
-    margin-bottom: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginBottom_xsmall_tablet__1hjdb9vdh {
-    margin-bottom: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginBottom_small_tablet__1hjdb9vdl {
-    margin-bottom: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginBottom_medium_tablet__1hjdb9vdp {
-    margin-bottom: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginBottom_large_tablet__1hjdb9vdt {
-    margin-bottom: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginBottom_xlarge_tablet__1hjdb9vdx {
-    margin-bottom: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginBottom_xxlarge_tablet__1hjdb9ve1 {
-    margin-bottom: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginBottom_xxxlarge_tablet__1hjdb9ve5 {
-    margin-bottom: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginBottom_none_tablet__1hjdb9ve9 {
-    margin-bottom: 0;
-  }
-  .sprinkles_marginRight_gutter_tablet__1hjdb9ved {
-    margin-right: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginRight_xxsmall_tablet__1hjdb9veh {
-    margin-right: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginRight_xsmall_tablet__1hjdb9vel {
-    margin-right: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginRight_small_tablet__1hjdb9vep {
-    margin-right: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginRight_medium_tablet__1hjdb9vet {
-    margin-right: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginRight_large_tablet__1hjdb9vex {
-    margin-right: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginRight_xlarge_tablet__1hjdb9vf1 {
-    margin-right: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginRight_xxlarge_tablet__1hjdb9vf5 {
-    margin-right: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginRight_xxxlarge_tablet__1hjdb9vf9 {
-    margin-right: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginRight_none_tablet__1hjdb9vfd {
-    margin-right: 0;
-  }
-  .sprinkles_marginLeft_gutter_tablet__1hjdb9vfh {
-    margin-left: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginLeft_xxsmall_tablet__1hjdb9vfl {
-    margin-left: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginLeft_xsmall_tablet__1hjdb9vfp {
-    margin-left: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginLeft_small_tablet__1hjdb9vft {
-    margin-left: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginLeft_medium_tablet__1hjdb9vfx {
-    margin-left: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginLeft_large_tablet__1hjdb9vg1 {
-    margin-left: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginLeft_xlarge_tablet__1hjdb9vg5 {
-    margin-left: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginLeft_xxlarge_tablet__1hjdb9vg9 {
-    margin-left: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginLeft_xxxlarge_tablet__1hjdb9vgd {
-    margin-left: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginLeft_none_tablet__1hjdb9vgh {
-    margin-left: 0;
-  }
-  .sprinkles_alignItems_flexStart_tablet__1hjdb9vgl {
-    align-items: flex-start;
-  }
-  .sprinkles_alignItems_center_tablet__1hjdb9vgp {
-    align-items: center;
-  }
-  .sprinkles_alignItems_flexEnd_tablet__1hjdb9vgt {
-    align-items: flex-end;
-  }
-  .sprinkles_justifyContent_flexStart_tablet__1hjdb9vgx {
-    justify-content: flex-start;
-  }
-  .sprinkles_justifyContent_center_tablet__1hjdb9vh1 {
-    justify-content: center;
-  }
-  .sprinkles_justifyContent_flexEnd_tablet__1hjdb9vh5 {
-    justify-content: flex-end;
-  }
-  .sprinkles_justifyContent_spaceBetween_tablet__1hjdb9vh9 {
-    justify-content: space-between;
-  }
-  .sprinkles_flexDirection_row_tablet__1hjdb9vhd {
-    flex-direction: row;
-  }
-  .sprinkles_flexDirection_rowReverse_tablet__1hjdb9vhh {
-    flex-direction: row-reverse;
-  }
-  .sprinkles_flexDirection_column_tablet__1hjdb9vhl {
-    flex-direction: column;
-  }
-  .sprinkles_flexDirection_columnReverse_tablet__1hjdb9vhp {
-    flex-direction: column-reverse;
-  }
-  .sprinkles_flexWrap_wrap_tablet__1hjdb9vht {
-    flex-wrap: wrap;
-  }
-  .sprinkles_flexWrap_nowrap_tablet__1hjdb9vhx {
-    flex-wrap: nowrap;
-  }
-  .sprinkles_flexShrink_0_tablet__1hjdb9vi1 {
-    flex-shrink: 0;
-  }
-  .sprinkles_flexGrow_0_tablet__1hjdb9vi5 {
-    flex-grow: 0;
-  }
-  .sprinkles_flexGrow_1_tablet__1hjdb9vi9 {
-    flex-grow: 1;
-  }
-  .sprinkles_textAlign_left_tablet__1hjdb9vid {
-    text-align: left;
-  }
-  .sprinkles_textAlign_center_tablet__1hjdb9vih {
-    text-align: center;
-  }
-  .sprinkles_textAlign_right_tablet__1hjdb9vil {
-    text-align: right;
-  }
-}
-@media screen and (min-width: 992px) {
-  .sprinkles_display_none_desktop__1hjdb9v4y {
-    display: none;
-  }
-  .sprinkles_display_block_desktop__1hjdb9v52 {
-    display: block;
-  }
-  .sprinkles_display_inline_desktop__1hjdb9v56 {
-    display: inline;
-  }
-  .sprinkles_display_inlineBlock_desktop__1hjdb9v5a {
-    display: inline-block;
-  }
-  .sprinkles_display_flex_desktop__1hjdb9v5e {
-    display: flex;
-  }
-  .sprinkles_position_relative_desktop__1hjdb9v5i {
-    position: relative;
-  }
-  .sprinkles_position_absolute_desktop__1hjdb9v5m {
-    position: absolute;
-  }
-  .sprinkles_position_fixed_desktop__1hjdb9v5q {
-    position: fixed;
-  }
-  .sprinkles_position_sticky_desktop__1hjdb9v5u {
-    position: sticky;
-  }
-  .sprinkles_borderRadius_none_desktop__1hjdb9v5y {
-    border-radius: 0px;
-  }
-  .sprinkles_borderRadius_full_desktop__1hjdb9v62 {
-    border-radius: 9999px;
-  }
-  .sprinkles_borderRadius_small_desktop__1hjdb9v66 {
-    border-radius: var(--borderRadius-small__qhrpjvb);
-  }
-  .sprinkles_borderRadius_standard_desktop__1hjdb9v6a {
-    border-radius: var(--borderRadius-standard__qhrpjvc);
-  }
-  .sprinkles_borderRadius_large_desktop__1hjdb9v6e {
-    border-radius: var(--borderRadius-large__qhrpjvd);
-  }
-  .sprinkles_borderRadius_xlarge_desktop__1hjdb9v6i {
-    border-radius: var(--borderRadius-xlarge__qhrpjve);
-  }
-  .sprinkles_gap_gutter_desktop__1hjdb9v6m {
-    gap: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_gap_xxsmall_desktop__1hjdb9v6q {
-    gap: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_gap_xsmall_desktop__1hjdb9v6u {
-    gap: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_gap_small_desktop__1hjdb9v6y {
-    gap: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_gap_medium_desktop__1hjdb9v72 {
-    gap: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_gap_large_desktop__1hjdb9v76 {
-    gap: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_gap_xlarge_desktop__1hjdb9v7a {
-    gap: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_gap_xxlarge_desktop__1hjdb9v7e {
-    gap: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_gap_xxxlarge_desktop__1hjdb9v7i {
-    gap: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_gap_none_desktop__1hjdb9v7m {
-    gap: 0;
-  }
-  .sprinkles_paddingTop_gutter_desktop__1hjdb9v7q {
-    padding-top: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingTop_xxsmall_desktop__1hjdb9v7u {
-    padding-top: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingTop_xsmall_desktop__1hjdb9v7y {
-    padding-top: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingTop_small_desktop__1hjdb9v82 {
-    padding-top: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingTop_medium_desktop__1hjdb9v86 {
-    padding-top: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingTop_large_desktop__1hjdb9v8a {
-    padding-top: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingTop_xlarge_desktop__1hjdb9v8e {
-    padding-top: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingTop_xxlarge_desktop__1hjdb9v8i {
-    padding-top: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingTop_xxxlarge_desktop__1hjdb9v8m {
-    padding-top: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingTop_none_desktop__1hjdb9v8q {
-    padding-top: 0;
-  }
-  .sprinkles_paddingBottom_gutter_desktop__1hjdb9v8u {
-    padding-bottom: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingBottom_xxsmall_desktop__1hjdb9v8y {
-    padding-bottom: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingBottom_xsmall_desktop__1hjdb9v92 {
-    padding-bottom: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingBottom_small_desktop__1hjdb9v96 {
-    padding-bottom: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingBottom_medium_desktop__1hjdb9v9a {
-    padding-bottom: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingBottom_large_desktop__1hjdb9v9e {
-    padding-bottom: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingBottom_xlarge_desktop__1hjdb9v9i {
-    padding-bottom: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingBottom_xxlarge_desktop__1hjdb9v9m {
-    padding-bottom: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingBottom_xxxlarge_desktop__1hjdb9v9q {
-    padding-bottom: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingBottom_none_desktop__1hjdb9v9u {
-    padding-bottom: 0;
-  }
-  .sprinkles_paddingRight_gutter_desktop__1hjdb9v9y {
-    padding-right: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingRight_xxsmall_desktop__1hjdb9va2 {
-    padding-right: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingRight_xsmall_desktop__1hjdb9va6 {
-    padding-right: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingRight_small_desktop__1hjdb9vaa {
-    padding-right: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingRight_medium_desktop__1hjdb9vae {
-    padding-right: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingRight_large_desktop__1hjdb9vai {
-    padding-right: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingRight_xlarge_desktop__1hjdb9vam {
-    padding-right: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingRight_xxlarge_desktop__1hjdb9vaq {
-    padding-right: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingRight_xxxlarge_desktop__1hjdb9vau {
-    padding-right: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingRight_none_desktop__1hjdb9vay {
-    padding-right: 0;
-  }
-  .sprinkles_paddingLeft_gutter_desktop__1hjdb9vb2 {
-    padding-left: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingLeft_xxsmall_desktop__1hjdb9vb6 {
-    padding-left: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingLeft_xsmall_desktop__1hjdb9vba {
-    padding-left: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingLeft_small_desktop__1hjdb9vbe {
-    padding-left: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingLeft_medium_desktop__1hjdb9vbi {
-    padding-left: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingLeft_large_desktop__1hjdb9vbm {
-    padding-left: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingLeft_xlarge_desktop__1hjdb9vbq {
-    padding-left: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingLeft_xxlarge_desktop__1hjdb9vbu {
-    padding-left: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingLeft_xxxlarge_desktop__1hjdb9vby {
-    padding-left: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingLeft_none_desktop__1hjdb9vc2 {
-    padding-left: 0;
-  }
-  .sprinkles_marginTop_gutter_desktop__1hjdb9vc6 {
-    margin-top: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginTop_xxsmall_desktop__1hjdb9vca {
-    margin-top: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginTop_xsmall_desktop__1hjdb9vce {
-    margin-top: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginTop_small_desktop__1hjdb9vci {
-    margin-top: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginTop_medium_desktop__1hjdb9vcm {
-    margin-top: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginTop_large_desktop__1hjdb9vcq {
-    margin-top: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginTop_xlarge_desktop__1hjdb9vcu {
-    margin-top: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginTop_xxlarge_desktop__1hjdb9vcy {
-    margin-top: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginTop_xxxlarge_desktop__1hjdb9vd2 {
-    margin-top: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginTop_none_desktop__1hjdb9vd6 {
-    margin-top: 0;
-  }
-  .sprinkles_marginBottom_gutter_desktop__1hjdb9vda {
-    margin-bottom: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginBottom_xxsmall_desktop__1hjdb9vde {
-    margin-bottom: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginBottom_xsmall_desktop__1hjdb9vdi {
-    margin-bottom: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginBottom_small_desktop__1hjdb9vdm {
-    margin-bottom: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginBottom_medium_desktop__1hjdb9vdq {
-    margin-bottom: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginBottom_large_desktop__1hjdb9vdu {
-    margin-bottom: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginBottom_xlarge_desktop__1hjdb9vdy {
-    margin-bottom: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginBottom_xxlarge_desktop__1hjdb9ve2 {
-    margin-bottom: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginBottom_xxxlarge_desktop__1hjdb9ve6 {
-    margin-bottom: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginBottom_none_desktop__1hjdb9vea {
-    margin-bottom: 0;
-  }
-  .sprinkles_marginRight_gutter_desktop__1hjdb9vee {
-    margin-right: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginRight_xxsmall_desktop__1hjdb9vei {
-    margin-right: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginRight_xsmall_desktop__1hjdb9vem {
-    margin-right: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginRight_small_desktop__1hjdb9veq {
-    margin-right: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginRight_medium_desktop__1hjdb9veu {
-    margin-right: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginRight_large_desktop__1hjdb9vey {
-    margin-right: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginRight_xlarge_desktop__1hjdb9vf2 {
-    margin-right: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginRight_xxlarge_desktop__1hjdb9vf6 {
-    margin-right: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginRight_xxxlarge_desktop__1hjdb9vfa {
-    margin-right: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginRight_none_desktop__1hjdb9vfe {
-    margin-right: 0;
-  }
-  .sprinkles_marginLeft_gutter_desktop__1hjdb9vfi {
-    margin-left: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginLeft_xxsmall_desktop__1hjdb9vfm {
-    margin-left: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginLeft_xsmall_desktop__1hjdb9vfq {
-    margin-left: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginLeft_small_desktop__1hjdb9vfu {
-    margin-left: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginLeft_medium_desktop__1hjdb9vfy {
-    margin-left: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginLeft_large_desktop__1hjdb9vg2 {
-    margin-left: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginLeft_xlarge_desktop__1hjdb9vg6 {
-    margin-left: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginLeft_xxlarge_desktop__1hjdb9vga {
-    margin-left: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginLeft_xxxlarge_desktop__1hjdb9vge {
-    margin-left: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginLeft_none_desktop__1hjdb9vgi {
-    margin-left: 0;
-  }
-  .sprinkles_alignItems_flexStart_desktop__1hjdb9vgm {
-    align-items: flex-start;
-  }
-  .sprinkles_alignItems_center_desktop__1hjdb9vgq {
-    align-items: center;
-  }
-  .sprinkles_alignItems_flexEnd_desktop__1hjdb9vgu {
-    align-items: flex-end;
-  }
-  .sprinkles_justifyContent_flexStart_desktop__1hjdb9vgy {
-    justify-content: flex-start;
-  }
-  .sprinkles_justifyContent_center_desktop__1hjdb9vh2 {
-    justify-content: center;
-  }
-  .sprinkles_justifyContent_flexEnd_desktop__1hjdb9vh6 {
-    justify-content: flex-end;
-  }
-  .sprinkles_justifyContent_spaceBetween_desktop__1hjdb9vha {
-    justify-content: space-between;
-  }
-  .sprinkles_flexDirection_row_desktop__1hjdb9vhe {
-    flex-direction: row;
-  }
-  .sprinkles_flexDirection_rowReverse_desktop__1hjdb9vhi {
-    flex-direction: row-reverse;
-  }
-  .sprinkles_flexDirection_column_desktop__1hjdb9vhm {
-    flex-direction: column;
-  }
-  .sprinkles_flexDirection_columnReverse_desktop__1hjdb9vhq {
-    flex-direction: column-reverse;
-  }
-  .sprinkles_flexWrap_wrap_desktop__1hjdb9vhu {
-    flex-wrap: wrap;
-  }
-  .sprinkles_flexWrap_nowrap_desktop__1hjdb9vhy {
-    flex-wrap: nowrap;
-  }
-  .sprinkles_flexShrink_0_desktop__1hjdb9vi2 {
-    flex-shrink: 0;
-  }
-  .sprinkles_flexGrow_0_desktop__1hjdb9vi6 {
-    flex-grow: 0;
-  }
-  .sprinkles_flexGrow_1_desktop__1hjdb9via {
-    flex-grow: 1;
-  }
-  .sprinkles_textAlign_left_desktop__1hjdb9vie {
-    text-align: left;
-  }
-  .sprinkles_textAlign_center_desktop__1hjdb9vii {
-    text-align: center;
-  }
-  .sprinkles_textAlign_right_desktop__1hjdb9vim {
-    text-align: right;
-  }
-}
-@media screen and (min-width: 1200px) {
-  .sprinkles_display_none_wide__1hjdb9v4z {
-    display: none;
-  }
-  .sprinkles_display_block_wide__1hjdb9v53 {
-    display: block;
-  }
-  .sprinkles_display_inline_wide__1hjdb9v57 {
-    display: inline;
-  }
-  .sprinkles_display_inlineBlock_wide__1hjdb9v5b {
-    display: inline-block;
-  }
-  .sprinkles_display_flex_wide__1hjdb9v5f {
-    display: flex;
-  }
-  .sprinkles_position_relative_wide__1hjdb9v5j {
-    position: relative;
-  }
-  .sprinkles_position_absolute_wide__1hjdb9v5n {
-    position: absolute;
-  }
-  .sprinkles_position_fixed_wide__1hjdb9v5r {
-    position: fixed;
-  }
-  .sprinkles_position_sticky_wide__1hjdb9v5v {
-    position: sticky;
-  }
-  .sprinkles_borderRadius_none_wide__1hjdb9v5z {
-    border-radius: 0px;
-  }
-  .sprinkles_borderRadius_full_wide__1hjdb9v63 {
-    border-radius: 9999px;
-  }
-  .sprinkles_borderRadius_small_wide__1hjdb9v67 {
-    border-radius: var(--borderRadius-small__qhrpjvb);
-  }
-  .sprinkles_borderRadius_standard_wide__1hjdb9v6b {
-    border-radius: var(--borderRadius-standard__qhrpjvc);
-  }
-  .sprinkles_borderRadius_large_wide__1hjdb9v6f {
-    border-radius: var(--borderRadius-large__qhrpjvd);
-  }
-  .sprinkles_borderRadius_xlarge_wide__1hjdb9v6j {
-    border-radius: var(--borderRadius-xlarge__qhrpjve);
-  }
-  .sprinkles_gap_gutter_wide__1hjdb9v6n {
-    gap: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_gap_xxsmall_wide__1hjdb9v6r {
-    gap: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_gap_xsmall_wide__1hjdb9v6v {
-    gap: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_gap_small_wide__1hjdb9v6z {
-    gap: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_gap_medium_wide__1hjdb9v73 {
-    gap: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_gap_large_wide__1hjdb9v77 {
-    gap: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_gap_xlarge_wide__1hjdb9v7b {
-    gap: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_gap_xxlarge_wide__1hjdb9v7f {
-    gap: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_gap_xxxlarge_wide__1hjdb9v7j {
-    gap: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_gap_none_wide__1hjdb9v7n {
-    gap: 0;
-  }
-  .sprinkles_paddingTop_gutter_wide__1hjdb9v7r {
-    padding-top: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingTop_xxsmall_wide__1hjdb9v7v {
-    padding-top: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingTop_xsmall_wide__1hjdb9v7z {
-    padding-top: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingTop_small_wide__1hjdb9v83 {
-    padding-top: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingTop_medium_wide__1hjdb9v87 {
-    padding-top: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingTop_large_wide__1hjdb9v8b {
-    padding-top: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingTop_xlarge_wide__1hjdb9v8f {
-    padding-top: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingTop_xxlarge_wide__1hjdb9v8j {
-    padding-top: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingTop_xxxlarge_wide__1hjdb9v8n {
-    padding-top: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingTop_none_wide__1hjdb9v8r {
-    padding-top: 0;
-  }
-  .sprinkles_paddingBottom_gutter_wide__1hjdb9v8v {
-    padding-bottom: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingBottom_xxsmall_wide__1hjdb9v8z {
-    padding-bottom: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingBottom_xsmall_wide__1hjdb9v93 {
-    padding-bottom: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingBottom_small_wide__1hjdb9v97 {
-    padding-bottom: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingBottom_medium_wide__1hjdb9v9b {
-    padding-bottom: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingBottom_large_wide__1hjdb9v9f {
-    padding-bottom: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingBottom_xlarge_wide__1hjdb9v9j {
-    padding-bottom: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingBottom_xxlarge_wide__1hjdb9v9n {
-    padding-bottom: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingBottom_xxxlarge_wide__1hjdb9v9r {
-    padding-bottom: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingBottom_none_wide__1hjdb9v9v {
-    padding-bottom: 0;
-  }
-  .sprinkles_paddingRight_gutter_wide__1hjdb9v9z {
-    padding-right: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingRight_xxsmall_wide__1hjdb9va3 {
-    padding-right: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingRight_xsmall_wide__1hjdb9va7 {
-    padding-right: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingRight_small_wide__1hjdb9vab {
-    padding-right: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingRight_medium_wide__1hjdb9vaf {
-    padding-right: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingRight_large_wide__1hjdb9vaj {
-    padding-right: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingRight_xlarge_wide__1hjdb9van {
-    padding-right: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingRight_xxlarge_wide__1hjdb9var {
-    padding-right: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingRight_xxxlarge_wide__1hjdb9vav {
-    padding-right: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingRight_none_wide__1hjdb9vaz {
-    padding-right: 0;
-  }
-  .sprinkles_paddingLeft_gutter_wide__1hjdb9vb3 {
-    padding-left: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingLeft_xxsmall_wide__1hjdb9vb7 {
-    padding-left: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingLeft_xsmall_wide__1hjdb9vbb {
-    padding-left: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingLeft_small_wide__1hjdb9vbf {
-    padding-left: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingLeft_medium_wide__1hjdb9vbj {
-    padding-left: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingLeft_large_wide__1hjdb9vbn {
-    padding-left: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingLeft_xlarge_wide__1hjdb9vbr {
-    padding-left: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingLeft_xxlarge_wide__1hjdb9vbv {
-    padding-left: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingLeft_xxxlarge_wide__1hjdb9vbz {
-    padding-left: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingLeft_none_wide__1hjdb9vc3 {
-    padding-left: 0;
-  }
-  .sprinkles_marginTop_gutter_wide__1hjdb9vc7 {
-    margin-top: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginTop_xxsmall_wide__1hjdb9vcb {
-    margin-top: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginTop_xsmall_wide__1hjdb9vcf {
-    margin-top: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginTop_small_wide__1hjdb9vcj {
-    margin-top: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginTop_medium_wide__1hjdb9vcn {
-    margin-top: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginTop_large_wide__1hjdb9vcr {
-    margin-top: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginTop_xlarge_wide__1hjdb9vcv {
-    margin-top: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginTop_xxlarge_wide__1hjdb9vcz {
-    margin-top: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginTop_xxxlarge_wide__1hjdb9vd3 {
-    margin-top: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginTop_none_wide__1hjdb9vd7 {
-    margin-top: 0;
-  }
-  .sprinkles_marginBottom_gutter_wide__1hjdb9vdb {
-    margin-bottom: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginBottom_xxsmall_wide__1hjdb9vdf {
-    margin-bottom: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginBottom_xsmall_wide__1hjdb9vdj {
-    margin-bottom: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginBottom_small_wide__1hjdb9vdn {
-    margin-bottom: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginBottom_medium_wide__1hjdb9vdr {
-    margin-bottom: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginBottom_large_wide__1hjdb9vdv {
-    margin-bottom: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginBottom_xlarge_wide__1hjdb9vdz {
-    margin-bottom: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginBottom_xxlarge_wide__1hjdb9ve3 {
-    margin-bottom: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginBottom_xxxlarge_wide__1hjdb9ve7 {
-    margin-bottom: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginBottom_none_wide__1hjdb9veb {
-    margin-bottom: 0;
-  }
-  .sprinkles_marginRight_gutter_wide__1hjdb9vef {
-    margin-right: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginRight_xxsmall_wide__1hjdb9vej {
-    margin-right: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginRight_xsmall_wide__1hjdb9ven {
-    margin-right: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginRight_small_wide__1hjdb9ver {
-    margin-right: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginRight_medium_wide__1hjdb9vev {
-    margin-right: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginRight_large_wide__1hjdb9vez {
-    margin-right: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginRight_xlarge_wide__1hjdb9vf3 {
-    margin-right: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginRight_xxlarge_wide__1hjdb9vf7 {
-    margin-right: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginRight_xxxlarge_wide__1hjdb9vfb {
-    margin-right: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginRight_none_wide__1hjdb9vff {
-    margin-right: 0;
-  }
-  .sprinkles_marginLeft_gutter_wide__1hjdb9vfj {
-    margin-left: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginLeft_xxsmall_wide__1hjdb9vfn {
-    margin-left: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginLeft_xsmall_wide__1hjdb9vfr {
-    margin-left: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginLeft_small_wide__1hjdb9vfv {
-    margin-left: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginLeft_medium_wide__1hjdb9vfz {
-    margin-left: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginLeft_large_wide__1hjdb9vg3 {
-    margin-left: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginLeft_xlarge_wide__1hjdb9vg7 {
-    margin-left: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginLeft_xxlarge_wide__1hjdb9vgb {
-    margin-left: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginLeft_xxxlarge_wide__1hjdb9vgf {
-    margin-left: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginLeft_none_wide__1hjdb9vgj {
-    margin-left: 0;
-  }
-  .sprinkles_alignItems_flexStart_wide__1hjdb9vgn {
-    align-items: flex-start;
-  }
-  .sprinkles_alignItems_center_wide__1hjdb9vgr {
-    align-items: center;
-  }
-  .sprinkles_alignItems_flexEnd_wide__1hjdb9vgv {
-    align-items: flex-end;
-  }
-  .sprinkles_justifyContent_flexStart_wide__1hjdb9vgz {
-    justify-content: flex-start;
-  }
-  .sprinkles_justifyContent_center_wide__1hjdb9vh3 {
-    justify-content: center;
-  }
-  .sprinkles_justifyContent_flexEnd_wide__1hjdb9vh7 {
-    justify-content: flex-end;
-  }
-  .sprinkles_justifyContent_spaceBetween_wide__1hjdb9vhb {
-    justify-content: space-between;
-  }
-  .sprinkles_flexDirection_row_wide__1hjdb9vhf {
-    flex-direction: row;
-  }
-  .sprinkles_flexDirection_rowReverse_wide__1hjdb9vhj {
-    flex-direction: row-reverse;
-  }
-  .sprinkles_flexDirection_column_wide__1hjdb9vhn {
-    flex-direction: column;
-  }
-  .sprinkles_flexDirection_columnReverse_wide__1hjdb9vhr {
-    flex-direction: column-reverse;
-  }
-  .sprinkles_flexWrap_wrap_wide__1hjdb9vhv {
-    flex-wrap: wrap;
-  }
-  .sprinkles_flexWrap_nowrap_wide__1hjdb9vhz {
-    flex-wrap: nowrap;
-  }
-  .sprinkles_flexShrink_0_wide__1hjdb9vi3 {
-    flex-shrink: 0;
-  }
-  .sprinkles_flexGrow_0_wide__1hjdb9vi7 {
-    flex-grow: 0;
-  }
-  .sprinkles_flexGrow_1_wide__1hjdb9vib {
-    flex-grow: 1;
-  }
-  .sprinkles_textAlign_left_wide__1hjdb9vif {
-    text-align: left;
-  }
-  .sprinkles_textAlign_center_wide__1hjdb9vij {
-    text-align: center;
-  }
-  .sprinkles_textAlign_right_wide__1hjdb9vin {
-    text-align: right;
-  }
-}
-.capsize_capsizeStyle__1lwixuj4 {
-  font-size: var(--fontSize__1lwixuj0);
-  line-height: var(--lineHeight__1lwixuj1);
-}
-.capsize_capsizeStyle__1lwixuj4::before {
-  content: '';
-  margin-bottom: var(--capHeightTrim__1lwixuj2);
-  display: table;
-}
-.capsize_capsizeStyle__1lwixuj4::after {
-  content: '';
-  margin-top: var(--baselineTrim__1lwixuj3);
-  display: table;
-}
-.typography_fontFamily__co4djb0 {
-  font-family: var(--fontFamily__qhrpjv2w);
-}
-.typography_fontWeight_regular__co4djb1 {
-  font-weight: var(--textWeight-regular__qhrpjv46);
-}
-.typography_fontWeight_medium__co4djb2 {
-  font-weight: var(--textWeight-medium__qhrpjv47);
-}
-.typography_fontWeight_strong__co4djb3 {
-  font-weight: var(--textWeight-strong__qhrpjv48);
-}
-.typography_textSize_xsmall__co4djb4 {
-  --fontSize__1lwixuj0: var(--textSize-xsmall-mobile-fontSize__qhrpjv32);
-  --lineHeight__1lwixuj1: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
-  --capHeightTrim__1lwixuj2: var(--textSize-xsmall-mobile-capsizeTrims-capHeightTrim__qhrpjv35);
-  --baselineTrim__1lwixuj3: var(--textSize-xsmall-mobile-capsizeTrims-baselineTrim__qhrpjv36);
-}
-.typography_textSize_small__co4djb6 {
-  --fontSize__1lwixuj0: var(--textSize-small-mobile-fontSize__qhrpjv3c);
-  --lineHeight__1lwixuj1: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
-  --capHeightTrim__1lwixuj2: var(--textSize-small-mobile-capsizeTrims-capHeightTrim__qhrpjv3f);
-  --baselineTrim__1lwixuj3: var(--textSize-small-mobile-capsizeTrims-baselineTrim__qhrpjv3g);
-}
-.typography_textSize_standard__co4djb8 {
-  --fontSize__1lwixuj0: var(--textSize-standard-mobile-fontSize__qhrpjv3m);
-  --lineHeight__1lwixuj1: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
-  --capHeightTrim__1lwixuj2: var(--textSize-standard-mobile-capsizeTrims-capHeightTrim__qhrpjv3p);
-  --baselineTrim__1lwixuj3: var(--textSize-standard-mobile-capsizeTrims-baselineTrim__qhrpjv3q);
-}
-.typography_textSize_large__co4djba {
-  --fontSize__1lwixuj0: var(--textSize-large-mobile-fontSize__qhrpjv3w);
-  --lineHeight__1lwixuj1: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
-  --capHeightTrim__1lwixuj2: var(--textSize-large-mobile-capsizeTrims-capHeightTrim__qhrpjv3z);
-  --baselineTrim__1lwixuj3: var(--textSize-large-mobile-capsizeTrims-baselineTrim__qhrpjv40);
-}
-.typography_textSizeUntrimmed_xsmall__co4djbc {
-  font-size: var(--textSize-xsmall-mobile-fontSize__qhrpjv32);
-  line-height: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
-}
-.typography_textSizeUntrimmed_small__co4djbd {
-  font-size: var(--textSize-small-mobile-fontSize__qhrpjv3c);
-  line-height: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
-}
-.typography_textSizeUntrimmed_standard__co4djbe {
-  font-size: var(--textSize-standard-mobile-fontSize__qhrpjv3m);
-  line-height: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
-}
-.typography_textSizeUntrimmed_large__co4djbf {
-  font-size: var(--textSize-large-mobile-fontSize__qhrpjv3w);
-  line-height: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
-}
-.typography_headingWeight_weak__co4djbg {
-  font-weight: var(--headingWeight-weak__qhrpjv5d);
-}
-.typography_headingWeight_regular__co4djbh {
-  font-weight: var(--headingWeight-regular__qhrpjv5e);
-}
-.typography_heading_1__co4djbi {
-  --fontSize__1lwixuj0: var(--headingLevel-1-mobile-fontSize__qhrpjv49);
-  --lineHeight__1lwixuj1: var(--headingLevel-1-mobile-lineHeight__qhrpjv4a);
-  --capHeightTrim__1lwixuj2: var(--headingLevel-1-mobile-capsizeTrims-capHeightTrim__qhrpjv4c);
-  --baselineTrim__1lwixuj3: var(--headingLevel-1-mobile-capsizeTrims-baselineTrim__qhrpjv4d);
-}
-.typography_heading_2__co4djbk {
-  --fontSize__1lwixuj0: var(--headingLevel-2-mobile-fontSize__qhrpjv4j);
-  --lineHeight__1lwixuj1: var(--headingLevel-2-mobile-lineHeight__qhrpjv4k);
-  --capHeightTrim__1lwixuj2: var(--headingLevel-2-mobile-capsizeTrims-capHeightTrim__qhrpjv4m);
-  --baselineTrim__1lwixuj3: var(--headingLevel-2-mobile-capsizeTrims-baselineTrim__qhrpjv4n);
-}
-.typography_heading_3__co4djbm {
-  --fontSize__1lwixuj0: var(--headingLevel-3-mobile-fontSize__qhrpjv4t);
-  --lineHeight__1lwixuj1: var(--headingLevel-3-mobile-lineHeight__qhrpjv4u);
-  --capHeightTrim__1lwixuj2: var(--headingLevel-3-mobile-capsizeTrims-capHeightTrim__qhrpjv4w);
-  --baselineTrim__1lwixuj3: var(--headingLevel-3-mobile-capsizeTrims-baselineTrim__qhrpjv4x);
-}
-.typography_heading_4__co4djbo {
-  --fontSize__1lwixuj0: var(--headingLevel-4-mobile-fontSize__qhrpjv53);
-  --lineHeight__1lwixuj1: var(--headingLevel-4-mobile-lineHeight__qhrpjv54);
-  --capHeightTrim__1lwixuj2: var(--headingLevel-4-mobile-capsizeTrims-capHeightTrim__qhrpjv56);
-  --baselineTrim__1lwixuj3: var(--headingLevel-4-mobile-capsizeTrims-baselineTrim__qhrpjv57);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeTone_light__co4djb10 {
-  --critical__co4djbq: var(--foregroundColor-critical__qhrpjv19);
-  --caution__co4djbr: var(--foregroundColor-caution__qhrpjv17);
-  --info__co4djbs: var(--foregroundColor-info__qhrpjv1d);
-  --promote__co4djbt: var(--foregroundColor-promote__qhrpjv1o);
-  --positive__co4djbu: var(--foregroundColor-positive__qhrpjv1m);
-  --brandAccent__co4djbv: var(--foregroundColor-brandAccent__qhrpjv15);
-  --formAccent__co4djbw: var(--foregroundColor-formAccent__qhrpjv1b);
-  --neutral__co4djbx: var(--foregroundColor-neutral__qhrpjv1k);
-  --secondary__co4djby: var(--foregroundColor-secondary__qhrpjv1r);
-  --link__co4djbz: var(--foregroundColor-link__qhrpjv1f);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeTone_dark__co4djb11 {
-  --critical__co4djbq: var(--foregroundColor-criticalLight__qhrpjv1a);
-  --caution__co4djbr: var(--foregroundColor-cautionLight__qhrpjv18);
-  --info__co4djbs: var(--foregroundColor-infoLight__qhrpjv1e);
-  --promote__co4djbt: var(--foregroundColor-promoteLight__qhrpjv1p);
-  --positive__co4djbu: var(--foregroundColor-positiveLight__qhrpjv1n);
-  --brandAccent__co4djbv: var(--foregroundColor-brandAccentLight__qhrpjv16);
-  --formAccent__co4djbw: var(--foregroundColor-formAccentLight__qhrpjv1c);
-  --neutral__co4djbx: var(--foregroundColor-neutralInverted__qhrpjv1l);
-  --secondary__co4djby: var(--foregroundColor-secondaryInverted__qhrpjv1s);
-  --link__co4djbz: var(--foregroundColor-linkLight__qhrpjv1h);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeTone_light__co4djb12 {
-  --critical__co4djbq: var(--foregroundColor-critical__qhrpjv19);
-  --caution__co4djbr: var(--foregroundColor-caution__qhrpjv17);
-  --info__co4djbs: var(--foregroundColor-info__qhrpjv1d);
-  --promote__co4djbt: var(--foregroundColor-promote__qhrpjv1o);
-  --positive__co4djbu: var(--foregroundColor-positive__qhrpjv1m);
-  --brandAccent__co4djbv: var(--foregroundColor-brandAccent__qhrpjv15);
-  --formAccent__co4djbw: var(--foregroundColor-formAccent__qhrpjv1b);
-  --neutral__co4djbx: var(--foregroundColor-neutral__qhrpjv1k);
-  --secondary__co4djby: var(--foregroundColor-secondary__qhrpjv1r);
-  --link__co4djbz: var(--foregroundColor-link__qhrpjv1f);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeTone_dark__co4djb13 {
-  --critical__co4djbq: var(--foregroundColor-criticalLight__qhrpjv1a);
-  --caution__co4djbr: var(--foregroundColor-cautionLight__qhrpjv18);
-  --info__co4djbs: var(--foregroundColor-infoLight__qhrpjv1e);
-  --promote__co4djbt: var(--foregroundColor-promoteLight__qhrpjv1p);
-  --positive__co4djbu: var(--foregroundColor-positiveLight__qhrpjv1n);
-  --brandAccent__co4djbv: var(--foregroundColor-brandAccentLight__qhrpjv16);
-  --formAccent__co4djbw: var(--foregroundColor-formAccentLight__qhrpjv1c);
-  --neutral__co4djbx: var(--foregroundColor-neutralInverted__qhrpjv1l);
-  --secondary__co4djby: var(--foregroundColor-secondaryInverted__qhrpjv1s);
-  --link__co4djbz: var(--foregroundColor-linkLight__qhrpjv1h);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalLight__co4djb14 {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalSoft__co4djb15 {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalSoftActive__co4djb16 {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalSoftHover__co4djb17 {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_caution__co4djb18 {
-  --neutral__co4djbx: var(--caution__co4djbr);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_cautionLight__co4djb19 {
-  --neutral__co4djbx: var(--caution__co4djbr);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_positiveLight__co4djb1a {
-  --neutral__co4djbx: var(--positive__co4djbu);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_infoLight__co4djb1b {
-  --neutral__co4djbx: var(--info__co4djbs);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_promoteLight__co4djb1c {
-  --neutral__co4djbx: var(--promote__co4djbt);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalLight__co4djb1d {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalSoft__co4djb1e {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalSoftActive__co4djb1f {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalSoftHover__co4djb1g {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_caution__co4djb1h {
-  --neutral__co4djbx: var(--caution__co4djbr);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_cautionLight__co4djb1i {
-  --neutral__co4djbx: var(--caution__co4djbr);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_positiveLight__co4djb1j {
-  --neutral__co4djbx: var(--positive__co4djbu);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_infoLight__co4djb1k {
-  --neutral__co4djbx: var(--info__co4djbs);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_promoteLight__co4djb1l {
-  --neutral__co4djbx: var(--promote__co4djbt);
-}
-.typography_tone_critical__co4djb1m {
-  color: var(--critical__co4djbq);
-}
-.typography_tone_caution__co4djb1n {
-  color: var(--caution__co4djbr);
-}
-.typography_tone_info__co4djb1o {
-  color: var(--info__co4djbs);
-}
-.typography_tone_promote__co4djb1p {
-  color: var(--promote__co4djbt);
-}
-.typography_tone_positive__co4djb1q {
-  color: var(--positive__co4djbu);
-}
-.typography_tone_brandAccent__co4djb1r {
-  color: var(--brandAccent__co4djbv);
-}
-.typography_tone_formAccent__co4djb1s {
-  color: var(--formAccent__co4djbw);
-}
-.typography_tone_neutral__co4djb1t {
-  color: var(--neutral__co4djbx);
-}
-.typography_tone_secondary__co4djb1u {
-  color: var(--secondary__co4djby);
-}
-.typography_tone_link__co4djb1v {
-  color: var(--link__co4djbz);
-}
-.typography_touchableText_xsmall__co4djb1w {
-  padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-mobile-lineHeight__qhrpjv33)) / 2);
-  padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-mobile-lineHeight__qhrpjv33)) / 2);
-}
-.typography_touchableText_small__co4djb1x {
-  padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-mobile-lineHeight__qhrpjv3d)) / 2);
-  padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-mobile-lineHeight__qhrpjv3d)) / 2);
-}
-.typography_touchableText_standard__co4djb1y {
-  padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-mobile-lineHeight__qhrpjv3n)) / 2);
-  padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-mobile-lineHeight__qhrpjv3n)) / 2);
-}
-.typography_touchableText_large__co4djb1z {
-  padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-mobile-lineHeight__qhrpjv3x)) / 2);
-  padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-mobile-lineHeight__qhrpjv3x)) / 2);
-}
-@media screen and (min-width: 740px) {
-  .typography_textSize_xsmall__co4djb4 {
-    --fontSize__1lwixuj0: var(--textSize-xsmall-tablet-fontSize__qhrpjv37);
-    --lineHeight__1lwixuj1: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
-    --capHeightTrim__1lwixuj2: var(--textSize-xsmall-tablet-capsizeTrims-capHeightTrim__qhrpjv3a);
-    --baselineTrim__1lwixuj3: var(--textSize-xsmall-tablet-capsizeTrims-baselineTrim__qhrpjv3b);
-  }
-  .typography_textSize_small__co4djb6 {
-    --fontSize__1lwixuj0: var(--textSize-small-tablet-fontSize__qhrpjv3h);
-    --lineHeight__1lwixuj1: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
-    --capHeightTrim__1lwixuj2: var(--textSize-small-tablet-capsizeTrims-capHeightTrim__qhrpjv3k);
-    --baselineTrim__1lwixuj3: var(--textSize-small-tablet-capsizeTrims-baselineTrim__qhrpjv3l);
-  }
-  .typography_textSize_standard__co4djb8 {
-    --fontSize__1lwixuj0: var(--textSize-standard-tablet-fontSize__qhrpjv3r);
-    --lineHeight__1lwixuj1: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
-    --capHeightTrim__1lwixuj2: var(--textSize-standard-tablet-capsizeTrims-capHeightTrim__qhrpjv3u);
-    --baselineTrim__1lwixuj3: var(--textSize-standard-tablet-capsizeTrims-baselineTrim__qhrpjv3v);
-  }
-  .typography_textSize_large__co4djba {
-    --fontSize__1lwixuj0: var(--textSize-large-tablet-fontSize__qhrpjv41);
-    --lineHeight__1lwixuj1: var(--textSize-large-tablet-lineHeight__qhrpjv42);
-    --capHeightTrim__1lwixuj2: var(--textSize-large-tablet-capsizeTrims-capHeightTrim__qhrpjv44);
-    --baselineTrim__1lwixuj3: var(--textSize-large-tablet-capsizeTrims-baselineTrim__qhrpjv45);
-  }
-  .typography_textSizeUntrimmed_xsmall__co4djbc {
-    font-size: var(--textSize-xsmall-tablet-fontSize__qhrpjv37);
-    line-height: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
-  }
-  .typography_textSizeUntrimmed_small__co4djbd {
-    font-size: var(--textSize-small-tablet-fontSize__qhrpjv3h);
-    line-height: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
-  }
-  .typography_textSizeUntrimmed_standard__co4djbe {
-    font-size: var(--textSize-standard-tablet-fontSize__qhrpjv3r);
-    line-height: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
-  }
-  .typography_textSizeUntrimmed_large__co4djbf {
-    font-size: var(--textSize-large-tablet-fontSize__qhrpjv41);
-    line-height: var(--textSize-large-tablet-lineHeight__qhrpjv42);
-  }
-  .typography_heading_1__co4djbi {
-    --fontSize__1lwixuj0: var(--headingLevel-1-tablet-fontSize__qhrpjv4e);
-    --lineHeight__1lwixuj1: var(--headingLevel-1-tablet-lineHeight__qhrpjv4f);
-    --capHeightTrim__1lwixuj2: var(--headingLevel-1-tablet-capsizeTrims-capHeightTrim__qhrpjv4h);
-    --baselineTrim__1lwixuj3: var(--headingLevel-1-tablet-capsizeTrims-baselineTrim__qhrpjv4i);
-  }
-  .typography_heading_2__co4djbk {
-    --fontSize__1lwixuj0: var(--headingLevel-2-tablet-fontSize__qhrpjv4o);
-    --lineHeight__1lwixuj1: var(--headingLevel-2-tablet-lineHeight__qhrpjv4p);
-    --capHeightTrim__1lwixuj2: var(--headingLevel-2-tablet-capsizeTrims-capHeightTrim__qhrpjv4r);
-    --baselineTrim__1lwixuj3: var(--headingLevel-2-tablet-capsizeTrims-baselineTrim__qhrpjv4s);
-  }
-  .typography_heading_3__co4djbm {
-    --fontSize__1lwixuj0: var(--headingLevel-3-tablet-fontSize__qhrpjv4y);
-    --lineHeight__1lwixuj1: var(--headingLevel-3-tablet-lineHeight__qhrpjv4z);
-    --capHeightTrim__1lwixuj2: var(--headingLevel-3-tablet-capsizeTrims-capHeightTrim__qhrpjv51);
-    --baselineTrim__1lwixuj3: var(--headingLevel-3-tablet-capsizeTrims-baselineTrim__qhrpjv52);
-  }
-  .typography_heading_4__co4djbo {
-    --fontSize__1lwixuj0: var(--headingLevel-4-tablet-fontSize__qhrpjv58);
-    --lineHeight__1lwixuj1: var(--headingLevel-4-tablet-lineHeight__qhrpjv59);
-    --capHeightTrim__1lwixuj2: var(--headingLevel-4-tablet-capsizeTrims-capHeightTrim__qhrpjv5b);
-    --baselineTrim__1lwixuj3: var(--headingLevel-4-tablet-capsizeTrims-baselineTrim__qhrpjv5c);
-  }
-  .typography_touchableText_xsmall__co4djb1w {
-    padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-tablet-lineHeight__qhrpjv38)) / 2);
-    padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-tablet-lineHeight__qhrpjv38)) / 2);
-  }
-  .typography_touchableText_small__co4djb1x {
-    padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-tablet-lineHeight__qhrpjv3i)) / 2);
-    padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-tablet-lineHeight__qhrpjv3i)) / 2);
-  }
-  .typography_touchableText_standard__co4djb1y {
-    padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-tablet-lineHeight__qhrpjv3s)) / 2);
-    padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-tablet-lineHeight__qhrpjv3s)) / 2);
-  }
-  .typography_touchableText_large__co4djb1z {
-    padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-tablet-lineHeight__qhrpjv42)) / 2);
-    padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-tablet-lineHeight__qhrpjv42)) / 2);
-  }
-}
-.Divider_base__rgb1580 {
-  height: var(--borderWidth-standard__qhrpjvy);
-}
-.Divider_regular__rgb1583 {
-  background: var(--regular__rgb1581);
-}
-.Divider_strong__rgb1584 {
-  background: var(--strong__rgb1582);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Divider_lightModeWeight_light__rgb1585 {
-  --regular__rgb1581: var(--borderColor-neutralLight__qhrpjvt);
-  --strong__rgb1582: var(--borderColor-neutral__qhrpjvr);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Divider_lightModeWeight_dark__rgb1586 {
-  --regular__rgb1581: var(--borderColor-neutral__qhrpjvr);
-  --strong__rgb1582: var(--borderColor-neutralLight__qhrpjvt);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Divider_darkModeWeight_light__rgb1587 {
-  --regular__rgb1581: var(--borderColor-neutralLight__qhrpjvt);
-  --strong__rgb1582: var(--borderColor-neutral__qhrpjvr);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Divider_darkModeWeight_dark__rgb1588 {
-  --regular__rgb1581: var(--borderColor-neutral__qhrpjvr);
-  --strong__rgb1582: var(--borderColor-neutralLight__qhrpjvt);
-}
-.Spread_fitContent__19xp08d0 > * {
-  flex-basis: auto;
-  width: auto;
-}
-.Spread_maxWidth__19xp08d1 > * {
-  max-width: 100%;
-}
-.MaxLines_descenderCropFixForWebkitBox__1lw3qoe0 {
-  margin-bottom: -0.1em;
-}
-.MaxLines_base__1lw3qoe2 {
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow-wrap: break-word;
-}
-.MaxLines_descenderCropFixForWebkitBox__1lw3qoe0 .MaxLines_base__1lw3qoe2 {
-  padding-bottom: 0.1em;
-}
-@supports (display: -webkit-box) and (-webkit-line-clamp: 1) {
-  .MaxLines_multiLine__1lw3qoe4 {
-    white-space: initial;
-    display: -webkit-box;
-    -webkit-line-clamp: var(--lineLimit__1lw3qoe3);
-    -webkit-box-orient: vertical;
-  }
-}
-.virtualTouchable_virtualTouchable__9705do0 {
-  position: relative;
-}
-.virtualTouchable_virtualTouchable__9705do0::after {
-  content: "";
-  position: absolute;
-  min-height: 44px;
-  min-width: 44px;
-  height: 100%;
-  width: 100%;
-  transform: translate(-50%, -50%);
-  top: 50%;
-  left: 50%;
-}
-[data-braid-debug] .virtualTouchable_virtualTouchable__9705do0::after {
-  background: red;
-  opacity: 0.2;
-}
-.AccordionItem_focusRing__pr4mlf2 {
-  outline-offset: var(--space-xxsmall__qhrpjv1);
-}
-.icon_size__1ltfiyk0 {
-  width: 1.2em;
-  height: 1.2em;
-}
-.icon_cropToTextSize__1ltfiyk1 {
-  margin: -0.1em;
-}
-.icon_inlineCrop__1ltfiyk2 {
-  margin-top: -0.2em;
-  margin-bottom: -0.2em;
-}
-.icon_inline__1ltfiyk3 {
-  vertical-align: middle;
-}
-.icon_alignY_uppercase_none__1ltfiyk4 {
-  top: -0.105em;
-}
-.icon_alignY_uppercase_up__1ltfiyk5 {
-  top: -0.16499999999999998em;
-}
-.icon_alignY_uppercase_down__1ltfiyk6 {
-  top: -0.045em;
-}
-.icon_alignY_lowercase_none__1ltfiyk7 {
-  top: -0.065em;
-}
-.icon_alignY_lowercase_up__1ltfiyk8 {
-  top: -0.125em;
-}
-.icon_alignY_lowercase_down__1ltfiyk9 {
-  top: -0.0050000000000000044em;
-}
-.icon_blockWidths_xsmall__1ltfiyka {
-  width: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
-}
-.icon_blockWidths_small__1ltfiykb {
-  width: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
-}
-.icon_blockWidths_standard__1ltfiykc {
-  width: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
-}
-.icon_blockWidths_large__1ltfiykd {
-  width: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
-}
-@media screen and (min-width: 740px) {
-  .icon_blockWidths_xsmall__1ltfiyka {
-    width: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
-  }
-  .icon_blockWidths_small__1ltfiykb {
-    width: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
-  }
-  .icon_blockWidths_standard__1ltfiykc {
-    width: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
-  }
-  .icon_blockWidths_large__1ltfiykd {
-    width: var(--textSize-large-tablet-lineHeight__qhrpjv42);
-  }
-}
-.lineHeightContainer_lineHeightContainer_xsmall__pnbjt00 {
-  height: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
-}
-.lineHeightContainer_lineHeightContainer_small__pnbjt01 {
-  height: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
-}
-.lineHeightContainer_lineHeightContainer_standard__pnbjt02 {
-  height: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
-}
-.lineHeightContainer_lineHeightContainer_large__pnbjt03 {
-  height: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
-}
-@media screen and (min-width: 740px) {
-  .lineHeightContainer_lineHeightContainer_xsmall__pnbjt00 {
-    height: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
-  }
-  .lineHeightContainer_lineHeightContainer_small__pnbjt01 {
-    height: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
-  }
-  .lineHeightContainer_lineHeightContainer_standard__pnbjt02 {
-    height: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
-  }
-  .lineHeightContainer_lineHeightContainer_large__pnbjt03 {
-    height: var(--textSize-large-tablet-lineHeight__qhrpjv42);
-  }
-}
-.IconChevron_root__v2pdba0 {
-  transition: transform 0.3s ease;
-  transform-origin: 50% 50%;
-}
-.IconChevron_left__v2pdba1 {
-  transform: rotate(90deg);
-}
-.IconChevron_up__v2pdba2 {
-  transform: rotate(180deg);
-}
-.IconChevron_right__v2pdba3 {
-  transform: rotate(270deg);
-}
-.Inline_fitContentMobile__hkzz4h0 > * {
-  flex-basis: auto;
-  width: auto;
-  min-width: 0;
-}
-@media screen and (min-width: 740px) {
-  .Inline_fitContentTablet__hkzz4h1 > * {
-    flex-basis: auto;
-    width: auto;
-    min-width: 0;
-  }
-}
-@media screen and (min-width: 992px) {
-  .Inline_fitContentDesktop__hkzz4h2 > * {
-    flex-basis: auto;
-    width: auto;
-    min-width: 0;
-  }
-}
-@media screen and (min-width: 1200px) {
-  .Inline_fitContentWide__hkzz4h3 > * {
-    flex-basis: auto;
-    width: auto;
-    min-width: 0;
-  }
-}
-.Column_noSpaceBeforeFirstWhenCollapsed__1w6x3sw0:first-child {
-  padding-top: 0;
-}
-.Column_width_1\\/2__1w6x3sw1 {
-  flex-basis: 50%;
-}
-.Column_width_1\\/3__1w6x3sw2 {
-  flex-basis: 33.33333333333333%;
-}
-.Column_width_2\\/3__1w6x3sw3 {
-  flex-basis: 66.66666666666666%;
-}
-.Column_width_1\\/4__1w6x3sw4 {
-  flex-basis: 25%;
-}
-.Column_width_3\\/4__1w6x3sw5 {
-  flex-basis: 75%;
-}
-.Column_width_1\\/5__1w6x3sw6 {
-  flex-basis: 20%;
-}
-.Column_width_2\\/5__1w6x3sw7 {
-  flex-basis: 40%;
-}
-.Column_width_3\\/5__1w6x3sw8 {
-  flex-basis: 60%;
-}
-.Column_width_4\\/5__1w6x3sw9 {
-  flex-basis: 80%;
-}
-.negativeMargin_preventCollapsePseudo_top__1063ve10::before {
-  content: "";
-  display: table;
-}
-.negativeMargin_preventCollapsePseudo_bottom__1063ve11::after {
-  content: "";
-  display: table;
-}
-.negativeMargin_stylesForBreakpoint_gutter__1063ve12::before {
-  margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxsmall__1063ve13::before {
-  margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xsmall__1063ve14::before {
-  margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
-}
-.negativeMargin_stylesForBreakpoint_small__1063ve15::before {
-  margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
-}
-.negativeMargin_stylesForBreakpoint_medium__1063ve16::before {
-  margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
-}
-.negativeMargin_stylesForBreakpoint_large__1063ve17::before {
-  margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xlarge__1063ve18::before {
-  margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxlarge__1063ve19::before {
-  margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxxlarge__1063ve1a::before {
-  margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-}
-.negativeMargin_stylesForBreakpoint_none__1063ve1b::before {
-  margin-bottom: 0;
-}
-.negativeMargin_stylesForBreakpoint_gutter__1063ve116::after {
-  margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxsmall__1063ve117::after {
-  margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xsmall__1063ve118::after {
-  margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
-}
-.negativeMargin_stylesForBreakpoint_small__1063ve119::after {
-  margin-top: calc(var(--space-small__qhrpjv3) * -1);
-}
-.negativeMargin_stylesForBreakpoint_medium__1063ve11a::after {
-  margin-top: calc(var(--space-medium__qhrpjv4) * -1);
-}
-.negativeMargin_stylesForBreakpoint_large__1063ve11b::after {
-  margin-top: calc(var(--space-large__qhrpjv5) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xlarge__1063ve11c::after {
-  margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxlarge__1063ve11d::after {
-  margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxxlarge__1063ve11e::after {
-  margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-}
-.negativeMargin_stylesForBreakpoint_none__1063ve11f::after {
-  margin-top: 0;
-}
-.negativeMargin_stylesForBreakpoint_gutter__1063ve12a {
-  margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxsmall__1063ve12b {
-  margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xsmall__1063ve12c {
-  margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
-}
-.negativeMargin_stylesForBreakpoint_small__1063ve12d {
-  margin-left: calc(var(--space-small__qhrpjv3) * -1);
-}
-.negativeMargin_stylesForBreakpoint_medium__1063ve12e {
-  margin-left: calc(var(--space-medium__qhrpjv4) * -1);
-}
-.negativeMargin_stylesForBreakpoint_large__1063ve12f {
-  margin-left: calc(var(--space-large__qhrpjv5) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xlarge__1063ve12g {
-  margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxlarge__1063ve12h {
-  margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxxlarge__1063ve12i {
-  margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-}
-.negativeMargin_stylesForBreakpoint_none__1063ve12j {
-  margin-left: 0;
-}
-.negativeMargin_stylesForBreakpoint_gutter__1063ve13e {
-  margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxsmall__1063ve13f {
-  margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xsmall__1063ve13g {
-  margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
-}
-.negativeMargin_stylesForBreakpoint_small__1063ve13h {
-  margin-right: calc(var(--space-small__qhrpjv3) * -1);
-}
-.negativeMargin_stylesForBreakpoint_medium__1063ve13i {
-  margin-right: calc(var(--space-medium__qhrpjv4) * -1);
-}
-.negativeMargin_stylesForBreakpoint_large__1063ve13j {
-  margin-right: calc(var(--space-large__qhrpjv5) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xlarge__1063ve13k {
-  margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxlarge__1063ve13l {
-  margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxxlarge__1063ve13m {
-  margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-}
-.negativeMargin_stylesForBreakpoint_none__1063ve13n {
-  margin-right: 0;
-}
-@media screen and (min-width: 740px) {
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve1c::before {
-    margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve1d::before {
-    margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve1e::before {
-    margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve1f::before {
-    margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve1g::before {
-    margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve1h::before {
-    margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve1i::before {
-    margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve1j::before {
-    margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve1k::before {
-    margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve1l::before {
-    margin-bottom: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve11g::after {
-    margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve11h::after {
-    margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve11i::after {
-    margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve11j::after {
-    margin-top: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve11k::after {
-    margin-top: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve11l::after {
-    margin-top: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve11m::after {
-    margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve11n::after {
-    margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve11o::after {
-    margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve11p::after {
-    margin-top: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve12k {
-    margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve12l {
-    margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve12m {
-    margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve12n {
-    margin-left: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve12o {
-    margin-left: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve12p {
-    margin-left: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve12q {
-    margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve12r {
-    margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve12s {
-    margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve12t {
-    margin-left: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve13o {
-    margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve13p {
-    margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve13q {
-    margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve13r {
-    margin-right: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve13s {
-    margin-right: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve13t {
-    margin-right: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve13u {
-    margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve13v {
-    margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve13w {
-    margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve13x {
-    margin-right: 0;
-  }
-}
-@media screen and (min-width: 992px) {
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve1m::before {
-    margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve1n::before {
-    margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve1o::before {
-    margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve1p::before {
-    margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve1q::before {
-    margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve1r::before {
-    margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve1s::before {
-    margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve1t::before {
-    margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve1u::before {
-    margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve1v::before {
-    margin-bottom: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve11q::after {
-    margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve11r::after {
-    margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve11s::after {
-    margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve11t::after {
-    margin-top: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve11u::after {
-    margin-top: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve11v::after {
-    margin-top: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve11w::after {
-    margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve11x::after {
-    margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve11y::after {
-    margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve11z::after {
-    margin-top: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve12u {
-    margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve12v {
-    margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve12w {
-    margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve12x {
-    margin-left: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve12y {
-    margin-left: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve12z {
-    margin-left: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve130 {
-    margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve131 {
-    margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve132 {
-    margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve133 {
-    margin-left: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve13y {
-    margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve13z {
-    margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve140 {
-    margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve141 {
-    margin-right: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve142 {
-    margin-right: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve143 {
-    margin-right: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve144 {
-    margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve145 {
-    margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve146 {
-    margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve147 {
-    margin-right: 0;
-  }
-}
-@media screen and (min-width: 1200px) {
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve1w::before {
-    margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve1x::before {
-    margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve1y::before {
-    margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve1z::before {
-    margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve110::before {
-    margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve111::before {
-    margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve112::before {
-    margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve113::before {
-    margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve114::before {
-    margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve115::before {
-    margin-bottom: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve120::after {
-    margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve121::after {
-    margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve122::after {
-    margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve123::after {
-    margin-top: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve124::after {
-    margin-top: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve125::after {
-    margin-top: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve126::after {
-    margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve127::after {
-    margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve128::after {
-    margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve129::after {
-    margin-top: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve134 {
-    margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve135 {
-    margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve136 {
-    margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve137 {
-    margin-left: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve138 {
-    margin-left: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve139 {
-    margin-left: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve13a {
-    margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve13b {
-    margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve13c {
-    margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve13d {
-    margin-left: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve148 {
-    margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve149 {
-    margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve14a {
-    margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve14b {
-    margin-right: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve14c {
-    margin-right: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve14d {
-    margin-right: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve14e {
-    margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve14f {
-    margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve14g {
-    margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve14h {
-    margin-right: 0;
-  }
-}
-.Alert_closeButton__1fve7fu0:focus .Alert_closeButtonHover__1fve7fu1, .Alert_closeButton__1fve7fu0:hover .Alert_closeButtonHover__1fve7fu1 {
-  opacity: 1;
-}
-.textAlignedToIcon_textAlignedToIcon_standard__u3vg1s0 {
-  padding-top: calc((var(--textSize-standard-mobile-lineHeight__qhrpjv3n) - var(--textSize-standard-mobile-capHeight__qhrpjv3o)) / 2);
-  padding-bottom: calc((var(--textSize-standard-mobile-lineHeight__qhrpjv3n) - var(--textSize-standard-mobile-capHeight__qhrpjv3o)) / 2);
-}
-@media screen and (min-width: 740px) {
-  .textAlignedToIcon_textAlignedToIcon_standard__u3vg1s0 {
-    padding-top: calc((var(--textSize-standard-tablet-lineHeight__qhrpjv3s) - var(--textSize-standard-tablet-capHeight__qhrpjv3t)) / 2);
-    padding-bottom: calc((var(--textSize-standard-tablet-lineHeight__qhrpjv3s) - var(--textSize-standard-tablet-capHeight__qhrpjv3t)) / 2);
-  }
-}
-.AvoidWidowIcon_nowrap__8ldtmt0 {
-  white-space: nowrap;
-}
-@keyframes Button_dot1__kmgydja {
-  14% {
-    opacity: 0;
-  }
-  15%,100% {
-    opacity: 1;
-  }
-}
-@keyframes Button_dot2__kmgydjb {
-  29% {
-    opacity: 0;
-  }
-  30%,100% {
-    opacity: 1;
-  }
-}
-@keyframes Button_dot3__kmgydjc {
-  44% {
-    opacity: 0;
-  }
-  45%,100% {
-    opacity: 1;
-  }
-}
-.Button_root__kmgydj0 {
-  text-decoration: none;
-  align-items: stretch;
-  outline-offset: 0;
-}
-.Button_root__kmgydj0:active .Button_activeAnimation__kmgydj2, .Button_forceActive__kmgydj1.Button_activeAnimation__kmgydj2 {
-  transform: var(--transform-touchable__qhrpjv5k);
-}
-.Button_root__kmgydj0:active .Button_activeOverlay__kmgydj3, .Button_forceActive__kmgydj1.Button_activeOverlay__kmgydj3 {
-  opacity: 1;
-}
-.Button_root__kmgydj0:hover:not(:disabled) .Button_hoverOverlay__kmgydj4 {
-  opacity: 1;
-}
-.Button_standard__kmgydj6 {
-  --capHeightToMinHeight__kmgydj5: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-mobile-capHeight__qhrpjv3o)) / 2);
-}
-.Button_small__kmgydj7 {
-  --capHeightToMinHeight__kmgydj5: calc(((var(--touchableSize__qhrpjv9) * 0.8) - var(--textSize-small-mobile-capHeight__qhrpjv3e)) / 2);
-}
-.Button_bleedVerticallyToCapHeight__kmgydj8 {
-  margin-top: calc(var(--capHeightToMinHeight__kmgydj5) * -1);
-  margin-bottom: calc(var(--capHeightToMinHeight__kmgydj5) * -1);
-}
-.Button_padToMinHeight__kmgydj9 {
-  padding-top: var(--capHeightToMinHeight__kmgydj5);
-  padding-bottom: var(--capHeightToMinHeight__kmgydj5);
-}
-.Button_loadingDot__kmgydjd {
-  animation-duration: 1s;
-  animation-iteration-count: infinite;
-  opacity: 0;
-}
-.Button_loadingDot__kmgydjd:nth-child(1) {
-  animation-name: Button_dot1__kmgydja;
-}
-.Button_loadingDot__kmgydjd:nth-child(2) {
-  animation-name: Button_dot2__kmgydjb;
-}
-.Button_loadingDot__kmgydjd:nth-child(3) {
-  animation-name: Button_dot3__kmgydjc;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Button_invertedBackgroundsLightMode_soft__kmgydje {
-  background: rgba(255,255,255,0.1);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Button_invertedBackgroundsLightMode_hover__kmgydjf {
-  background: rgba(255,255,255,0.15);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Button_invertedBackgroundsLightMode_active__kmgydjg {
-  background: rgba(255,255,255,0.15);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Button_invertedBackgroundsDarkMode_soft__kmgydjh {
-  background: rgba(255,255,255,0.1);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Button_invertedBackgroundsDarkMode_hover__kmgydji {
-  background: rgba(255,255,255,0.15);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Button_invertedBackgroundsDarkMode_active__kmgydjj {
-  background: rgba(255,255,255,0.15);
-}
-@media screen and (min-width: 740px) {
-  .Button_standard__kmgydj6 {
-    --capHeightToMinHeight__kmgydj5: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-tablet-capHeight__qhrpjv3t)) / 2);
-  }
-  .Button_small__kmgydj7 {
-    --capHeightToMinHeight__kmgydj5: calc(((var(--touchableSize__qhrpjv9) * 0.8) - var(--textSize-small-tablet-capHeight__qhrpjv3j)) / 2);
-  }
-}
-@keyframes Popover_popupAnimation__1yo0tp8a {
-  from {
-    opacity: 0;
-    transform: translateY(calc(var(--space-xxsmall__qhrpjv1) * var(--placementModifier__1yo0tp88, 1)));
-  }
-}
-.Popover_backdrop__1yo0tp80 {
-  width: 100vw;
-  height: 100vh;
-}
-.Popover_popoverPosition__1yo0tp87 {
-  --dynamicHeight__1yo0tp86: 100svh;
-  top: calc(var(--triggerVars_bottom__1yo0tp83) * 1px);
-  bottom: calc(var(--dynamicHeight__1yo0tp86, 100vh) - (var(--triggerVars_top__1yo0tp81) * 1px));
-  left: calc((var(--triggerVars_left__1yo0tp82) + var(--horizontalOffset__1yo0tp85)) * 1px);
-  right: calc((var(--triggerVars_right__1yo0tp84) + var(--horizontalOffset__1yo0tp85)) * 1px);
-}
-.Popover_invertPlacement__1yo0tp89 {
-  --placementModifier__1yo0tp88: -1;
-}
-.Popover_animation__1yo0tp8b {
-  animation-name: Popover_popupAnimation__1yo0tp8a;
-  animation-fill-mode: both;
-  animation-timing-function: ease;
-  animation-duration: 0.125s;
-  animation-delay: 15ms;
-}
-.Popover_delayVisibility__1yo0tp8c {
-  animation-delay: 250ms;
-}
-.TooltipRenderer_maxWidth__821e3y0 {
-  max-width: 260px;
-}
-.TooltipRenderer_overflowWrap__821e3y1 {
-  overflow-wrap: break-word;
-}
-.TooltipRenderer_translateZ0__821e3y2 {
-  transform: translateZ(0);
-}
-.TooltipRenderer_baseArrow__821e3y4 {
-  left: clamp(var(--space-medium__qhrpjv4), var(--horizontalOffset__821e3y3), calc(100% - var(--space-medium__qhrpjv4)));
-  transform: translateX(-50%);
-  visibility: hidden;
-}
-.TooltipRenderer_baseArrow__821e3y4:before {
-  content: '';
-  visibility: visible;
-  transform: rotate(45deg);
-}
-.TooltipRenderer_baseArrow__821e3y4, .TooltipRenderer_baseArrow__821e3y4::before {
-  width: calc(12px + (var(--borderRadius-small__qhrpjvb) * 2));
-  height: calc(12px + (var(--borderRadius-small__qhrpjvb) * 2));
-  position: absolute;
-  background: inherit;
-  border-radius: var(--borderRadius-small__qhrpjvb);
-}
-.TooltipRenderer_arrow_top__821e3y5 {
-  bottom: calc((12px / 2) * -1);
-}
-.TooltipRenderer_arrow_bottom__821e3y6 {
-  top: calc((12px / 2) * -1);
-}
-.ButtonIcon_button__11ol9k00:hover {
-  z-index: 1;
-}
-.ButtonIcon_button__11ol9k00::-moz-focus-inner {
-  border: 0;
-}
-.HiddenVisually_root__v7ph350 {
-  width: 1px;
-  height: 1px;
-  clip: rect(1px, 1px, 1px, 1px);
-  white-space: nowrap;
-}
-.Field_placeholderColor__klw7kj1::placeholder {
-  color: var(--foregroundColor-secondary__qhrpjv1r);
-}
-.Field_secondaryIconSpace__klw7kj2 {
-  padding-right: var(--touchableSize__qhrpjv9);
-}
-.Field_iconSpace__klw7kj3 {
-  padding-left: calc(var(--touchableSize__qhrpjv9) - 2px);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Field_hideBorderOnDarkBackgroundInLightMode__klw7kj4 {
-  opacity: 0;
-}
-.Field_field__klw7kj0:hover:not(:disabled) ~ .Field_hoverOverlay__klw7kj5, .Field_field__klw7kj0:focus ~ .Field_hoverOverlay__klw7kj5 {
-  opacity: 1;
-}
-.Field_verticalDivider__klw7kj6 {
-  width: var(--borderWidth-standard__qhrpjvy);
-  background: var(--borderColor-field__qhrpjvl);
-  opacity: 0.4;
-}
-.Autosuggest_backdrop__153m10i0 {
-  width: 100vw;
-  height: 100vh;
-  background: black;
-}
-.Autosuggest_backdropVisible__153m10i1 {
-  opacity: 0.4;
-}
-.Autosuggest_menu__153m10i2 {
-  max-height: calc((var(--touchableSize__qhrpjv9) * 6) + var(--space-xxsmall__qhrpjv1));
-  overflow-y: auto;
-}
-@media screen and (min-width: 740px) {
-  .Autosuggest_menu__153m10i2 {
-    max-height: calc((var(--touchableSize__qhrpjv9) * 8) + var(--space-xxsmall__qhrpjv1));
-  }
-}
-.Badge_inline__1r5hl7m0 {
-  display: inline-flex;
-  vertical-align: middle;
-  margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  margin-top: calc((var(--space-xxsmall__qhrpjv1) + .2em) * -1);
-}
-.Keyline_tone_promote__1kn7lf76 {
-  background: var(--promote__1kn7lf70);
-}
-.Keyline_tone_info__1kn7lf77 {
-  background: var(--info__1kn7lf71);
-}
-.Keyline_tone_positive__1kn7lf78 {
-  background: var(--positive__1kn7lf72);
-}
-.Keyline_tone_caution__1kn7lf79 {
-  background: var(--caution__1kn7lf73);
-}
-.Keyline_tone_critical__1kn7lf7a {
-  background: var(--critical__1kn7lf74);
-}
-.Keyline_tone_formAccent__1kn7lf7b {
-  background: var(--formAccent__1kn7lf75);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Keyline_lightMode_light__1kn7lf7c {
-  --promote__1kn7lf70: var(--borderColor-promote__qhrpjvw);
-  --info__1kn7lf71: var(--borderColor-info__qhrpjvp);
-  --positive__1kn7lf72: var(--borderColor-positive__qhrpjvu);
-  --caution__1kn7lf73: var(--borderColor-caution__qhrpjvh);
-  --critical__1kn7lf74: var(--borderColor-critical__qhrpjvj);
-  --formAccent__1kn7lf75: var(--borderColor-formAccent__qhrpjvn);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Keyline_lightMode_dark__1kn7lf7d {
-  --promote__1kn7lf70: var(--borderColor-promoteLight__qhrpjvx);
-  --info__1kn7lf71: var(--borderColor-infoLight__qhrpjvq);
-  --positive__1kn7lf72: var(--borderColor-positiveLight__qhrpjvv);
-  --caution__1kn7lf73: var(--borderColor-cautionLight__qhrpjvi);
-  --critical__1kn7lf74: var(--borderColor-criticalLight__qhrpjvk);
-  --formAccent__1kn7lf75: var(--borderColor-formAccentLight__qhrpjvo);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Keyline_darkMode_light__1kn7lf7e {
-  --promote__1kn7lf70: var(--borderColor-promote__qhrpjvw);
-  --info__1kn7lf71: var(--borderColor-info__qhrpjvp);
-  --positive__1kn7lf72: var(--borderColor-positive__qhrpjvu);
-  --caution__1kn7lf73: var(--borderColor-caution__qhrpjvh);
-  --critical__1kn7lf74: var(--borderColor-critical__qhrpjvj);
-  --formAccent__1kn7lf75: var(--borderColor-formAccent__qhrpjvn);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Keyline_darkMode_dark__1kn7lf7f {
-  --promote__1kn7lf70: var(--borderColor-promoteLight__qhrpjvx);
-  --info__1kn7lf71: var(--borderColor-infoLight__qhrpjvq);
-  --positive__1kn7lf72: var(--borderColor-positiveLight__qhrpjvv);
-  --caution__1kn7lf73: var(--borderColor-cautionLight__qhrpjvi);
-  --critical__1kn7lf74: var(--borderColor-criticalLight__qhrpjvk);
-  --formAccent__1kn7lf75: var(--borderColor-formAccentLight__qhrpjvo);
-}
-.Keyline_noRadiusOnRight__1kn7lf7g {
-  border-top-right-radius: 0 !important;
-  border-bottom-right-radius: 0 !important;
-}
-.Keyline_largestWidth__1kn7lf7h {
-  width: var(--borderRadius-xlarge__qhrpjve);
-}
-.Keyline_width__1kn7lf7i {
-  width: var(--grid__qhrpjva);
-}
-.InlineField_sizeVars_standard__1b4ltjx2 {
-  --fieldSize__1b4ltjx0: var(--inlineFieldSize-standard__qhrpjv5g);
-  --labelCapHeight__1b4ltjx1: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
-}
-.InlineField_sizeVars_small__1b4ltjx3 {
-  --fieldSize__1b4ltjx0: var(--inlineFieldSize-small__qhrpjv5h);
-  --labelCapHeight__1b4ltjx1: var(--textSize-small-mobile-capHeight__qhrpjv3e);
-}
-.InlineField_realField__1b4ltjx4 {
-  width: 44px;
-  height: 44px;
-  top: calc(((44px - var(--fieldSize__1b4ltjx0)) / 2) * -1);
-  left: calc(((44px - var(--fieldSize__1b4ltjx0)) / 2) * -1);
-}
-[data-braid-debug] .InlineField_realField__1b4ltjx4 {
-  background: red;
-  opacity: 0.2;
-}
-.InlineField_fakeField__1b4ltjx5 {
-  height: var(--fieldSize__1b4ltjx0);
-  width: var(--fieldSize__1b4ltjx0);
-  outline: var(--focusRingSize__qhrpjv10) solid transparent;
-  transition: outline-color .125s ease;
-}
-.InlineField_realField__1b4ltjx4[type="checkbox"]:checked ~ .InlineField_fakeField__1b4ltjx5 {
-  background: transparent;
-}
-.InlineField_realField__1b4ltjx4:focus-visible ~ .InlineField_fakeField__1b4ltjx5 {
-  outline-color: var(--borderColor-focus__qhrpjvm);
-}
-.InlineField_labelOffset__1b4ltjx6 {
-  padding-top: calc((var(--fieldSize__1b4ltjx0) - var(--labelCapHeight__1b4ltjx1)) / 2);
-}
-.InlineField_realField__1b4ltjx4:checked ~ * .InlineField_children__1b4ltjx8,
-  .InlineField_realField__1b4ltjx4.InlineField_isMixed__1b4ltjx7 ~ * .InlineField_children__1b4ltjx8 {
-  display: block;
-  z-index: 1;
-}
-.InlineField_realField__1b4ltjx4:checked + .InlineField_fakeField__1b4ltjx5 > .InlineField_selected__1b4ltjx9,
-  .InlineField_realField__1b4ltjx4.InlineField_isMixed__1b4ltjx7 + .InlineField_fakeField__1b4ltjx5 > .InlineField_selected__1b4ltjx9 {
-  opacity: 1;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .InlineField_hideBorderOnDarkBackgroundInLightMode__1b4ltjxa {
-  opacity: 0;
-}
-.InlineField_realField__1b4ltjx4:hover:not(:checked):not(.InlineField_isMixed__1b4ltjx7):not(:disabled) + .InlineField_fakeField__1b4ltjx5 > .InlineField_hoverOverlay__1b4ltjxb,
-  .InlineField_realField__1b4ltjx4:focus:not(.InlineField_isMixed__1b4ltjx7) + .InlineField_fakeField__1b4ltjx5 > .InlineField_hoverOverlay__1b4ltjxb {
-  opacity: 1;
-}
-.InlineField_hoverOverlay__1b4ltjxb > .InlineField_indicator__1b4ltjxc {
-  opacity: 0.2;
-}
-.InlineField_disabledRadioIndicator__1b4ltjxd {
-  opacity: 0.3;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .InlineField_disabledRadioIndicator__1b4ltjxd {
-  background-color: var(--foregroundColor-secondary__qhrpjv1r);
-}
-html.sprinkles_darkMode__1hjdb9v11 .InlineField_disabledRadioIndicator__1b4ltjxd {
-  background-color: var(--foregroundColor-secondaryInverted__qhrpjv1s);
-}
-.InlineField_checkboxScale__1b4ltjxe {
-  transform: scale(0.85);
-}
-.InlineField_realField__1b4ltjx4:active + .InlineField_fakeField__1b4ltjx5 > * > .InlineField_checkboxScale__1b4ltjxe {
-  transform: scale(0.75);
-}
-.InlineField_radioScale__1b4ltjxf {
-  transform: scale(0.6);
-}
-.InlineField_realField__1b4ltjx4:active + .InlineField_fakeField__1b4ltjx5 > * > .InlineField_radioScale__1b4ltjxf {
-  transform: scale(0.5);
-}
-@media screen and (min-width: 740px) {
-  .InlineField_sizeVars_standard__1b4ltjx2 {
-    --labelCapHeight__1b4ltjx1: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
-  }
-  .InlineField_sizeVars_small__1b4ltjx3 {
-    --labelCapHeight__1b4ltjx1: var(--textSize-small-tablet-capHeight__qhrpjv3j);
-  }
-}
-.ContentBlock_marginAuto__1xx6jv80 {
-  margin: 0 auto;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Modal_backdrop__13n71fr2 {
-  background: rgba(0, 0, 0, 0.4);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Modal_backdrop__13n71fr2 {
-  background: rgba(0, 0, 0, 0.6);
-}
-.Modal_rightAnimation__13n71fr4 {
-  opacity: 1;
-  transform: translateX(110%);
-}
-.Modal_leftAnimation__13n71fr5 {
-  opacity: 1;
-  transform: translateX(-110%);
-}
-.Modal_centerAnimation__13n71fr6 {
-  transform: scale(.8);
-}
-.Modal_horizontalTransition__13n71fr7 {
-  transition: transform .3s cubic-bezier(0.4, 0, 0, 1), opacity .3s cubic-bezier(0.4, 0, 0, 1);
-}
-.Modal_pointerEventsAll__13n71fr9 {
-  pointer-events: all;
-}
-.Modal_viewportHeight__13n71frd {
-  max-height: var(--fullHeightVar__13n71frb);
-}
-.Modal_maxSize_center__13n71fre {
-  --gutterSizeVar__13n71fra: var(--space-xsmall__qhrpjv2);
-  max-height: calc(var(--fullHeightVar__13n71frb) - (var(--gutterSizeVar__13n71fra) * 2));
-  max-width: calc(var(--fullWidthVar__13n71frc) - (var(--gutterSizeVar__13n71fra) * 2));
-}
-.Modal_modalContainer__13n71frf {
-  --fullHeightVar__13n71frb: 100vh;
-  --fullWidthVar__13n71frc: 100vw;
-  max-height: var(--fullHeightVar__13n71frb);
-  max-width: var(--fullWidthVar__13n71frc);
-}
-.Modal_headingRoot__13n71frg {
-  overflow-wrap: break-word;
-}
-.Modal_closeIconOffset__13n71frh {
-  top: -5px;
-  right: -5px;
-}
-@media screen and (prefers-reduced-motion) {
-  .Modal_reducedMotion__13n71fr3 {
-    transform: none !important;
-  }
-}
-@media screen and (min-width: 740px) {
-  .Modal_rightAnimation__13n71fr4 {
-    opacity: 0;
-    transform: translateX(40px);
-  }
-  .Modal_leftAnimation__13n71fr5 {
-    opacity: 0;
-    transform: translateX(-40px);
-  }
-  .Modal_horizontalTransition__13n71fr7 {
-    transition: transform .175s cubic-bezier(0.4, 0, 0, 1), opacity .175s cubic-bezier(0.4, 0, 0, 1);
-  }
-  .Modal_maxSize_center__13n71fre {
-    --gutterSizeVar__13n71fra: var(--space-gutter__qhrpjv0);
-  }
-}
-@media screen and (min-width: 992px) {
-  .Modal_maxSize_center__13n71fre {
-    --gutterSizeVar__13n71fra: var(--space-xlarge__qhrpjv6);
-  }
-}
-@supports (height: 1dvh) {
-  .Modal_modalContainer__13n71frf {
-    --fullHeightVar__13n71frb: 100dvh;
-    --fullWidthVar__13n71frc: 100dvw;
-  }
-}
-.TextLink_base__beoo42 {
-  color: var(--color__beoo40);
-  text-decoration: var(--linkDecoration__qhrpjv5f);
-  text-decoration-thickness: 0.08em;
-  text-underline-offset: 3px;
-  outline-offset: 0.2em;
-  border-radius: var(--borderRadius-small__qhrpjvb);
-}
-.TextLink_base__beoo42:hover {
-  color: var(--colorHover__beoo41);
-  text-decoration: underline;
-  text-decoration-thickness: 0.08em;
-}
-.TextLink_base__beoo42:focus-visible {
-  color: var(--colorHover__beoo41);
-}
-.TextLink_weakLink__beoo43 {
-  --color__beoo40: inherit;
-  --colorHover__beoo41: inherit;
-  text-decoration: underline;
-  text-decoration-thickness: 0.08em;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_regularLinkLightMode_light__beoo44 {
-  --color__beoo40: var(--foregroundColor-link__qhrpjv1f);
-  --colorHover__beoo41: var(--foregroundColor-linkHover__qhrpjv1g);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_regularLinkLightMode_dark__beoo45 {
-  --color__beoo40: var(--foregroundColor-linkLight__qhrpjv1h);
-  --colorHover__beoo41: var(--foregroundColor-linkLight__qhrpjv1h);
-}
-html.sprinkles_darkMode__1hjdb9v11 .TextLink_regularLinkDarkMode_light__beoo46 {
-  --color__beoo40: var(--foregroundColor-link__qhrpjv1f);
-  --colorHover__beoo41: var(--foregroundColor-linkHover__qhrpjv1g);
-}
-html.sprinkles_darkMode__1hjdb9v11 .TextLink_regularLinkDarkMode_dark__beoo47 {
-  --color__beoo40: var(--foregroundColor-linkLight__qhrpjv1h);
-  --colorHover__beoo41: var(--foregroundColor-linkLight__qhrpjv1h);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_visitedLightMode_light__beoo48:visited {
-  color: var(--foregroundColor-linkVisited__qhrpjv1i);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_visitedLightMode_dark__beoo49:visited {
-  color: var(--foregroundColor-linkLightVisited__qhrpjv1j);
-}
-html.sprinkles_darkMode__1hjdb9v11 .TextLink_visitedDarkMode_light__beoo4a:visited {
-  color: var(--foregroundColor-linkVisited__qhrpjv1i);
-}
-html.sprinkles_darkMode__1hjdb9v11 .TextLink_visitedDarkMode_dark__beoo4b:visited {
-  color: var(--foregroundColor-linkLightVisited__qhrpjv1j);
-}
-.Dropdown_field__gz3fci0 {
-  padding-right: var(--touchableSize__qhrpjv9);
-}
-@media print {
-  .Hidden_hiddenOnPrint__1mw96wl0 {
-    display: none !important;
-  }
-}
-.List_currentColor__1an15sm0 {
-  background: currentColor;
-}
-.List_large__1an15sm1 {
-  width: 5px;
-  height: 5px;
-}
-.List_standard__1an15sm2 {
-  width: 4px;
-  height: 4px;
-}
-.List_xsmall__1an15sm3 {
-  width: 3px;
-  height: 3px;
-}
-.List_minCharacterWidth__1an15sm4 {
-  min-width: 1.4ch;
-}
-.List_minCharacterWidth__1an15sm5 {
-  min-width: 2.4ch;
-}
-.List_trimGutter__1an15sm6 {
-  margin-right: -0.4ch;
-}
-@keyframes Loader_bounce__e5c4uh9 {
-  33% {
-    transform: translateY(-1.4em);
-  }
-  66% {
-    transform: translateY(1.4em);
-  }
-}
-@keyframes Loader_fade__e5c4uhd {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-.Loader_rootSize_xsmall__e5c4uh0 {
-  height: var(--textSize-xsmall-mobile-capHeight__qhrpjv34);
-}
-.Loader_rootSize_small__e5c4uh1 {
-  height: var(--textSize-small-mobile-capHeight__qhrpjv3e);
-}
-.Loader_rootSize_standard__e5c4uh2 {
-  height: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
-}
-.Loader_rootSize_large__e5c4uh3 {
-  height: var(--textSize-large-mobile-capHeight__qhrpjv3y);
-}
-.Loader_size_xsmall__e5c4uh4 {
-  height: var(--textSize-xsmall-mobile-fontSize__qhrpjv32);
-}
-.Loader_size_small__e5c4uh5 {
-  height: var(--textSize-small-mobile-fontSize__qhrpjv3c);
-}
-.Loader_size_standard__e5c4uh6 {
-  height: var(--textSize-standard-mobile-fontSize__qhrpjv3m);
-}
-.Loader_size_large__e5c4uh7 {
-  height: var(--textSize-large-mobile-fontSize__qhrpjv3w);
-}
-.Loader_currentColor__e5c4uh8 {
-  fill: currentcolor;
-}
-.Loader_bounceAnimation__e5c4uha {
-  animation-name: Loader_bounce__e5c4uh9;
-  animation-fill-mode: both;
-  animation-iteration-count: infinite;
-  animation-timing-function: ease-in-out;
-  animation-duration: 0.6s;
-}
-.Loader_circle__e5c4uhb {
-  transform: translateY(1.4em);
-}
-.Loader_circle__e5c4uhb:nth-child(1) {
-  animation-delay: 140ms;
-}
-.Loader_circle__e5c4uhb:nth-child(2) {
-  animation-delay: 70ms;
-}
-.Loader_delay__e5c4uhe {
-  opacity: 0;
-  animation-name: Loader_fade__e5c4uhd;
-  animation-iteration-count: 1;
-  animation-fill-mode: forwards;
-  animation-timing-function: ease-in;
-  animation-duration: 0.25s;
-  animation-delay: 800ms;
-}
-@media screen and (min-width: 740px) {
-  .Loader_rootSize_xsmall__e5c4uh0 {
-    height: var(--textSize-xsmall-tablet-capHeight__qhrpjv39);
-  }
-  .Loader_rootSize_small__e5c4uh1 {
-    height: var(--textSize-small-tablet-capHeight__qhrpjv3j);
-  }
-  .Loader_rootSize_standard__e5c4uh2 {
-    height: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
-  }
-  .Loader_rootSize_large__e5c4uh3 {
-    height: var(--textSize-large-tablet-capHeight__qhrpjv43);
-  }
-  .Loader_size_xsmall__e5c4uh4 {
-    height: var(--textSize-xsmall-tablet-fontSize__qhrpjv37);
-  }
-  .Loader_size_small__e5c4uh5 {
-    height: var(--textSize-small-tablet-fontSize__qhrpjv3h);
-  }
-  .Loader_size_standard__e5c4uh6 {
-    height: var(--textSize-standard-tablet-fontSize__qhrpjv3r);
-  }
-  .Loader_size_large__e5c4uh7 {
-    height: var(--textSize-large-tablet-fontSize__qhrpjv41);
-  }
-}
-.ScrollContainer_container__1aqz9r10 {
-  -webkit-overflow-scrolling: touch;
-  -webkit-mask-composite: destination-in;
-  mask-composite: intersect;
-}
-.ScrollContainer_hideScrollbar__1aqz9r11 {
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-.ScrollContainer_hideScrollbar__1aqz9r11::-webkit-scrollbar {
-  width: 0;
-  height: 0;
-}
-.ScrollContainer_fadeSize_small__1aqz9r13 {
-  --scrollOverlaySize__1aqz9r12: 40px;
-}
-.ScrollContainer_fadeSize_medium__1aqz9r14 {
-  --scrollOverlaySize__1aqz9r12: 60px;
-}
-.ScrollContainer_fadeSize_large__1aqz9r15 {
-  --scrollOverlaySize__1aqz9r12: 80px;
-}
-.ScrollContainer_direction_horizontal__1aqz9r16 {
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: fit-content;
-}
-.ScrollContainer_direction_vertical__1aqz9r17 {
-  overflow-x: hidden;
-  overflow-y: auto;
-}
-.ScrollContainer_direction_all__1aqz9r18 {
-  overflow: auto;
-}
-.ScrollContainer_mask__1aqz9r1d {
-  mask-image: linear-gradient(to bottom, transparent 0, black var(--top__1aqz9r1b, 0)),linear-gradient(to right, transparent 0, black var(--left__1aqz9r19, 0)),linear-gradient(to left, transparent 0, black var(--right__1aqz9r1a, 0)),linear-gradient(to top, transparent 0, black var(--bottom__1aqz9r1c, 0));
-}
-.ScrollContainer_maskLeft__1aqz9r1e {
-  --left__1aqz9r19: var(--scrollOverlaySize__1aqz9r12);
-}
-.ScrollContainer_maskRight__1aqz9r1f {
-  --right__1aqz9r1a: var(--scrollOverlaySize__1aqz9r12);
-}
-.ScrollContainer_maskTop__1aqz9r1g {
-  --top__1aqz9r1b: var(--scrollOverlaySize__1aqz9r12);
-}
-.ScrollContainer_maskBottom__1aqz9r1h {
-  --bottom__1aqz9r1c: var(--scrollOverlaySize__1aqz9r12);
-}
-.MenuRenderer_backdrop__p34lbl1 {
-  width: 100vw;
-  height: 100vh;
-}
-.MenuRenderer_menuPosition__p34lbl6 {
-  top: var(--triggerVars_bottom__p34lbl4);
-  bottom: var(--triggerVars_top__p34lbl2);
-  left: var(--triggerVars_left__p34lbl3);
-  right: var(--triggerVars_right__p34lbl5);
-}
-.MenuRenderer_baseWidth__p34lbl8 {
-  width: calc(var(--widthVar__p34lbl7) / 4);
-}
-.MenuRenderer_width_small__p34lbl9 {
-  --widthVar__p34lbl7: var(--contentWidth-small__qhrpjv12);
-}
-.MenuRenderer_width_medium__p34lbla {
-  --widthVar__p34lbl7: var(--contentWidth-medium__qhrpjv13);
-}
-.MenuRenderer_width_large__p34lblb {
-  --widthVar__p34lbl7: var(--contentWidth-large__qhrpjv14);
-}
-.MenuRenderer_menuHeightLimit__p34lblc {
-  max-height: calc((var(--touchableSize__qhrpjv9) * 9.5) + (var(--menuYPadding__p34lbl0) * 2));
-}
-.useMenuItem_menuItem__wz3nke0::-moz-focus-inner {
-  border: 0;
-}
-.useMenuItem_menuItemLeftSlot__wz3nke1 {
-  height: 0px;
-}
-.MenuItemCheckbox_checkboxSize__17whdqr2 {
-  --menuItemCapHeight__17whdqr0: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
-  --crop__17whdqr1: calc(((var(--inlineFieldSize-small__qhrpjv5h) - var(--menuItemCapHeight__17whdqr0)) / 2) * -1);
-  height: var(--inlineFieldSize-small__qhrpjv5h);
-  width: var(--inlineFieldSize-small__qhrpjv5h);
-  margin-top: var(--crop__17whdqr1);
-  margin-bottom: var(--crop__17whdqr1);
-}
-@media screen and (min-width: 740px) {
-  .MenuItemCheckbox_checkboxSize__17whdqr2 {
-    --menuItemCapHeight__17whdqr0: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
-  }
-}
-.OverflowMenu_wrapperPositioning__18ydm7f0 {
-  margin: -1px -6px;
-}
-.MonthPicker_nativeInput__1xbm4s00::-webkit-inner-spin-button, .MonthPicker_nativeInput__1xbm4s00::-webkit-calendar-picker-indicator, .MonthPicker_nativeInput__1xbm4s00::-webkit-clear-button {
-  display: none;
-  -webkit-appearance: none;
-}
-.Page_fullHeight__7puj9a1 {
-  min-height: var(--heightLimit__7puj9a0, 100vh);
-}
-.Pagination_focusRing__oms9uc1 {
-  outline-offset: 0;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Pagination_lightModeCurrentKeyline__oms9uc3 {
-  opacity: 0.3;
-}
-html.sprinkles_darkMode__1hjdb9v11 .Pagination_darkModeCurrentKeyline__oms9uc4 {
-  opacity: 0.3;
-}
-.Pagination_current__oms9uc5 {
-  opacity: 0.075;
-}
-.Pagination_hover__oms9uc2:hover .Pagination_background__oms9uc6:not(.Pagination_current__oms9uc5) {
-  opacity: 0.5;
-}
-.Rating_inlineFlex__nkq5400 {
-  display: inline-flex;
-  gap: 1px;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_tone_formAccent__6woprh2 {
-  --highlightVar__6woprh1: var(--borderColor-formAccent__qhrpjvn);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Stepper_tone_formAccent__6woprh2 {
-  --highlightVar__6woprh1: var(--borderColor-formAccentLight__qhrpjvo);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_tone_neutral__6woprh3 {
-  --highlightVar__6woprh1: var(--borderColor-neutral__qhrpjvr);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Stepper_tone_neutral__6woprh3 {
-  --highlightVar__6woprh1: var(--borderColor-neutralLight__qhrpjvt);
-}
-.Stepper_step__6woprh4 {
-  outline: none;
-  text-align: left;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_step__6woprh4 {
-  --baseColourVar__6woprh0: var(--borderColor-neutralLight__qhrpjvt);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Stepper_step__6woprh4 {
-  --baseColourVar__6woprh0: var(--borderColor-neutral__qhrpjvr);
-}
-.Stepper_indicator__6woprh6 {
-  height: var(--inlineFieldSize-small__qhrpjv5h);
-  width: var(--inlineFieldSize-small__qhrpjv5h);
-  color: var(--baseColourVar__6woprh0);
-}
-.Stepper_stretch__6woprh7 {
-  flex: 1;
-}
-.Stepper_highlight__6woprh9 {
-  color: var(--highlightVar__6woprh1);
-}
-.Stepper_inner__6woprhd {
-  fill: currentcolor;
-  transform-origin: 50% 50%;
-  transform: scale(0);
-}
-.Stepper_active__6woprhb > .Stepper_inner__6woprhd {
-  transform: scale(1);
-  opacity: 1;
-}
-.Stepper_complete__6woprha > .Stepper_inner__6woprhd {
-  transform: scale(2.1);
-  opacity: 1;
-}
-.Stepper_tick__6woprhf {
-  transition-delay: .1s;
-  transform-origin: 50% 50%;
-}
-:not(.Stepper_complete__6woprha) > .Stepper_tick__6woprhf {
-  opacity: 0;
-  transition-delay: 0s;
-  transform: scale(.5) rotate(50deg);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_tick__6woprhf {
-  fill: var(--foregroundColor-neutralInverted__qhrpjv1l);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Stepper_tick__6woprhf {
-  fill: var(--foregroundColor-neutral__qhrpjv1k);
-}
-.Stepper_progressTrack__6woprhg {
-  background: repeating-linear-gradient(90deg, var(--baseColourVar__6woprh0), var(--baseColourVar__6woprh0) 2px, transparent 2px, transparent 4px);
-  height: var(--borderWidth-large__qhrpjvz);
-  width: calc((100% - var(--inlineFieldSize-small__qhrpjv5h)) - (var(--space-xxsmall__qhrpjv1) * 2));
-  top: calc((var(--inlineFieldSize-small__qhrpjv5h) - var(--borderWidth-large__qhrpjvz)) / 2);
-  left: calc(var(--inlineFieldSize-small__qhrpjv5h) + var(--space-xxsmall__qhrpjv1));
-}
-.Stepper_progressLine__6woprhi {
-  background: var(--highlightVar__6woprh1);
-  transition: transform .2s ease;
-}
-.Stepper_progressUnfilled__6woprhj {
-  transform: translateX(-101%);
-}
-.Stepper_indicatorContainer__6woprhk {
-  outline: var(--focusRingSize__qhrpjv10) solid transparent;
-  width: var(--inlineFieldSize-small__qhrpjv5h);
-  transition: var(--transition-fast__qhrpjv5i), outline-color .125s ease;
-}
-.Stepper_step__6woprh4:focus-visible .Stepper_indicatorContainer__6woprhk {
-  outline-color: var(--borderColor-focus__qhrpjvm);
-  transform: scale(1.2);
-}
-.Stepper_step__6woprh4:active .Stepper_indicatorContainer__6woprhk {
-  transform: var(--transform-touchable__qhrpjv5k);
-}
-@media screen and (min-width: 740px) {
-  .Stepper_stretchLastAboveTablet__6woprh8 {
-    flex: 1;
-  }
-  .Stepper_progressTrackCentered__6woprhh {
-    left: calc((50% + (var(--inlineFieldSize-small__qhrpjv5h) / 2)) + var(--space-xxsmall__qhrpjv1));
-  }
-}
-.Table_table__y0v62q1 {
-  border-collapse: separate;
-  border: var(--borderWidth-standard__qhrpjvy) solid var(--borderColor__y0v62q0);
-  font-variant-numeric: tabular-nums;
-  word-break: break-word;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Table_table__y0v62q1 {
-  --borderColor__y0v62q0: var(--borderColor-neutralLight__qhrpjvt);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Table_table__y0v62q1 {
-  --borderColor__y0v62q0: var(--borderColor-neutral__qhrpjvr);
-}
-.Table_row__y0v62q4:not(:last-child) > .Table_cell__y0v62q5 {
-  border-bottom: 1px solid var(--borderColor__y0v62q0);
-}
-.Table_tableSection__y0v62q3:not(.Table_tableHeader__y0v62q2) > .Table_row__y0v62q4 > .Table_headCell__y0v62q6:not(:first-child) {
-  border-left: 1px solid var(--borderColor__y0v62q0);
-}
-.Table_tableSection__y0v62q3:not(.Table_tableHeader__y0v62q2) > .Table_row__y0v62q4 > .Table_headCell__y0v62q6:not(:last-child) {
-  border-right: 1px solid var(--borderColor__y0v62q0);
-}
-.Table_tableSection__y0v62q3:not(:first-child) > .Table_row__y0v62q4:first-child > .Table_cell__y0v62q5 {
-  border-top: var(--borderWidth-standard__qhrpjvy) solid var(--borderColor__y0v62q0);
-}
-.Table_alignY_center__y0v62q7 {
-  vertical-align: middle;
-}
-.Table_alignY_top__y0v62q8 {
-  vertical-align: top;
-}
-.Table_nowrap__y0v62q9 {
-  white-space: nowrap;
-}
-.Table_softWidth__y0v62qb {
-  width: var(--softWidthVar__y0v62qa);
-}
-.Table_minWidth__y0v62qd {
-  min-width: var(--minWidthVar__y0v62qc);
-}
-.Table_maxWidth__y0v62qf {
-  max-width: var(--maxWidthVar__y0v62qe);
-}
-@media screen and (min-width: 740px) {
-  .Table_showOnTablet__y0v62qg {
-    display: table-cell;
-  }
-}
-@media screen and (min-width: 992px) {
-  .Table_showOnDesktop__y0v62qh {
-    display: table-cell;
-  }
-}
-@media screen and (min-width: 1200px) {
-  .Table_showOnWide__y0v62qi {
-    display: table-cell;
-  }
-}
-.Tabs_tab__wez1qd0::-moz-focus-inner {
-  border: 0;
-}
-.Tabs_tab__wez1qd0:hover .Tabs_hoveredTab__wez1qd1 {
-  opacity: 1;
-}
-.Tabs_nowrap__wez1qd2 {
-  white-space: nowrap;
-}
-.Tabs_scroll__wez1qd3 {
-  -webkit-overflow-scrolling: touch;
-  overflow-x: auto;
-  overflow-y: hidden;
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-.Tabs_scroll__wez1qd3::-webkit-scrollbar {
-  width: 0;
-  height: 0;
-}
-.Tabs_mask__wez1qd4 {
-  mask-image: linear-gradient(90deg, rgba(0,0,0,1) 0, rgba(0,0,0,1) calc(100% - 80px), rgba(0,0,0,0) 100%);
-}
-.Tabs_marginAuto__wez1qd5 {
-  margin-left: auto;
-  margin-right: auto;
-}
-.Tabs_tabFocusRing__wez1qd6 {
-  outline-offset: calc(var(--focusRingSize__qhrpjv10) * -1);
-}
-.Tabs_tabUnderline__wez1qdb {
-  --underlineRadius__wez1qd9: calc(var(--borderRadius-small__qhrpjvb) / var(--underlineScale__wez1qda));
-  --underlineScale__wez1qda: calc(var(--underlineWidth__wez1qd8) / 100);
-  height: var(--borderWidth-large__qhrpjvz);
-  border-top-left-radius: var(--underlineRadius__wez1qd9);
-  border-top-right-radius: var(--underlineRadius__wez1qd9);
-  width: 100px;
-  transform-origin: 0 0;
-  transition: transform .3s ease;
-  transform: translateZ(0) translateX(calc(var(--underlineLeft__wez1qd7) * 1px)) scaleX(var(--underlineScale__wez1qda));
-}
-html.sprinkles_darkMode__1hjdb9v11 .Tabs_tabUnderlineActiveDarkMode__wez1qdc {
-  background: var(--borderColor-formAccentLight__qhrpjvo);
-}
-.Tabs_divider__wez1qde {
-  height: var(--borderWidth-standard__qhrpjvy);
-}
-.Tag_clearGutter__1jrpwfo0 {
-  padding-left: 1px;
-}
-.Highlight_root__cnytm1 {
-  padding: 0 2px;
-  margin: 0 -2px;
-  text-decoration: underline;
-  text-decoration-style: wavy;
-  text-decoration-skip-ink: none;
-  text-decoration-thickness: 2px;
-  text-underline-offset: 2px;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Highlight_critical__cnytm2 {
-  text-decoration-color: var(--borderColor-critical__qhrpjvj);
-  background: var(--backgroundColor-criticalLight__qhrpjv27);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Highlight_critical__cnytm2 {
-  text-decoration-color: var(--borderColor-criticalLight__qhrpjvk);
-}
-.Highlight_caution__cnytm3 {
-  text-decoration-color: var(--borderColor-caution__qhrpjvh);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Highlight_caution__cnytm3 {
-  background: var(--backgroundColor-cautionLight__qhrpjv23);
-}
-.Textarea_field__ak2u6d0 {
-  resize: vertical;
-  background: transparent;
-  min-height: calc(var(--grid__qhrpjva) * 15);
-}
-.Textarea_highlights__ak2u6d1 {
-  color: transparent !important;
-  word-break: break-word;
-  white-space: pre-wrap;
-}
-.Textarea_highlights__ak2u6d1:after {
-  content: "\\A";
-}
-.TextDropdown_select__pu1g620 {
-  min-height: 44px;
-  min-width: 44px;
-  height: 100%;
-  width: 100%;
-  transform: translate(-50%, -50%);
-  top: 50%;
-  left: 50%;
-}
-[data-braid-debug] .TextDropdown_select__pu1g620 {
-  background: red;
-  opacity: 0.2;
-}
-.TextDropdown_focusRing__pu1g622 {
-  outline: var(--focusRingSize__qhrpjv10) solid transparent;
-  transition: outline-color .125s ease;
-  outline-offset: var(--space-xxsmall__qhrpjv1);
-}
-.TextDropdown_select__pu1g620:focus-visible ~ .TextDropdown_focusRing__pu1g622 {
-  outline-color: var(--borderColor-focus__qhrpjvm);
-}
-.Tiles_tiles__5j02iv5 {
-  --columns__5j02iv0: var(--mobileColumnsVar__5j02iv1);
-  display: grid;
-  grid-template-columns: repeat(var(--columns__5j02iv0), 1fr);
-}
-.Tiles_tiles__5j02iv5 > * {
-  min-width: 0;
-}
-@media screen and (min-width: 740px) {
-  .Tiles_tiles__5j02iv5 {
-    --columns__5j02iv0: var(--tabletColumnsVar__5j02iv2);
-  }
-}
-@media screen and (min-width: 992px) {
-  .Tiles_tiles__5j02iv5 {
-    --columns__5j02iv0: var(--desktopColumnsVar__5j02iv3);
-  }
-}
-@media screen and (min-width: 1200px) {
-  .Tiles_tiles__5j02iv5 {
-    --columns__5j02iv0: var(--wideColumnsVar__5j02iv4);
-  }
-}
-.Toggle_bleedToCapHeight_standard__158h80u0 {
-  height: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
-}
-.Toggle_bleedToCapHeight_small__158h80u1 {
-  height: var(--textSize-small-mobile-capHeight__qhrpjv3e);
-}
-.Toggle_root__158h80u2:hover {
-  z-index: 1;
-}
-.Toggle_realField__158h80u3 {
-  height: 44px;
-}
-[data-braid-debug] .Toggle_realField__158h80u3 {
-  background: red;
-  opacity: 0.2;
-}
-.Toggle_realFieldPosition_standard__158h80u4 {
-  top: calc(((44px - var(--inlineFieldSize-standard__qhrpjv5g)) / 2) * -1);
-}
-.Toggle_realFieldPosition_small__158h80u5 {
-  top: calc(((44px - var(--inlineFieldSize-small__qhrpjv5h)) / 2) * -1);
-}
-.Toggle_fieldSize_standard__158h80u6 {
-  width: calc(var(--inlineFieldSize-standard__qhrpjv5g) * 1.6);
-}
-.Toggle_fieldSize_small__158h80u7 {
-  width: calc(var(--inlineFieldSize-small__qhrpjv5h) * 1.6);
-}
-.Toggle_slideContainerSize_standard__158h80u9 {
-  height: var(--inlineFieldSize-standard__qhrpjv5g);
-}
-.Toggle_slideContainerSize_small__158h80ua {
-  height: var(--inlineFieldSize-small__qhrpjv5h);
-}
-.Toggle_slideTrack_standard__158h80ub {
-  height: calc(var(--inlineFieldSize-standard__qhrpjv5g) - var(--grid__qhrpjva));
-}
-.Toggle_slideTrack_small__158h80uc {
-  height: calc(var(--inlineFieldSize-small__qhrpjv5h) - var(--grid__qhrpjva));
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Toggle_slideTrackBgLightMode_light__158h80ud {
-  background: rgba(0,0,0,0.08);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Toggle_slideTrackBgLightMode_dark__158h80ue {
-  background: rgba(255,255,255,0.12);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Toggle_slideTrackBgDarkMode_light__158h80uf {
-  background: rgba(0,0,0,0.08);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Toggle_slideTrackBgDarkMode_dark__158h80ug {
-  background: rgba(255,255,255,0.12);
-}
-.Toggle_slideTrackMask__158h80uh {
-  -webkit-mask-image: -webkit-radial-gradient(white, black);
-}
-.Toggle_realField__158h80u3:not(:checked) + .Toggle_slideContainer__158h80u8 .Toggle_slideTrackSelected__158h80ui {
-  transform: translateX(calc(var(--touchableSize__qhrpjv9) * -1));
-}
-.Toggle_slider_standard__158h80uj {
-  outline: var(--focusRingSize__qhrpjv10) solid transparent;
-  height: var(--inlineFieldSize-standard__qhrpjv5g);
-  width: var(--inlineFieldSize-standard__qhrpjv5g);
-  transition: var(--transition-fast__qhrpjv5i), outline-color .125s ease;
-}
-.Toggle_realField__158h80u3:focus-visible + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
-  outline-color: var(--borderColor-focus__qhrpjvm);
-}
-.Toggle_realField__158h80u3:active + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
-  transform: translateX(calc((var(--inlineFieldSize-standard__qhrpjv5g) * 0.12) * -1));
-}
-.Toggle_realField__158h80u3:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
-  transform: translateX(calc((var(--inlineFieldSize-standard__qhrpjv5g) * 1.6) - var(--inlineFieldSize-standard__qhrpjv5g)));
-}
-.Toggle_realField__158h80u3:active:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
-  transform: translateX(calc(((var(--inlineFieldSize-standard__qhrpjv5g) * 1.6) - var(--inlineFieldSize-standard__qhrpjv5g)) + (var(--inlineFieldSize-standard__qhrpjv5g) * 0.12)));
-}
-.Toggle_slider_small__158h80uk {
-  outline: var(--focusRingSize__qhrpjv10) solid transparent;
-  height: var(--inlineFieldSize-small__qhrpjv5h);
-  width: var(--inlineFieldSize-small__qhrpjv5h);
-  transition: var(--transition-fast__qhrpjv5i), outline-color .125s ease;
-}
-.Toggle_realField__158h80u3:focus-visible + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
-  outline-color: var(--borderColor-focus__qhrpjvm);
-}
-.Toggle_realField__158h80u3:active + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
-  transform: translateX(calc((var(--inlineFieldSize-small__qhrpjv5h) * 0.12) * -1));
-}
-.Toggle_realField__158h80u3:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
-  transform: translateX(calc((var(--inlineFieldSize-small__qhrpjv5h) * 1.6) - var(--inlineFieldSize-small__qhrpjv5h)));
-}
-.Toggle_realField__158h80u3:active:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
-  transform: translateX(calc(((var(--inlineFieldSize-small__qhrpjv5h) * 1.6) - var(--inlineFieldSize-small__qhrpjv5h)) + (var(--inlineFieldSize-small__qhrpjv5h) * 0.12)));
-}
-.Toggle_sliderThumbOutlineFix__158h80ul {
-  transform: scale(1.04);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Toggle_hideBorderOnDarkBackgroundInLightMode__158h80um {
-  opacity: 0;
-}
-.Toggle_realField__158h80u3:hover:not(:disabled) + .Toggle_slideContainer__158h80u8 .Toggle_hoverOverlay__158h80un,
-  .Toggle_realField__158h80u3:focus + .Toggle_slideContainer__158h80u8 .Toggle_hoverOverlay__158h80un {
-  opacity: 1;
-}
-@media screen and (min-width: 740px) {
-  .Toggle_bleedToCapHeight_standard__158h80u0 {
-    height: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
-  }
-  .Toggle_bleedToCapHeight_small__158h80u1 {
-    height: var(--textSize-small-tablet-capHeight__qhrpjv3j);
-  }
-}
-.Toast_toast__1nhoi470 {
-  pointer-events: all;
-}
-.Toast_collapsed__1nhoi471 .Toast_collapsedToastContent__1nhoi472 {
-  opacity: 0;
-}
-.Toaster_toaster__103l6ur0 {
-  left: 0;
-  right: 0;
-  margin-inline: auto;
-  bottom: var(--space-xsmall__qhrpjv2);
-  max-width: min(var(--contentWidth-xsmall__qhrpjv11), calc(100vw - (2 * var(--space-small__qhrpjv3))));
-}
-.IconArrow_root__1igczit0 {
-  transition: transform 0.3s ease;
-  transform-origin: 50% 50%;
-}
-.IconArrow_flip__1igczit1 {
-  transform: rotateX(180deg);
-}
-.IconArrow_rotate__1igczit3 {
-  transform: scaleX(var(--mirrorVar__1igczit2, 1)) rotate(90deg);
-}
-.IconArrow_mirror__1igczit4 {
-  --mirrorVar__1igczit2: -1;
-}
-.IconThumb_root__fympft0 {
-  transition: transform 0.3s ease;
-  transform-origin: 50% 50%;
-}
-.IconThumb_down__fympft1 {
-  transform: rotate(180deg);
-}
-.seekJobs_seekJobs__1fmskxf0 {
-  --space-gutter__qhrpjv0: 24px;
-  --space-xxsmall__qhrpjv1: 8px;
-  --space-xsmall__qhrpjv2: 12px;
-  --space-small__qhrpjv3: 16px;
-  --space-medium__qhrpjv4: 24px;
-  --space-large__qhrpjv5: 32px;
-  --space-xlarge__qhrpjv6: 48px;
-  --space-xxlarge__qhrpjv7: 64px;
-  --space-xxxlarge__qhrpjv8: 96px;
-  --touchableSize__qhrpjv9: 48px;
-  --grid__qhrpjva: 4px;
-  --borderRadius-small__qhrpjvb: 4px;
-  --borderRadius-standard__qhrpjvc: 8px;
-  --borderRadius-large__qhrpjvd: 16px;
-  --borderRadius-xlarge__qhrpjve: 24px;
-  --borderColor-brandAccent__qhrpjvf: #E60278;
-  --borderColor-brandAccentLight__qhrpjvg: #F8B1DC;
-  --borderColor-caution__qhrpjvh: #FDC221;
-  --borderColor-cautionLight__qhrpjvi: #FEE384;
-  --borderColor-critical__qhrpjvj: #B91E1E;
-  --borderColor-criticalLight__qhrpjvk: #FB999A;
-  --borderColor-field__qhrpjvl: #838FA5;
-  --borderColor-focus__qhrpjvm: rgba(153,191,247,0.7);
-  --borderColor-formAccent__qhrpjvn: #1E47A9;
-  --borderColor-formAccentLight__qhrpjvo: #99BFF7;
-  --borderColor-info__qhrpjvp: #1D559D;
-  --borderColor-infoLight__qhrpjvq: #98C9F1;
-  --borderColor-neutral__qhrpjvr: #2E3849;
-  --borderColor-neutralLight__qhrpjvt: #EAECF1;
-  --borderColor-neutralInverted__qhrpjvs: #fff;
-  --borderColor-positive__qhrpjvu: #12784F;
-  --borderColor-positiveLight__qhrpjvv: #8BDEC5;
-  --borderColor-promote__qhrpjvw: #7F35A9;
-  --borderColor-promoteLight__qhrpjvx: #E1B2F5;
-  --borderWidth-standard__qhrpjvy: 2px;
-  --borderWidth-large__qhrpjvz: 4px;
-  --focusRingSize__qhrpjv10: 6px;
-  --contentWidth-xsmall__qhrpjv11: 400px;
-  --contentWidth-small__qhrpjv12: 660px;
-  --contentWidth-medium__qhrpjv13: 940px;
-  --contentWidth-large__qhrpjv14: 1280px;
-  --foregroundColor-brandAccent__qhrpjv15: #E60278;
-  --foregroundColor-brandAccentLight__qhrpjv16: #F8B1DC;
-  --foregroundColor-caution__qhrpjv17: #723D02;
-  --foregroundColor-cautionLight__qhrpjv18: #FEE384;
-  --foregroundColor-critical__qhrpjv19: #B91E1E;
-  --foregroundColor-criticalLight__qhrpjv1a: #FB999A;
-  --foregroundColor-formAccent__qhrpjv1b: #1E47A9;
-  --foregroundColor-formAccentLight__qhrpjv1c: #99BFF7;
-  --foregroundColor-info__qhrpjv1d: #1D559D;
-  --foregroundColor-infoLight__qhrpjv1e: #98C9F1;
-  --foregroundColor-link__qhrpjv1f: #2E3849;
-  --foregroundColor-linkLight__qhrpjv1h: #fff;
-  --foregroundColor-linkHover__qhrpjv1g: #2E3849;
-  --foregroundColor-linkVisited__qhrpjv1i: #5B2084;
-  --foregroundColor-linkLightVisited__qhrpjv1j: #F0D6FA;
-  --foregroundColor-neutral__qhrpjv1k: #2E3849;
-  --foregroundColor-neutralInverted__qhrpjv1l: #fff;
-  --foregroundColor-positive__qhrpjv1m: #12784F;
-  --foregroundColor-positiveLight__qhrpjv1n: #8BDEC5;
-  --foregroundColor-promote__qhrpjv1o: #7F35A9;
-  --foregroundColor-promoteLight__qhrpjv1p: #E1B2F5;
-  --foregroundColor-rating__qhrpjv1q: #E60278;
-  --foregroundColor-secondary__qhrpjv1r: #5A6881;
-  --foregroundColor-secondaryInverted__qhrpjv1s: rgba(255,255,255,0.65);
-  --backgroundColor-body__qhrpjv1t: #fff;
-  --backgroundColor-bodyDark__qhrpjv1u: #1C2330;
-  --backgroundColor-brand__qhrpjv1v: #051A49;
-  --backgroundColor-brandAccent__qhrpjv1w: #E60278;
-  --backgroundColor-brandAccentActive__qhrpjv1x: #cd026b;
-  --backgroundColor-brandAccentHover__qhrpjv1y: #fd0585;
-  --backgroundColor-brandAccentSoft__qhrpjv1z: #FEEFFA;
-  --backgroundColor-brandAccentSoftActive__qhrpjv20: #fdd7f3;
-  --backgroundColor-brandAccentSoftHover__qhrpjv21: #fde3f6;
-  --backgroundColor-caution__qhrpjv22: #FDC221;
-  --backgroundColor-cautionLight__qhrpjv23: #FEF8DE;
-  --backgroundColor-critical__qhrpjv24: #B91E1E;
-  --backgroundColor-criticalActive__qhrpjv25: #a31a1a;
-  --backgroundColor-criticalHover__qhrpjv26: #db1616;
-  --backgroundColor-criticalLight__qhrpjv27: #FFE3E2;
-  --backgroundColor-criticalSoft__qhrpjv28: #FEF3F3;
-  --backgroundColor-criticalSoftActive__qhrpjv29: #fcdbdb;
-  --backgroundColor-criticalSoftHover__qhrpjv2a: #fde7e7;
-  --backgroundColor-formAccent__qhrpjv2b: #1E47A9;
-  --backgroundColor-formAccentActive__qhrpjv2c: #1a3e93;
-  --backgroundColor-formAccentHover__qhrpjv2d: #2455c9;
-  --backgroundColor-formAccentSoft__qhrpjv2e: #F0F7FE;
-  --backgroundColor-formAccentSoftActive__qhrpjv2f: #d8eafc;
-  --backgroundColor-formAccentSoftHover__qhrpjv2g: #e4f1fd;
-  --backgroundColor-info__qhrpjv2h: #1D559D;
-  --backgroundColor-infoLight__qhrpjv2i: #E3F2FB;
-  --backgroundColor-neutral__qhrpjv2j: #2E3849;
-  --backgroundColor-neutralActive__qhrpjv2k: #242c39;
-  --backgroundColor-neutralHover__qhrpjv2l: #384459;
-  --backgroundColor-neutralLight__qhrpjv2m: #F3F5F7;
-  --backgroundColor-neutralSoft__qhrpjv2n: #F3F5F7;
-  --backgroundColor-neutralSoftActive__qhrpjv2o: #e4e8ed;
-  --backgroundColor-neutralSoftHover__qhrpjv2p: #ebeff2;
-  --backgroundColor-positive__qhrpjv2q: #12784F;
-  --backgroundColor-positiveLight__qhrpjv2r: #E2F7F1;
-  --backgroundColor-promote__qhrpjv2s: #7F35A9;
-  --backgroundColor-promoteLight__qhrpjv2t: #F9EBFD;
-  --backgroundColor-surface__qhrpjv2u: #fff;
-  --backgroundColor-surfaceDark__qhrpjv2v: #1C2330;
-  --fontFamily__qhrpjv2w: SeekSans, "SeekSans Fallback", Arial, Tahoma, sans-serif;
-  --fontMetrics-capHeight__qhrpjv2x: 783;
-  --fontMetrics-ascent__qhrpjv2y: 1057;
-  --fontMetrics-descent__qhrpjv2z: -274;
-  --fontMetrics-lineGap__qhrpjv30: 0;
-  --fontMetrics-unitsPerEm__qhrpjv31: 1000;
-  --textSize-large-mobile-fontSize__qhrpjv3w: 18px;
-  --textSize-large-mobile-lineHeight__qhrpjv3x: 27.094px;
-  --textSize-large-mobile-capHeight__qhrpjv3y: 14.094px;
-  --textSize-large-mobile-capsizeTrims-capHeightTrim__qhrpjv3z: -0.3611em;
-  --textSize-large-mobile-capsizeTrims-baselineTrim__qhrpjv40: -0.3611em;
-  --textSize-large-tablet-fontSize__qhrpjv41: 18px;
-  --textSize-large-tablet-lineHeight__qhrpjv42: 27.094px;
-  --textSize-large-tablet-capHeight__qhrpjv43: 14.094px;
-  --textSize-large-tablet-capsizeTrims-capHeightTrim__qhrpjv44: -0.3611em;
-  --textSize-large-tablet-capsizeTrims-baselineTrim__qhrpjv45: -0.3611em;
-  --textSize-standard-mobile-fontSize__qhrpjv3m: 16px;
-  --textSize-standard-mobile-lineHeight__qhrpjv3n: 24.528px;
-  --textSize-standard-mobile-capHeight__qhrpjv3o: 12.528px;
-  --textSize-standard-mobile-capsizeTrims-capHeightTrim__qhrpjv3p: -0.375em;
-  --textSize-standard-mobile-capsizeTrims-baselineTrim__qhrpjv3q: -0.375em;
-  --textSize-standard-tablet-fontSize__qhrpjv3r: 16px;
-  --textSize-standard-tablet-lineHeight__qhrpjv3s: 24.528px;
-  --textSize-standard-tablet-capHeight__qhrpjv3t: 12.528px;
-  --textSize-standard-tablet-capsizeTrims-capHeightTrim__qhrpjv3u: -0.375em;
-  --textSize-standard-tablet-capsizeTrims-baselineTrim__qhrpjv3v: -0.375em;
-  --textSize-small-mobile-fontSize__qhrpjv3c: 14px;
-  --textSize-small-mobile-lineHeight__qhrpjv3d: 20.962px;
-  --textSize-small-mobile-capHeight__qhrpjv3e: 10.962px;
-  --textSize-small-mobile-capsizeTrims-capHeightTrim__qhrpjv3f: -0.3571em;
-  --textSize-small-mobile-capsizeTrims-baselineTrim__qhrpjv3g: -0.3571em;
-  --textSize-small-tablet-fontSize__qhrpjv3h: 14px;
-  --textSize-small-tablet-lineHeight__qhrpjv3i: 20.962px;
-  --textSize-small-tablet-capHeight__qhrpjv3j: 10.962px;
-  --textSize-small-tablet-capsizeTrims-capHeightTrim__qhrpjv3k: -0.3571em;
-  --textSize-small-tablet-capsizeTrims-baselineTrim__qhrpjv3l: -0.3571em;
-  --textSize-xsmall-mobile-fontSize__qhrpjv32: 12px;
-  --textSize-xsmall-mobile-lineHeight__qhrpjv33: 18.396px;
-  --textSize-xsmall-mobile-capHeight__qhrpjv34: 9.396px;
-  --textSize-xsmall-mobile-capsizeTrims-capHeightTrim__qhrpjv35: -0.375em;
-  --textSize-xsmall-mobile-capsizeTrims-baselineTrim__qhrpjv36: -0.375em;
-  --textSize-xsmall-tablet-fontSize__qhrpjv37: 12px;
-  --textSize-xsmall-tablet-lineHeight__qhrpjv38: 18.396px;
-  --textSize-xsmall-tablet-capHeight__qhrpjv39: 9.396px;
-  --textSize-xsmall-tablet-capsizeTrims-capHeightTrim__qhrpjv3a: -0.375em;
-  --textSize-xsmall-tablet-capsizeTrims-baselineTrim__qhrpjv3b: -0.375em;
-  --textWeight-regular__qhrpjv46: 400;
-  --textWeight-medium__qhrpjv47: 600;
-  --textWeight-strong__qhrpjv48: 700;
-  --headingLevel-1-mobile-fontSize__qhrpjv49: 28px;
-  --headingLevel-1-mobile-lineHeight__qhrpjv4a: 32.924px;
-  --headingLevel-1-mobile-capHeight__qhrpjv4b: 21.924px;
-  --headingLevel-1-mobile-capsizeTrims-capHeightTrim__qhrpjv4c: -0.1964em;
-  --headingLevel-1-mobile-capsizeTrims-baselineTrim__qhrpjv4d: -0.1964em;
-  --headingLevel-1-tablet-fontSize__qhrpjv4e: 36px;
-  --headingLevel-1-tablet-lineHeight__qhrpjv4f: 42.188px;
-  --headingLevel-1-tablet-capHeight__qhrpjv4g: 28.188px;
-  --headingLevel-1-tablet-capsizeTrims-capHeightTrim__qhrpjv4h: -0.1944em;
-  --headingLevel-1-tablet-capsizeTrims-baselineTrim__qhrpjv4i: -0.1944em;
-  --headingLevel-2-mobile-fontSize__qhrpjv4j: 24px;
-  --headingLevel-2-mobile-lineHeight__qhrpjv4k: 29.792px;
-  --headingLevel-2-mobile-capHeight__qhrpjv4l: 18.792px;
-  --headingLevel-2-mobile-capsizeTrims-capHeightTrim__qhrpjv4m: -0.2292em;
-  --headingLevel-2-mobile-capsizeTrims-baselineTrim__qhrpjv4n: -0.2292em;
-  --headingLevel-2-tablet-fontSize__qhrpjv4o: 30px;
-  --headingLevel-2-tablet-lineHeight__qhrpjv4p: 36.49px;
-  --headingLevel-2-tablet-capHeight__qhrpjv4q: 23.49px;
-  --headingLevel-2-tablet-capsizeTrims-capHeightTrim__qhrpjv4r: -0.2167em;
-  --headingLevel-2-tablet-capsizeTrims-baselineTrim__qhrpjv4s: -0.2167em;
-  --headingLevel-3-mobile-fontSize__qhrpjv4t: 22px;
-  --headingLevel-3-mobile-lineHeight__qhrpjv4u: 27.226px;
-  --headingLevel-3-mobile-capHeight__qhrpjv4v: 17.226px;
-  --headingLevel-3-mobile-capsizeTrims-capHeightTrim__qhrpjv4w: -0.2273em;
-  --headingLevel-3-mobile-capsizeTrims-baselineTrim__qhrpjv4x: -0.2273em;
-  --headingLevel-3-tablet-fontSize__qhrpjv4y: 24px;
-  --headingLevel-3-tablet-lineHeight__qhrpjv4z: 29.792px;
-  --headingLevel-3-tablet-capHeight__qhrpjv50: 18.792px;
-  --headingLevel-3-tablet-capsizeTrims-capHeightTrim__qhrpjv51: -0.2292em;
-  --headingLevel-3-tablet-capsizeTrims-baselineTrim__qhrpjv52: -0.2292em;
-  --headingLevel-4-mobile-fontSize__qhrpjv53: 20px;
-  --headingLevel-4-mobile-lineHeight__qhrpjv54: 24.66px;
-  --headingLevel-4-mobile-capHeight__qhrpjv55: 15.66px;
-  --headingLevel-4-mobile-capsizeTrims-capHeightTrim__qhrpjv56: -0.225em;
-  --headingLevel-4-mobile-capsizeTrims-baselineTrim__qhrpjv57: -0.225em;
-  --headingLevel-4-tablet-fontSize__qhrpjv58: 20px;
-  --headingLevel-4-tablet-lineHeight__qhrpjv59: 24.66px;
-  --headingLevel-4-tablet-capHeight__qhrpjv5a: 15.66px;
-  --headingLevel-4-tablet-capsizeTrims-capHeightTrim__qhrpjv5b: -0.225em;
-  --headingLevel-4-tablet-capsizeTrims-baselineTrim__qhrpjv5c: -0.225em;
-  --headingWeight-weak__qhrpjv5d: 400;
-  --headingWeight-regular__qhrpjv5e: 600;
-  --linkDecoration__qhrpjv5f: underline;
-  --inlineFieldSize-standard__qhrpjv5g: 24px;
-  --inlineFieldSize-small__qhrpjv5h: 20px;
-  --transition-fast__qhrpjv5i: transform .125s ease, opacity .125s ease;
-  --transition-touchable__qhrpjv5j: transform 0.2s cubic-bezier(0.02, 1.505, 0.745, 1.235);
-  --transform-touchable__qhrpjv5k: scale(0.95);
-  --shadow-small__qhrpjv5l: 0 0 4px 0 rgba(28,35,48,0.08), 0 4px 8px -2px rgba(28,35,48,0.08);
-  --shadow-medium__qhrpjv5m: 0 0 8px 0 rgba(28,35,48,0.08), 0 8px 16px -4px rgba(28,35,48,0.08);
-  --shadow-large__qhrpjv5n: 0 0 12px 0 rgba(28,35,48,0.08), 0 12px 24px -6px rgba(28,35,48,0.08);
-}
-.App_vanillaBox__inn18b0 {
-  --backgroundColor__zv7nmx0: blueviolet;
-  background-color: var(--backgroundColor__zv7nmx0);
-  color: white;
-  font-size: 20px;
-  padding: 100px;
-}
-    </style>
-    <script type="module">
-      import { injectIntoGlobalHook } from "/@react-refresh";
-injectIntoGlobalHook(window);
-window.$RefreshReg$ = () => {};
-window.$RefreshSig$ = () => (type) => type;
-    </script>
-    <script
-      type="module"
-      src="/@vite/client"
-    >
-    </script>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <script>
-      window.SKU_SITE = 'jobStreet';
-    </script>
-    <script
-      type="module"
-      src="/@id/__x00__/index.html?html-proxy&index=0.js"
-    >
-    </script>
-    <script
-      type="module"
-      src="/@id/__x00__/index.html?html-proxy&index=1.js"
-    >
-    </script>
-  </head>
-  <body>
-    <div id="app">
-      <style type="text/css">
-        html,body{margin:0;padding:0;background:#fff}
-            html.sprinkles_darkMode__1hjdb9v11,html.sprinkles_darkMode__1hjdb9v11 body{color-scheme:dark;background:#1C2330}
-      </style>
-      <div class="seekJobs_seekJobs__1fmskxf0 typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13">
-        <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSizeTrimmed_standard__co4djb9 typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
-          Hello
-          jobStreet
-          <span class="reset_base__yw2qws0 sprinkles_display_inlineBlock_mobile__1hjdb9v58">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewbox="0 0 24 24"
-              xml:space="preserve"
-              focusable="false"
-              fill="currentColor"
-              width="16"
-              height="16"
-              class="reset_base__yw2qws0 IconChevron_root__v2pdba0 sprinkles_display_inlineBlock_mobile__1hjdb9v58 sprinkles_position_relative_mobile__1hjdb9v5g icon_size__1ltfiyk0 icon_inlineCrop__1ltfiyk2 icon_inline__1ltfiyk3 icon_alignY_uppercase_none__1ltfiyk4"
-              aria-hidden="true"
-            >
-              <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
-              </path>
-            </svg>
-          </span>
-        </span>
-        <div class="reset_base__yw2qws0 sprinkles_paddingBottom_gutter_mobile__1hjdb9v8s sprinkles_paddingTop_gutter_mobile__1hjdb9v7o sprinkles_paddingLeft_gutter_mobile__1hjdb9vb0 sprinkles_paddingRight_gutter_mobile__1hjdb9v9w sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_large_mobile__1hjdb9v6c sprinkles_textAlign_left_mobile__1hjdb9vic sprinkles_boxShadow_borderNeutralLight_lightMode__1hjdb9v4k sprinkles_boxShadow_borderNeutral_darkMode__1hjdb9v4d typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13 sprinkles_background_surface_lightMode__1hjdb9v34 sprinkles_background_surfaceDark_darkMode__1hjdb9v37">
-          <div class="reset_base__yw2qws0 sprinkles_position_relative_mobile__1hjdb9v5g">
-            <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c sprinkles_textAlign_left_mobile__1hjdb9vic">
-              <input
-                class="reset_base__yw2qws0 reset_input__yw2qwse reset_field__yw2qws9 reset_block__yw2qws1 reset_appearance__yw2qws6 reset_transparent__yw2qws7 reset_focusVisible__yw2qws8 reset_input__yw2qwsd sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_zIndex_1__1hjdb9v9 sprinkles_cursor_pointer__1hjdb9vi sprinkles_opacity_0__1hjdb9v7 InlineField_realField__1b4ltjx4 InlineField_sizeVars_standard__1b4ltjx2"
-                type="checkbox"
-                id="id_1"
-                aria-checked="false"
-              >
-              <div class="reset_base__yw2qws0 sprinkles_flexShrink_0_mobile__1hjdb9vi0 sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_standard_mobile__1hjdb9v68 InlineField_fakeField__1b4ltjx5 InlineField_sizeVars_standard__1b4ltjx2 typography_lightModeTone_light__co4djb10  sprinkles_background_surface_lightMode__1hjdb9v34">
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_selected__1b4ltjx9 typography_lightModeTone_dark__co4djb11 typography_darkModeTone_dark__co4djb13 sprinkles_background_formAccent_lightMode__1hjdb9v22 sprinkles_background_formAccent_darkMode__1hjdb9v23">
-                  <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_boxShadow_borderField_lightMode__1hjdb9v3y sprinkles_boxShadow_borderField_darkMode__1hjdb9v3z">
-                </span>
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 sprinkles_boxShadow_borderCritical_lightMode__1hjdb9v3q sprinkles_boxShadow_borderCriticalLight_darkMode__1hjdb9v3v">
-                </span>
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_hoverOverlay__1b4ltjxb sprinkles_boxShadow_borderFormAccent_lightMode__1hjdb9v40 sprinkles_boxShadow_borderFormAccentLight_darkMode__1hjdb9v45">
-                  <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-              </div>
-              <div class="reset_base__yw2qws0 sprinkles_paddingLeft_xsmall_mobile__1hjdb9vb8 sprinkles_flexGrow_1_mobile__1hjdb9vi8">
-                <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c InlineField_sizeVars_standard__1b4ltjx2 InlineField_labelOffset__1b4ltjx6">
-                  <label
-                    class="reset_base__yw2qws0 sprinkles_userSelect_none__1hjdb9v4 sprinkles_display_block_mobile__1hjdb9v50 sprinkles_cursor_pointer__1hjdb9vi virtualTouchable_virtualTouchable__9705do0"
-                    for="id_1"
-                  >
-                    <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSizeTrimmed_standard__co4djb9 typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
-                      This is a checkbox
-                    </span>
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="reset_base__yw2qws0 App_vanillaBox__inn18b0">
-          🧁 Vanilla content
-          Initial
-        </div>
-      </div>
-    </div>
-    <script
-      type="module"
-      src="{cwd}/packages/sku/dist/services/vite/entries/vite-client.js"
-    >
-    </script>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"site":"jobStreet"}
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -4548,14 +4548,4837 @@
+@@ -1,4707 +1,9530 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <style
+       type="text/css"
+       data-vanilla-extract-inline-dev-css
+     >
+       .reset_base__yw2qws0 {
+   margin: 0;
+   padding: 0;
+   border: 0;
+   box-sizing: border-box;
+   font-size: 100%;
+   font: inherit;
+   vertical-align: baseline;
+   -webkit-tap-highlight-color: transparent;
+ }
+ .reset_block__yw2qws1 {
+   display: block;
+ }
+ .reset_body__yw2qws2 {
+   line-height: 1;
+ }
+ .reset_list__yw2qws3 {
+   list-style: none;
+ }
+ .reset_quote__yw2qws4 {
+   quotes: none;
+ }
+ .reset_quote__yw2qws4:before, .reset_quote__yw2qws4:after {
+   content: '';
+ }
+ .reset_table__yw2qws5 {
+   border-collapse: collapse;
+   border-spacing: 0;
+ }
+ .reset_appearance__yw2qws6 {
+   appearance: none;
+ }
+ .reset_transparent__yw2qws7 {
+   background-color: transparent;
+ }
+ .reset_focusVisible__yw2qws8 {
+   outline: var(--focusRingSize__qhrpjv10) solid transparent;
+   transition: outline-color .125s ease;
+ }
+ .reset_focusVisible__yw2qws8:focus-visible {
+   outline-color: var(--borderColor-focus__qhrpjvm);
+ }
+ .reset_mark__yw2qwsa {
+   color: inherit;
+ }
+ .reset_select__yw2qwsb:disabled {
+   opacity: 1;
+ }
+ .reset_select__yw2qwsb::-ms-expand {
+   display: none;
+ }
+ .reset_input__yw2qwsd[type="number"] {
+   -moz-appearance: textfield;
+ }
+ .reset_input__yw2qwsd[type="number"]::-webkit-inner-spin-button,.reset_input__yw2qwsd[type="number"]::-webkit-outer-spin-button {
+   -webkit-appearance: none;
+   margin: 0;
+ }
+ .reset_input__yw2qwsd::-ms-clear {
+   display: none;
+ }
+ .reset_input__yw2qwsd::-webkit-search-cancel-button {
+   -webkit-appearance: none;
+ }
+ .reset_a__yw2qwsg {
+   text-decoration: none;
+   color: inherit;
+ }
+ .sprinkles_overflow_hidden__1hjdb9v0 {
+   overflow: hidden;
+ }
+ .sprinkles_overflow_scroll__1hjdb9v1 {
+   overflow: scroll;
+ }
+ .sprinkles_overflow_visible__1hjdb9v2 {
+   overflow: visible;
+ }
+ .sprinkles_overflow_auto__1hjdb9v3 {
+   overflow: auto;
+ }
+ .sprinkles_userSelect_none__1hjdb9v4 {
+   user-select: none;
+ }
+ .sprinkles_outline_none__1hjdb9v5 {
+   outline: none;
+ }
+ .sprinkles_outline_focus__1hjdb9v6 {
+   outline: var(--focusRingSize__qhrpjv10) solid transparent;
+   transition: outline-color .125s ease;
+ }
+ .sprinkles_outline_focus__1hjdb9v6:focus-visible {
+   outline-color: var(--borderColor-focus__qhrpjvm);
+ }
+ .sprinkles_opacity_0__1hjdb9v7 {
+   opacity: 0;
+ }
+ .sprinkles_zIndex_0__1hjdb9v8 {
+   z-index: 0;
+ }
+ .sprinkles_zIndex_1__1hjdb9v9 {
+   z-index: 1;
+ }
+ .sprinkles_zIndex_2__1hjdb9va {
+   z-index: 2;
+ }
+ .sprinkles_zIndex_dropdownBackdrop__1hjdb9vb {
+   z-index: 90;
+ }
+ .sprinkles_zIndex_dropdown__1hjdb9vc {
+   z-index: 100;
+ }
+ .sprinkles_zIndex_sticky__1hjdb9vd {
+   z-index: 200;
+ }
+ .sprinkles_zIndex_modalBackdrop__1hjdb9ve {
+   z-index: 290;
+ }
+ .sprinkles_zIndex_modal__1hjdb9vf {
+   z-index: 300;
+ }
+ .sprinkles_zIndex_notification__1hjdb9vg {
+   z-index: 400;
+ }
+ .sprinkles_cursor_default__1hjdb9vh {
+   cursor: default;
+ }
+ .sprinkles_cursor_pointer__1hjdb9vi {
+   cursor: pointer;
+ }
+ .sprinkles_pointerEvents_none__1hjdb9vj {
+   pointer-events: none;
+ }
+ .sprinkles_top_0__1hjdb9vk {
+   top: 0;
+ }
+ .sprinkles_bottom_0__1hjdb9vl {
+   bottom: 0;
+ }
+ .sprinkles_left_0__1hjdb9vm {
+   left: 0;
+ }
+ .sprinkles_right_0__1hjdb9vn {
+   right: 0;
+ }
+ .sprinkles_height_full__1hjdb9vo {
+   height: 100%;
+ }
+ .sprinkles_height_touchable__1hjdb9vp {
+   height: var(--touchableSize__qhrpjv9);
+ }
+ .sprinkles_width_full__1hjdb9vq {
+   width: 100%;
+ }
+ .sprinkles_width_touchable__1hjdb9vr {
+   width: var(--touchableSize__qhrpjv9);
+ }
+ .sprinkles_minWidth_0__1hjdb9vs {
+   min-width: 0%;
+ }
+ .sprinkles_maxWidth_xsmall__1hjdb9vt {
+   max-width: var(--contentWidth-xsmall__qhrpjv11);
+ }
+ .sprinkles_maxWidth_small__1hjdb9vu {
+   max-width: var(--contentWidth-small__qhrpjv12);
+ }
+ .sprinkles_maxWidth_medium__1hjdb9vv {
+   max-width: var(--contentWidth-medium__qhrpjv13);
+ }
+ .sprinkles_maxWidth_large__1hjdb9vw {
+   max-width: var(--contentWidth-large__qhrpjv14);
+ }
+ .sprinkles_maxWidth_content__1hjdb9vx {
+   max-width: fit-content;
+ }
+ .sprinkles_transition_fast__1hjdb9vy {
+   transition: var(--transition-fast__qhrpjv5i);
+ }
+ .sprinkles_transition_touchable__1hjdb9vz {
+   transition: var(--transition-touchable__qhrpjv5j);
+ }
+ .sprinkles_transform_touchable_active__1hjdb9v10:active {
+   transform: var(--transform-touchable__qhrpjv5k);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_body_lightMode__1hjdb9v12 {
+   background: var(--backgroundColor-body__qhrpjv1t);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_body_darkMode__1hjdb9v13 {
+   background: var(--backgroundColor-body__qhrpjv1t);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_bodyDark_lightMode__1hjdb9v14 {
+   background: var(--backgroundColor-bodyDark__qhrpjv1u);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_bodyDark_darkMode__1hjdb9v15 {
+   background: var(--backgroundColor-bodyDark__qhrpjv1u);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brand_lightMode__1hjdb9v16 {
+   background: var(--backgroundColor-brand__qhrpjv1v);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brand_darkMode__1hjdb9v17 {
+   background: var(--backgroundColor-brand__qhrpjv1v);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccent_lightMode__1hjdb9v18 {
+   background: var(--backgroundColor-brandAccent__qhrpjv1w);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccent_darkMode__1hjdb9v19 {
+   background: var(--backgroundColor-brandAccent__qhrpjv1w);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentActive_lightMode__1hjdb9v1a {
+   background: var(--backgroundColor-brandAccentActive__qhrpjv1x);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentActive_darkMode__1hjdb9v1b {
+   background: var(--backgroundColor-brandAccentActive__qhrpjv1x);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentHover_lightMode__1hjdb9v1c {
+   background: var(--backgroundColor-brandAccentHover__qhrpjv1y);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentHover_darkMode__1hjdb9v1d {
+   background: var(--backgroundColor-brandAccentHover__qhrpjv1y);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentSoft_lightMode__1hjdb9v1e {
+   background: var(--backgroundColor-brandAccentSoft__qhrpjv1z);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentSoft_darkMode__1hjdb9v1f {
+   background: var(--backgroundColor-brandAccentSoft__qhrpjv1z);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentSoftActive_lightMode__1hjdb9v1g {
+   background: var(--backgroundColor-brandAccentSoftActive__qhrpjv20);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentSoftActive_darkMode__1hjdb9v1h {
+   background: var(--backgroundColor-brandAccentSoftActive__qhrpjv20);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentSoftHover_lightMode__1hjdb9v1i {
+   background: var(--backgroundColor-brandAccentSoftHover__qhrpjv21);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentSoftHover_darkMode__1hjdb9v1j {
+   background: var(--backgroundColor-brandAccentSoftHover__qhrpjv21);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_caution_lightMode__1hjdb9v1k {
+   background: var(--backgroundColor-caution__qhrpjv22);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_caution_darkMode__1hjdb9v1l {
+   background: var(--backgroundColor-caution__qhrpjv22);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_cautionLight_lightMode__1hjdb9v1m {
+   background: var(--backgroundColor-cautionLight__qhrpjv23);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_cautionLight_darkMode__1hjdb9v1n {
+   background: var(--backgroundColor-cautionLight__qhrpjv23);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_critical_lightMode__1hjdb9v1o {
+   background: var(--backgroundColor-critical__qhrpjv24);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_critical_darkMode__1hjdb9v1p {
+   background: var(--backgroundColor-critical__qhrpjv24);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalActive_lightMode__1hjdb9v1q {
+   background: var(--backgroundColor-criticalActive__qhrpjv25);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalActive_darkMode__1hjdb9v1r {
+   background: var(--backgroundColor-criticalActive__qhrpjv25);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalHover_lightMode__1hjdb9v1s {
+   background: var(--backgroundColor-criticalHover__qhrpjv26);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalHover_darkMode__1hjdb9v1t {
+   background: var(--backgroundColor-criticalHover__qhrpjv26);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalLight_lightMode__1hjdb9v1u {
+   background: var(--backgroundColor-criticalLight__qhrpjv27);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalLight_darkMode__1hjdb9v1v {
+   background: var(--backgroundColor-criticalLight__qhrpjv27);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalSoft_lightMode__1hjdb9v1w {
+   background: var(--backgroundColor-criticalSoft__qhrpjv28);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalSoft_darkMode__1hjdb9v1x {
+   background: var(--backgroundColor-criticalSoft__qhrpjv28);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalSoftActive_lightMode__1hjdb9v1y {
+   background: var(--backgroundColor-criticalSoftActive__qhrpjv29);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalSoftActive_darkMode__1hjdb9v1z {
+   background: var(--backgroundColor-criticalSoftActive__qhrpjv29);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalSoftHover_lightMode__1hjdb9v20 {
+   background: var(--backgroundColor-criticalSoftHover__qhrpjv2a);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalSoftHover_darkMode__1hjdb9v21 {
+   background: var(--backgroundColor-criticalSoftHover__qhrpjv2a);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccent_lightMode__1hjdb9v22 {
+   background: var(--backgroundColor-formAccent__qhrpjv2b);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccent_darkMode__1hjdb9v23 {
+   background: var(--backgroundColor-formAccent__qhrpjv2b);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentActive_lightMode__1hjdb9v24 {
+   background: var(--backgroundColor-formAccentActive__qhrpjv2c);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentActive_darkMode__1hjdb9v25 {
+   background: var(--backgroundColor-formAccentActive__qhrpjv2c);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentHover_lightMode__1hjdb9v26 {
+   background: var(--backgroundColor-formAccentHover__qhrpjv2d);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentHover_darkMode__1hjdb9v27 {
+   background: var(--backgroundColor-formAccentHover__qhrpjv2d);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentSoft_lightMode__1hjdb9v28 {
+   background: var(--backgroundColor-formAccentSoft__qhrpjv2e);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentSoft_darkMode__1hjdb9v29 {
+   background: var(--backgroundColor-formAccentSoft__qhrpjv2e);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentSoftActive_lightMode__1hjdb9v2a {
+   background: var(--backgroundColor-formAccentSoftActive__qhrpjv2f);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentSoftActive_darkMode__1hjdb9v2b {
+   background: var(--backgroundColor-formAccentSoftActive__qhrpjv2f);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentSoftHover_lightMode__1hjdb9v2c {
+   background: var(--backgroundColor-formAccentSoftHover__qhrpjv2g);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentSoftHover_darkMode__1hjdb9v2d {
+   background: var(--backgroundColor-formAccentSoftHover__qhrpjv2g);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_info_lightMode__1hjdb9v2e {
+   background: var(--backgroundColor-info__qhrpjv2h);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_info_darkMode__1hjdb9v2f {
+   background: var(--backgroundColor-info__qhrpjv2h);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_infoLight_lightMode__1hjdb9v2g {
+   background: var(--backgroundColor-infoLight__qhrpjv2i);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_infoLight_darkMode__1hjdb9v2h {
+   background: var(--backgroundColor-infoLight__qhrpjv2i);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutral_lightMode__1hjdb9v2i {
+   background: var(--backgroundColor-neutral__qhrpjv2j);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutral_darkMode__1hjdb9v2j {
+   background: var(--backgroundColor-neutral__qhrpjv2j);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralActive_lightMode__1hjdb9v2k {
+   background: var(--backgroundColor-neutralActive__qhrpjv2k);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralActive_darkMode__1hjdb9v2l {
+   background: var(--backgroundColor-neutralActive__qhrpjv2k);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralHover_lightMode__1hjdb9v2m {
+   background: var(--backgroundColor-neutralHover__qhrpjv2l);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralHover_darkMode__1hjdb9v2n {
+   background: var(--backgroundColor-neutralHover__qhrpjv2l);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralLight_lightMode__1hjdb9v2o {
+   background: var(--backgroundColor-neutralLight__qhrpjv2m);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralLight_darkMode__1hjdb9v2p {
+   background: var(--backgroundColor-neutralLight__qhrpjv2m);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralSoft_lightMode__1hjdb9v2q {
+   background: var(--backgroundColor-neutralSoft__qhrpjv2n);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralSoft_darkMode__1hjdb9v2r {
+   background: var(--backgroundColor-neutralSoft__qhrpjv2n);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralSoftActive_lightMode__1hjdb9v2s {
+   background: var(--backgroundColor-neutralSoftActive__qhrpjv2o);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralSoftActive_darkMode__1hjdb9v2t {
+   background: var(--backgroundColor-neutralSoftActive__qhrpjv2o);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralSoftHover_lightMode__1hjdb9v2u {
+   background: var(--backgroundColor-neutralSoftHover__qhrpjv2p);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralSoftHover_darkMode__1hjdb9v2v {
+   background: var(--backgroundColor-neutralSoftHover__qhrpjv2p);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_positive_lightMode__1hjdb9v2w {
+   background: var(--backgroundColor-positive__qhrpjv2q);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_positive_darkMode__1hjdb9v2x {
+   background: var(--backgroundColor-positive__qhrpjv2q);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_positiveLight_lightMode__1hjdb9v2y {
+   background: var(--backgroundColor-positiveLight__qhrpjv2r);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_positiveLight_darkMode__1hjdb9v2z {
+   background: var(--backgroundColor-positiveLight__qhrpjv2r);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_promote_lightMode__1hjdb9v30 {
+   background: var(--backgroundColor-promote__qhrpjv2s);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_promote_darkMode__1hjdb9v31 {
+   background: var(--backgroundColor-promote__qhrpjv2s);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_promoteLight_lightMode__1hjdb9v32 {
+   background: var(--backgroundColor-promoteLight__qhrpjv2t);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_promoteLight_darkMode__1hjdb9v33 {
+   background: var(--backgroundColor-promoteLight__qhrpjv2t);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_surface_lightMode__1hjdb9v34 {
+   background: var(--backgroundColor-surface__qhrpjv2u);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_surface_darkMode__1hjdb9v35 {
+   background: var(--backgroundColor-surface__qhrpjv2u);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_surfaceDark_lightMode__1hjdb9v36 {
+   background: var(--backgroundColor-surfaceDark__qhrpjv2v);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_surfaceDark_darkMode__1hjdb9v37 {
+   background: var(--backgroundColor-surfaceDark__qhrpjv2v);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_small_lightMode__1hjdb9v38 {
+   box-shadow: var(--shadow-small__qhrpjv5l);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_small_darkMode__1hjdb9v39 {
+   box-shadow: var(--shadow-small__qhrpjv5l);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_medium_lightMode__1hjdb9v3a {
+   box-shadow: var(--shadow-medium__qhrpjv5m);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_medium_darkMode__1hjdb9v3b {
+   box-shadow: var(--shadow-medium__qhrpjv5m);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_large_lightMode__1hjdb9v3c {
+   box-shadow: var(--shadow-large__qhrpjv5n);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_large_darkMode__1hjdb9v3d {
+   box-shadow: var(--shadow-large__qhrpjv5n);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccent_lightMode__1hjdb9v3e {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccent__qhrpjvf);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccent_darkMode__1hjdb9v3f {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccent__qhrpjvf);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccentLight_lightMode__1hjdb9v3g {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccentLight__qhrpjvg);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccentLight_darkMode__1hjdb9v3h {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccentLight__qhrpjvg);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccentLarge_lightMode__1hjdb9v3i {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccent__qhrpjvf);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccentLarge_darkMode__1hjdb9v3j {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccent__qhrpjvf);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccentLightLarge_lightMode__1hjdb9v3k {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccentLight__qhrpjvg);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccentLightLarge_darkMode__1hjdb9v3l {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccentLight__qhrpjvg);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCaution_lightMode__1hjdb9v3m {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-caution__qhrpjvh);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCaution_darkMode__1hjdb9v3n {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-caution__qhrpjvh);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCautionLight_lightMode__1hjdb9v3o {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-cautionLight__qhrpjvi);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCautionLight_darkMode__1hjdb9v3p {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-cautionLight__qhrpjvi);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCritical_lightMode__1hjdb9v3q {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-critical__qhrpjvj);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCritical_darkMode__1hjdb9v3r {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-critical__qhrpjvj);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCriticalLarge_lightMode__1hjdb9v3s {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-critical__qhrpjvj);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCriticalLarge_darkMode__1hjdb9v3t {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-critical__qhrpjvj);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCriticalLight_lightMode__1hjdb9v3u {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-criticalLight__qhrpjvk);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCriticalLight_darkMode__1hjdb9v3v {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-criticalLight__qhrpjvk);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCriticalLightLarge_lightMode__1hjdb9v3w {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-criticalLight__qhrpjvk);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCriticalLightLarge_darkMode__1hjdb9v3x {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-criticalLight__qhrpjvk);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderField_lightMode__1hjdb9v3y {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-field__qhrpjvl);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderField_darkMode__1hjdb9v3z {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-field__qhrpjvl);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccent_lightMode__1hjdb9v40 {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccent__qhrpjvn);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccent_darkMode__1hjdb9v41 {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccent__qhrpjvn);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccentLarge_lightMode__1hjdb9v42 {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccent__qhrpjvn);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccentLarge_darkMode__1hjdb9v43 {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccent__qhrpjvn);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccentLight_lightMode__1hjdb9v44 {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccentLight_darkMode__1hjdb9v45 {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccentLightLarge_lightMode__1hjdb9v46 {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccentLightLarge_darkMode__1hjdb9v47 {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderInfo_lightMode__1hjdb9v48 {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-info__qhrpjvp);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderInfo_darkMode__1hjdb9v49 {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-info__qhrpjvp);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderInfoLight_lightMode__1hjdb9v4a {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-infoLight__qhrpjvq);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderInfoLight_darkMode__1hjdb9v4b {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-infoLight__qhrpjvq);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutral_lightMode__1hjdb9v4c {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutral__qhrpjvr);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutral_darkMode__1hjdb9v4d {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutral__qhrpjvr);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralLarge_lightMode__1hjdb9v4e {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutral__qhrpjvr);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralLarge_darkMode__1hjdb9v4f {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutral__qhrpjvr);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralInverted_lightMode__1hjdb9v4g {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralInverted__qhrpjvs);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralInverted_darkMode__1hjdb9v4h {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralInverted__qhrpjvs);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralInvertedLarge_lightMode__1hjdb9v4i {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutralInverted__qhrpjvs);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralInvertedLarge_darkMode__1hjdb9v4j {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutralInverted__qhrpjvs);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralLight_lightMode__1hjdb9v4k {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralLight__qhrpjvt);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralLight_darkMode__1hjdb9v4l {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralLight__qhrpjvt);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPositive_lightMode__1hjdb9v4m {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positive__qhrpjvu);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPositive_darkMode__1hjdb9v4n {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positive__qhrpjvu);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPositiveLight_lightMode__1hjdb9v4o {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positiveLight__qhrpjvv);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPositiveLight_darkMode__1hjdb9v4p {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positiveLight__qhrpjvv);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPromote_lightMode__1hjdb9v4q {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promote__qhrpjvw);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPromote_darkMode__1hjdb9v4r {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promote__qhrpjvw);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPromoteLight_lightMode__1hjdb9v4s {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promoteLight__qhrpjvx);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPromoteLight_darkMode__1hjdb9v4t {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promoteLight__qhrpjvx);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_outlineFocus_lightMode__1hjdb9v4u {
+   box-shadow: 0 0 0 var(--focusRingSize__qhrpjv10) var(--borderColor-focus__qhrpjvm);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_outlineFocus_darkMode__1hjdb9v4v {
+   box-shadow: 0 0 0 var(--focusRingSize__qhrpjv10) var(--borderColor-focus__qhrpjvm);
+ }
+ .sprinkles_display_none_mobile__1hjdb9v4w {
+   display: none;
+ }
+ .sprinkles_display_block_mobile__1hjdb9v50 {
+   display: block;
+ }
+ .sprinkles_display_inline_mobile__1hjdb9v54 {
+   display: inline;
+ }
+ .sprinkles_display_inlineBlock_mobile__1hjdb9v58 {
+   display: inline-block;
+ }
+ .sprinkles_display_flex_mobile__1hjdb9v5c {
+   display: flex;
+ }
+ .sprinkles_position_relative_mobile__1hjdb9v5g {
+   position: relative;
+ }
+ .sprinkles_position_absolute_mobile__1hjdb9v5k {
+   position: absolute;
+ }
+ .sprinkles_position_fixed_mobile__1hjdb9v5o {
+   position: fixed;
+ }
+ .sprinkles_position_sticky_mobile__1hjdb9v5s {
+   position: sticky;
+ }
+ .sprinkles_borderRadius_none_mobile__1hjdb9v5w {
+   border-radius: 0px;
+ }
+ .sprinkles_borderRadius_full_mobile__1hjdb9v60 {
+   border-radius: 9999px;
+ }
+ .sprinkles_borderRadius_small_mobile__1hjdb9v64 {
+   border-radius: var(--borderRadius-small__qhrpjvb);
+ }
+ .sprinkles_borderRadius_standard_mobile__1hjdb9v68 {
+   border-radius: var(--borderRadius-standard__qhrpjvc);
+ }
+ .sprinkles_borderRadius_large_mobile__1hjdb9v6c {
+   border-radius: var(--borderRadius-large__qhrpjvd);
+ }
+ .sprinkles_borderRadius_xlarge_mobile__1hjdb9v6g {
+   border-radius: var(--borderRadius-xlarge__qhrpjve);
+ }
+ .sprinkles_gap_gutter_mobile__1hjdb9v6k {
+   gap: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_gap_xxsmall_mobile__1hjdb9v6o {
+   gap: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_gap_xsmall_mobile__1hjdb9v6s {
+   gap: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_gap_small_mobile__1hjdb9v6w {
+   gap: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_gap_medium_mobile__1hjdb9v70 {
+   gap: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_gap_large_mobile__1hjdb9v74 {
+   gap: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_gap_xlarge_mobile__1hjdb9v78 {
+   gap: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_gap_xxlarge_mobile__1hjdb9v7c {
+   gap: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_gap_xxxlarge_mobile__1hjdb9v7g {
+   gap: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_gap_none_mobile__1hjdb9v7k {
+   gap: 0;
+ }
+ .sprinkles_paddingTop_gutter_mobile__1hjdb9v7o {
+   padding-top: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_paddingTop_xxsmall_mobile__1hjdb9v7s {
+   padding-top: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_paddingTop_xsmall_mobile__1hjdb9v7w {
+   padding-top: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_paddingTop_small_mobile__1hjdb9v80 {
+   padding-top: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_paddingTop_medium_mobile__1hjdb9v84 {
+   padding-top: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_paddingTop_large_mobile__1hjdb9v88 {
+   padding-top: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_paddingTop_xlarge_mobile__1hjdb9v8c {
+   padding-top: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_paddingTop_xxlarge_mobile__1hjdb9v8g {
+   padding-top: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_paddingTop_xxxlarge_mobile__1hjdb9v8k {
+   padding-top: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_paddingTop_none_mobile__1hjdb9v8o {
+   padding-top: 0;
+ }
+ .sprinkles_paddingBottom_gutter_mobile__1hjdb9v8s {
+   padding-bottom: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_paddingBottom_xxsmall_mobile__1hjdb9v8w {
+   padding-bottom: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_paddingBottom_xsmall_mobile__1hjdb9v90 {
+   padding-bottom: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_paddingBottom_small_mobile__1hjdb9v94 {
+   padding-bottom: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_paddingBottom_medium_mobile__1hjdb9v98 {
+   padding-bottom: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_paddingBottom_large_mobile__1hjdb9v9c {
+   padding-bottom: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_paddingBottom_xlarge_mobile__1hjdb9v9g {
+   padding-bottom: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_paddingBottom_xxlarge_mobile__1hjdb9v9k {
+   padding-bottom: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_paddingBottom_xxxlarge_mobile__1hjdb9v9o {
+   padding-bottom: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_paddingBottom_none_mobile__1hjdb9v9s {
+   padding-bottom: 0;
+ }
+ .sprinkles_paddingRight_gutter_mobile__1hjdb9v9w {
+   padding-right: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_paddingRight_xxsmall_mobile__1hjdb9va0 {
+   padding-right: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_paddingRight_xsmall_mobile__1hjdb9va4 {
+   padding-right: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_paddingRight_small_mobile__1hjdb9va8 {
+   padding-right: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_paddingRight_medium_mobile__1hjdb9vac {
+   padding-right: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_paddingRight_large_mobile__1hjdb9vag {
+   padding-right: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_paddingRight_xlarge_mobile__1hjdb9vak {
+   padding-right: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_paddingRight_xxlarge_mobile__1hjdb9vao {
+   padding-right: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_paddingRight_xxxlarge_mobile__1hjdb9vas {
+   padding-right: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_paddingRight_none_mobile__1hjdb9vaw {
+   padding-right: 0;
+ }
+ .sprinkles_paddingLeft_gutter_mobile__1hjdb9vb0 {
+   padding-left: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_paddingLeft_xxsmall_mobile__1hjdb9vb4 {
+   padding-left: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_paddingLeft_xsmall_mobile__1hjdb9vb8 {
+   padding-left: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_paddingLeft_small_mobile__1hjdb9vbc {
+   padding-left: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_paddingLeft_medium_mobile__1hjdb9vbg {
+   padding-left: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_paddingLeft_large_mobile__1hjdb9vbk {
+   padding-left: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_paddingLeft_xlarge_mobile__1hjdb9vbo {
+   padding-left: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_paddingLeft_xxlarge_mobile__1hjdb9vbs {
+   padding-left: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_paddingLeft_xxxlarge_mobile__1hjdb9vbw {
+   padding-left: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_paddingLeft_none_mobile__1hjdb9vc0 {
+   padding-left: 0;
+ }
+ .sprinkles_marginTop_gutter_mobile__1hjdb9vc4 {
+   margin-top: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_marginTop_xxsmall_mobile__1hjdb9vc8 {
+   margin-top: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_marginTop_xsmall_mobile__1hjdb9vcc {
+   margin-top: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_marginTop_small_mobile__1hjdb9vcg {
+   margin-top: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_marginTop_medium_mobile__1hjdb9vck {
+   margin-top: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_marginTop_large_mobile__1hjdb9vco {
+   margin-top: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_marginTop_xlarge_mobile__1hjdb9vcs {
+   margin-top: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_marginTop_xxlarge_mobile__1hjdb9vcw {
+   margin-top: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_marginTop_xxxlarge_mobile__1hjdb9vd0 {
+   margin-top: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_marginTop_none_mobile__1hjdb9vd4 {
+   margin-top: 0;
+ }
+ .sprinkles_marginBottom_gutter_mobile__1hjdb9vd8 {
+   margin-bottom: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_marginBottom_xxsmall_mobile__1hjdb9vdc {
+   margin-bottom: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_marginBottom_xsmall_mobile__1hjdb9vdg {
+   margin-bottom: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_marginBottom_small_mobile__1hjdb9vdk {
+   margin-bottom: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_marginBottom_medium_mobile__1hjdb9vdo {
+   margin-bottom: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_marginBottom_large_mobile__1hjdb9vds {
+   margin-bottom: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_marginBottom_xlarge_mobile__1hjdb9vdw {
+   margin-bottom: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_marginBottom_xxlarge_mobile__1hjdb9ve0 {
+   margin-bottom: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_marginBottom_xxxlarge_mobile__1hjdb9ve4 {
+   margin-bottom: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_marginBottom_none_mobile__1hjdb9ve8 {
+   margin-bottom: 0;
+ }
+ .sprinkles_marginRight_gutter_mobile__1hjdb9vec {
+   margin-right: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_marginRight_xxsmall_mobile__1hjdb9veg {
+   margin-right: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_marginRight_xsmall_mobile__1hjdb9vek {
+   margin-right: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_marginRight_small_mobile__1hjdb9veo {
+   margin-right: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_marginRight_medium_mobile__1hjdb9ves {
+   margin-right: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_marginRight_large_mobile__1hjdb9vew {
+   margin-right: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_marginRight_xlarge_mobile__1hjdb9vf0 {
+   margin-right: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_marginRight_xxlarge_mobile__1hjdb9vf4 {
+   margin-right: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_marginRight_xxxlarge_mobile__1hjdb9vf8 {
+   margin-right: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_marginRight_none_mobile__1hjdb9vfc {
+   margin-right: 0;
+ }
+ .sprinkles_marginLeft_gutter_mobile__1hjdb9vfg {
+   margin-left: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_marginLeft_xxsmall_mobile__1hjdb9vfk {
+   margin-left: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_marginLeft_xsmall_mobile__1hjdb9vfo {
+   margin-left: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_marginLeft_small_mobile__1hjdb9vfs {
+   margin-left: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_marginLeft_medium_mobile__1hjdb9vfw {
+   margin-left: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_marginLeft_large_mobile__1hjdb9vg0 {
+   margin-left: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_marginLeft_xlarge_mobile__1hjdb9vg4 {
+   margin-left: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_marginLeft_xxlarge_mobile__1hjdb9vg8 {
+   margin-left: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_marginLeft_xxxlarge_mobile__1hjdb9vgc {
+   margin-left: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_marginLeft_none_mobile__1hjdb9vgg {
+   margin-left: 0;
+ }
+ .sprinkles_alignItems_flexStart_mobile__1hjdb9vgk {
+   align-items: flex-start;
+ }
+ .sprinkles_alignItems_center_mobile__1hjdb9vgo {
+   align-items: center;
+ }
+ .sprinkles_alignItems_flexEnd_mobile__1hjdb9vgs {
+   align-items: flex-end;
+ }
+ .sprinkles_justifyContent_flexStart_mobile__1hjdb9vgw {
+   justify-content: flex-start;
+ }
+ .sprinkles_justifyContent_center_mobile__1hjdb9vh0 {
+   justify-content: center;
+ }
+ .sprinkles_justifyContent_flexEnd_mobile__1hjdb9vh4 {
+   justify-content: flex-end;
+ }
+ .sprinkles_justifyContent_spaceBetween_mobile__1hjdb9vh8 {
+   justify-content: space-between;
+ }
+ .sprinkles_flexDirection_row_mobile__1hjdb9vhc {
+   flex-direction: row;
+ }
+ .sprinkles_flexDirection_rowReverse_mobile__1hjdb9vhg {
+   flex-direction: row-reverse;
+ }
+ .sprinkles_flexDirection_column_mobile__1hjdb9vhk {
+   flex-direction: column;
+ }
+ .sprinkles_flexDirection_columnReverse_mobile__1hjdb9vho {
+   flex-direction: column-reverse;
+ }
+ .sprinkles_flexWrap_wrap_mobile__1hjdb9vhs {
+   flex-wrap: wrap;
+ }
+ .sprinkles_flexWrap_nowrap_mobile__1hjdb9vhw {
+   flex-wrap: nowrap;
+ }
+ .sprinkles_flexShrink_0_mobile__1hjdb9vi0 {
+   flex-shrink: 0;
+ }
+ .sprinkles_flexGrow_0_mobile__1hjdb9vi4 {
+   flex-grow: 0;
+ }
+ .sprinkles_flexGrow_1_mobile__1hjdb9vi8 {
+   flex-grow: 1;
+ }
+ .sprinkles_textAlign_left_mobile__1hjdb9vic {
+   text-align: left;
+ }
+ .sprinkles_textAlign_center_mobile__1hjdb9vig {
+   text-align: center;
+ }
+ .sprinkles_textAlign_right_mobile__1hjdb9vik {
+   text-align: right;
+ }
+ @media screen and (min-width: 740px) {
+   .sprinkles_display_none_tablet__1hjdb9v4x {
+     display: none;
+   }
+   .sprinkles_display_block_tablet__1hjdb9v51 {
+     display: block;
+   }
+   .sprinkles_display_inline_tablet__1hjdb9v55 {
+     display: inline;
+   }
+   .sprinkles_display_inlineBlock_tablet__1hjdb9v59 {
+     display: inline-block;
+   }
+   .sprinkles_display_flex_tablet__1hjdb9v5d {
+     display: flex;
+   }
+   .sprinkles_position_relative_tablet__1hjdb9v5h {
+     position: relative;
+   }
+   .sprinkles_position_absolute_tablet__1hjdb9v5l {
+     position: absolute;
+   }
+   .sprinkles_position_fixed_tablet__1hjdb9v5p {
+     position: fixed;
+   }
+   .sprinkles_position_sticky_tablet__1hjdb9v5t {
+     position: sticky;
+   }
+   .sprinkles_borderRadius_none_tablet__1hjdb9v5x {
+     border-radius: 0px;
+   }
+   .sprinkles_borderRadius_full_tablet__1hjdb9v61 {
+     border-radius: 9999px;
+   }
+   .sprinkles_borderRadius_small_tablet__1hjdb9v65 {
+     border-radius: var(--borderRadius-small__qhrpjvb);
+   }
+   .sprinkles_borderRadius_standard_tablet__1hjdb9v69 {
+     border-radius: var(--borderRadius-standard__qhrpjvc);
+   }
+   .sprinkles_borderRadius_large_tablet__1hjdb9v6d {
+     border-radius: var(--borderRadius-large__qhrpjvd);
+   }
+   .sprinkles_borderRadius_xlarge_tablet__1hjdb9v6h {
+     border-radius: var(--borderRadius-xlarge__qhrpjve);
+   }
+   .sprinkles_gap_gutter_tablet__1hjdb9v6l {
+     gap: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_gap_xxsmall_tablet__1hjdb9v6p {
+     gap: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_gap_xsmall_tablet__1hjdb9v6t {
+     gap: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_gap_small_tablet__1hjdb9v6x {
+     gap: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_gap_medium_tablet__1hjdb9v71 {
+     gap: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_gap_large_tablet__1hjdb9v75 {
+     gap: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_gap_xlarge_tablet__1hjdb9v79 {
+     gap: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_gap_xxlarge_tablet__1hjdb9v7d {
+     gap: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_gap_xxxlarge_tablet__1hjdb9v7h {
+     gap: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_gap_none_tablet__1hjdb9v7l {
+     gap: 0;
+   }
+   .sprinkles_paddingTop_gutter_tablet__1hjdb9v7p {
+     padding-top: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingTop_xxsmall_tablet__1hjdb9v7t {
+     padding-top: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingTop_xsmall_tablet__1hjdb9v7x {
+     padding-top: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingTop_small_tablet__1hjdb9v81 {
+     padding-top: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingTop_medium_tablet__1hjdb9v85 {
+     padding-top: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingTop_large_tablet__1hjdb9v89 {
+     padding-top: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingTop_xlarge_tablet__1hjdb9v8d {
+     padding-top: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingTop_xxlarge_tablet__1hjdb9v8h {
+     padding-top: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingTop_xxxlarge_tablet__1hjdb9v8l {
+     padding-top: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingTop_none_tablet__1hjdb9v8p {
+     padding-top: 0;
+   }
+   .sprinkles_paddingBottom_gutter_tablet__1hjdb9v8t {
+     padding-bottom: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingBottom_xxsmall_tablet__1hjdb9v8x {
+     padding-bottom: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingBottom_xsmall_tablet__1hjdb9v91 {
+     padding-bottom: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingBottom_small_tablet__1hjdb9v95 {
+     padding-bottom: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingBottom_medium_tablet__1hjdb9v99 {
+     padding-bottom: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingBottom_large_tablet__1hjdb9v9d {
+     padding-bottom: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingBottom_xlarge_tablet__1hjdb9v9h {
+     padding-bottom: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingBottom_xxlarge_tablet__1hjdb9v9l {
+     padding-bottom: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingBottom_xxxlarge_tablet__1hjdb9v9p {
+     padding-bottom: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingBottom_none_tablet__1hjdb9v9t {
+     padding-bottom: 0;
+   }
+   .sprinkles_paddingRight_gutter_tablet__1hjdb9v9x {
+     padding-right: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingRight_xxsmall_tablet__1hjdb9va1 {
+     padding-right: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingRight_xsmall_tablet__1hjdb9va5 {
+     padding-right: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingRight_small_tablet__1hjdb9va9 {
+     padding-right: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingRight_medium_tablet__1hjdb9vad {
+     padding-right: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingRight_large_tablet__1hjdb9vah {
+     padding-right: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingRight_xlarge_tablet__1hjdb9val {
+     padding-right: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingRight_xxlarge_tablet__1hjdb9vap {
+     padding-right: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingRight_xxxlarge_tablet__1hjdb9vat {
+     padding-right: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingRight_none_tablet__1hjdb9vax {
+     padding-right: 0;
+   }
+   .sprinkles_paddingLeft_gutter_tablet__1hjdb9vb1 {
+     padding-left: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingLeft_xxsmall_tablet__1hjdb9vb5 {
+     padding-left: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingLeft_xsmall_tablet__1hjdb9vb9 {
+     padding-left: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingLeft_small_tablet__1hjdb9vbd {
+     padding-left: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingLeft_medium_tablet__1hjdb9vbh {
+     padding-left: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingLeft_large_tablet__1hjdb9vbl {
+     padding-left: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingLeft_xlarge_tablet__1hjdb9vbp {
+     padding-left: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingLeft_xxlarge_tablet__1hjdb9vbt {
+     padding-left: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingLeft_xxxlarge_tablet__1hjdb9vbx {
+     padding-left: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingLeft_none_tablet__1hjdb9vc1 {
+     padding-left: 0;
+   }
+   .sprinkles_marginTop_gutter_tablet__1hjdb9vc5 {
+     margin-top: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginTop_xxsmall_tablet__1hjdb9vc9 {
+     margin-top: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginTop_xsmall_tablet__1hjdb9vcd {
+     margin-top: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginTop_small_tablet__1hjdb9vch {
+     margin-top: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginTop_medium_tablet__1hjdb9vcl {
+     margin-top: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginTop_large_tablet__1hjdb9vcp {
+     margin-top: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginTop_xlarge_tablet__1hjdb9vct {
+     margin-top: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginTop_xxlarge_tablet__1hjdb9vcx {
+     margin-top: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginTop_xxxlarge_tablet__1hjdb9vd1 {
+     margin-top: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginTop_none_tablet__1hjdb9vd5 {
+     margin-top: 0;
+   }
+   .sprinkles_marginBottom_gutter_tablet__1hjdb9vd9 {
+     margin-bottom: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginBottom_xxsmall_tablet__1hjdb9vdd {
+     margin-bottom: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginBottom_xsmall_tablet__1hjdb9vdh {
+     margin-bottom: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginBottom_small_tablet__1hjdb9vdl {
+     margin-bottom: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginBottom_medium_tablet__1hjdb9vdp {
+     margin-bottom: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginBottom_large_tablet__1hjdb9vdt {
+     margin-bottom: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginBottom_xlarge_tablet__1hjdb9vdx {
+     margin-bottom: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginBottom_xxlarge_tablet__1hjdb9ve1 {
+     margin-bottom: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginBottom_xxxlarge_tablet__1hjdb9ve5 {
+     margin-bottom: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginBottom_none_tablet__1hjdb9ve9 {
+     margin-bottom: 0;
+   }
+   .sprinkles_marginRight_gutter_tablet__1hjdb9ved {
+     margin-right: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginRight_xxsmall_tablet__1hjdb9veh {
+     margin-right: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginRight_xsmall_tablet__1hjdb9vel {
+     margin-right: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginRight_small_tablet__1hjdb9vep {
+     margin-right: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginRight_medium_tablet__1hjdb9vet {
+     margin-right: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginRight_large_tablet__1hjdb9vex {
+     margin-right: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginRight_xlarge_tablet__1hjdb9vf1 {
+     margin-right: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginRight_xxlarge_tablet__1hjdb9vf5 {
+     margin-right: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginRight_xxxlarge_tablet__1hjdb9vf9 {
+     margin-right: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginRight_none_tablet__1hjdb9vfd {
+     margin-right: 0;
+   }
+   .sprinkles_marginLeft_gutter_tablet__1hjdb9vfh {
+     margin-left: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginLeft_xxsmall_tablet__1hjdb9vfl {
+     margin-left: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginLeft_xsmall_tablet__1hjdb9vfp {
+     margin-left: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginLeft_small_tablet__1hjdb9vft {
+     margin-left: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginLeft_medium_tablet__1hjdb9vfx {
+     margin-left: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginLeft_large_tablet__1hjdb9vg1 {
+     margin-left: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginLeft_xlarge_tablet__1hjdb9vg5 {
+     margin-left: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginLeft_xxlarge_tablet__1hjdb9vg9 {
+     margin-left: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginLeft_xxxlarge_tablet__1hjdb9vgd {
+     margin-left: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginLeft_none_tablet__1hjdb9vgh {
+     margin-left: 0;
+   }
+   .sprinkles_alignItems_flexStart_tablet__1hjdb9vgl {
+     align-items: flex-start;
+   }
+   .sprinkles_alignItems_center_tablet__1hjdb9vgp {
+     align-items: center;
+   }
+   .sprinkles_alignItems_flexEnd_tablet__1hjdb9vgt {
+     align-items: flex-end;
+   }
+   .sprinkles_justifyContent_flexStart_tablet__1hjdb9vgx {
+     justify-content: flex-start;
+   }
+   .sprinkles_justifyContent_center_tablet__1hjdb9vh1 {
+     justify-content: center;
+   }
+   .sprinkles_justifyContent_flexEnd_tablet__1hjdb9vh5 {
+     justify-content: flex-end;
+   }
+   .sprinkles_justifyContent_spaceBetween_tablet__1hjdb9vh9 {
+     justify-content: space-between;
+   }
+   .sprinkles_flexDirection_row_tablet__1hjdb9vhd {
+     flex-direction: row;
+   }
+   .sprinkles_flexDirection_rowReverse_tablet__1hjdb9vhh {
+     flex-direction: row-reverse;
+   }
+   .sprinkles_flexDirection_column_tablet__1hjdb9vhl {
+     flex-direction: column;
+   }
+   .sprinkles_flexDirection_columnReverse_tablet__1hjdb9vhp {
+     flex-direction: column-reverse;
+   }
+   .sprinkles_flexWrap_wrap_tablet__1hjdb9vht {
+     flex-wrap: wrap;
+   }
+   .sprinkles_flexWrap_nowrap_tablet__1hjdb9vhx {
+     flex-wrap: nowrap;
+   }
+   .sprinkles_flexShrink_0_tablet__1hjdb9vi1 {
+     flex-shrink: 0;
+   }
+   .sprinkles_flexGrow_0_tablet__1hjdb9vi5 {
+     flex-grow: 0;
+   }
+   .sprinkles_flexGrow_1_tablet__1hjdb9vi9 {
+     flex-grow: 1;
+   }
+   .sprinkles_textAlign_left_tablet__1hjdb9vid {
+     text-align: left;
+   }
+   .sprinkles_textAlign_center_tablet__1hjdb9vih {
+     text-align: center;
+   }
+   .sprinkles_textAlign_right_tablet__1hjdb9vil {
+     text-align: right;
+   }
+ }
+ @media screen and (min-width: 992px) {
+   .sprinkles_display_none_desktop__1hjdb9v4y {
+     display: none;
+   }
+   .sprinkles_display_block_desktop__1hjdb9v52 {
+     display: block;
+   }
+   .sprinkles_display_inline_desktop__1hjdb9v56 {
+     display: inline;
+   }
+   .sprinkles_display_inlineBlock_desktop__1hjdb9v5a {
+     display: inline-block;
+   }
+   .sprinkles_display_flex_desktop__1hjdb9v5e {
+     display: flex;
+   }
+   .sprinkles_position_relative_desktop__1hjdb9v5i {
+     position: relative;
+   }
+   .sprinkles_position_absolute_desktop__1hjdb9v5m {
+     position: absolute;
+   }
+   .sprinkles_position_fixed_desktop__1hjdb9v5q {
+     position: fixed;
+   }
+   .sprinkles_position_sticky_desktop__1hjdb9v5u {
+     position: sticky;
+   }
+   .sprinkles_borderRadius_none_desktop__1hjdb9v5y {
+     border-radius: 0px;
+   }
+   .sprinkles_borderRadius_full_desktop__1hjdb9v62 {
+     border-radius: 9999px;
+   }
+   .sprinkles_borderRadius_small_desktop__1hjdb9v66 {
+     border-radius: var(--borderRadius-small__qhrpjvb);
+   }
+   .sprinkles_borderRadius_standard_desktop__1hjdb9v6a {
+     border-radius: var(--borderRadius-standard__qhrpjvc);
+   }
+   .sprinkles_borderRadius_large_desktop__1hjdb9v6e {
+     border-radius: var(--borderRadius-large__qhrpjvd);
+   }
+   .sprinkles_borderRadius_xlarge_desktop__1hjdb9v6i {
+     border-radius: var(--borderRadius-xlarge__qhrpjve);
+   }
+   .sprinkles_gap_gutter_desktop__1hjdb9v6m {
+     gap: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_gap_xxsmall_desktop__1hjdb9v6q {
+     gap: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_gap_xsmall_desktop__1hjdb9v6u {
+     gap: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_gap_small_desktop__1hjdb9v6y {
+     gap: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_gap_medium_desktop__1hjdb9v72 {
+     gap: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_gap_large_desktop__1hjdb9v76 {
+     gap: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_gap_xlarge_desktop__1hjdb9v7a {
+     gap: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_gap_xxlarge_desktop__1hjdb9v7e {
+     gap: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_gap_xxxlarge_desktop__1hjdb9v7i {
+     gap: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_gap_none_desktop__1hjdb9v7m {
+     gap: 0;
+   }
+   .sprinkles_paddingTop_gutter_desktop__1hjdb9v7q {
+     padding-top: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingTop_xxsmall_desktop__1hjdb9v7u {
+     padding-top: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingTop_xsmall_desktop__1hjdb9v7y {
+     padding-top: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingTop_small_desktop__1hjdb9v82 {
+     padding-top: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingTop_medium_desktop__1hjdb9v86 {
+     padding-top: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingTop_large_desktop__1hjdb9v8a {
+     padding-top: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingTop_xlarge_desktop__1hjdb9v8e {
+     padding-top: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingTop_xxlarge_desktop__1hjdb9v8i {
+     padding-top: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingTop_xxxlarge_desktop__1hjdb9v8m {
+     padding-top: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingTop_none_desktop__1hjdb9v8q {
+     padding-top: 0;
+   }
+   .sprinkles_paddingBottom_gutter_desktop__1hjdb9v8u {
+     padding-bottom: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingBottom_xxsmall_desktop__1hjdb9v8y {
+     padding-bottom: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingBottom_xsmall_desktop__1hjdb9v92 {
+     padding-bottom: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingBottom_small_desktop__1hjdb9v96 {
+     padding-bottom: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingBottom_medium_desktop__1hjdb9v9a {
+     padding-bottom: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingBottom_large_desktop__1hjdb9v9e {
+     padding-bottom: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingBottom_xlarge_desktop__1hjdb9v9i {
+     padding-bottom: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingBottom_xxlarge_desktop__1hjdb9v9m {
+     padding-bottom: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingBottom_xxxlarge_desktop__1hjdb9v9q {
+     padding-bottom: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingBottom_none_desktop__1hjdb9v9u {
+     padding-bottom: 0;
+   }
+   .sprinkles_paddingRight_gutter_desktop__1hjdb9v9y {
+     padding-right: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingRight_xxsmall_desktop__1hjdb9va2 {
+     padding-right: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingRight_xsmall_desktop__1hjdb9va6 {
+     padding-right: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingRight_small_desktop__1hjdb9vaa {
+     padding-right: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingRight_medium_desktop__1hjdb9vae {
+     padding-right: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingRight_large_desktop__1hjdb9vai {
+     padding-right: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingRight_xlarge_desktop__1hjdb9vam {
+     padding-right: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingRight_xxlarge_desktop__1hjdb9vaq {
+     padding-right: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingRight_xxxlarge_desktop__1hjdb9vau {
+     padding-right: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingRight_none_desktop__1hjdb9vay {
+     padding-right: 0;
+   }
+   .sprinkles_paddingLeft_gutter_desktop__1hjdb9vb2 {
+     padding-left: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingLeft_xxsmall_desktop__1hjdb9vb6 {
+     padding-left: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingLeft_xsmall_desktop__1hjdb9vba {
+     padding-left: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingLeft_small_desktop__1hjdb9vbe {
+     padding-left: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingLeft_medium_desktop__1hjdb9vbi {
+     padding-left: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingLeft_large_desktop__1hjdb9vbm {
+     padding-left: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingLeft_xlarge_desktop__1hjdb9vbq {
+     padding-left: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingLeft_xxlarge_desktop__1hjdb9vbu {
+     padding-left: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingLeft_xxxlarge_desktop__1hjdb9vby {
+     padding-left: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingLeft_none_desktop__1hjdb9vc2 {
+     padding-left: 0;
+   }
+   .sprinkles_marginTop_gutter_desktop__1hjdb9vc6 {
+     margin-top: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginTop_xxsmall_desktop__1hjdb9vca {
+     margin-top: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginTop_xsmall_desktop__1hjdb9vce {
+     margin-top: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginTop_small_desktop__1hjdb9vci {
+     margin-top: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginTop_medium_desktop__1hjdb9vcm {
+     margin-top: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginTop_large_desktop__1hjdb9vcq {
+     margin-top: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginTop_xlarge_desktop__1hjdb9vcu {
+     margin-top: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginTop_xxlarge_desktop__1hjdb9vcy {
+     margin-top: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginTop_xxxlarge_desktop__1hjdb9vd2 {
+     margin-top: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginTop_none_desktop__1hjdb9vd6 {
+     margin-top: 0;
+   }
+   .sprinkles_marginBottom_gutter_desktop__1hjdb9vda {
+     margin-bottom: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginBottom_xxsmall_desktop__1hjdb9vde {
+     margin-bottom: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginBottom_xsmall_desktop__1hjdb9vdi {
+     margin-bottom: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginBottom_small_desktop__1hjdb9vdm {
+     margin-bottom: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginBottom_medium_desktop__1hjdb9vdq {
+     margin-bottom: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginBottom_large_desktop__1hjdb9vdu {
+     margin-bottom: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginBottom_xlarge_desktop__1hjdb9vdy {
+     margin-bottom: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginBottom_xxlarge_desktop__1hjdb9ve2 {
+     margin-bottom: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginBottom_xxxlarge_desktop__1hjdb9ve6 {
+     margin-bottom: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginBottom_none_desktop__1hjdb9vea {
+     margin-bottom: 0;
+   }
+   .sprinkles_marginRight_gutter_desktop__1hjdb9vee {
+     margin-right: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginRight_xxsmall_desktop__1hjdb9vei {
+     margin-right: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginRight_xsmall_desktop__1hjdb9vem {
+     margin-right: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginRight_small_desktop__1hjdb9veq {
+     margin-right: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginRight_medium_desktop__1hjdb9veu {
+     margin-right: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginRight_large_desktop__1hjdb9vey {
+     margin-right: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginRight_xlarge_desktop__1hjdb9vf2 {
+     margin-right: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginRight_xxlarge_desktop__1hjdb9vf6 {
+     margin-right: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginRight_xxxlarge_desktop__1hjdb9vfa {
+     margin-right: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginRight_none_desktop__1hjdb9vfe {
+     margin-right: 0;
+   }
+   .sprinkles_marginLeft_gutter_desktop__1hjdb9vfi {
+     margin-left: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginLeft_xxsmall_desktop__1hjdb9vfm {
+     margin-left: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginLeft_xsmall_desktop__1hjdb9vfq {
+     margin-left: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginLeft_small_desktop__1hjdb9vfu {
+     margin-left: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginLeft_medium_desktop__1hjdb9vfy {
+     margin-left: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginLeft_large_desktop__1hjdb9vg2 {
+     margin-left: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginLeft_xlarge_desktop__1hjdb9vg6 {
+     margin-left: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginLeft_xxlarge_desktop__1hjdb9vga {
+     margin-left: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginLeft_xxxlarge_desktop__1hjdb9vge {
+     margin-left: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginLeft_none_desktop__1hjdb9vgi {
+     margin-left: 0;
+   }
+   .sprinkles_alignItems_flexStart_desktop__1hjdb9vgm {
+     align-items: flex-start;
+   }
+   .sprinkles_alignItems_center_desktop__1hjdb9vgq {
+     align-items: center;
+   }
+   .sprinkles_alignItems_flexEnd_desktop__1hjdb9vgu {
+     align-items: flex-end;
+   }
+   .sprinkles_justifyContent_flexStart_desktop__1hjdb9vgy {
+     justify-content: flex-start;
+   }
+   .sprinkles_justifyContent_center_desktop__1hjdb9vh2 {
+     justify-content: center;
+   }
+   .sprinkles_justifyContent_flexEnd_desktop__1hjdb9vh6 {
+     justify-content: flex-end;
+   }
+   .sprinkles_justifyContent_spaceBetween_desktop__1hjdb9vha {
+     justify-content: space-between;
+   }
+   .sprinkles_flexDirection_row_desktop__1hjdb9vhe {
+     flex-direction: row;
+   }
+   .sprinkles_flexDirection_rowReverse_desktop__1hjdb9vhi {
+     flex-direction: row-reverse;
+   }
+   .sprinkles_flexDirection_column_desktop__1hjdb9vhm {
+     flex-direction: column;
+   }
+   .sprinkles_flexDirection_columnReverse_desktop__1hjdb9vhq {
+     flex-direction: column-reverse;
+   }
+   .sprinkles_flexWrap_wrap_desktop__1hjdb9vhu {
+     flex-wrap: wrap;
+   }
+   .sprinkles_flexWrap_nowrap_desktop__1hjdb9vhy {
+     flex-wrap: nowrap;
+   }
+   .sprinkles_flexShrink_0_desktop__1hjdb9vi2 {
+     flex-shrink: 0;
+   }
+   .sprinkles_flexGrow_0_desktop__1hjdb9vi6 {
+     flex-grow: 0;
+   }
+   .sprinkles_flexGrow_1_desktop__1hjdb9via {
+     flex-grow: 1;
+   }
+   .sprinkles_textAlign_left_desktop__1hjdb9vie {
+     text-align: left;
+   }
+   .sprinkles_textAlign_center_desktop__1hjdb9vii {
+     text-align: center;
+   }
+   .sprinkles_textAlign_right_desktop__1hjdb9vim {
+     text-align: right;
+   }
+ }
+ @media screen and (min-width: 1200px) {
+   .sprinkles_display_none_wide__1hjdb9v4z {
+     display: none;
+   }
+   .sprinkles_display_block_wide__1hjdb9v53 {
+     display: block;
+   }
+   .sprinkles_display_inline_wide__1hjdb9v57 {
+     display: inline;
+   }
+   .sprinkles_display_inlineBlock_wide__1hjdb9v5b {
+     display: inline-block;
+   }
+   .sprinkles_display_flex_wide__1hjdb9v5f {
+     display: flex;
+   }
+   .sprinkles_position_relative_wide__1hjdb9v5j {
+     position: relative;
+   }
+   .sprinkles_position_absolute_wide__1hjdb9v5n {
+     position: absolute;
+   }
+   .sprinkles_position_fixed_wide__1hjdb9v5r {
+     position: fixed;
+   }
+   .sprinkles_position_sticky_wide__1hjdb9v5v {
+     position: sticky;
+   }
+   .sprinkles_borderRadius_none_wide__1hjdb9v5z {
+     border-radius: 0px;
+   }
+   .sprinkles_borderRadius_full_wide__1hjdb9v63 {
+     border-radius: 9999px;
+   }
+   .sprinkles_borderRadius_small_wide__1hjdb9v67 {
+     border-radius: var(--borderRadius-small__qhrpjvb);
+   }
+   .sprinkles_borderRadius_standard_wide__1hjdb9v6b {
+     border-radius: var(--borderRadius-standard__qhrpjvc);
+   }
+   .sprinkles_borderRadius_large_wide__1hjdb9v6f {
+     border-radius: var(--borderRadius-large__qhrpjvd);
+   }
+   .sprinkles_borderRadius_xlarge_wide__1hjdb9v6j {
+     border-radius: var(--borderRadius-xlarge__qhrpjve);
+   }
+   .sprinkles_gap_gutter_wide__1hjdb9v6n {
+     gap: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_gap_xxsmall_wide__1hjdb9v6r {
+     gap: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_gap_xsmall_wide__1hjdb9v6v {
+     gap: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_gap_small_wide__1hjdb9v6z {
+     gap: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_gap_medium_wide__1hjdb9v73 {
+     gap: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_gap_large_wide__1hjdb9v77 {
+     gap: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_gap_xlarge_wide__1hjdb9v7b {
+     gap: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_gap_xxlarge_wide__1hjdb9v7f {
+     gap: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_gap_xxxlarge_wide__1hjdb9v7j {
+     gap: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_gap_none_wide__1hjdb9v7n {
+     gap: 0;
+   }
+   .sprinkles_paddingTop_gutter_wide__1hjdb9v7r {
+     padding-top: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingTop_xxsmall_wide__1hjdb9v7v {
+     padding-top: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingTop_xsmall_wide__1hjdb9v7z {
+     padding-top: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingTop_small_wide__1hjdb9v83 {
+     padding-top: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingTop_medium_wide__1hjdb9v87 {
+     padding-top: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingTop_large_wide__1hjdb9v8b {
+     padding-top: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingTop_xlarge_wide__1hjdb9v8f {
+     padding-top: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingTop_xxlarge_wide__1hjdb9v8j {
+     padding-top: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingTop_xxxlarge_wide__1hjdb9v8n {
+     padding-top: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingTop_none_wide__1hjdb9v8r {
+     padding-top: 0;
+   }
+   .sprinkles_paddingBottom_gutter_wide__1hjdb9v8v {
+     padding-bottom: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingBottom_xxsmall_wide__1hjdb9v8z {
+     padding-bottom: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingBottom_xsmall_wide__1hjdb9v93 {
+     padding-bottom: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingBottom_small_wide__1hjdb9v97 {
+     padding-bottom: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingBottom_medium_wide__1hjdb9v9b {
+     padding-bottom: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingBottom_large_wide__1hjdb9v9f {
+     padding-bottom: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingBottom_xlarge_wide__1hjdb9v9j {
+     padding-bottom: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingBottom_xxlarge_wide__1hjdb9v9n {
+     padding-bottom: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingBottom_xxxlarge_wide__1hjdb9v9r {
+     padding-bottom: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingBottom_none_wide__1hjdb9v9v {
+     padding-bottom: 0;
+   }
+   .sprinkles_paddingRight_gutter_wide__1hjdb9v9z {
+     padding-right: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingRight_xxsmall_wide__1hjdb9va3 {
+     padding-right: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingRight_xsmall_wide__1hjdb9va7 {
+     padding-right: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingRight_small_wide__1hjdb9vab {
+     padding-right: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingRight_medium_wide__1hjdb9vaf {
+     padding-right: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingRight_large_wide__1hjdb9vaj {
+     padding-right: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingRight_xlarge_wide__1hjdb9van {
+     padding-right: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingRight_xxlarge_wide__1hjdb9var {
+     padding-right: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingRight_xxxlarge_wide__1hjdb9vav {
+     padding-right: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingRight_none_wide__1hjdb9vaz {
+     padding-right: 0;
+   }
+   .sprinkles_paddingLeft_gutter_wide__1hjdb9vb3 {
+     padding-left: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingLeft_xxsmall_wide__1hjdb9vb7 {
+     padding-left: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingLeft_xsmall_wide__1hjdb9vbb {
+     padding-left: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingLeft_small_wide__1hjdb9vbf {
+     padding-left: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingLeft_medium_wide__1hjdb9vbj {
+     padding-left: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingLeft_large_wide__1hjdb9vbn {
+     padding-left: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingLeft_xlarge_wide__1hjdb9vbr {
+     padding-left: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingLeft_xxlarge_wide__1hjdb9vbv {
+     padding-left: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingLeft_xxxlarge_wide__1hjdb9vbz {
+     padding-left: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingLeft_none_wide__1hjdb9vc3 {
+     padding-left: 0;
+   }
+   .sprinkles_marginTop_gutter_wide__1hjdb9vc7 {
+     margin-top: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginTop_xxsmall_wide__1hjdb9vcb {
+     margin-top: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginTop_xsmall_wide__1hjdb9vcf {
+     margin-top: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginTop_small_wide__1hjdb9vcj {
+     margin-top: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginTop_medium_wide__1hjdb9vcn {
+     margin-top: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginTop_large_wide__1hjdb9vcr {
+     margin-top: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginTop_xlarge_wide__1hjdb9vcv {
+     margin-top: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginTop_xxlarge_wide__1hjdb9vcz {
+     margin-top: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginTop_xxxlarge_wide__1hjdb9vd3 {
+     margin-top: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginTop_none_wide__1hjdb9vd7 {
+     margin-top: 0;
+   }
+   .sprinkles_marginBottom_gutter_wide__1hjdb9vdb {
+     margin-bottom: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginBottom_xxsmall_wide__1hjdb9vdf {
+     margin-bottom: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginBottom_xsmall_wide__1hjdb9vdj {
+     margin-bottom: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginBottom_small_wide__1hjdb9vdn {
+     margin-bottom: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginBottom_medium_wide__1hjdb9vdr {
+     margin-bottom: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginBottom_large_wide__1hjdb9vdv {
+     margin-bottom: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginBottom_xlarge_wide__1hjdb9vdz {
+     margin-bottom: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginBottom_xxlarge_wide__1hjdb9ve3 {
+     margin-bottom: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginBottom_xxxlarge_wide__1hjdb9ve7 {
+     margin-bottom: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginBottom_none_wide__1hjdb9veb {
+     margin-bottom: 0;
+   }
+   .sprinkles_marginRight_gutter_wide__1hjdb9vef {
+     margin-right: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginRight_xxsmall_wide__1hjdb9vej {
+     margin-right: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginRight_xsmall_wide__1hjdb9ven {
+     margin-right: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginRight_small_wide__1hjdb9ver {
+     margin-right: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginRight_medium_wide__1hjdb9vev {
+     margin-right: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginRight_large_wide__1hjdb9vez {
+     margin-right: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginRight_xlarge_wide__1hjdb9vf3 {
+     margin-right: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginRight_xxlarge_wide__1hjdb9vf7 {
+     margin-right: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginRight_xxxlarge_wide__1hjdb9vfb {
+     margin-right: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginRight_none_wide__1hjdb9vff {
+     margin-right: 0;
+   }
+   .sprinkles_marginLeft_gutter_wide__1hjdb9vfj {
+     margin-left: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginLeft_xxsmall_wide__1hjdb9vfn {
+     margin-left: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginLeft_xsmall_wide__1hjdb9vfr {
+     margin-left: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginLeft_small_wide__1hjdb9vfv {
+     margin-left: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginLeft_medium_wide__1hjdb9vfz {
+     margin-left: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginLeft_large_wide__1hjdb9vg3 {
+     margin-left: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginLeft_xlarge_wide__1hjdb9vg7 {
+     margin-left: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginLeft_xxlarge_wide__1hjdb9vgb {
+     margin-left: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginLeft_xxxlarge_wide__1hjdb9vgf {
+     margin-left: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginLeft_none_wide__1hjdb9vgj {
+     margin-left: 0;
+   }
+   .sprinkles_alignItems_flexStart_wide__1hjdb9vgn {
+     align-items: flex-start;
+   }
+   .sprinkles_alignItems_center_wide__1hjdb9vgr {
+     align-items: center;
+   }
+   .sprinkles_alignItems_flexEnd_wide__1hjdb9vgv {
+     align-items: flex-end;
+   }
+   .sprinkles_justifyContent_flexStart_wide__1hjdb9vgz {
+     justify-content: flex-start;
+   }
+   .sprinkles_justifyContent_center_wide__1hjdb9vh3 {
+     justify-content: center;
+   }
+   .sprinkles_justifyContent_flexEnd_wide__1hjdb9vh7 {
+     justify-content: flex-end;
+   }
+   .sprinkles_justifyContent_spaceBetween_wide__1hjdb9vhb {
+     justify-content: space-between;
+   }
+   .sprinkles_flexDirection_row_wide__1hjdb9vhf {
+     flex-direction: row;
+   }
+   .sprinkles_flexDirection_rowReverse_wide__1hjdb9vhj {
+     flex-direction: row-reverse;
+   }
+   .sprinkles_flexDirection_column_wide__1hjdb9vhn {
+     flex-direction: column;
+   }
+   .sprinkles_flexDirection_columnReverse_wide__1hjdb9vhr {
+     flex-direction: column-reverse;
+   }
+   .sprinkles_flexWrap_wrap_wide__1hjdb9vhv {
+     flex-wrap: wrap;
+   }
+   .sprinkles_flexWrap_nowrap_wide__1hjdb9vhz {
+     flex-wrap: nowrap;
+   }
+   .sprinkles_flexShrink_0_wide__1hjdb9vi3 {
+     flex-shrink: 0;
+   }
+   .sprinkles_flexGrow_0_wide__1hjdb9vi7 {
+     flex-grow: 0;
+   }
+   .sprinkles_flexGrow_1_wide__1hjdb9vib {
+     flex-grow: 1;
+   }
+   .sprinkles_textAlign_left_wide__1hjdb9vif {
+     text-align: left;
+   }
+   .sprinkles_textAlign_center_wide__1hjdb9vij {
+     text-align: center;
+   }
+   .sprinkles_textAlign_right_wide__1hjdb9vin {
+     text-align: right;
+   }
+ }
+ .capsize_capsizeStyle__1lwixuj4 {
+   font-size: var(--fontSize__1lwixuj0);
+   line-height: var(--lineHeight__1lwixuj1);
+ }
+ .capsize_capsizeStyle__1lwixuj4::before {
+   content: '';
+   margin-bottom: var(--capHeightTrim__1lwixuj2);
+   display: table;
+ }
+ .capsize_capsizeStyle__1lwixuj4::after {
+   content: '';
+   margin-top: var(--baselineTrim__1lwixuj3);
+   display: table;
+ }
+ .typography_fontFamily__co4djb0 {
+   font-family: var(--fontFamily__qhrpjv2w);
+ }
+ .typography_fontWeight_regular__co4djb1 {
+   font-weight: var(--textWeight-regular__qhrpjv46);
+ }
+ .typography_fontWeight_medium__co4djb2 {
+   font-weight: var(--textWeight-medium__qhrpjv47);
+ }
+ .typography_fontWeight_strong__co4djb3 {
+   font-weight: var(--textWeight-strong__qhrpjv48);
+ }
+ .typography_textSize_xsmall__co4djb4 {
+   --fontSize__1lwixuj0: var(--textSize-xsmall-mobile-fontSize__qhrpjv32);
+   --lineHeight__1lwixuj1: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
+   --capHeightTrim__1lwixuj2: var(--textSize-xsmall-mobile-capsizeTrims-capHeightTrim__qhrpjv35);
+   --baselineTrim__1lwixuj3: var(--textSize-xsmall-mobile-capsizeTrims-baselineTrim__qhrpjv36);
+ }
+ .typography_textSize_small__co4djb6 {
+   --fontSize__1lwixuj0: var(--textSize-small-mobile-fontSize__qhrpjv3c);
+   --lineHeight__1lwixuj1: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
+   --capHeightTrim__1lwixuj2: var(--textSize-small-mobile-capsizeTrims-capHeightTrim__qhrpjv3f);
+   --baselineTrim__1lwixuj3: var(--textSize-small-mobile-capsizeTrims-baselineTrim__qhrpjv3g);
+ }
+ .typography_textSize_standard__co4djb8 {
+   --fontSize__1lwixuj0: var(--textSize-standard-mobile-fontSize__qhrpjv3m);
+   --lineHeight__1lwixuj1: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
+   --capHeightTrim__1lwixuj2: var(--textSize-standard-mobile-capsizeTrims-capHeightTrim__qhrpjv3p);
+   --baselineTrim__1lwixuj3: var(--textSize-standard-mobile-capsizeTrims-baselineTrim__qhrpjv3q);
+ }
+ .typography_textSize_large__co4djba {
+   --fontSize__1lwixuj0: var(--textSize-large-mobile-fontSize__qhrpjv3w);
+   --lineHeight__1lwixuj1: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
+   --capHeightTrim__1lwixuj2: var(--textSize-large-mobile-capsizeTrims-capHeightTrim__qhrpjv3z);
+   --baselineTrim__1lwixuj3: var(--textSize-large-mobile-capsizeTrims-baselineTrim__qhrpjv40);
+ }
+ .typography_textSizeUntrimmed_xsmall__co4djbc {
+   font-size: var(--textSize-xsmall-mobile-fontSize__qhrpjv32);
+   line-height: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
+ }
+ .typography_textSizeUntrimmed_small__co4djbd {
+   font-size: var(--textSize-small-mobile-fontSize__qhrpjv3c);
+   line-height: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
+ }
+ .typography_textSizeUntrimmed_standard__co4djbe {
+   font-size: var(--textSize-standard-mobile-fontSize__qhrpjv3m);
+   line-height: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
+ }
+ .typography_textSizeUntrimmed_large__co4djbf {
+   font-size: var(--textSize-large-mobile-fontSize__qhrpjv3w);
+   line-height: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
+ }
+ .typography_headingWeight_weak__co4djbg {
+   font-weight: var(--headingWeight-weak__qhrpjv5d);
+ }
+ .typography_headingWeight_regular__co4djbh {
+   font-weight: var(--headingWeight-regular__qhrpjv5e);
+ }
+ .typography_heading_1__co4djbi {
+   --fontSize__1lwixuj0: var(--headingLevel-1-mobile-fontSize__qhrpjv49);
+   --lineHeight__1lwixuj1: var(--headingLevel-1-mobile-lineHeight__qhrpjv4a);
+   --capHeightTrim__1lwixuj2: var(--headingLevel-1-mobile-capsizeTrims-capHeightTrim__qhrpjv4c);
+   --baselineTrim__1lwixuj3: var(--headingLevel-1-mobile-capsizeTrims-baselineTrim__qhrpjv4d);
+ }
+ .typography_heading_2__co4djbk {
+   --fontSize__1lwixuj0: var(--headingLevel-2-mobile-fontSize__qhrpjv4j);
+   --lineHeight__1lwixuj1: var(--headingLevel-2-mobile-lineHeight__qhrpjv4k);
+   --capHeightTrim__1lwixuj2: var(--headingLevel-2-mobile-capsizeTrims-capHeightTrim__qhrpjv4m);
+   --baselineTrim__1lwixuj3: var(--headingLevel-2-mobile-capsizeTrims-baselineTrim__qhrpjv4n);
+ }
+ .typography_heading_3__co4djbm {
+   --fontSize__1lwixuj0: var(--headingLevel-3-mobile-fontSize__qhrpjv4t);
+   --lineHeight__1lwixuj1: var(--headingLevel-3-mobile-lineHeight__qhrpjv4u);
+   --capHeightTrim__1lwixuj2: var(--headingLevel-3-mobile-capsizeTrims-capHeightTrim__qhrpjv4w);
+   --baselineTrim__1lwixuj3: var(--headingLevel-3-mobile-capsizeTrims-baselineTrim__qhrpjv4x);
+ }
+ .typography_heading_4__co4djbo {
+   --fontSize__1lwixuj0: var(--headingLevel-4-mobile-fontSize__qhrpjv53);
+   --lineHeight__1lwixuj1: var(--headingLevel-4-mobile-lineHeight__qhrpjv54);
+   --capHeightTrim__1lwixuj2: var(--headingLevel-4-mobile-capsizeTrims-capHeightTrim__qhrpjv56);
+   --baselineTrim__1lwixuj3: var(--headingLevel-4-mobile-capsizeTrims-baselineTrim__qhrpjv57);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeTone_light__co4djb10 {
+   --critical__co4djbq: var(--foregroundColor-critical__qhrpjv19);
+   --caution__co4djbr: var(--foregroundColor-caution__qhrpjv17);
+   --info__co4djbs: var(--foregroundColor-info__qhrpjv1d);
+   --promote__co4djbt: var(--foregroundColor-promote__qhrpjv1o);
+   --positive__co4djbu: var(--foregroundColor-positive__qhrpjv1m);
+   --brandAccent__co4djbv: var(--foregroundColor-brandAccent__qhrpjv15);
+   --formAccent__co4djbw: var(--foregroundColor-formAccent__qhrpjv1b);
+   --neutral__co4djbx: var(--foregroundColor-neutral__qhrpjv1k);
+   --secondary__co4djby: var(--foregroundColor-secondary__qhrpjv1r);
+   --link__co4djbz: var(--foregroundColor-link__qhrpjv1f);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeTone_dark__co4djb11 {
+   --critical__co4djbq: var(--foregroundColor-criticalLight__qhrpjv1a);
+   --caution__co4djbr: var(--foregroundColor-cautionLight__qhrpjv18);
+   --info__co4djbs: var(--foregroundColor-infoLight__qhrpjv1e);
+   --promote__co4djbt: var(--foregroundColor-promoteLight__qhrpjv1p);
+   --positive__co4djbu: var(--foregroundColor-positiveLight__qhrpjv1n);
+   --brandAccent__co4djbv: var(--foregroundColor-brandAccentLight__qhrpjv16);
+   --formAccent__co4djbw: var(--foregroundColor-formAccentLight__qhrpjv1c);
+   --neutral__co4djbx: var(--foregroundColor-neutralInverted__qhrpjv1l);
+   --secondary__co4djby: var(--foregroundColor-secondaryInverted__qhrpjv1s);
+   --link__co4djbz: var(--foregroundColor-linkLight__qhrpjv1h);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeTone_light__co4djb12 {
+   --critical__co4djbq: var(--foregroundColor-critical__qhrpjv19);
+   --caution__co4djbr: var(--foregroundColor-caution__qhrpjv17);
+   --info__co4djbs: var(--foregroundColor-info__qhrpjv1d);
+   --promote__co4djbt: var(--foregroundColor-promote__qhrpjv1o);
+   --positive__co4djbu: var(--foregroundColor-positive__qhrpjv1m);
+   --brandAccent__co4djbv: var(--foregroundColor-brandAccent__qhrpjv15);
+   --formAccent__co4djbw: var(--foregroundColor-formAccent__qhrpjv1b);
+   --neutral__co4djbx: var(--foregroundColor-neutral__qhrpjv1k);
+   --secondary__co4djby: var(--foregroundColor-secondary__qhrpjv1r);
+   --link__co4djbz: var(--foregroundColor-link__qhrpjv1f);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeTone_dark__co4djb13 {
+   --critical__co4djbq: var(--foregroundColor-criticalLight__qhrpjv1a);
+   --caution__co4djbr: var(--foregroundColor-cautionLight__qhrpjv18);
+   --info__co4djbs: var(--foregroundColor-infoLight__qhrpjv1e);
+   --promote__co4djbt: var(--foregroundColor-promoteLight__qhrpjv1p);
+   --positive__co4djbu: var(--foregroundColor-positiveLight__qhrpjv1n);
+   --brandAccent__co4djbv: var(--foregroundColor-brandAccentLight__qhrpjv16);
+   --formAccent__co4djbw: var(--foregroundColor-formAccentLight__qhrpjv1c);
+   --neutral__co4djbx: var(--foregroundColor-neutralInverted__qhrpjv1l);
+   --secondary__co4djby: var(--foregroundColor-secondaryInverted__qhrpjv1s);
+   --link__co4djbz: var(--foregroundColor-linkLight__qhrpjv1h);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalLight__co4djb14 {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalSoft__co4djb15 {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalSoftActive__co4djb16 {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalSoftHover__co4djb17 {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_caution__co4djb18 {
+   --neutral__co4djbx: var(--caution__co4djbr);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_cautionLight__co4djb19 {
+   --neutral__co4djbx: var(--caution__co4djbr);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_positiveLight__co4djb1a {
+   --neutral__co4djbx: var(--positive__co4djbu);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_infoLight__co4djb1b {
+   --neutral__co4djbx: var(--info__co4djbs);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_promoteLight__co4djb1c {
+   --neutral__co4djbx: var(--promote__co4djbt);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalLight__co4djb1d {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalSoft__co4djb1e {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalSoftActive__co4djb1f {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalSoftHover__co4djb1g {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_caution__co4djb1h {
+   --neutral__co4djbx: var(--caution__co4djbr);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_cautionLight__co4djb1i {
+   --neutral__co4djbx: var(--caution__co4djbr);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_positiveLight__co4djb1j {
+   --neutral__co4djbx: var(--positive__co4djbu);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_infoLight__co4djb1k {
+   --neutral__co4djbx: var(--info__co4djbs);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_promoteLight__co4djb1l {
+   --neutral__co4djbx: var(--promote__co4djbt);
+ }
+ .typography_tone_critical__co4djb1m {
+   color: var(--critical__co4djbq);
+ }
+ .typography_tone_caution__co4djb1n {
+   color: var(--caution__co4djbr);
+ }
+ .typography_tone_info__co4djb1o {
+   color: var(--info__co4djbs);
+ }
+ .typography_tone_promote__co4djb1p {
+   color: var(--promote__co4djbt);
+ }
+ .typography_tone_positive__co4djb1q {
+   color: var(--positive__co4djbu);
+ }
+ .typography_tone_brandAccent__co4djb1r {
+   color: var(--brandAccent__co4djbv);
+ }
+ .typography_tone_formAccent__co4djb1s {
+   color: var(--formAccent__co4djbw);
+ }
+ .typography_tone_neutral__co4djb1t {
+   color: var(--neutral__co4djbx);
+ }
+ .typography_tone_secondary__co4djb1u {
+   color: var(--secondary__co4djby);
+ }
+ .typography_tone_link__co4djb1v {
+   color: var(--link__co4djbz);
+ }
+ .typography_touchableText_xsmall__co4djb1w {
+   padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-mobile-lineHeight__qhrpjv33)) / 2);
+   padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-mobile-lineHeight__qhrpjv33)) / 2);
+ }
+ .typography_touchableText_small__co4djb1x {
+   padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-mobile-lineHeight__qhrpjv3d)) / 2);
+   padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-mobile-lineHeight__qhrpjv3d)) / 2);
+ }
+ .typography_touchableText_standard__co4djb1y {
+   padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-mobile-lineHeight__qhrpjv3n)) / 2);
+   padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-mobile-lineHeight__qhrpjv3n)) / 2);
+ }
+ .typography_touchableText_large__co4djb1z {
+   padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-mobile-lineHeight__qhrpjv3x)) / 2);
+   padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-mobile-lineHeight__qhrpjv3x)) / 2);
+ }
+ @media screen and (min-width: 740px) {
+   .typography_textSize_xsmall__co4djb4 {
+     --fontSize__1lwixuj0: var(--textSize-xsmall-tablet-fontSize__qhrpjv37);
+     --lineHeight__1lwixuj1: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
+     --capHeightTrim__1lwixuj2: var(--textSize-xsmall-tablet-capsizeTrims-capHeightTrim__qhrpjv3a);
+     --baselineTrim__1lwixuj3: var(--textSize-xsmall-tablet-capsizeTrims-baselineTrim__qhrpjv3b);
+   }
+   .typography_textSize_small__co4djb6 {
+     --fontSize__1lwixuj0: var(--textSize-small-tablet-fontSize__qhrpjv3h);
+     --lineHeight__1lwixuj1: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
+     --capHeightTrim__1lwixuj2: var(--textSize-small-tablet-capsizeTrims-capHeightTrim__qhrpjv3k);
+     --baselineTrim__1lwixuj3: var(--textSize-small-tablet-capsizeTrims-baselineTrim__qhrpjv3l);
+   }
+   .typography_textSize_standard__co4djb8 {
+     --fontSize__1lwixuj0: var(--textSize-standard-tablet-fontSize__qhrpjv3r);
+     --lineHeight__1lwixuj1: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
+     --capHeightTrim__1lwixuj2: var(--textSize-standard-tablet-capsizeTrims-capHeightTrim__qhrpjv3u);
+     --baselineTrim__1lwixuj3: var(--textSize-standard-tablet-capsizeTrims-baselineTrim__qhrpjv3v);
+   }
+   .typography_textSize_large__co4djba {
+     --fontSize__1lwixuj0: var(--textSize-large-tablet-fontSize__qhrpjv41);
+     --lineHeight__1lwixuj1: var(--textSize-large-tablet-lineHeight__qhrpjv42);
+     --capHeightTrim__1lwixuj2: var(--textSize-large-tablet-capsizeTrims-capHeightTrim__qhrpjv44);
+     --baselineTrim__1lwixuj3: var(--textSize-large-tablet-capsizeTrims-baselineTrim__qhrpjv45);
+   }
+   .typography_textSizeUntrimmed_xsmall__co4djbc {
+     font-size: var(--textSize-xsmall-tablet-fontSize__qhrpjv37);
+     line-height: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
+   }
+   .typography_textSizeUntrimmed_small__co4djbd {
+     font-size: var(--textSize-small-tablet-fontSize__qhrpjv3h);
+     line-height: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
+   }
+   .typography_textSizeUntrimmed_standard__co4djbe {
+     font-size: var(--textSize-standard-tablet-fontSize__qhrpjv3r);
+     line-height: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
+   }
+   .typography_textSizeUntrimmed_large__co4djbf {
+     font-size: var(--textSize-large-tablet-fontSize__qhrpjv41);
+     line-height: var(--textSize-large-tablet-lineHeight__qhrpjv42);
+   }
+   .typography_heading_1__co4djbi {
+     --fontSize__1lwixuj0: var(--headingLevel-1-tablet-fontSize__qhrpjv4e);
+     --lineHeight__1lwixuj1: var(--headingLevel-1-tablet-lineHeight__qhrpjv4f);
+     --capHeightTrim__1lwixuj2: var(--headingLevel-1-tablet-capsizeTrims-capHeightTrim__qhrpjv4h);
+     --baselineTrim__1lwixuj3: var(--headingLevel-1-tablet-capsizeTrims-baselineTrim__qhrpjv4i);
+   }
+   .typography_heading_2__co4djbk {
+     --fontSize__1lwixuj0: var(--headingLevel-2-tablet-fontSize__qhrpjv4o);
+     --lineHeight__1lwixuj1: var(--headingLevel-2-tablet-lineHeight__qhrpjv4p);
+     --capHeightTrim__1lwixuj2: var(--headingLevel-2-tablet-capsizeTrims-capHeightTrim__qhrpjv4r);
+     --baselineTrim__1lwixuj3: var(--headingLevel-2-tablet-capsizeTrims-baselineTrim__qhrpjv4s);
+   }
+   .typography_heading_3__co4djbm {
+     --fontSize__1lwixuj0: var(--headingLevel-3-tablet-fontSize__qhrpjv4y);
+     --lineHeight__1lwixuj1: var(--headingLevel-3-tablet-lineHeight__qhrpjv4z);
+     --capHeightTrim__1lwixuj2: var(--headingLevel-3-tablet-capsizeTrims-capHeightTrim__qhrpjv51);
+     --baselineTrim__1lwixuj3: var(--headingLevel-3-tablet-capsizeTrims-baselineTrim__qhrpjv52);
+   }
+   .typography_heading_4__co4djbo {
+     --fontSize__1lwixuj0: var(--headingLevel-4-tablet-fontSize__qhrpjv58);
+     --lineHeight__1lwixuj1: var(--headingLevel-4-tablet-lineHeight__qhrpjv59);
+     --capHeightTrim__1lwixuj2: var(--headingLevel-4-tablet-capsizeTrims-capHeightTrim__qhrpjv5b);
+     --baselineTrim__1lwixuj3: var(--headingLevel-4-tablet-capsizeTrims-baselineTrim__qhrpjv5c);
+   }
+   .typography_touchableText_xsmall__co4djb1w {
+     padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-tablet-lineHeight__qhrpjv38)) / 2);
+     padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-tablet-lineHeight__qhrpjv38)) / 2);
+   }
+   .typography_touchableText_small__co4djb1x {
+     padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-tablet-lineHeight__qhrpjv3i)) / 2);
+     padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-tablet-lineHeight__qhrpjv3i)) / 2);
+   }
+   .typography_touchableText_standard__co4djb1y {
+     padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-tablet-lineHeight__qhrpjv3s)) / 2);
+     padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-tablet-lineHeight__qhrpjv3s)) / 2);
+   }
+   .typography_touchableText_large__co4djb1z {
+     padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-tablet-lineHeight__qhrpjv42)) / 2);
+     padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-tablet-lineHeight__qhrpjv42)) / 2);
+   }
+ }
+ .Divider_base__rgb1580 {
+   height: var(--borderWidth-standard__qhrpjvy);
+ }
+ .Divider_regular__rgb1583 {
+   background: var(--regular__rgb1581);
+ }
+ .Divider_strong__rgb1584 {
+   background: var(--strong__rgb1582);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Divider_lightModeWeight_light__rgb1585 {
+   --regular__rgb1581: var(--borderColor-neutralLight__qhrpjvt);
+   --strong__rgb1582: var(--borderColor-neutral__qhrpjvr);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Divider_lightModeWeight_dark__rgb1586 {
+   --regular__rgb1581: var(--borderColor-neutral__qhrpjvr);
+   --strong__rgb1582: var(--borderColor-neutralLight__qhrpjvt);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Divider_darkModeWeight_light__rgb1587 {
+   --regular__rgb1581: var(--borderColor-neutralLight__qhrpjvt);
+   --strong__rgb1582: var(--borderColor-neutral__qhrpjvr);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Divider_darkModeWeight_dark__rgb1588 {
+   --regular__rgb1581: var(--borderColor-neutral__qhrpjvr);
+   --strong__rgb1582: var(--borderColor-neutralLight__qhrpjvt);
+ }
+ .Spread_fitContent__19xp08d0 > * {
+   flex-basis: auto;
+   width: auto;
+ }
+ .Spread_maxWidth__19xp08d1 > * {
+   max-width: 100%;
+ }
+ .MaxLines_descenderCropFixForWebkitBox__1lw3qoe0 {
+   margin-bottom: -0.1em;
+ }
+ .MaxLines_base__1lw3qoe2 {
+   text-overflow: ellipsis;
+   white-space: nowrap;
+   overflow-wrap: break-word;
+ }
+ .MaxLines_descenderCropFixForWebkitBox__1lw3qoe0 .MaxLines_base__1lw3qoe2 {
+   padding-bottom: 0.1em;
+ }
+ @supports (display: -webkit-box) and (-webkit-line-clamp: 1) {
+   .MaxLines_multiLine__1lw3qoe4 {
+     white-space: initial;
+     display: -webkit-box;
+     -webkit-line-clamp: var(--lineLimit__1lw3qoe3);
+     -webkit-box-orient: vertical;
+   }
+ }
+ .virtualTouchable_virtualTouchable__9705do0 {
+   position: relative;
+ }
+ .virtualTouchable_virtualTouchable__9705do0::after {
+   content: "";
+   position: absolute;
+   min-height: 44px;
+   min-width: 44px;
+   height: 100%;
+   width: 100%;
+   transform: translate(-50%, -50%);
+   top: 50%;
+   left: 50%;
+ }
+ [data-braid-debug] .virtualTouchable_virtualTouchable__9705do0::after {
+   background: red;
+   opacity: 0.2;
+ }
+ .AccordionItem_focusRing__pr4mlf2 {
+   outline-offset: var(--space-xxsmall__qhrpjv1);
+ }
+ .icon_size__1ltfiyk0 {
+   width: 1.2em;
+   height: 1.2em;
+ }
+ .icon_cropToTextSize__1ltfiyk1 {
+   margin: -0.1em;
+ }
+ .icon_inlineCrop__1ltfiyk2 {
+   margin-top: -0.2em;
+   margin-bottom: -0.2em;
+ }
+ .icon_inline__1ltfiyk3 {
+   vertical-align: middle;
+ }
+ .icon_alignY_uppercase_none__1ltfiyk4 {
+   top: -0.105em;
+ }
+ .icon_alignY_uppercase_up__1ltfiyk5 {
+   top: -0.16499999999999998em;
+ }
+ .icon_alignY_uppercase_down__1ltfiyk6 {
+   top: -0.045em;
+ }
+ .icon_alignY_lowercase_none__1ltfiyk7 {
+   top: -0.065em;
+ }
+ .icon_alignY_lowercase_up__1ltfiyk8 {
+   top: -0.125em;
+ }
+ .icon_alignY_lowercase_down__1ltfiyk9 {
+   top: -0.0050000000000000044em;
+ }
+ .icon_blockWidths_xsmall__1ltfiyka {
+   width: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
+ }
+ .icon_blockWidths_small__1ltfiykb {
+   width: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
+ }
+ .icon_blockWidths_standard__1ltfiykc {
+   width: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
+ }
+ .icon_blockWidths_large__1ltfiykd {
+   width: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
+ }
+ @media screen and (min-width: 740px) {
+   .icon_blockWidths_xsmall__1ltfiyka {
+     width: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
+   }
+   .icon_blockWidths_small__1ltfiykb {
+     width: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
+   }
+   .icon_blockWidths_standard__1ltfiykc {
+     width: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
+   }
+   .icon_blockWidths_large__1ltfiykd {
+     width: var(--textSize-large-tablet-lineHeight__qhrpjv42);
+   }
+ }
+ .lineHeightContainer_lineHeightContainer_xsmall__pnbjt00 {
+   height: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
+ }
+ .lineHeightContainer_lineHeightContainer_small__pnbjt01 {
+   height: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
+ }
+ .lineHeightContainer_lineHeightContainer_standard__pnbjt02 {
+   height: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
+ }
+ .lineHeightContainer_lineHeightContainer_large__pnbjt03 {
+   height: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
+ }
+ @media screen and (min-width: 740px) {
+   .lineHeightContainer_lineHeightContainer_xsmall__pnbjt00 {
+     height: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
+   }
+   .lineHeightContainer_lineHeightContainer_small__pnbjt01 {
+     height: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
+   }
+   .lineHeightContainer_lineHeightContainer_standard__pnbjt02 {
+     height: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
+   }
+   .lineHeightContainer_lineHeightContainer_large__pnbjt03 {
+     height: var(--textSize-large-tablet-lineHeight__qhrpjv42);
+   }
+ }
+ .IconChevron_root__v2pdba0 {
+   transition: transform 0.3s ease;
+   transform-origin: 50% 50%;
+ }
+ .IconChevron_left__v2pdba1 {
+   transform: rotate(90deg);
+ }
+ .IconChevron_up__v2pdba2 {
+   transform: rotate(180deg);
+ }
+ .IconChevron_right__v2pdba3 {
+   transform: rotate(270deg);
+ }
+ .Inline_fitContentMobile__hkzz4h0 > * {
+   flex-basis: auto;
+   width: auto;
+   min-width: 0;
+ }
+ @media screen and (min-width: 740px) {
+   .Inline_fitContentTablet__hkzz4h1 > * {
+     flex-basis: auto;
+     width: auto;
+     min-width: 0;
+   }
+ }
+ @media screen and (min-width: 992px) {
+   .Inline_fitContentDesktop__hkzz4h2 > * {
+     flex-basis: auto;
+     width: auto;
+     min-width: 0;
+   }
+ }
+ @media screen and (min-width: 1200px) {
+   .Inline_fitContentWide__hkzz4h3 > * {
+     flex-basis: auto;
+     width: auto;
+     min-width: 0;
+   }
+ }
+ .Column_noSpaceBeforeFirstWhenCollapsed__1w6x3sw0:first-child {
+   padding-top: 0;
+ }
+ .Column_width_1\\/2__1w6x3sw1 {
+   flex-basis: 50%;
+ }
+ .Column_width_1\\/3__1w6x3sw2 {
+   flex-basis: 33.33333333333333%;
+ }
+ .Column_width_2\\/3__1w6x3sw3 {
+   flex-basis: 66.66666666666666%;
+ }
+ .Column_width_1\\/4__1w6x3sw4 {
+   flex-basis: 25%;
+ }
+ .Column_width_3\\/4__1w6x3sw5 {
+   flex-basis: 75%;
+ }
+ .Column_width_1\\/5__1w6x3sw6 {
+   flex-basis: 20%;
+ }
+ .Column_width_2\\/5__1w6x3sw7 {
+   flex-basis: 40%;
+ }
+ .Column_width_3\\/5__1w6x3sw8 {
+   flex-basis: 60%;
+ }
+ .Column_width_4\\/5__1w6x3sw9 {
+   flex-basis: 80%;
+ }
+ .negativeMargin_preventCollapsePseudo_top__1063ve10::before {
+   content: "";
+   display: table;
+ }
+ .negativeMargin_preventCollapsePseudo_bottom__1063ve11::after {
+   content: "";
+   display: table;
+ }
+ .negativeMargin_stylesForBreakpoint_gutter__1063ve12::before {
+   margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxsmall__1063ve13::before {
+   margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xsmall__1063ve14::before {
+   margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_small__1063ve15::before {
+   margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_medium__1063ve16::before {
+   margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_large__1063ve17::before {
+   margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xlarge__1063ve18::before {
+   margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxlarge__1063ve19::before {
+   margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve1a::before {
+   margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_none__1063ve1b::before {
+   margin-bottom: 0;
+ }
+ .negativeMargin_stylesForBreakpoint_gutter__1063ve116::after {
+   margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxsmall__1063ve117::after {
+   margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xsmall__1063ve118::after {
+   margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_small__1063ve119::after {
+   margin-top: calc(var(--space-small__qhrpjv3) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_medium__1063ve11a::after {
+   margin-top: calc(var(--space-medium__qhrpjv4) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_large__1063ve11b::after {
+   margin-top: calc(var(--space-large__qhrpjv5) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xlarge__1063ve11c::after {
+   margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxlarge__1063ve11d::after {
+   margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve11e::after {
+   margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_none__1063ve11f::after {
+   margin-top: 0;
+ }
+ .negativeMargin_stylesForBreakpoint_gutter__1063ve12a {
+   margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxsmall__1063ve12b {
+   margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xsmall__1063ve12c {
+   margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_small__1063ve12d {
+   margin-left: calc(var(--space-small__qhrpjv3) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_medium__1063ve12e {
+   margin-left: calc(var(--space-medium__qhrpjv4) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_large__1063ve12f {
+   margin-left: calc(var(--space-large__qhrpjv5) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xlarge__1063ve12g {
+   margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxlarge__1063ve12h {
+   margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve12i {
+   margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_none__1063ve12j {
+   margin-left: 0;
+ }
+ .negativeMargin_stylesForBreakpoint_gutter__1063ve13e {
+   margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxsmall__1063ve13f {
+   margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xsmall__1063ve13g {
+   margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_small__1063ve13h {
+   margin-right: calc(var(--space-small__qhrpjv3) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_medium__1063ve13i {
+   margin-right: calc(var(--space-medium__qhrpjv4) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_large__1063ve13j {
+   margin-right: calc(var(--space-large__qhrpjv5) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xlarge__1063ve13k {
+   margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxlarge__1063ve13l {
+   margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve13m {
+   margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_none__1063ve13n {
+   margin-right: 0;
+ }
+ @media screen and (min-width: 740px) {
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve1c::before {
+     margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve1d::before {
+     margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve1e::before {
+     margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve1f::before {
+     margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve1g::before {
+     margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve1h::before {
+     margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve1i::before {
+     margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve1j::before {
+     margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve1k::before {
+     margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve1l::before {
+     margin-bottom: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve11g::after {
+     margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve11h::after {
+     margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve11i::after {
+     margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve11j::after {
+     margin-top: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve11k::after {
+     margin-top: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve11l::after {
+     margin-top: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve11m::after {
+     margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve11n::after {
+     margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve11o::after {
+     margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve11p::after {
+     margin-top: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve12k {
+     margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve12l {
+     margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve12m {
+     margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve12n {
+     margin-left: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve12o {
+     margin-left: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve12p {
+     margin-left: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve12q {
+     margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve12r {
+     margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve12s {
+     margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve12t {
+     margin-left: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve13o {
+     margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve13p {
+     margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve13q {
+     margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve13r {
+     margin-right: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve13s {
+     margin-right: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve13t {
+     margin-right: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve13u {
+     margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve13v {
+     margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve13w {
+     margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve13x {
+     margin-right: 0;
+   }
+ }
+ @media screen and (min-width: 992px) {
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve1m::before {
+     margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve1n::before {
+     margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve1o::before {
+     margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve1p::before {
+     margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve1q::before {
+     margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve1r::before {
+     margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve1s::before {
+     margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve1t::before {
+     margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve1u::before {
+     margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve1v::before {
+     margin-bottom: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve11q::after {
+     margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve11r::after {
+     margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve11s::after {
+     margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve11t::after {
+     margin-top: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve11u::after {
+     margin-top: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve11v::after {
+     margin-top: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve11w::after {
+     margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve11x::after {
+     margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve11y::after {
+     margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve11z::after {
+     margin-top: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve12u {
+     margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve12v {
+     margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve12w {
+     margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve12x {
+     margin-left: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve12y {
+     margin-left: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve12z {
+     margin-left: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve130 {
+     margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve131 {
+     margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve132 {
+     margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve133 {
+     margin-left: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve13y {
+     margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve13z {
+     margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve140 {
+     margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve141 {
+     margin-right: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve142 {
+     margin-right: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve143 {
+     margin-right: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve144 {
+     margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve145 {
+     margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve146 {
+     margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve147 {
+     margin-right: 0;
+   }
+ }
+ @media screen and (min-width: 1200px) {
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve1w::before {
+     margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve1x::before {
+     margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve1y::before {
+     margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve1z::before {
+     margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve110::before {
+     margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve111::before {
+     margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve112::before {
+     margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve113::before {
+     margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve114::before {
+     margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve115::before {
+     margin-bottom: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve120::after {
+     margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve121::after {
+     margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve122::after {
+     margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve123::after {
+     margin-top: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve124::after {
+     margin-top: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve125::after {
+     margin-top: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve126::after {
+     margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve127::after {
+     margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve128::after {
+     margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve129::after {
+     margin-top: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve134 {
+     margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve135 {
+     margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve136 {
+     margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve137 {
+     margin-left: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve138 {
+     margin-left: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve139 {
+     margin-left: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve13a {
+     margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve13b {
+     margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve13c {
+     margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve13d {
+     margin-left: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve148 {
+     margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve149 {
+     margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve14a {
+     margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve14b {
+     margin-right: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve14c {
+     margin-right: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve14d {
+     margin-right: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve14e {
+     margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve14f {
+     margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve14g {
+     margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve14h {
+     margin-right: 0;
+   }
+ }
+ .Alert_closeButton__1fve7fu0:focus .Alert_closeButtonHover__1fve7fu1, .Alert_closeButton__1fve7fu0:hover .Alert_closeButtonHover__1fve7fu1 {
+   opacity: 1;
+ }
+ .textAlignedToIcon_textAlignedToIcon_standard__u3vg1s0 {
+   padding-top: calc((var(--textSize-standard-mobile-lineHeight__qhrpjv3n) - var(--textSize-standard-mobile-capHeight__qhrpjv3o)) / 2);
+   padding-bottom: calc((var(--textSize-standard-mobile-lineHeight__qhrpjv3n) - var(--textSize-standard-mobile-capHeight__qhrpjv3o)) / 2);
+ }
+ @media screen and (min-width: 740px) {
+   .textAlignedToIcon_textAlignedToIcon_standard__u3vg1s0 {
+     padding-top: calc((var(--textSize-standard-tablet-lineHeight__qhrpjv3s) - var(--textSize-standard-tablet-capHeight__qhrpjv3t)) / 2);
+     padding-bottom: calc((var(--textSize-standard-tablet-lineHeight__qhrpjv3s) - var(--textSize-standard-tablet-capHeight__qhrpjv3t)) / 2);
+   }
+ }
+ .AvoidWidowIcon_nowrap__8ldtmt0 {
+   white-space: nowrap;
+ }
+ @keyframes Button_dot1__kmgydja {
+   14% {
+     opacity: 0;
+   }
+   15%,100% {
+     opacity: 1;
+   }
+ }
+ @keyframes Button_dot2__kmgydjb {
+   29% {
+     opacity: 0;
+   }
+   30%,100% {
+     opacity: 1;
+   }
+ }
+ @keyframes Button_dot3__kmgydjc {
+   44% {
+     opacity: 0;
+   }
+   45%,100% {
+     opacity: 1;
+   }
+ }
+ .Button_root__kmgydj0 {
+   text-decoration: none;
+   align-items: stretch;
+   outline-offset: 0;
+ }
+ .Button_root__kmgydj0:active .Button_activeAnimation__kmgydj2, .Button_forceActive__kmgydj1.Button_activeAnimation__kmgydj2 {
+   transform: var(--transform-touchable__qhrpjv5k);
+ }
+ .Button_root__kmgydj0:active .Button_activeOverlay__kmgydj3, .Button_forceActive__kmgydj1.Button_activeOverlay__kmgydj3 {
+   opacity: 1;
+ }
+ .Button_root__kmgydj0:hover:not(:disabled) .Button_hoverOverlay__kmgydj4 {
+   opacity: 1;
+ }
+ .Button_standard__kmgydj6 {
+   --capHeightToMinHeight__kmgydj5: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-mobile-capHeight__qhrpjv3o)) / 2);
+ }
+ .Button_small__kmgydj7 {
+   --capHeightToMinHeight__kmgydj5: calc(((var(--touchableSize__qhrpjv9) * 0.8) - var(--textSize-small-mobile-capHeight__qhrpjv3e)) / 2);
+ }
+ .Button_bleedVerticallyToCapHeight__kmgydj8 {
+   margin-top: calc(var(--capHeightToMinHeight__kmgydj5) * -1);
+   margin-bottom: calc(var(--capHeightToMinHeight__kmgydj5) * -1);
+ }
+ .Button_padToMinHeight__kmgydj9 {
+   padding-top: var(--capHeightToMinHeight__kmgydj5);
+   padding-bottom: var(--capHeightToMinHeight__kmgydj5);
+ }
+ .Button_loadingDot__kmgydjd {
+   animation-duration: 1s;
+   animation-iteration-count: infinite;
+   opacity: 0;
+ }
+ .Button_loadingDot__kmgydjd:nth-child(1) {
+   animation-name: Button_dot1__kmgydja;
+ }
+ .Button_loadingDot__kmgydjd:nth-child(2) {
+   animation-name: Button_dot2__kmgydjb;
+ }
+ .Button_loadingDot__kmgydjd:nth-child(3) {
+   animation-name: Button_dot3__kmgydjc;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Button_invertedBackgroundsLightMode_soft__kmgydje {
+   background: rgba(255,255,255,0.1);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Button_invertedBackgroundsLightMode_hover__kmgydjf {
+   background: rgba(255,255,255,0.15);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Button_invertedBackgroundsLightMode_active__kmgydjg {
+   background: rgba(255,255,255,0.15);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Button_invertedBackgroundsDarkMode_soft__kmgydjh {
+   background: rgba(255,255,255,0.1);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Button_invertedBackgroundsDarkMode_hover__kmgydji {
+   background: rgba(255,255,255,0.15);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Button_invertedBackgroundsDarkMode_active__kmgydjj {
+   background: rgba(255,255,255,0.15);
+ }
+ @media screen and (min-width: 740px) {
+   .Button_standard__kmgydj6 {
+     --capHeightToMinHeight__kmgydj5: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-tablet-capHeight__qhrpjv3t)) / 2);
+   }
+   .Button_small__kmgydj7 {
+     --capHeightToMinHeight__kmgydj5: calc(((var(--touchableSize__qhrpjv9) * 0.8) - var(--textSize-small-tablet-capHeight__qhrpjv3j)) / 2);
+   }
+ }
+ @keyframes Popover_popupAnimation__1yo0tp8a {
+   from {
+     opacity: 0;
+     transform: translateY(calc(var(--space-xxsmall__qhrpjv1) * var(--placementModifier__1yo0tp88, 1)));
+   }
+ }
+ .Popover_backdrop__1yo0tp80 {
+   width: 100vw;
+   height: 100vh;
+ }
+ .Popover_popoverPosition__1yo0tp87 {
+   --dynamicHeight__1yo0tp86: 100svh;
+   top: calc(var(--triggerVars_bottom__1yo0tp83) * 1px);
+   bottom: calc(var(--dynamicHeight__1yo0tp86, 100vh) - (var(--triggerVars_top__1yo0tp81) * 1px));
+   left: calc((var(--triggerVars_left__1yo0tp82) + var(--horizontalOffset__1yo0tp85)) * 1px);
+   right: calc((var(--triggerVars_right__1yo0tp84) + var(--horizontalOffset__1yo0tp85)) * 1px);
+ }
+ .Popover_invertPlacement__1yo0tp89 {
+   --placementModifier__1yo0tp88: -1;
+ }
+ .Popover_animation__1yo0tp8b {
+   animation-name: Popover_popupAnimation__1yo0tp8a;
+   animation-fill-mode: both;
+   animation-timing-function: ease;
+   animation-duration: 0.125s;
+   animation-delay: 15ms;
+ }
+ .Popover_delayVisibility__1yo0tp8c {
+   animation-delay: 250ms;
+ }
+ .TooltipRenderer_maxWidth__821e3y0 {
+   max-width: 260px;
+ }
+ .TooltipRenderer_overflowWrap__821e3y1 {
+   overflow-wrap: break-word;
+ }
+ .TooltipRenderer_translateZ0__821e3y2 {
+   transform: translateZ(0);
+ }
+ .TooltipRenderer_baseArrow__821e3y4 {
+   left: clamp(var(--space-medium__qhrpjv4), var(--horizontalOffset__821e3y3), calc(100% - var(--space-medium__qhrpjv4)));
+   transform: translateX(-50%);
+   visibility: hidden;
+ }
+ .TooltipRenderer_baseArrow__821e3y4:before {
+   content: '';
+   visibility: visible;
+   transform: rotate(45deg);
+ }
+ .TooltipRenderer_baseArrow__821e3y4, .TooltipRenderer_baseArrow__821e3y4::before {
+   width: calc(12px + (var(--borderRadius-small__qhrpjvb) * 2));
+   height: calc(12px + (var(--borderRadius-small__qhrpjvb) * 2));
+   position: absolute;
+   background: inherit;
+   border-radius: var(--borderRadius-small__qhrpjvb);
+ }
+ .TooltipRenderer_arrow_top__821e3y5 {
+   bottom: calc((12px / 2) * -1);
+ }
+ .TooltipRenderer_arrow_bottom__821e3y6 {
+   top: calc((12px / 2) * -1);
+ }
+ .ButtonIcon_button__11ol9k00:hover {
+   z-index: 1;
+ }
+ .ButtonIcon_button__11ol9k00::-moz-focus-inner {
+   border: 0;
+ }
+ .HiddenVisually_root__v7ph350 {
+   width: 1px;
+   height: 1px;
+   clip: rect(1px, 1px, 1px, 1px);
+   white-space: nowrap;
+ }
+ .Field_placeholderColor__klw7kj1::placeholder {
+   color: var(--foregroundColor-secondary__qhrpjv1r);
+ }
+ .Field_secondaryIconSpace__klw7kj2 {
+   padding-right: var(--touchableSize__qhrpjv9);
+ }
+ .Field_iconSpace__klw7kj3 {
+   padding-left: calc(var(--touchableSize__qhrpjv9) - 2px);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Field_hideBorderOnDarkBackgroundInLightMode__klw7kj4 {
+   opacity: 0;
+ }
+ .Field_field__klw7kj0:hover:not(:disabled) ~ .Field_hoverOverlay__klw7kj5, .Field_field__klw7kj0:focus ~ .Field_hoverOverlay__klw7kj5 {
+   opacity: 1;
+ }
+ .Field_verticalDivider__klw7kj6 {
+   width: var(--borderWidth-standard__qhrpjvy);
+   background: var(--borderColor-field__qhrpjvl);
+   opacity: 0.4;
+ }
+ .Autosuggest_backdrop__153m10i0 {
+   width: 100vw;
+   height: 100vh;
+   background: black;
+ }
+ .Autosuggest_backdropVisible__153m10i1 {
+   opacity: 0.4;
+ }
+ .Autosuggest_menu__153m10i2 {
+   max-height: calc((var(--touchableSize__qhrpjv9) * 6) + var(--space-xxsmall__qhrpjv1));
+   overflow-y: auto;
+ }
+ @media screen and (min-width: 740px) {
+   .Autosuggest_menu__153m10i2 {
+     max-height: calc((var(--touchableSize__qhrpjv9) * 8) + var(--space-xxsmall__qhrpjv1));
+   }
+ }
+ .Badge_inline__1r5hl7m0 {
+   display: inline-flex;
+   vertical-align: middle;
+   margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   margin-top: calc((var(--space-xxsmall__qhrpjv1) + .2em) * -1);
+ }
+ .Keyline_tone_promote__1kn7lf76 {
+   background: var(--promote__1kn7lf70);
+ }
+ .Keyline_tone_info__1kn7lf77 {
+   background: var(--info__1kn7lf71);
+ }
+ .Keyline_tone_positive__1kn7lf78 {
+   background: var(--positive__1kn7lf72);
+ }
+ .Keyline_tone_caution__1kn7lf79 {
+   background: var(--caution__1kn7lf73);
+ }
+ .Keyline_tone_critical__1kn7lf7a {
+   background: var(--critical__1kn7lf74);
+ }
+ .Keyline_tone_formAccent__1kn7lf7b {
+   background: var(--formAccent__1kn7lf75);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Keyline_lightMode_light__1kn7lf7c {
+   --promote__1kn7lf70: var(--borderColor-promote__qhrpjvw);
+   --info__1kn7lf71: var(--borderColor-info__qhrpjvp);
+   --positive__1kn7lf72: var(--borderColor-positive__qhrpjvu);
+   --caution__1kn7lf73: var(--borderColor-caution__qhrpjvh);
+   --critical__1kn7lf74: var(--borderColor-critical__qhrpjvj);
+   --formAccent__1kn7lf75: var(--borderColor-formAccent__qhrpjvn);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Keyline_lightMode_dark__1kn7lf7d {
+   --promote__1kn7lf70: var(--borderColor-promoteLight__qhrpjvx);
+   --info__1kn7lf71: var(--borderColor-infoLight__qhrpjvq);
+   --positive__1kn7lf72: var(--borderColor-positiveLight__qhrpjvv);
+   --caution__1kn7lf73: var(--borderColor-cautionLight__qhrpjvi);
+   --critical__1kn7lf74: var(--borderColor-criticalLight__qhrpjvk);
+   --formAccent__1kn7lf75: var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Keyline_darkMode_light__1kn7lf7e {
+   --promote__1kn7lf70: var(--borderColor-promote__qhrpjvw);
+   --info__1kn7lf71: var(--borderColor-info__qhrpjvp);
+   --positive__1kn7lf72: var(--borderColor-positive__qhrpjvu);
+   --caution__1kn7lf73: var(--borderColor-caution__qhrpjvh);
+   --critical__1kn7lf74: var(--borderColor-critical__qhrpjvj);
+   --formAccent__1kn7lf75: var(--borderColor-formAccent__qhrpjvn);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Keyline_darkMode_dark__1kn7lf7f {
+   --promote__1kn7lf70: var(--borderColor-promoteLight__qhrpjvx);
+   --info__1kn7lf71: var(--borderColor-infoLight__qhrpjvq);
+   --positive__1kn7lf72: var(--borderColor-positiveLight__qhrpjvv);
+   --caution__1kn7lf73: var(--borderColor-cautionLight__qhrpjvi);
+   --critical__1kn7lf74: var(--borderColor-criticalLight__qhrpjvk);
+   --formAccent__1kn7lf75: var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ .Keyline_noRadiusOnRight__1kn7lf7g {
+   border-top-right-radius: 0 !important;
+   border-bottom-right-radius: 0 !important;
+ }
+ .Keyline_largestWidth__1kn7lf7h {
+   width: var(--borderRadius-xlarge__qhrpjve);
+ }
+ .Keyline_width__1kn7lf7i {
+   width: var(--grid__qhrpjva);
+ }
+ .InlineField_sizeVars_standard__1b4ltjx2 {
+   --fieldSize__1b4ltjx0: var(--inlineFieldSize-standard__qhrpjv5g);
+   --labelCapHeight__1b4ltjx1: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
+ }
+ .InlineField_sizeVars_small__1b4ltjx3 {
+   --fieldSize__1b4ltjx0: var(--inlineFieldSize-small__qhrpjv5h);
+   --labelCapHeight__1b4ltjx1: var(--textSize-small-mobile-capHeight__qhrpjv3e);
+ }
+ .InlineField_realField__1b4ltjx4 {
+   width: 44px;
+   height: 44px;
+   top: calc(((44px - var(--fieldSize__1b4ltjx0)) / 2) * -1);
+   left: calc(((44px - var(--fieldSize__1b4ltjx0)) / 2) * -1);
+ }
+ [data-braid-debug] .InlineField_realField__1b4ltjx4 {
+   background: red;
+   opacity: 0.2;
+ }
+ .InlineField_fakeField__1b4ltjx5 {
+   height: var(--fieldSize__1b4ltjx0);
+   width: var(--fieldSize__1b4ltjx0);
+   outline: var(--focusRingSize__qhrpjv10) solid transparent;
+   transition: outline-color .125s ease;
+ }
+ .InlineField_realField__1b4ltjx4[type="checkbox"]:checked ~ .InlineField_fakeField__1b4ltjx5 {
+   background: transparent;
+ }
+ .InlineField_realField__1b4ltjx4:focus-visible ~ .InlineField_fakeField__1b4ltjx5 {
+   outline-color: var(--borderColor-focus__qhrpjvm);
+ }
+ .InlineField_labelOffset__1b4ltjx6 {
+   padding-top: calc((var(--fieldSize__1b4ltjx0) - var(--labelCapHeight__1b4ltjx1)) / 2);
+ }
+ .InlineField_realField__1b4ltjx4:checked ~ * .InlineField_children__1b4ltjx8,
+   .InlineField_realField__1b4ltjx4.InlineField_isMixed__1b4ltjx7 ~ * .InlineField_children__1b4ltjx8 {
+   display: block;
+   z-index: 1;
+ }
+ .InlineField_realField__1b4ltjx4:checked + .InlineField_fakeField__1b4ltjx5 > .InlineField_selected__1b4ltjx9,
+   .InlineField_realField__1b4ltjx4.InlineField_isMixed__1b4ltjx7 + .InlineField_fakeField__1b4ltjx5 > .InlineField_selected__1b4ltjx9 {
+   opacity: 1;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .InlineField_hideBorderOnDarkBackgroundInLightMode__1b4ltjxa {
+   opacity: 0;
+ }
+ .InlineField_realField__1b4ltjx4:hover:not(:checked):not(.InlineField_isMixed__1b4ltjx7):not(:disabled) + .InlineField_fakeField__1b4ltjx5 > .InlineField_hoverOverlay__1b4ltjxb,
+   .InlineField_realField__1b4ltjx4:focus:not(.InlineField_isMixed__1b4ltjx7) + .InlineField_fakeField__1b4ltjx5 > .InlineField_hoverOverlay__1b4ltjxb {
+   opacity: 1;
+ }
+ .InlineField_hoverOverlay__1b4ltjxb > .InlineField_indicator__1b4ltjxc {
+   opacity: 0.2;
+ }
+ .InlineField_disabledRadioIndicator__1b4ltjxd {
+   opacity: 0.3;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .InlineField_disabledRadioIndicator__1b4ltjxd {
+   background-color: var(--foregroundColor-secondary__qhrpjv1r);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .InlineField_disabledRadioIndicator__1b4ltjxd {
+   background-color: var(--foregroundColor-secondaryInverted__qhrpjv1s);
+ }
+ .InlineField_checkboxScale__1b4ltjxe {
+   transform: scale(0.85);
+ }
+ .InlineField_realField__1b4ltjx4:active + .InlineField_fakeField__1b4ltjx5 > * > .InlineField_checkboxScale__1b4ltjxe {
+   transform: scale(0.75);
+ }
+ .InlineField_radioScale__1b4ltjxf {
+   transform: scale(0.6);
+ }
+ .InlineField_realField__1b4ltjx4:active + .InlineField_fakeField__1b4ltjx5 > * > .InlineField_radioScale__1b4ltjxf {
+   transform: scale(0.5);
+ }
+ @media screen and (min-width: 740px) {
+   .InlineField_sizeVars_standard__1b4ltjx2 {
+     --labelCapHeight__1b4ltjx1: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
+   }
+   .InlineField_sizeVars_small__1b4ltjx3 {
+     --labelCapHeight__1b4ltjx1: var(--textSize-small-tablet-capHeight__qhrpjv3j);
+   }
+ }
+ .ContentBlock_marginAuto__1xx6jv80 {
+   margin: 0 auto;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Modal_backdrop__13n71fr2 {
+   background: rgba(0, 0, 0, 0.4);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Modal_backdrop__13n71fr2 {
+   background: rgba(0, 0, 0, 0.6);
+ }
+ .Modal_rightAnimation__13n71fr4 {
+   opacity: 1;
+   transform: translateX(110%);
+ }
+ .Modal_leftAnimation__13n71fr5 {
+   opacity: 1;
+   transform: translateX(-110%);
+ }
+ .Modal_centerAnimation__13n71fr6 {
+   transform: scale(.8);
+ }
+ .Modal_horizontalTransition__13n71fr7 {
+   transition: transform .3s cubic-bezier(0.4, 0, 0, 1), opacity .3s cubic-bezier(0.4, 0, 0, 1);
+ }
+ .Modal_pointerEventsAll__13n71fr9 {
+   pointer-events: all;
+ }
+ .Modal_viewportHeight__13n71frd {
+   max-height: var(--fullHeightVar__13n71frb);
+ }
+ .Modal_maxSize_center__13n71fre {
+   --gutterSizeVar__13n71fra: var(--space-xsmall__qhrpjv2);
+   max-height: calc(var(--fullHeightVar__13n71frb) - (var(--gutterSizeVar__13n71fra) * 2));
+   max-width: calc(var(--fullWidthVar__13n71frc) - (var(--gutterSizeVar__13n71fra) * 2));
+ }
+ .Modal_modalContainer__13n71frf {
+   --fullHeightVar__13n71frb: 100vh;
+   --fullWidthVar__13n71frc: 100vw;
+   max-height: var(--fullHeightVar__13n71frb);
+   max-width: var(--fullWidthVar__13n71frc);
+ }
+ .Modal_headingRoot__13n71frg {
+   overflow-wrap: break-word;
+ }
+ .Modal_closeIconOffset__13n71frh {
+   top: -5px;
+   right: -5px;
+ }
+ @media screen and (prefers-reduced-motion) {
+   .Modal_reducedMotion__13n71fr3 {
+     transform: none !important;
+   }
+ }
+ @media screen and (min-width: 740px) {
+   .Modal_rightAnimation__13n71fr4 {
+     opacity: 0;
+     transform: translateX(40px);
+   }
+   .Modal_leftAnimation__13n71fr5 {
+     opacity: 0;
+     transform: translateX(-40px);
+   }
+   .Modal_horizontalTransition__13n71fr7 {
+     transition: transform .175s cubic-bezier(0.4, 0, 0, 1), opacity .175s cubic-bezier(0.4, 0, 0, 1);
+   }
+   .Modal_maxSize_center__13n71fre {
+     --gutterSizeVar__13n71fra: var(--space-gutter__qhrpjv0);
+   }
+ }
+ @media screen and (min-width: 992px) {
+   .Modal_maxSize_center__13n71fre {
+     --gutterSizeVar__13n71fra: var(--space-xlarge__qhrpjv6);
+   }
+ }
+ @supports (height: 1dvh) {
+   .Modal_modalContainer__13n71frf {
+     --fullHeightVar__13n71frb: 100dvh;
+     --fullWidthVar__13n71frc: 100dvw;
+   }
+ }
+ .TextLink_base__beoo42 {
+   color: var(--color__beoo40);
+   text-decoration: var(--linkDecoration__qhrpjv5f);
+   text-decoration-thickness: 0.08em;
+   text-underline-offset: 3px;
+   outline-offset: 0.2em;
+   border-radius: var(--borderRadius-small__qhrpjvb);
+ }
+ .TextLink_base__beoo42:hover {
+   color: var(--colorHover__beoo41);
+   text-decoration: underline;
+   text-decoration-thickness: 0.08em;
+ }
+ .TextLink_base__beoo42:focus-visible {
+   color: var(--colorHover__beoo41);
+ }
+ .TextLink_weakLink__beoo43 {
+   --color__beoo40: inherit;
+   --colorHover__beoo41: inherit;
+   text-decoration: underline;
+   text-decoration-thickness: 0.08em;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_regularLinkLightMode_light__beoo44 {
+   --color__beoo40: var(--foregroundColor-link__qhrpjv1f);
+   --colorHover__beoo41: var(--foregroundColor-linkHover__qhrpjv1g);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_regularLinkLightMode_dark__beoo45 {
+   --color__beoo40: var(--foregroundColor-linkLight__qhrpjv1h);
+   --colorHover__beoo41: var(--foregroundColor-linkLight__qhrpjv1h);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .TextLink_regularLinkDarkMode_light__beoo46 {
+   --color__beoo40: var(--foregroundColor-link__qhrpjv1f);
+   --colorHover__beoo41: var(--foregroundColor-linkHover__qhrpjv1g);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .TextLink_regularLinkDarkMode_dark__beoo47 {
+   --color__beoo40: var(--foregroundColor-linkLight__qhrpjv1h);
+   --colorHover__beoo41: var(--foregroundColor-linkLight__qhrpjv1h);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_visitedLightMode_light__beoo48:visited {
+   color: var(--foregroundColor-linkVisited__qhrpjv1i);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_visitedLightMode_dark__beoo49:visited {
+   color: var(--foregroundColor-linkLightVisited__qhrpjv1j);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .TextLink_visitedDarkMode_light__beoo4a:visited {
+   color: var(--foregroundColor-linkVisited__qhrpjv1i);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .TextLink_visitedDarkMode_dark__beoo4b:visited {
+   color: var(--foregroundColor-linkLightVisited__qhrpjv1j);
+ }
+ .Dropdown_field__gz3fci0 {
+   padding-right: var(--touchableSize__qhrpjv9);
+ }
+ @media print {
+   .Hidden_hiddenOnPrint__1mw96wl0 {
+     display: none !important;
+   }
+ }
+ .List_currentColor__1an15sm0 {
+   background: currentColor;
+ }
+ .List_large__1an15sm1 {
+   width: 5px;
+   height: 5px;
+ }
+ .List_standard__1an15sm2 {
+   width: 4px;
+   height: 4px;
+ }
+ .List_xsmall__1an15sm3 {
+   width: 3px;
+   height: 3px;
+ }
+ .List_minCharacterWidth__1an15sm4 {
+   min-width: 1.4ch;
+ }
+ .List_minCharacterWidth__1an15sm5 {
+   min-width: 2.4ch;
+ }
+ .List_trimGutter__1an15sm6 {
+   margin-right: -0.4ch;
+ }
+ @keyframes Loader_bounce__e5c4uh9 {
+   33% {
+     transform: translateY(-1.4em);
+   }
+   66% {
+     transform: translateY(1.4em);
+   }
+ }
+ @keyframes Loader_fade__e5c4uhd {
+   from {
+     opacity: 0;
+   }
+   to {
+     opacity: 1;
+   }
+ }
+ .Loader_rootSize_xsmall__e5c4uh0 {
+   height: var(--textSize-xsmall-mobile-capHeight__qhrpjv34);
+ }
+ .Loader_rootSize_small__e5c4uh1 {
+   height: var(--textSize-small-mobile-capHeight__qhrpjv3e);
+ }
+ .Loader_rootSize_standard__e5c4uh2 {
+   height: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
+ }
+ .Loader_rootSize_large__e5c4uh3 {
+   height: var(--textSize-large-mobile-capHeight__qhrpjv3y);
+ }
+ .Loader_size_xsmall__e5c4uh4 {
+   height: var(--textSize-xsmall-mobile-fontSize__qhrpjv32);
+ }
+ .Loader_size_small__e5c4uh5 {
+   height: var(--textSize-small-mobile-fontSize__qhrpjv3c);
+ }
+ .Loader_size_standard__e5c4uh6 {
+   height: var(--textSize-standard-mobile-fontSize__qhrpjv3m);
+ }
+ .Loader_size_large__e5c4uh7 {
+   height: var(--textSize-large-mobile-fontSize__qhrpjv3w);
+ }
+ .Loader_currentColor__e5c4uh8 {
+   fill: currentcolor;
+ }
+ .Loader_bounceAnimation__e5c4uha {
+   animation-name: Loader_bounce__e5c4uh9;
+   animation-fill-mode: both;
+   animation-iteration-count: infinite;
+   animation-timing-function: ease-in-out;
+   animation-duration: 0.6s;
+ }
+ .Loader_circle__e5c4uhb {
+   transform: translateY(1.4em);
+ }
+ .Loader_circle__e5c4uhb:nth-child(1) {
+   animation-delay: 140ms;
+ }
+ .Loader_circle__e5c4uhb:nth-child(2) {
+   animation-delay: 70ms;
+ }
+ .Loader_delay__e5c4uhe {
+   opacity: 0;
+   animation-name: Loader_fade__e5c4uhd;
+   animation-iteration-count: 1;
+   animation-fill-mode: forwards;
+   animation-timing-function: ease-in;
+   animation-duration: 0.25s;
+   animation-delay: 800ms;
+ }
+ @media screen and (min-width: 740px) {
+   .Loader_rootSize_xsmall__e5c4uh0 {
+     height: var(--textSize-xsmall-tablet-capHeight__qhrpjv39);
+   }
+   .Loader_rootSize_small__e5c4uh1 {
+     height: var(--textSize-small-tablet-capHeight__qhrpjv3j);
+   }
+   .Loader_rootSize_standard__e5c4uh2 {
+     height: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
+   }
+   .Loader_rootSize_large__e5c4uh3 {
+     height: var(--textSize-large-tablet-capHeight__qhrpjv43);
+   }
+   .Loader_size_xsmall__e5c4uh4 {
+     height: var(--textSize-xsmall-tablet-fontSize__qhrpjv37);
+   }
+   .Loader_size_small__e5c4uh5 {
+     height: var(--textSize-small-tablet-fontSize__qhrpjv3h);
+   }
+   .Loader_size_standard__e5c4uh6 {
+     height: var(--textSize-standard-tablet-fontSize__qhrpjv3r);
+   }
+   .Loader_size_large__e5c4uh7 {
+     height: var(--textSize-large-tablet-fontSize__qhrpjv41);
+   }
+ }
+ .ScrollContainer_container__1aqz9r10 {
+   -webkit-overflow-scrolling: touch;
+   -webkit-mask-composite: destination-in;
+   mask-composite: intersect;
+ }
+ .ScrollContainer_hideScrollbar__1aqz9r11 {
+   scrollbar-width: none;
+   -ms-overflow-style: none;
+ }
+ .ScrollContainer_hideScrollbar__1aqz9r11::-webkit-scrollbar {
+   width: 0;
+   height: 0;
+ }
+ .ScrollContainer_fadeSize_small__1aqz9r13 {
+   --scrollOverlaySize__1aqz9r12: 40px;
+ }
+ .ScrollContainer_fadeSize_medium__1aqz9r14 {
+   --scrollOverlaySize__1aqz9r12: 60px;
+ }
+ .ScrollContainer_fadeSize_large__1aqz9r15 {
+   --scrollOverlaySize__1aqz9r12: 80px;
+ }
+ .ScrollContainer_direction_horizontal__1aqz9r16 {
+   overflow-x: auto;
+   overflow-y: hidden;
+   min-height: fit-content;
+ }
+ .ScrollContainer_direction_vertical__1aqz9r17 {
+   overflow-x: hidden;
+   overflow-y: auto;
+ }
+ .ScrollContainer_direction_all__1aqz9r18 {
+   overflow: auto;
+ }
+ .ScrollContainer_mask__1aqz9r1d {
+   mask-image: linear-gradient(to bottom, transparent 0, black var(--top__1aqz9r1b, 0)),linear-gradient(to right, transparent 0, black var(--left__1aqz9r19, 0)),linear-gradient(to left, transparent 0, black var(--right__1aqz9r1a, 0)),linear-gradient(to top, transparent 0, black var(--bottom__1aqz9r1c, 0));
+ }
+ .ScrollContainer_maskLeft__1aqz9r1e {
+   --left__1aqz9r19: var(--scrollOverlaySize__1aqz9r12);
+ }
+ .ScrollContainer_maskRight__1aqz9r1f {
+   --right__1aqz9r1a: var(--scrollOverlaySize__1aqz9r12);
+ }
+ .ScrollContainer_maskTop__1aqz9r1g {
+   --top__1aqz9r1b: var(--scrollOverlaySize__1aqz9r12);
+ }
+ .ScrollContainer_maskBottom__1aqz9r1h {
+   --bottom__1aqz9r1c: var(--scrollOverlaySize__1aqz9r12);
+ }
+ .MenuRenderer_backdrop__p34lbl1 {
+   width: 100vw;
+   height: 100vh;
+ }
+ .MenuRenderer_menuPosition__p34lbl6 {
+   top: var(--triggerVars_bottom__p34lbl4);
+   bottom: var(--triggerVars_top__p34lbl2);
+   left: var(--triggerVars_left__p34lbl3);
+   right: var(--triggerVars_right__p34lbl5);
+ }
+ .MenuRenderer_baseWidth__p34lbl8 {
+   width: calc(var(--widthVar__p34lbl7) / 4);
+ }
+ .MenuRenderer_width_small__p34lbl9 {
+   --widthVar__p34lbl7: var(--contentWidth-small__qhrpjv12);
+ }
+ .MenuRenderer_width_medium__p34lbla {
+   --widthVar__p34lbl7: var(--contentWidth-medium__qhrpjv13);
+ }
+ .MenuRenderer_width_large__p34lblb {
+   --widthVar__p34lbl7: var(--contentWidth-large__qhrpjv14);
+ }
+ .MenuRenderer_menuHeightLimit__p34lblc {
+   max-height: calc((var(--touchableSize__qhrpjv9) * 9.5) + (var(--menuYPadding__p34lbl0) * 2));
+ }
+ .useMenuItem_menuItem__wz3nke0::-moz-focus-inner {
+   border: 0;
+ }
+ .useMenuItem_menuItemLeftSlot__wz3nke1 {
+   height: 0px;
+ }
+ .MenuItemCheckbox_checkboxSize__17whdqr2 {
+   --menuItemCapHeight__17whdqr0: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
+   --crop__17whdqr1: calc(((var(--inlineFieldSize-small__qhrpjv5h) - var(--menuItemCapHeight__17whdqr0)) / 2) * -1);
+   height: var(--inlineFieldSize-small__qhrpjv5h);
+   width: var(--inlineFieldSize-small__qhrpjv5h);
+   margin-top: var(--crop__17whdqr1);
+   margin-bottom: var(--crop__17whdqr1);
+ }
+ @media screen and (min-width: 740px) {
+   .MenuItemCheckbox_checkboxSize__17whdqr2 {
+     --menuItemCapHeight__17whdqr0: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
+   }
+ }
+ .OverflowMenu_wrapperPositioning__18ydm7f0 {
+   margin: -1px -6px;
+ }
+ .MonthPicker_nativeInput__1xbm4s00::-webkit-inner-spin-button, .MonthPicker_nativeInput__1xbm4s00::-webkit-calendar-picker-indicator, .MonthPicker_nativeInput__1xbm4s00::-webkit-clear-button {
+   display: none;
+   -webkit-appearance: none;
+ }
+ .Page_fullHeight__7puj9a1 {
+   min-height: var(--heightLimit__7puj9a0, 100vh);
+ }
+ .Pagination_focusRing__oms9uc1 {
+   outline-offset: 0;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Pagination_lightModeCurrentKeyline__oms9uc3 {
+   opacity: 0.3;
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Pagination_darkModeCurrentKeyline__oms9uc4 {
+   opacity: 0.3;
+ }
+ .Pagination_current__oms9uc5 {
+   opacity: 0.075;
+ }
+ .Pagination_hover__oms9uc2:hover .Pagination_background__oms9uc6:not(.Pagination_current__oms9uc5) {
+   opacity: 0.5;
+ }
+ .Rating_inlineFlex__nkq5400 {
+   display: inline-flex;
+   gap: 1px;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_tone_formAccent__6woprh2 {
+   --highlightVar__6woprh1: var(--borderColor-formAccent__qhrpjvn);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Stepper_tone_formAccent__6woprh2 {
+   --highlightVar__6woprh1: var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_tone_neutral__6woprh3 {
+   --highlightVar__6woprh1: var(--borderColor-neutral__qhrpjvr);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Stepper_tone_neutral__6woprh3 {
+   --highlightVar__6woprh1: var(--borderColor-neutralLight__qhrpjvt);
+ }
+ .Stepper_step__6woprh4 {
+   outline: none;
+   text-align: left;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_step__6woprh4 {
+   --baseColourVar__6woprh0: var(--borderColor-neutralLight__qhrpjvt);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Stepper_step__6woprh4 {
+   --baseColourVar__6woprh0: var(--borderColor-neutral__qhrpjvr);
+ }
+ .Stepper_indicator__6woprh6 {
+   height: var(--inlineFieldSize-small__qhrpjv5h);
+   width: var(--inlineFieldSize-small__qhrpjv5h);
+   color: var(--baseColourVar__6woprh0);
+ }
+ .Stepper_stretch__6woprh7 {
+   flex: 1;
+ }
+ .Stepper_highlight__6woprh9 {
+   color: var(--highlightVar__6woprh1);
+ }
+ .Stepper_inner__6woprhd {
+   fill: currentcolor;
+   transform-origin: 50% 50%;
+   transform: scale(0);
+ }
+ .Stepper_active__6woprhb > .Stepper_inner__6woprhd {
+   transform: scale(1);
+   opacity: 1;
+ }
+ .Stepper_complete__6woprha > .Stepper_inner__6woprhd {
+   transform: scale(2.1);
+   opacity: 1;
+ }
+ .Stepper_tick__6woprhf {
+   transition-delay: .1s;
+   transform-origin: 50% 50%;
+ }
+ :not(.Stepper_complete__6woprha) > .Stepper_tick__6woprhf {
+   opacity: 0;
+   transition-delay: 0s;
+   transform: scale(.5) rotate(50deg);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_tick__6woprhf {
+   fill: var(--foregroundColor-neutralInverted__qhrpjv1l);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Stepper_tick__6woprhf {
+   fill: var(--foregroundColor-neutral__qhrpjv1k);
+ }
+ .Stepper_progressTrack__6woprhg {
+   background: repeating-linear-gradient(90deg, var(--baseColourVar__6woprh0), var(--baseColourVar__6woprh0) 2px, transparent 2px, transparent 4px);
+   height: var(--borderWidth-large__qhrpjvz);
+   width: calc((100% - var(--inlineFieldSize-small__qhrpjv5h)) - (var(--space-xxsmall__qhrpjv1) * 2));
+   top: calc((var(--inlineFieldSize-small__qhrpjv5h) - var(--borderWidth-large__qhrpjvz)) / 2);
+   left: calc(var(--inlineFieldSize-small__qhrpjv5h) + var(--space-xxsmall__qhrpjv1));
+ }
+ .Stepper_progressLine__6woprhi {
+   background: var(--highlightVar__6woprh1);
+   transition: transform .2s ease;
+ }
+ .Stepper_progressUnfilled__6woprhj {
+   transform: translateX(-101%);
+ }
+ .Stepper_indicatorContainer__6woprhk {
+   outline: var(--focusRingSize__qhrpjv10) solid transparent;
+   width: var(--inlineFieldSize-small__qhrpjv5h);
+   transition: var(--transition-fast__qhrpjv5i), outline-color .125s ease;
+ }
+ .Stepper_step__6woprh4:focus-visible .Stepper_indicatorContainer__6woprhk {
+   outline-color: var(--borderColor-focus__qhrpjvm);
+   transform: scale(1.2);
+ }
+ .Stepper_step__6woprh4:active .Stepper_indicatorContainer__6woprhk {
+   transform: var(--transform-touchable__qhrpjv5k);
+ }
+ @media screen and (min-width: 740px) {
+   .Stepper_stretchLastAboveTablet__6woprh8 {
+     flex: 1;
+   }
+   .Stepper_progressTrackCentered__6woprhh {
+     left: calc((50% + (var(--inlineFieldSize-small__qhrpjv5h) / 2)) + var(--space-xxsmall__qhrpjv1));
+   }
+ }
+ .Table_table__y0v62q1 {
+   border-collapse: separate;
+   border: var(--borderWidth-standard__qhrpjvy) solid var(--borderColor__y0v62q0);
+   font-variant-numeric: tabular-nums;
+   word-break: break-word;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Table_table__y0v62q1 {
+   --borderColor__y0v62q0: var(--borderColor-neutralLight__qhrpjvt);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Table_table__y0v62q1 {
+   --borderColor__y0v62q0: var(--borderColor-neutral__qhrpjvr);
+ }
+ .Table_row__y0v62q4:not(:last-child) > .Table_cell__y0v62q5 {
+   border-bottom: 1px solid var(--borderColor__y0v62q0);
+ }
+ .Table_tableSection__y0v62q3:not(.Table_tableHeader__y0v62q2) > .Table_row__y0v62q4 > .Table_headCell__y0v62q6:not(:first-child) {
+   border-left: 1px solid var(--borderColor__y0v62q0);
+ }
+ .Table_tableSection__y0v62q3:not(.Table_tableHeader__y0v62q2) > .Table_row__y0v62q4 > .Table_headCell__y0v62q6:not(:last-child) {
+   border-right: 1px solid var(--borderColor__y0v62q0);
+ }
+ .Table_tableSection__y0v62q3:not(:first-child) > .Table_row__y0v62q4:first-child > .Table_cell__y0v62q5 {
+   border-top: var(--borderWidth-standard__qhrpjvy) solid var(--borderColor__y0v62q0);
+ }
+ .Table_alignY_center__y0v62q7 {
+   vertical-align: middle;
+ }
+ .Table_alignY_top__y0v62q8 {
+   vertical-align: top;
+ }
+ .Table_nowrap__y0v62q9 {
+   white-space: nowrap;
+ }
+ .Table_softWidth__y0v62qb {
+   width: var(--softWidthVar__y0v62qa);
+ }
+ .Table_minWidth__y0v62qd {
+   min-width: var(--minWidthVar__y0v62qc);
+ }
+ .Table_maxWidth__y0v62qf {
+   max-width: var(--maxWidthVar__y0v62qe);
+ }
+ @media screen and (min-width: 740px) {
+   .Table_showOnTablet__y0v62qg {
+     display: table-cell;
+   }
+ }
+ @media screen and (min-width: 992px) {
+   .Table_showOnDesktop__y0v62qh {
+     display: table-cell;
+   }
+ }
+ @media screen and (min-width: 1200px) {
+   .Table_showOnWide__y0v62qi {
+     display: table-cell;
+   }
+ }
+ .Tabs_tab__wez1qd0::-moz-focus-inner {
+   border: 0;
+ }
+ .Tabs_tab__wez1qd0:hover .Tabs_hoveredTab__wez1qd1 {
+   opacity: 1;
+ }
+ .Tabs_nowrap__wez1qd2 {
+   white-space: nowrap;
+ }
+ .Tabs_scroll__wez1qd3 {
+   -webkit-overflow-scrolling: touch;
+   overflow-x: auto;
+   overflow-y: hidden;
+   scrollbar-width: none;
+   -ms-overflow-style: none;
+ }
+ .Tabs_scroll__wez1qd3::-webkit-scrollbar {
+   width: 0;
+   height: 0;
+ }
+ .Tabs_mask__wez1qd4 {
+   mask-image: linear-gradient(90deg, rgba(0,0,0,1) 0, rgba(0,0,0,1) calc(100% - 80px), rgba(0,0,0,0) 100%);
+ }
+ .Tabs_marginAuto__wez1qd5 {
+   margin-left: auto;
+   margin-right: auto;
+ }
+ .Tabs_tabFocusRing__wez1qd6 {
+   outline-offset: calc(var(--focusRingSize__qhrpjv10) * -1);
+ }
+ .Tabs_tabUnderline__wez1qdb {
+   --underlineRadius__wez1qd9: calc(var(--borderRadius-small__qhrpjvb) / var(--underlineScale__wez1qda));
+   --underlineScale__wez1qda: calc(var(--underlineWidth__wez1qd8) / 100);
+   height: var(--borderWidth-large__qhrpjvz);
+   border-top-left-radius: var(--underlineRadius__wez1qd9);
+   border-top-right-radius: var(--underlineRadius__wez1qd9);
+   width: 100px;
+   transform-origin: 0 0;
+   transition: transform .3s ease;
+   transform: translateZ(0) translateX(calc(var(--underlineLeft__wez1qd7) * 1px)) scaleX(var(--underlineScale__wez1qda));
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Tabs_tabUnderlineActiveDarkMode__wez1qdc {
+   background: var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ .Tabs_divider__wez1qde {
+   height: var(--borderWidth-standard__qhrpjvy);
+ }
+ .Tag_clearGutter__1jrpwfo0 {
+   padding-left: 1px;
+ }
+ .Highlight_root__cnytm1 {
+   padding: 0 2px;
+   margin: 0 -2px;
+   text-decoration: underline;
+   text-decoration-style: wavy;
+   text-decoration-skip-ink: none;
+   text-decoration-thickness: 2px;
+   text-underline-offset: 2px;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Highlight_critical__cnytm2 {
+   text-decoration-color: var(--borderColor-critical__qhrpjvj);
+   background: var(--backgroundColor-criticalLight__qhrpjv27);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Highlight_critical__cnytm2 {
+   text-decoration-color: var(--borderColor-criticalLight__qhrpjvk);
+ }
+ .Highlight_caution__cnytm3 {
+   text-decoration-color: var(--borderColor-caution__qhrpjvh);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Highlight_caution__cnytm3 {
+   background: var(--backgroundColor-cautionLight__qhrpjv23);
+ }
+ .Textarea_field__ak2u6d0 {
+   resize: vertical;
+   background: transparent;
+   min-height: calc(var(--grid__qhrpjva) * 15);
+ }
+ .Textarea_highlights__ak2u6d1 {
+   color: transparent !important;
+   word-break: break-word;
+   white-space: pre-wrap;
+ }
+ .Textarea_highlights__ak2u6d1:after {
+   content: "\\A";
+ }
+ .TextDropdown_select__pu1g620 {
+   min-height: 44px;
+   min-width: 44px;
+   height: 100%;
+   width: 100%;
+   transform: translate(-50%, -50%);
+   top: 50%;
+   left: 50%;
+ }
+ [data-braid-debug] .TextDropdown_select__pu1g620 {
+   background: red;
+   opacity: 0.2;
+ }
+ .TextDropdown_focusRing__pu1g622 {
+   outline: var(--focusRingSize__qhrpjv10) solid transparent;
+   transition: outline-color .125s ease;
+   outline-offset: var(--space-xxsmall__qhrpjv1);
+ }
+ .TextDropdown_select__pu1g620:focus-visible ~ .TextDropdown_focusRing__pu1g622 {
+   outline-color: var(--borderColor-focus__qhrpjvm);
+ }
+ .Tiles_tiles__5j02iv5 {
+   --columns__5j02iv0: var(--mobileColumnsVar__5j02iv1);
+   display: grid;
+   grid-template-columns: repeat(var(--columns__5j02iv0), 1fr);
+ }
+ .Tiles_tiles__5j02iv5 > * {
+   min-width: 0;
+ }
+ @media screen and (min-width: 740px) {
+   .Tiles_tiles__5j02iv5 {
+     --columns__5j02iv0: var(--tabletColumnsVar__5j02iv2);
+   }
+ }
+ @media screen and (min-width: 992px) {
+   .Tiles_tiles__5j02iv5 {
+     --columns__5j02iv0: var(--desktopColumnsVar__5j02iv3);
+   }
+ }
+ @media screen and (min-width: 1200px) {
+   .Tiles_tiles__5j02iv5 {
+     --columns__5j02iv0: var(--wideColumnsVar__5j02iv4);
+   }
+ }
+ .Toggle_bleedToCapHeight_standard__158h80u0 {
+   height: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
+ }
+ .Toggle_bleedToCapHeight_small__158h80u1 {
+   height: var(--textSize-small-mobile-capHeight__qhrpjv3e);
+ }
+ .Toggle_root__158h80u2:hover {
+   z-index: 1;
+ }
+ .Toggle_realField__158h80u3 {
+   height: 44px;
+ }
+ [data-braid-debug] .Toggle_realField__158h80u3 {
+   background: red;
+   opacity: 0.2;
+ }
+ .Toggle_realFieldPosition_standard__158h80u4 {
+   top: calc(((44px - var(--inlineFieldSize-standard__qhrpjv5g)) / 2) * -1);
+ }
+ .Toggle_realFieldPosition_small__158h80u5 {
+   top: calc(((44px - var(--inlineFieldSize-small__qhrpjv5h)) / 2) * -1);
+ }
+ .Toggle_fieldSize_standard__158h80u6 {
+   width: calc(var(--inlineFieldSize-standard__qhrpjv5g) * 1.6);
+ }
+ .Toggle_fieldSize_small__158h80u7 {
+   width: calc(var(--inlineFieldSize-small__qhrpjv5h) * 1.6);
+ }
+ .Toggle_slideContainerSize_standard__158h80u9 {
+   height: var(--inlineFieldSize-standard__qhrpjv5g);
+ }
+ .Toggle_slideContainerSize_small__158h80ua {
+   height: var(--inlineFieldSize-small__qhrpjv5h);
+ }
+ .Toggle_slideTrack_standard__158h80ub {
+   height: calc(var(--inlineFieldSize-standard__qhrpjv5g) - var(--grid__qhrpjva));
+ }
+ .Toggle_slideTrack_small__158h80uc {
+   height: calc(var(--inlineFieldSize-small__qhrpjv5h) - var(--grid__qhrpjva));
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Toggle_slideTrackBgLightMode_light__158h80ud {
+   background: rgba(0,0,0,0.08);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Toggle_slideTrackBgLightMode_dark__158h80ue {
+   background: rgba(255,255,255,0.12);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Toggle_slideTrackBgDarkMode_light__158h80uf {
+   background: rgba(0,0,0,0.08);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Toggle_slideTrackBgDarkMode_dark__158h80ug {
+   background: rgba(255,255,255,0.12);
+ }
+ .Toggle_slideTrackMask__158h80uh {
+   -webkit-mask-image: -webkit-radial-gradient(white, black);
+ }
+ .Toggle_realField__158h80u3:not(:checked) + .Toggle_slideContainer__158h80u8 .Toggle_slideTrackSelected__158h80ui {
+   transform: translateX(calc(var(--touchableSize__qhrpjv9) * -1));
+ }
+ .Toggle_slider_standard__158h80uj {
+   outline: var(--focusRingSize__qhrpjv10) solid transparent;
+   height: var(--inlineFieldSize-standard__qhrpjv5g);
+   width: var(--inlineFieldSize-standard__qhrpjv5g);
+   transition: var(--transition-fast__qhrpjv5i), outline-color .125s ease;
+ }
+ .Toggle_realField__158h80u3:focus-visible + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
+   outline-color: var(--borderColor-focus__qhrpjvm);
+ }
+ .Toggle_realField__158h80u3:active + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
+   transform: translateX(calc((var(--inlineFieldSize-standard__qhrpjv5g) * 0.12) * -1));
+ }
+ .Toggle_realField__158h80u3:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
+   transform: translateX(calc((var(--inlineFieldSize-standard__qhrpjv5g) * 1.6) - var(--inlineFieldSize-standard__qhrpjv5g)));
+ }
+ .Toggle_realField__158h80u3:active:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
+   transform: translateX(calc(((var(--inlineFieldSize-standard__qhrpjv5g) * 1.6) - var(--inlineFieldSize-standard__qhrpjv5g)) + (var(--inlineFieldSize-standard__qhrpjv5g) * 0.12)));
+ }
+ .Toggle_slider_small__158h80uk {
+   outline: var(--focusRingSize__qhrpjv10) solid transparent;
+   height: var(--inlineFieldSize-small__qhrpjv5h);
+   width: var(--inlineFieldSize-small__qhrpjv5h);
+   transition: var(--transition-fast__qhrpjv5i), outline-color .125s ease;
+ }
+ .Toggle_realField__158h80u3:focus-visible + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
+   outline-color: var(--borderColor-focus__qhrpjvm);
+ }
+ .Toggle_realField__158h80u3:active + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
+   transform: translateX(calc((var(--inlineFieldSize-small__qhrpjv5h) * 0.12) * -1));
+ }
+ .Toggle_realField__158h80u3:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
+   transform: translateX(calc((var(--inlineFieldSize-small__qhrpjv5h) * 1.6) - var(--inlineFieldSize-small__qhrpjv5h)));
+ }
+ .Toggle_realField__158h80u3:active:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
+   transform: translateX(calc(((var(--inlineFieldSize-small__qhrpjv5h) * 1.6) - var(--inlineFieldSize-small__qhrpjv5h)) + (var(--inlineFieldSize-small__qhrpjv5h) * 0.12)));
+ }
+ .Toggle_sliderThumbOutlineFix__158h80ul {
+   transform: scale(1.04);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Toggle_hideBorderOnDarkBackgroundInLightMode__158h80um {
+   opacity: 0;
+ }
+ .Toggle_realField__158h80u3:hover:not(:disabled) + .Toggle_slideContainer__158h80u8 .Toggle_hoverOverlay__158h80un,
+   .Toggle_realField__158h80u3:focus + .Toggle_slideContainer__158h80u8 .Toggle_hoverOverlay__158h80un {
+   opacity: 1;
+ }
+ @media screen and (min-width: 740px) {
+   .Toggle_bleedToCapHeight_standard__158h80u0 {
+     height: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
+   }
+   .Toggle_bleedToCapHeight_small__158h80u1 {
+     height: var(--textSize-small-tablet-capHeight__qhrpjv3j);
+   }
+ }
+ .Toast_toast__1nhoi470 {
+   pointer-events: all;
+ }
+ .Toast_collapsed__1nhoi471 .Toast_collapsedToastContent__1nhoi472 {
+   opacity: 0;
+ }
+ .Toaster_toaster__103l6ur0 {
+   left: 0;
+   right: 0;
+   margin-inline: auto;
+   bottom: var(--space-xsmall__qhrpjv2);
+   max-width: min(var(--contentWidth-xsmall__qhrpjv11), calc(100vw - (2 * var(--space-small__qhrpjv3))));
+ }
+ .IconArrow_root__1igczit0 {
+   transition: transform 0.3s ease;
+   transform-origin: 50% 50%;
+ }
+ .IconArrow_flip__1igczit1 {
+   transform: rotateX(180deg);
+ }
+ .IconArrow_rotate__1igczit3 {
+   transform: scaleX(var(--mirrorVar__1igczit2, 1)) rotate(90deg);
+ }
+ .IconArrow_mirror__1igczit4 {
+   --mirrorVar__1igczit2: -1;
+ }
+ .IconThumb_root__fympft0 {
+   transition: transform 0.3s ease;
+   transform-origin: 50% 50%;
+ }
+ .IconThumb_down__fympft1 {
+   transform: rotate(180deg);
+ }
+ .seekJobs_seekJobs__1fmskxf0 {
+   --space-gutter__qhrpjv0: 24px;
+   --space-xxsmall__qhrpjv1: 8px;
+   --space-xsmall__qhrpjv2: 12px;
+   --space-small__qhrpjv3: 16px;
+   --space-medium__qhrpjv4: 24px;
+   --space-large__qhrpjv5: 32px;
+   --space-xlarge__qhrpjv6: 48px;
+   --space-xxlarge__qhrpjv7: 64px;
+   --space-xxxlarge__qhrpjv8: 96px;
+   --touchableSize__qhrpjv9: 48px;
+   --grid__qhrpjva: 4px;
+   --borderRadius-small__qhrpjvb: 4px;
+   --borderRadius-standard__qhrpjvc: 8px;
+   --borderRadius-large__qhrpjvd: 16px;
+   --borderRadius-xlarge__qhrpjve: 24px;
+   --borderColor-brandAccent__qhrpjvf: #E60278;
+   --borderColor-brandAccentLight__qhrpjvg: #F8B1DC;
+   --borderColor-caution__qhrpjvh: #FDC221;
+   --borderColor-cautionLight__qhrpjvi: #FEE384;
+   --borderColor-critical__qhrpjvj: #B91E1E;
+   --borderColor-criticalLight__qhrpjvk: #FB999A;
+   --borderColor-field__qhrpjvl: #838FA5;
+   --borderColor-focus__qhrpjvm: rgba(153,191,247,0.7);
+   --borderColor-formAccent__qhrpjvn: #1E47A9;
+   --borderColor-formAccentLight__qhrpjvo: #99BFF7;
+   --borderColor-info__qhrpjvp: #1D559D;
+   --borderColor-infoLight__qhrpjvq: #98C9F1;
+   --borderColor-neutral__qhrpjvr: #2E3849;
+   --borderColor-neutralLight__qhrpjvt: #EAECF1;
+   --borderColor-neutralInverted__qhrpjvs: #fff;
+   --borderColor-positive__qhrpjvu: #12784F;
+   --borderColor-positiveLight__qhrpjvv: #8BDEC5;
+   --borderColor-promote__qhrpjvw: #7F35A9;
+   --borderColor-promoteLight__qhrpjvx: #E1B2F5;
+   --borderWidth-standard__qhrpjvy: 2px;
+   --borderWidth-large__qhrpjvz: 4px;
+   --focusRingSize__qhrpjv10: 6px;
+   --contentWidth-xsmall__qhrpjv11: 400px;
+   --contentWidth-small__qhrpjv12: 660px;
+   --contentWidth-medium__qhrpjv13: 940px;
+   --contentWidth-large__qhrpjv14: 1280px;
+   --foregroundColor-brandAccent__qhrpjv15: #E60278;
+   --foregroundColor-brandAccentLight__qhrpjv16: #F8B1DC;
+   --foregroundColor-caution__qhrpjv17: #723D02;
+   --foregroundColor-cautionLight__qhrpjv18: #FEE384;
+   --foregroundColor-critical__qhrpjv19: #B91E1E;
+   --foregroundColor-criticalLight__qhrpjv1a: #FB999A;
+   --foregroundColor-formAccent__qhrpjv1b: #1E47A9;
+   --foregroundColor-formAccentLight__qhrpjv1c: #99BFF7;
+   --foregroundColor-info__qhrpjv1d: #1D559D;
+   --foregroundColor-infoLight__qhrpjv1e: #98C9F1;
+   --foregroundColor-link__qhrpjv1f: #2E3849;
+   --foregroundColor-linkLight__qhrpjv1h: #fff;
+   --foregroundColor-linkHover__qhrpjv1g: #2E3849;
+   --foregroundColor-linkVisited__qhrpjv1i: #5B2084;
+   --foregroundColor-linkLightVisited__qhrpjv1j: #F0D6FA;
+   --foregroundColor-neutral__qhrpjv1k: #2E3849;
+   --foregroundColor-neutralInverted__qhrpjv1l: #fff;
+   --foregroundColor-positive__qhrpjv1m: #12784F;
+   --foregroundColor-positiveLight__qhrpjv1n: #8BDEC5;
+   --foregroundColor-promote__qhrpjv1o: #7F35A9;
+   --foregroundColor-promoteLight__qhrpjv1p: #E1B2F5;
+   --foregroundColor-rating__qhrpjv1q: #E60278;
+   --foregroundColor-secondary__qhrpjv1r: #5A6881;
+   --foregroundColor-secondaryInverted__qhrpjv1s: rgba(255,255,255,0.65);
+   --backgroundColor-body__qhrpjv1t: #fff;
+   --backgroundColor-bodyDark__qhrpjv1u: #1C2330;
+   --backgroundColor-brand__qhrpjv1v: #051A49;
+   --backgroundColor-brandAccent__qhrpjv1w: #E60278;
+   --backgroundColor-brandAccentActive__qhrpjv1x: #cd026b;
+   --backgroundColor-brandAccentHover__qhrpjv1y: #fd0585;
+   --backgroundColor-brandAccentSoft__qhrpjv1z: #FEEFFA;
+   --backgroundColor-brandAccentSoftActive__qhrpjv20: #fdd7f3;
+   --backgroundColor-brandAccentSoftHover__qhrpjv21: #fde3f6;
+   --backgroundColor-caution__qhrpjv22: #FDC221;
+   --backgroundColor-cautionLight__qhrpjv23: #FEF8DE;
+   --backgroundColor-critical__qhrpjv24: #B91E1E;
+   --backgroundColor-criticalActive__qhrpjv25: #a31a1a;
+   --backgroundColor-criticalHover__qhrpjv26: #db1616;
+   --backgroundColor-criticalLight__qhrpjv27: #FFE3E2;
+   --backgroundColor-criticalSoft__qhrpjv28: #FEF3F3;
+   --backgroundColor-criticalSoftActive__qhrpjv29: #fcdbdb;
+   --backgroundColor-criticalSoftHover__qhrpjv2a: #fde7e7;
+   --backgroundColor-formAccent__qhrpjv2b: #1E47A9;
+   --backgroundColor-formAccentActive__qhrpjv2c: #1a3e93;
+   --backgroundColor-formAccentHover__qhrpjv2d: #2455c9;
+   --backgroundColor-formAccentSoft__qhrpjv2e: #F0F7FE;
+   --backgroundColor-formAccentSoftActive__qhrpjv2f: #d8eafc;
+   --backgroundColor-formAccentSoftHover__qhrpjv2g: #e4f1fd;
+   --backgroundColor-info__qhrpjv2h: #1D559D;
+   --backgroundColor-infoLight__qhrpjv2i: #E3F2FB;
+   --backgroundColor-neutral__qhrpjv2j: #2E3849;
+   --backgroundColor-neutralActive__qhrpjv2k: #242c39;
+   --backgroundColor-neutralHover__qhrpjv2l: #384459;
+   --backgroundColor-neutralLight__qhrpjv2m: #F3F5F7;
+   --backgroundColor-neutralSoft__qhrpjv2n: #F3F5F7;
+   --backgroundColor-neutralSoftActive__qhrpjv2o: #e4e8ed;
+   --backgroundColor-neutralSoftHover__qhrpjv2p: #ebeff2;
+   --backgroundColor-positive__qhrpjv2q: #12784F;
+   --backgroundColor-positiveLight__qhrpjv2r: #E2F7F1;
+   --backgroundColor-promote__qhrpjv2s: #7F35A9;
+   --backgroundColor-promoteLight__qhrpjv2t: #F9EBFD;
+   --backgroundColor-surface__qhrpjv2u: #fff;
+   --backgroundColor-surfaceDark__qhrpjv2v: #1C2330;
+   --fontFamily__qhrpjv2w: SeekSans, "SeekSans Fallback", Arial, Tahoma, sans-serif;
+   --fontMetrics-capHeight__qhrpjv2x: 783;
+   --fontMetrics-ascent__qhrpjv2y: 1057;
+   --fontMetrics-descent__qhrpjv2z: -274;
+   --fontMetrics-lineGap__qhrpjv30: 0;
+   --fontMetrics-unitsPerEm__qhrpjv31: 1000;
+   --textSize-large-mobile-fontSize__qhrpjv3w: 18px;
+   --textSize-large-mobile-lineHeight__qhrpjv3x: 27.094px;
+   --textSize-large-mobile-capHeight__qhrpjv3y: 14.094px;
+   --textSize-large-mobile-capsizeTrims-capHeightTrim__qhrpjv3z: -0.3611em;
+   --textSize-large-mobile-capsizeTrims-baselineTrim__qhrpjv40: -0.3611em;
+   --textSize-large-tablet-fontSize__qhrpjv41: 18px;
+   --textSize-large-tablet-lineHeight__qhrpjv42: 27.094px;
+   --textSize-large-tablet-capHeight__qhrpjv43: 14.094px;
+   --textSize-large-tablet-capsizeTrims-capHeightTrim__qhrpjv44: -0.3611em;
+   --textSize-large-tablet-capsizeTrims-baselineTrim__qhrpjv45: -0.3611em;
+   --textSize-standard-mobile-fontSize__qhrpjv3m: 16px;
+   --textSize-standard-mobile-lineHeight__qhrpjv3n: 24.528px;
+   --textSize-standard-mobile-capHeight__qhrpjv3o: 12.528px;
+   --textSize-standard-mobile-capsizeTrims-capHeightTrim__qhrpjv3p: -0.375em;
+   --textSize-standard-mobile-capsizeTrims-baselineTrim__qhrpjv3q: -0.375em;
+   --textSize-standard-tablet-fontSize__qhrpjv3r: 16px;
+   --textSize-standard-tablet-lineHeight__qhrpjv3s: 24.528px;
+   --textSize-standard-tablet-capHeight__qhrpjv3t: 12.528px;
+   --textSize-standard-tablet-capsizeTrims-capHeightTrim__qhrpjv3u: -0.375em;
+   --textSize-standard-tablet-capsizeTrims-baselineTrim__qhrpjv3v: -0.375em;
+   --textSize-small-mobile-fontSize__qhrpjv3c: 14px;
+   --textSize-small-mobile-lineHeight__qhrpjv3d: 20.962px;
+   --textSize-small-mobile-capHeight__qhrpjv3e: 10.962px;
+   --textSize-small-mobile-capsizeTrims-capHeightTrim__qhrpjv3f: -0.3571em;
+   --textSize-small-mobile-capsizeTrims-baselineTrim__qhrpjv3g: -0.3571em;
+   --textSize-small-tablet-fontSize__qhrpjv3h: 14px;
+   --textSize-small-tablet-lineHeight__qhrpjv3i: 20.962px;
+   --textSize-small-tablet-capHeight__qhrpjv3j: 10.962px;
+   --textSize-small-tablet-capsizeTrims-capHeightTrim__qhrpjv3k: -0.3571em;
+   --textSize-small-tablet-capsizeTrims-baselineTrim__qhrpjv3l: -0.3571em;
+   --textSize-xsmall-mobile-fontSize__qhrpjv32: 12px;
+   --textSize-xsmall-mobile-lineHeight__qhrpjv33: 18.396px;
+   --textSize-xsmall-mobile-capHeight__qhrpjv34: 9.396px;
+   --textSize-xsmall-mobile-capsizeTrims-capHeightTrim__qhrpjv35: -0.375em;
+   --textSize-xsmall-mobile-capsizeTrims-baselineTrim__qhrpjv36: -0.375em;
+   --textSize-xsmall-tablet-fontSize__qhrpjv37: 12px;
+   --textSize-xsmall-tablet-lineHeight__qhrpjv38: 18.396px;
+   --textSize-xsmall-tablet-capHeight__qhrpjv39: 9.396px;
+   --textSize-xsmall-tablet-capsizeTrims-capHeightTrim__qhrpjv3a: -0.375em;
+   --textSize-xsmall-tablet-capsizeTrims-baselineTrim__qhrpjv3b: -0.375em;
+   --textWeight-regular__qhrpjv46: 400;
+   --textWeight-medium__qhrpjv47: 600;
+   --textWeight-strong__qhrpjv48: 700;
+   --headingLevel-1-mobile-fontSize__qhrpjv49: 28px;
+   --headingLevel-1-mobile-lineHeight__qhrpjv4a: 32.924px;
+   --headingLevel-1-mobile-capHeight__qhrpjv4b: 21.924px;
+   --headingLevel-1-mobile-capsizeTrims-capHeightTrim__qhrpjv4c: -0.1964em;
+   --headingLevel-1-mobile-capsizeTrims-baselineTrim__qhrpjv4d: -0.1964em;
+   --headingLevel-1-tablet-fontSize__qhrpjv4e: 36px;
+   --headingLevel-1-tablet-lineHeight__qhrpjv4f: 42.188px;
+   --headingLevel-1-tablet-capHeight__qhrpjv4g: 28.188px;
+   --headingLevel-1-tablet-capsizeTrims-capHeightTrim__qhrpjv4h: -0.1944em;
+   --headingLevel-1-tablet-capsizeTrims-baselineTrim__qhrpjv4i: -0.1944em;
+   --headingLevel-2-mobile-fontSize__qhrpjv4j: 24px;
+   --headingLevel-2-mobile-lineHeight__qhrpjv4k: 29.792px;
+   --headingLevel-2-mobile-capHeight__qhrpjv4l: 18.792px;
+   --headingLevel-2-mobile-capsizeTrims-capHeightTrim__qhrpjv4m: -0.2292em;
+   --headingLevel-2-mobile-capsizeTrims-baselineTrim__qhrpjv4n: -0.2292em;
+   --headingLevel-2-tablet-fontSize__qhrpjv4o: 30px;
+   --headingLevel-2-tablet-lineHeight__qhrpjv4p: 36.49px;
+   --headingLevel-2-tablet-capHeight__qhrpjv4q: 23.49px;
+   --headingLevel-2-tablet-capsizeTrims-capHeightTrim__qhrpjv4r: -0.2167em;
+   --headingLevel-2-tablet-capsizeTrims-baselineTrim__qhrpjv4s: -0.2167em;
+   --headingLevel-3-mobile-fontSize__qhrpjv4t: 22px;
+   --headingLevel-3-mobile-lineHeight__qhrpjv4u: 27.226px;
+   --headingLevel-3-mobile-capHeight__qhrpjv4v: 17.226px;
+   --headingLevel-3-mobile-capsizeTrims-capHeightTrim__qhrpjv4w: -0.2273em;
+   --headingLevel-3-mobile-capsizeTrims-baselineTrim__qhrpjv4x: -0.2273em;
+   --headingLevel-3-tablet-fontSize__qhrpjv4y: 24px;
+   --headingLevel-3-tablet-lineHeight__qhrpjv4z: 29.792px;
+   --headingLevel-3-tablet-capHeight__qhrpjv50: 18.792px;
+   --headingLevel-3-tablet-capsizeTrims-capHeightTrim__qhrpjv51: -0.2292em;
+   --headingLevel-3-tablet-capsizeTrims-baselineTrim__qhrpjv52: -0.2292em;
+   --headingLevel-4-mobile-fontSize__qhrpjv53: 20px;
+   --headingLevel-4-mobile-lineHeight__qhrpjv54: 24.66px;
+   --headingLevel-4-mobile-capHeight__qhrpjv55: 15.66px;
+   --headingLevel-4-mobile-capsizeTrims-capHeightTrim__qhrpjv56: -0.225em;
+   --headingLevel-4-mobile-capsizeTrims-baselineTrim__qhrpjv57: -0.225em;
+   --headingLevel-4-tablet-fontSize__qhrpjv58: 20px;
+   --headingLevel-4-tablet-lineHeight__qhrpjv59: 24.66px;
+   --headingLevel-4-tablet-capHeight__qhrpjv5a: 15.66px;
+   --headingLevel-4-tablet-capsizeTrims-capHeightTrim__qhrpjv5b: -0.225em;
+   --headingLevel-4-tablet-capsizeTrims-baselineTrim__qhrpjv5c: -0.225em;
+   --headingWeight-weak__qhrpjv5d: 400;
+   --headingWeight-regular__qhrpjv5e: 600;
+   --linkDecoration__qhrpjv5f: underline;
+   --inlineFieldSize-standard__qhrpjv5g: 24px;
+   --inlineFieldSize-small__qhrpjv5h: 20px;
+   --transition-fast__qhrpjv5i: transform .125s ease, opacity .125s ease;
+   --transition-touchable__qhrpjv5j: transform 0.2s cubic-bezier(0.02, 1.505, 0.745, 1.235);
+   --transform-touchable__qhrpjv5k: scale(0.95);
+   --shadow-small__qhrpjv5l: 0 0 4px 0 rgba(28,35,48,0.08), 0 4px 8px -2px rgba(28,35,48,0.08);
+   --shadow-medium__qhrpjv5m: 0 0 8px 0 rgba(28,35,48,0.08), 0 8px 16px -4px rgba(28,35,48,0.08);
+   --shadow-large__qhrpjv5n: 0 0 12px 0 rgba(28,35,48,0.08), 0 12px 24px -6px rgba(28,35,48,0.08);
+ }
+ .App_vanillaBox__inn18b0 {
+   --backgroundColor__zv7nmx0: blueviolet;
+   background-color: var(--backgroundColor__zv7nmx0);
+   color: white;
+   font-size: 20px;
+   padding: 100px;
+ }
+     </style>
+     <script type="module">
+       import { injectIntoGlobalHook } from "/@react-refresh";
+ injectIntoGlobalHook(window);
+ window.$RefreshReg$ = () => {};
+ window.$RefreshSig$ = () => (type) => type;
+     </script>
+     <script
+       type="module"
+       src="/@vite/client"
+     >
+     </script>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <script>
+       window.SKU_SITE = 'jobStreet';
      </script>
      <script
        type="module"
@@ -12894,7 +12719,132 @@ POST HYDRATE DIFFS:
    </head>
    <body>
      <div id="app">
-@@ -4688,7 +9511,7 @@
+       <style type="text/css">
+         html,body{margin:0;padding:0;background:#fff}
+             html.sprinkles_darkMode__1hjdb9v11,html.sprinkles_darkMode__1hjdb9v11 body{color-scheme:dark;background:#1C2330}
+       </style>
+       <div class="seekJobs_seekJobs__1fmskxf0 typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13">
+         <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSizeTrimmed_standard__co4djb9 typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
+           Hello
+           jobStreet
+           <span class="reset_base__yw2qws0 sprinkles_display_inlineBlock_mobile__1hjdb9v58">
+             <svg
+               xmlns="http://www.w3.org/2000/svg"
+               viewbox="0 0 24 24"
+               xml:space="preserve"
+               focusable="false"
+               fill="currentColor"
+               width="16"
+               height="16"
+               class="reset_base__yw2qws0 IconChevron_root__v2pdba0 sprinkles_display_inlineBlock_mobile__1hjdb9v58 sprinkles_position_relative_mobile__1hjdb9v5g icon_size__1ltfiyk0 icon_inlineCrop__1ltfiyk2 icon_inline__1ltfiyk3 icon_alignY_uppercase_none__1ltfiyk4"
+               aria-hidden="true"
+             >
+               <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
+               </path>
+             </svg>
+           </span>
+         </span>
+         <div class="reset_base__yw2qws0 sprinkles_paddingBottom_gutter_mobile__1hjdb9v8s sprinkles_paddingTop_gutter_mobile__1hjdb9v7o sprinkles_paddingLeft_gutter_mobile__1hjdb9vb0 sprinkles_paddingRight_gutter_mobile__1hjdb9v9w sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_large_mobile__1hjdb9v6c sprinkles_textAlign_left_mobile__1hjdb9vic sprinkles_boxShadow_borderNeutralLight_lightMode__1hjdb9v4k sprinkles_boxShadow_borderNeutral_darkMode__1hjdb9v4d typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13 sprinkles_background_surface_lightMode__1hjdb9v34 sprinkles_background_surfaceDark_darkMode__1hjdb9v37">
+           <div class="reset_base__yw2qws0 sprinkles_position_relative_mobile__1hjdb9v5g">
+             <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c sprinkles_textAlign_left_mobile__1hjdb9vic">
+               <input
+                 class="reset_base__yw2qws0 reset_input__yw2qwse reset_field__yw2qws9 reset_block__yw2qws1 reset_appearance__yw2qws6 reset_transparent__yw2qws7 reset_focusVisible__yw2qws8 reset_input__yw2qwsd sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_zIndex_1__1hjdb9v9 sprinkles_cursor_pointer__1hjdb9vi sprinkles_opacity_0__1hjdb9v7 InlineField_realField__1b4ltjx4 InlineField_sizeVars_standard__1b4ltjx2"
+                 type="checkbox"
+                 id="id_1"
+                 aria-checked="false"
+               >
+               <div class="reset_base__yw2qws0 sprinkles_flexShrink_0_mobile__1hjdb9vi0 sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_standard_mobile__1hjdb9v68 InlineField_fakeField__1b4ltjx5 InlineField_sizeVars_standard__1b4ltjx2 typography_lightModeTone_light__co4djb10  sprinkles_background_surface_lightMode__1hjdb9v34">
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_selected__1b4ltjx9 typography_lightModeTone_dark__co4djb11 typography_darkModeTone_dark__co4djb13 sprinkles_background_formAccent_lightMode__1hjdb9v22 sprinkles_background_formAccent_darkMode__1hjdb9v23">
+                   <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_boxShadow_borderField_lightMode__1hjdb9v3y sprinkles_boxShadow_borderField_darkMode__1hjdb9v3z">
+                 </span>
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 sprinkles_boxShadow_borderCritical_lightMode__1hjdb9v3q sprinkles_boxShadow_borderCriticalLight_darkMode__1hjdb9v3v">
+                 </span>
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_hoverOverlay__1b4ltjxb sprinkles_boxShadow_borderFormAccent_lightMode__1hjdb9v40 sprinkles_boxShadow_borderFormAccentLight_darkMode__1hjdb9v45">
+                   <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+               </div>
+               <div class="reset_base__yw2qws0 sprinkles_paddingLeft_xsmall_mobile__1hjdb9vb8 sprinkles_flexGrow_1_mobile__1hjdb9vi8">
+                 <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c InlineField_sizeVars_standard__1b4ltjx2 InlineField_labelOffset__1b4ltjx6">
+                   <label
+                     class="reset_base__yw2qws0 sprinkles_userSelect_none__1hjdb9v4 sprinkles_display_block_mobile__1hjdb9v50 sprinkles_cursor_pointer__1hjdb9vi virtualTouchable_virtualTouchable__9705do0"
+                     for="id_1"
+                   >
+                     <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSizeTrimmed_standard__co4djb9 typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
+                       This is a checkbox
+                     </span>
+                   </label>
+                 </div>
+               </div>
+             </div>
+           </div>
          </div>
          <div class="reset_base__yw2qws0 App_vanillaBox__inn18b0">
            🧁 Vanilla content
@@ -12903,4721 +12853,4574 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
+     <script
+       type="module"
+       src="{cwd}/packages/sku/dist/services/vite/entries/vite-client.js"
+     >
+     </script>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"site":"jobStreet"}
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`braid-design-system > bundler vite > start > should return development seekAnz site 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <style
-      type="text/css"
-      data-vanilla-extract-inline-dev-css
-    >
-      .reset_base__yw2qws0 {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
-  -webkit-tap-highlight-color: transparent;
-}
-.reset_block__yw2qws1 {
-  display: block;
-}
-.reset_body__yw2qws2 {
-  line-height: 1;
-}
-.reset_list__yw2qws3 {
-  list-style: none;
-}
-.reset_quote__yw2qws4 {
-  quotes: none;
-}
-.reset_quote__yw2qws4:before, .reset_quote__yw2qws4:after {
-  content: '';
-}
-.reset_table__yw2qws5 {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-.reset_appearance__yw2qws6 {
-  appearance: none;
-}
-.reset_transparent__yw2qws7 {
-  background-color: transparent;
-}
-.reset_focusVisible__yw2qws8 {
-  outline: var(--focusRingSize__qhrpjv10) solid transparent;
-  transition: outline-color .125s ease;
-}
-.reset_focusVisible__yw2qws8:focus-visible {
-  outline-color: var(--borderColor-focus__qhrpjvm);
-}
-.reset_mark__yw2qwsa {
-  color: inherit;
-}
-.reset_select__yw2qwsb:disabled {
-  opacity: 1;
-}
-.reset_select__yw2qwsb::-ms-expand {
-  display: none;
-}
-.reset_input__yw2qwsd[type="number"] {
-  -moz-appearance: textfield;
-}
-.reset_input__yw2qwsd[type="number"]::-webkit-inner-spin-button,.reset_input__yw2qwsd[type="number"]::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-.reset_input__yw2qwsd::-ms-clear {
-  display: none;
-}
-.reset_input__yw2qwsd::-webkit-search-cancel-button {
-  -webkit-appearance: none;
-}
-.reset_a__yw2qwsg {
-  text-decoration: none;
-  color: inherit;
-}
-.sprinkles_overflow_hidden__1hjdb9v0 {
-  overflow: hidden;
-}
-.sprinkles_overflow_scroll__1hjdb9v1 {
-  overflow: scroll;
-}
-.sprinkles_overflow_visible__1hjdb9v2 {
-  overflow: visible;
-}
-.sprinkles_overflow_auto__1hjdb9v3 {
-  overflow: auto;
-}
-.sprinkles_userSelect_none__1hjdb9v4 {
-  user-select: none;
-}
-.sprinkles_outline_none__1hjdb9v5 {
-  outline: none;
-}
-.sprinkles_outline_focus__1hjdb9v6 {
-  outline: var(--focusRingSize__qhrpjv10) solid transparent;
-  transition: outline-color .125s ease;
-}
-.sprinkles_outline_focus__1hjdb9v6:focus-visible {
-  outline-color: var(--borderColor-focus__qhrpjvm);
-}
-.sprinkles_opacity_0__1hjdb9v7 {
-  opacity: 0;
-}
-.sprinkles_zIndex_0__1hjdb9v8 {
-  z-index: 0;
-}
-.sprinkles_zIndex_1__1hjdb9v9 {
-  z-index: 1;
-}
-.sprinkles_zIndex_2__1hjdb9va {
-  z-index: 2;
-}
-.sprinkles_zIndex_dropdownBackdrop__1hjdb9vb {
-  z-index: 90;
-}
-.sprinkles_zIndex_dropdown__1hjdb9vc {
-  z-index: 100;
-}
-.sprinkles_zIndex_sticky__1hjdb9vd {
-  z-index: 200;
-}
-.sprinkles_zIndex_modalBackdrop__1hjdb9ve {
-  z-index: 290;
-}
-.sprinkles_zIndex_modal__1hjdb9vf {
-  z-index: 300;
-}
-.sprinkles_zIndex_notification__1hjdb9vg {
-  z-index: 400;
-}
-.sprinkles_cursor_default__1hjdb9vh {
-  cursor: default;
-}
-.sprinkles_cursor_pointer__1hjdb9vi {
-  cursor: pointer;
-}
-.sprinkles_pointerEvents_none__1hjdb9vj {
-  pointer-events: none;
-}
-.sprinkles_top_0__1hjdb9vk {
-  top: 0;
-}
-.sprinkles_bottom_0__1hjdb9vl {
-  bottom: 0;
-}
-.sprinkles_left_0__1hjdb9vm {
-  left: 0;
-}
-.sprinkles_right_0__1hjdb9vn {
-  right: 0;
-}
-.sprinkles_height_full__1hjdb9vo {
-  height: 100%;
-}
-.sprinkles_height_touchable__1hjdb9vp {
-  height: var(--touchableSize__qhrpjv9);
-}
-.sprinkles_width_full__1hjdb9vq {
-  width: 100%;
-}
-.sprinkles_width_touchable__1hjdb9vr {
-  width: var(--touchableSize__qhrpjv9);
-}
-.sprinkles_minWidth_0__1hjdb9vs {
-  min-width: 0%;
-}
-.sprinkles_maxWidth_xsmall__1hjdb9vt {
-  max-width: var(--contentWidth-xsmall__qhrpjv11);
-}
-.sprinkles_maxWidth_small__1hjdb9vu {
-  max-width: var(--contentWidth-small__qhrpjv12);
-}
-.sprinkles_maxWidth_medium__1hjdb9vv {
-  max-width: var(--contentWidth-medium__qhrpjv13);
-}
-.sprinkles_maxWidth_large__1hjdb9vw {
-  max-width: var(--contentWidth-large__qhrpjv14);
-}
-.sprinkles_maxWidth_content__1hjdb9vx {
-  max-width: fit-content;
-}
-.sprinkles_transition_fast__1hjdb9vy {
-  transition: var(--transition-fast__qhrpjv5i);
-}
-.sprinkles_transition_touchable__1hjdb9vz {
-  transition: var(--transition-touchable__qhrpjv5j);
-}
-.sprinkles_transform_touchable_active__1hjdb9v10:active {
-  transform: var(--transform-touchable__qhrpjv5k);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_body_lightMode__1hjdb9v12 {
-  background: var(--backgroundColor-body__qhrpjv1t);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_body_darkMode__1hjdb9v13 {
-  background: var(--backgroundColor-body__qhrpjv1t);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_bodyDark_lightMode__1hjdb9v14 {
-  background: var(--backgroundColor-bodyDark__qhrpjv1u);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_bodyDark_darkMode__1hjdb9v15 {
-  background: var(--backgroundColor-bodyDark__qhrpjv1u);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brand_lightMode__1hjdb9v16 {
-  background: var(--backgroundColor-brand__qhrpjv1v);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brand_darkMode__1hjdb9v17 {
-  background: var(--backgroundColor-brand__qhrpjv1v);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccent_lightMode__1hjdb9v18 {
-  background: var(--backgroundColor-brandAccent__qhrpjv1w);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccent_darkMode__1hjdb9v19 {
-  background: var(--backgroundColor-brandAccent__qhrpjv1w);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentActive_lightMode__1hjdb9v1a {
-  background: var(--backgroundColor-brandAccentActive__qhrpjv1x);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentActive_darkMode__1hjdb9v1b {
-  background: var(--backgroundColor-brandAccentActive__qhrpjv1x);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentHover_lightMode__1hjdb9v1c {
-  background: var(--backgroundColor-brandAccentHover__qhrpjv1y);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentHover_darkMode__1hjdb9v1d {
-  background: var(--backgroundColor-brandAccentHover__qhrpjv1y);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentSoft_lightMode__1hjdb9v1e {
-  background: var(--backgroundColor-brandAccentSoft__qhrpjv1z);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentSoft_darkMode__1hjdb9v1f {
-  background: var(--backgroundColor-brandAccentSoft__qhrpjv1z);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentSoftActive_lightMode__1hjdb9v1g {
-  background: var(--backgroundColor-brandAccentSoftActive__qhrpjv20);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentSoftActive_darkMode__1hjdb9v1h {
-  background: var(--backgroundColor-brandAccentSoftActive__qhrpjv20);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentSoftHover_lightMode__1hjdb9v1i {
-  background: var(--backgroundColor-brandAccentSoftHover__qhrpjv21);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentSoftHover_darkMode__1hjdb9v1j {
-  background: var(--backgroundColor-brandAccentSoftHover__qhrpjv21);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_caution_lightMode__1hjdb9v1k {
-  background: var(--backgroundColor-caution__qhrpjv22);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_caution_darkMode__1hjdb9v1l {
-  background: var(--backgroundColor-caution__qhrpjv22);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_cautionLight_lightMode__1hjdb9v1m {
-  background: var(--backgroundColor-cautionLight__qhrpjv23);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_cautionLight_darkMode__1hjdb9v1n {
-  background: var(--backgroundColor-cautionLight__qhrpjv23);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_critical_lightMode__1hjdb9v1o {
-  background: var(--backgroundColor-critical__qhrpjv24);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_critical_darkMode__1hjdb9v1p {
-  background: var(--backgroundColor-critical__qhrpjv24);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalActive_lightMode__1hjdb9v1q {
-  background: var(--backgroundColor-criticalActive__qhrpjv25);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalActive_darkMode__1hjdb9v1r {
-  background: var(--backgroundColor-criticalActive__qhrpjv25);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalHover_lightMode__1hjdb9v1s {
-  background: var(--backgroundColor-criticalHover__qhrpjv26);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalHover_darkMode__1hjdb9v1t {
-  background: var(--backgroundColor-criticalHover__qhrpjv26);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalLight_lightMode__1hjdb9v1u {
-  background: var(--backgroundColor-criticalLight__qhrpjv27);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalLight_darkMode__1hjdb9v1v {
-  background: var(--backgroundColor-criticalLight__qhrpjv27);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalSoft_lightMode__1hjdb9v1w {
-  background: var(--backgroundColor-criticalSoft__qhrpjv28);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalSoft_darkMode__1hjdb9v1x {
-  background: var(--backgroundColor-criticalSoft__qhrpjv28);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalSoftActive_lightMode__1hjdb9v1y {
-  background: var(--backgroundColor-criticalSoftActive__qhrpjv29);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalSoftActive_darkMode__1hjdb9v1z {
-  background: var(--backgroundColor-criticalSoftActive__qhrpjv29);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalSoftHover_lightMode__1hjdb9v20 {
-  background: var(--backgroundColor-criticalSoftHover__qhrpjv2a);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalSoftHover_darkMode__1hjdb9v21 {
-  background: var(--backgroundColor-criticalSoftHover__qhrpjv2a);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccent_lightMode__1hjdb9v22 {
-  background: var(--backgroundColor-formAccent__qhrpjv2b);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccent_darkMode__1hjdb9v23 {
-  background: var(--backgroundColor-formAccent__qhrpjv2b);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentActive_lightMode__1hjdb9v24 {
-  background: var(--backgroundColor-formAccentActive__qhrpjv2c);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentActive_darkMode__1hjdb9v25 {
-  background: var(--backgroundColor-formAccentActive__qhrpjv2c);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentHover_lightMode__1hjdb9v26 {
-  background: var(--backgroundColor-formAccentHover__qhrpjv2d);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentHover_darkMode__1hjdb9v27 {
-  background: var(--backgroundColor-formAccentHover__qhrpjv2d);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentSoft_lightMode__1hjdb9v28 {
-  background: var(--backgroundColor-formAccentSoft__qhrpjv2e);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentSoft_darkMode__1hjdb9v29 {
-  background: var(--backgroundColor-formAccentSoft__qhrpjv2e);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentSoftActive_lightMode__1hjdb9v2a {
-  background: var(--backgroundColor-formAccentSoftActive__qhrpjv2f);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentSoftActive_darkMode__1hjdb9v2b {
-  background: var(--backgroundColor-formAccentSoftActive__qhrpjv2f);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentSoftHover_lightMode__1hjdb9v2c {
-  background: var(--backgroundColor-formAccentSoftHover__qhrpjv2g);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentSoftHover_darkMode__1hjdb9v2d {
-  background: var(--backgroundColor-formAccentSoftHover__qhrpjv2g);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_info_lightMode__1hjdb9v2e {
-  background: var(--backgroundColor-info__qhrpjv2h);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_info_darkMode__1hjdb9v2f {
-  background: var(--backgroundColor-info__qhrpjv2h);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_infoLight_lightMode__1hjdb9v2g {
-  background: var(--backgroundColor-infoLight__qhrpjv2i);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_infoLight_darkMode__1hjdb9v2h {
-  background: var(--backgroundColor-infoLight__qhrpjv2i);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutral_lightMode__1hjdb9v2i {
-  background: var(--backgroundColor-neutral__qhrpjv2j);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutral_darkMode__1hjdb9v2j {
-  background: var(--backgroundColor-neutral__qhrpjv2j);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralActive_lightMode__1hjdb9v2k {
-  background: var(--backgroundColor-neutralActive__qhrpjv2k);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralActive_darkMode__1hjdb9v2l {
-  background: var(--backgroundColor-neutralActive__qhrpjv2k);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralHover_lightMode__1hjdb9v2m {
-  background: var(--backgroundColor-neutralHover__qhrpjv2l);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralHover_darkMode__1hjdb9v2n {
-  background: var(--backgroundColor-neutralHover__qhrpjv2l);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralLight_lightMode__1hjdb9v2o {
-  background: var(--backgroundColor-neutralLight__qhrpjv2m);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralLight_darkMode__1hjdb9v2p {
-  background: var(--backgroundColor-neutralLight__qhrpjv2m);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralSoft_lightMode__1hjdb9v2q {
-  background: var(--backgroundColor-neutralSoft__qhrpjv2n);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralSoft_darkMode__1hjdb9v2r {
-  background: var(--backgroundColor-neutralSoft__qhrpjv2n);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralSoftActive_lightMode__1hjdb9v2s {
-  background: var(--backgroundColor-neutralSoftActive__qhrpjv2o);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralSoftActive_darkMode__1hjdb9v2t {
-  background: var(--backgroundColor-neutralSoftActive__qhrpjv2o);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralSoftHover_lightMode__1hjdb9v2u {
-  background: var(--backgroundColor-neutralSoftHover__qhrpjv2p);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralSoftHover_darkMode__1hjdb9v2v {
-  background: var(--backgroundColor-neutralSoftHover__qhrpjv2p);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_positive_lightMode__1hjdb9v2w {
-  background: var(--backgroundColor-positive__qhrpjv2q);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_positive_darkMode__1hjdb9v2x {
-  background: var(--backgroundColor-positive__qhrpjv2q);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_positiveLight_lightMode__1hjdb9v2y {
-  background: var(--backgroundColor-positiveLight__qhrpjv2r);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_positiveLight_darkMode__1hjdb9v2z {
-  background: var(--backgroundColor-positiveLight__qhrpjv2r);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_promote_lightMode__1hjdb9v30 {
-  background: var(--backgroundColor-promote__qhrpjv2s);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_promote_darkMode__1hjdb9v31 {
-  background: var(--backgroundColor-promote__qhrpjv2s);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_promoteLight_lightMode__1hjdb9v32 {
-  background: var(--backgroundColor-promoteLight__qhrpjv2t);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_promoteLight_darkMode__1hjdb9v33 {
-  background: var(--backgroundColor-promoteLight__qhrpjv2t);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_surface_lightMode__1hjdb9v34 {
-  background: var(--backgroundColor-surface__qhrpjv2u);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_surface_darkMode__1hjdb9v35 {
-  background: var(--backgroundColor-surface__qhrpjv2u);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_surfaceDark_lightMode__1hjdb9v36 {
-  background: var(--backgroundColor-surfaceDark__qhrpjv2v);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_surfaceDark_darkMode__1hjdb9v37 {
-  background: var(--backgroundColor-surfaceDark__qhrpjv2v);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_small_lightMode__1hjdb9v38 {
-  box-shadow: var(--shadow-small__qhrpjv5l);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_small_darkMode__1hjdb9v39 {
-  box-shadow: var(--shadow-small__qhrpjv5l);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_medium_lightMode__1hjdb9v3a {
-  box-shadow: var(--shadow-medium__qhrpjv5m);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_medium_darkMode__1hjdb9v3b {
-  box-shadow: var(--shadow-medium__qhrpjv5m);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_large_lightMode__1hjdb9v3c {
-  box-shadow: var(--shadow-large__qhrpjv5n);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_large_darkMode__1hjdb9v3d {
-  box-shadow: var(--shadow-large__qhrpjv5n);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccent_lightMode__1hjdb9v3e {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccent__qhrpjvf);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccent_darkMode__1hjdb9v3f {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccent__qhrpjvf);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccentLight_lightMode__1hjdb9v3g {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccentLight__qhrpjvg);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccentLight_darkMode__1hjdb9v3h {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccentLight__qhrpjvg);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccentLarge_lightMode__1hjdb9v3i {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccent__qhrpjvf);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccentLarge_darkMode__1hjdb9v3j {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccent__qhrpjvf);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccentLightLarge_lightMode__1hjdb9v3k {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccentLight__qhrpjvg);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccentLightLarge_darkMode__1hjdb9v3l {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccentLight__qhrpjvg);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCaution_lightMode__1hjdb9v3m {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-caution__qhrpjvh);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCaution_darkMode__1hjdb9v3n {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-caution__qhrpjvh);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCautionLight_lightMode__1hjdb9v3o {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-cautionLight__qhrpjvi);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCautionLight_darkMode__1hjdb9v3p {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-cautionLight__qhrpjvi);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCritical_lightMode__1hjdb9v3q {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-critical__qhrpjvj);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCritical_darkMode__1hjdb9v3r {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-critical__qhrpjvj);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCriticalLarge_lightMode__1hjdb9v3s {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-critical__qhrpjvj);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCriticalLarge_darkMode__1hjdb9v3t {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-critical__qhrpjvj);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCriticalLight_lightMode__1hjdb9v3u {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-criticalLight__qhrpjvk);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCriticalLight_darkMode__1hjdb9v3v {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-criticalLight__qhrpjvk);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCriticalLightLarge_lightMode__1hjdb9v3w {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-criticalLight__qhrpjvk);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCriticalLightLarge_darkMode__1hjdb9v3x {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-criticalLight__qhrpjvk);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderField_lightMode__1hjdb9v3y {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-field__qhrpjvl);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderField_darkMode__1hjdb9v3z {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-field__qhrpjvl);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccent_lightMode__1hjdb9v40 {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccent__qhrpjvn);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccent_darkMode__1hjdb9v41 {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccent__qhrpjvn);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccentLarge_lightMode__1hjdb9v42 {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccent__qhrpjvn);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccentLarge_darkMode__1hjdb9v43 {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccent__qhrpjvn);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccentLight_lightMode__1hjdb9v44 {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccentLight__qhrpjvo);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccentLight_darkMode__1hjdb9v45 {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccentLight__qhrpjvo);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccentLightLarge_lightMode__1hjdb9v46 {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccentLight__qhrpjvo);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccentLightLarge_darkMode__1hjdb9v47 {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccentLight__qhrpjvo);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderInfo_lightMode__1hjdb9v48 {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-info__qhrpjvp);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderInfo_darkMode__1hjdb9v49 {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-info__qhrpjvp);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderInfoLight_lightMode__1hjdb9v4a {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-infoLight__qhrpjvq);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderInfoLight_darkMode__1hjdb9v4b {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-infoLight__qhrpjvq);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutral_lightMode__1hjdb9v4c {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutral__qhrpjvr);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutral_darkMode__1hjdb9v4d {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutral__qhrpjvr);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralLarge_lightMode__1hjdb9v4e {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutral__qhrpjvr);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralLarge_darkMode__1hjdb9v4f {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutral__qhrpjvr);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralInverted_lightMode__1hjdb9v4g {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralInverted__qhrpjvs);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralInverted_darkMode__1hjdb9v4h {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralInverted__qhrpjvs);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralInvertedLarge_lightMode__1hjdb9v4i {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutralInverted__qhrpjvs);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralInvertedLarge_darkMode__1hjdb9v4j {
-  box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutralInverted__qhrpjvs);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralLight_lightMode__1hjdb9v4k {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralLight__qhrpjvt);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralLight_darkMode__1hjdb9v4l {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralLight__qhrpjvt);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPositive_lightMode__1hjdb9v4m {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positive__qhrpjvu);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPositive_darkMode__1hjdb9v4n {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positive__qhrpjvu);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPositiveLight_lightMode__1hjdb9v4o {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positiveLight__qhrpjvv);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPositiveLight_darkMode__1hjdb9v4p {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positiveLight__qhrpjvv);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPromote_lightMode__1hjdb9v4q {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promote__qhrpjvw);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPromote_darkMode__1hjdb9v4r {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promote__qhrpjvw);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPromoteLight_lightMode__1hjdb9v4s {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promoteLight__qhrpjvx);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPromoteLight_darkMode__1hjdb9v4t {
-  box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promoteLight__qhrpjvx);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_outlineFocus_lightMode__1hjdb9v4u {
-  box-shadow: 0 0 0 var(--focusRingSize__qhrpjv10) var(--borderColor-focus__qhrpjvm);
-}
-html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_outlineFocus_darkMode__1hjdb9v4v {
-  box-shadow: 0 0 0 var(--focusRingSize__qhrpjv10) var(--borderColor-focus__qhrpjvm);
-}
-.sprinkles_display_none_mobile__1hjdb9v4w {
-  display: none;
-}
-.sprinkles_display_block_mobile__1hjdb9v50 {
-  display: block;
-}
-.sprinkles_display_inline_mobile__1hjdb9v54 {
-  display: inline;
-}
-.sprinkles_display_inlineBlock_mobile__1hjdb9v58 {
-  display: inline-block;
-}
-.sprinkles_display_flex_mobile__1hjdb9v5c {
-  display: flex;
-}
-.sprinkles_position_relative_mobile__1hjdb9v5g {
-  position: relative;
-}
-.sprinkles_position_absolute_mobile__1hjdb9v5k {
-  position: absolute;
-}
-.sprinkles_position_fixed_mobile__1hjdb9v5o {
-  position: fixed;
-}
-.sprinkles_position_sticky_mobile__1hjdb9v5s {
-  position: sticky;
-}
-.sprinkles_borderRadius_none_mobile__1hjdb9v5w {
-  border-radius: 0px;
-}
-.sprinkles_borderRadius_full_mobile__1hjdb9v60 {
-  border-radius: 9999px;
-}
-.sprinkles_borderRadius_small_mobile__1hjdb9v64 {
-  border-radius: var(--borderRadius-small__qhrpjvb);
-}
-.sprinkles_borderRadius_standard_mobile__1hjdb9v68 {
-  border-radius: var(--borderRadius-standard__qhrpjvc);
-}
-.sprinkles_borderRadius_large_mobile__1hjdb9v6c {
-  border-radius: var(--borderRadius-large__qhrpjvd);
-}
-.sprinkles_borderRadius_xlarge_mobile__1hjdb9v6g {
-  border-radius: var(--borderRadius-xlarge__qhrpjve);
-}
-.sprinkles_gap_gutter_mobile__1hjdb9v6k {
-  gap: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_gap_xxsmall_mobile__1hjdb9v6o {
-  gap: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_gap_xsmall_mobile__1hjdb9v6s {
-  gap: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_gap_small_mobile__1hjdb9v6w {
-  gap: var(--space-small__qhrpjv3);
-}
-.sprinkles_gap_medium_mobile__1hjdb9v70 {
-  gap: var(--space-medium__qhrpjv4);
-}
-.sprinkles_gap_large_mobile__1hjdb9v74 {
-  gap: var(--space-large__qhrpjv5);
-}
-.sprinkles_gap_xlarge_mobile__1hjdb9v78 {
-  gap: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_gap_xxlarge_mobile__1hjdb9v7c {
-  gap: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_gap_xxxlarge_mobile__1hjdb9v7g {
-  gap: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_gap_none_mobile__1hjdb9v7k {
-  gap: 0;
-}
-.sprinkles_paddingTop_gutter_mobile__1hjdb9v7o {
-  padding-top: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_paddingTop_xxsmall_mobile__1hjdb9v7s {
-  padding-top: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_paddingTop_xsmall_mobile__1hjdb9v7w {
-  padding-top: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_paddingTop_small_mobile__1hjdb9v80 {
-  padding-top: var(--space-small__qhrpjv3);
-}
-.sprinkles_paddingTop_medium_mobile__1hjdb9v84 {
-  padding-top: var(--space-medium__qhrpjv4);
-}
-.sprinkles_paddingTop_large_mobile__1hjdb9v88 {
-  padding-top: var(--space-large__qhrpjv5);
-}
-.sprinkles_paddingTop_xlarge_mobile__1hjdb9v8c {
-  padding-top: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_paddingTop_xxlarge_mobile__1hjdb9v8g {
-  padding-top: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_paddingTop_xxxlarge_mobile__1hjdb9v8k {
-  padding-top: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_paddingTop_none_mobile__1hjdb9v8o {
-  padding-top: 0;
-}
-.sprinkles_paddingBottom_gutter_mobile__1hjdb9v8s {
-  padding-bottom: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_paddingBottom_xxsmall_mobile__1hjdb9v8w {
-  padding-bottom: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_paddingBottom_xsmall_mobile__1hjdb9v90 {
-  padding-bottom: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_paddingBottom_small_mobile__1hjdb9v94 {
-  padding-bottom: var(--space-small__qhrpjv3);
-}
-.sprinkles_paddingBottom_medium_mobile__1hjdb9v98 {
-  padding-bottom: var(--space-medium__qhrpjv4);
-}
-.sprinkles_paddingBottom_large_mobile__1hjdb9v9c {
-  padding-bottom: var(--space-large__qhrpjv5);
-}
-.sprinkles_paddingBottom_xlarge_mobile__1hjdb9v9g {
-  padding-bottom: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_paddingBottom_xxlarge_mobile__1hjdb9v9k {
-  padding-bottom: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_paddingBottom_xxxlarge_mobile__1hjdb9v9o {
-  padding-bottom: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_paddingBottom_none_mobile__1hjdb9v9s {
-  padding-bottom: 0;
-}
-.sprinkles_paddingRight_gutter_mobile__1hjdb9v9w {
-  padding-right: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_paddingRight_xxsmall_mobile__1hjdb9va0 {
-  padding-right: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_paddingRight_xsmall_mobile__1hjdb9va4 {
-  padding-right: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_paddingRight_small_mobile__1hjdb9va8 {
-  padding-right: var(--space-small__qhrpjv3);
-}
-.sprinkles_paddingRight_medium_mobile__1hjdb9vac {
-  padding-right: var(--space-medium__qhrpjv4);
-}
-.sprinkles_paddingRight_large_mobile__1hjdb9vag {
-  padding-right: var(--space-large__qhrpjv5);
-}
-.sprinkles_paddingRight_xlarge_mobile__1hjdb9vak {
-  padding-right: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_paddingRight_xxlarge_mobile__1hjdb9vao {
-  padding-right: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_paddingRight_xxxlarge_mobile__1hjdb9vas {
-  padding-right: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_paddingRight_none_mobile__1hjdb9vaw {
-  padding-right: 0;
-}
-.sprinkles_paddingLeft_gutter_mobile__1hjdb9vb0 {
-  padding-left: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_paddingLeft_xxsmall_mobile__1hjdb9vb4 {
-  padding-left: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_paddingLeft_xsmall_mobile__1hjdb9vb8 {
-  padding-left: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_paddingLeft_small_mobile__1hjdb9vbc {
-  padding-left: var(--space-small__qhrpjv3);
-}
-.sprinkles_paddingLeft_medium_mobile__1hjdb9vbg {
-  padding-left: var(--space-medium__qhrpjv4);
-}
-.sprinkles_paddingLeft_large_mobile__1hjdb9vbk {
-  padding-left: var(--space-large__qhrpjv5);
-}
-.sprinkles_paddingLeft_xlarge_mobile__1hjdb9vbo {
-  padding-left: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_paddingLeft_xxlarge_mobile__1hjdb9vbs {
-  padding-left: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_paddingLeft_xxxlarge_mobile__1hjdb9vbw {
-  padding-left: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_paddingLeft_none_mobile__1hjdb9vc0 {
-  padding-left: 0;
-}
-.sprinkles_marginTop_gutter_mobile__1hjdb9vc4 {
-  margin-top: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_marginTop_xxsmall_mobile__1hjdb9vc8 {
-  margin-top: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_marginTop_xsmall_mobile__1hjdb9vcc {
-  margin-top: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_marginTop_small_mobile__1hjdb9vcg {
-  margin-top: var(--space-small__qhrpjv3);
-}
-.sprinkles_marginTop_medium_mobile__1hjdb9vck {
-  margin-top: var(--space-medium__qhrpjv4);
-}
-.sprinkles_marginTop_large_mobile__1hjdb9vco {
-  margin-top: var(--space-large__qhrpjv5);
-}
-.sprinkles_marginTop_xlarge_mobile__1hjdb9vcs {
-  margin-top: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_marginTop_xxlarge_mobile__1hjdb9vcw {
-  margin-top: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_marginTop_xxxlarge_mobile__1hjdb9vd0 {
-  margin-top: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_marginTop_none_mobile__1hjdb9vd4 {
-  margin-top: 0;
-}
-.sprinkles_marginBottom_gutter_mobile__1hjdb9vd8 {
-  margin-bottom: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_marginBottom_xxsmall_mobile__1hjdb9vdc {
-  margin-bottom: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_marginBottom_xsmall_mobile__1hjdb9vdg {
-  margin-bottom: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_marginBottom_small_mobile__1hjdb9vdk {
-  margin-bottom: var(--space-small__qhrpjv3);
-}
-.sprinkles_marginBottom_medium_mobile__1hjdb9vdo {
-  margin-bottom: var(--space-medium__qhrpjv4);
-}
-.sprinkles_marginBottom_large_mobile__1hjdb9vds {
-  margin-bottom: var(--space-large__qhrpjv5);
-}
-.sprinkles_marginBottom_xlarge_mobile__1hjdb9vdw {
-  margin-bottom: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_marginBottom_xxlarge_mobile__1hjdb9ve0 {
-  margin-bottom: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_marginBottom_xxxlarge_mobile__1hjdb9ve4 {
-  margin-bottom: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_marginBottom_none_mobile__1hjdb9ve8 {
-  margin-bottom: 0;
-}
-.sprinkles_marginRight_gutter_mobile__1hjdb9vec {
-  margin-right: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_marginRight_xxsmall_mobile__1hjdb9veg {
-  margin-right: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_marginRight_xsmall_mobile__1hjdb9vek {
-  margin-right: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_marginRight_small_mobile__1hjdb9veo {
-  margin-right: var(--space-small__qhrpjv3);
-}
-.sprinkles_marginRight_medium_mobile__1hjdb9ves {
-  margin-right: var(--space-medium__qhrpjv4);
-}
-.sprinkles_marginRight_large_mobile__1hjdb9vew {
-  margin-right: var(--space-large__qhrpjv5);
-}
-.sprinkles_marginRight_xlarge_mobile__1hjdb9vf0 {
-  margin-right: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_marginRight_xxlarge_mobile__1hjdb9vf4 {
-  margin-right: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_marginRight_xxxlarge_mobile__1hjdb9vf8 {
-  margin-right: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_marginRight_none_mobile__1hjdb9vfc {
-  margin-right: 0;
-}
-.sprinkles_marginLeft_gutter_mobile__1hjdb9vfg {
-  margin-left: var(--space-gutter__qhrpjv0);
-}
-.sprinkles_marginLeft_xxsmall_mobile__1hjdb9vfk {
-  margin-left: var(--space-xxsmall__qhrpjv1);
-}
-.sprinkles_marginLeft_xsmall_mobile__1hjdb9vfo {
-  margin-left: var(--space-xsmall__qhrpjv2);
-}
-.sprinkles_marginLeft_small_mobile__1hjdb9vfs {
-  margin-left: var(--space-small__qhrpjv3);
-}
-.sprinkles_marginLeft_medium_mobile__1hjdb9vfw {
-  margin-left: var(--space-medium__qhrpjv4);
-}
-.sprinkles_marginLeft_large_mobile__1hjdb9vg0 {
-  margin-left: var(--space-large__qhrpjv5);
-}
-.sprinkles_marginLeft_xlarge_mobile__1hjdb9vg4 {
-  margin-left: var(--space-xlarge__qhrpjv6);
-}
-.sprinkles_marginLeft_xxlarge_mobile__1hjdb9vg8 {
-  margin-left: var(--space-xxlarge__qhrpjv7);
-}
-.sprinkles_marginLeft_xxxlarge_mobile__1hjdb9vgc {
-  margin-left: var(--space-xxxlarge__qhrpjv8);
-}
-.sprinkles_marginLeft_none_mobile__1hjdb9vgg {
-  margin-left: 0;
-}
-.sprinkles_alignItems_flexStart_mobile__1hjdb9vgk {
-  align-items: flex-start;
-}
-.sprinkles_alignItems_center_mobile__1hjdb9vgo {
-  align-items: center;
-}
-.sprinkles_alignItems_flexEnd_mobile__1hjdb9vgs {
-  align-items: flex-end;
-}
-.sprinkles_justifyContent_flexStart_mobile__1hjdb9vgw {
-  justify-content: flex-start;
-}
-.sprinkles_justifyContent_center_mobile__1hjdb9vh0 {
-  justify-content: center;
-}
-.sprinkles_justifyContent_flexEnd_mobile__1hjdb9vh4 {
-  justify-content: flex-end;
-}
-.sprinkles_justifyContent_spaceBetween_mobile__1hjdb9vh8 {
-  justify-content: space-between;
-}
-.sprinkles_flexDirection_row_mobile__1hjdb9vhc {
-  flex-direction: row;
-}
-.sprinkles_flexDirection_rowReverse_mobile__1hjdb9vhg {
-  flex-direction: row-reverse;
-}
-.sprinkles_flexDirection_column_mobile__1hjdb9vhk {
-  flex-direction: column;
-}
-.sprinkles_flexDirection_columnReverse_mobile__1hjdb9vho {
-  flex-direction: column-reverse;
-}
-.sprinkles_flexWrap_wrap_mobile__1hjdb9vhs {
-  flex-wrap: wrap;
-}
-.sprinkles_flexWrap_nowrap_mobile__1hjdb9vhw {
-  flex-wrap: nowrap;
-}
-.sprinkles_flexShrink_0_mobile__1hjdb9vi0 {
-  flex-shrink: 0;
-}
-.sprinkles_flexGrow_0_mobile__1hjdb9vi4 {
-  flex-grow: 0;
-}
-.sprinkles_flexGrow_1_mobile__1hjdb9vi8 {
-  flex-grow: 1;
-}
-.sprinkles_textAlign_left_mobile__1hjdb9vic {
-  text-align: left;
-}
-.sprinkles_textAlign_center_mobile__1hjdb9vig {
-  text-align: center;
-}
-.sprinkles_textAlign_right_mobile__1hjdb9vik {
-  text-align: right;
-}
-@media screen and (min-width: 740px) {
-  .sprinkles_display_none_tablet__1hjdb9v4x {
-    display: none;
-  }
-  .sprinkles_display_block_tablet__1hjdb9v51 {
-    display: block;
-  }
-  .sprinkles_display_inline_tablet__1hjdb9v55 {
-    display: inline;
-  }
-  .sprinkles_display_inlineBlock_tablet__1hjdb9v59 {
-    display: inline-block;
-  }
-  .sprinkles_display_flex_tablet__1hjdb9v5d {
-    display: flex;
-  }
-  .sprinkles_position_relative_tablet__1hjdb9v5h {
-    position: relative;
-  }
-  .sprinkles_position_absolute_tablet__1hjdb9v5l {
-    position: absolute;
-  }
-  .sprinkles_position_fixed_tablet__1hjdb9v5p {
-    position: fixed;
-  }
-  .sprinkles_position_sticky_tablet__1hjdb9v5t {
-    position: sticky;
-  }
-  .sprinkles_borderRadius_none_tablet__1hjdb9v5x {
-    border-radius: 0px;
-  }
-  .sprinkles_borderRadius_full_tablet__1hjdb9v61 {
-    border-radius: 9999px;
-  }
-  .sprinkles_borderRadius_small_tablet__1hjdb9v65 {
-    border-radius: var(--borderRadius-small__qhrpjvb);
-  }
-  .sprinkles_borderRadius_standard_tablet__1hjdb9v69 {
-    border-radius: var(--borderRadius-standard__qhrpjvc);
-  }
-  .sprinkles_borderRadius_large_tablet__1hjdb9v6d {
-    border-radius: var(--borderRadius-large__qhrpjvd);
-  }
-  .sprinkles_borderRadius_xlarge_tablet__1hjdb9v6h {
-    border-radius: var(--borderRadius-xlarge__qhrpjve);
-  }
-  .sprinkles_gap_gutter_tablet__1hjdb9v6l {
-    gap: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_gap_xxsmall_tablet__1hjdb9v6p {
-    gap: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_gap_xsmall_tablet__1hjdb9v6t {
-    gap: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_gap_small_tablet__1hjdb9v6x {
-    gap: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_gap_medium_tablet__1hjdb9v71 {
-    gap: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_gap_large_tablet__1hjdb9v75 {
-    gap: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_gap_xlarge_tablet__1hjdb9v79 {
-    gap: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_gap_xxlarge_tablet__1hjdb9v7d {
-    gap: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_gap_xxxlarge_tablet__1hjdb9v7h {
-    gap: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_gap_none_tablet__1hjdb9v7l {
-    gap: 0;
-  }
-  .sprinkles_paddingTop_gutter_tablet__1hjdb9v7p {
-    padding-top: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingTop_xxsmall_tablet__1hjdb9v7t {
-    padding-top: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingTop_xsmall_tablet__1hjdb9v7x {
-    padding-top: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingTop_small_tablet__1hjdb9v81 {
-    padding-top: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingTop_medium_tablet__1hjdb9v85 {
-    padding-top: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingTop_large_tablet__1hjdb9v89 {
-    padding-top: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingTop_xlarge_tablet__1hjdb9v8d {
-    padding-top: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingTop_xxlarge_tablet__1hjdb9v8h {
-    padding-top: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingTop_xxxlarge_tablet__1hjdb9v8l {
-    padding-top: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingTop_none_tablet__1hjdb9v8p {
-    padding-top: 0;
-  }
-  .sprinkles_paddingBottom_gutter_tablet__1hjdb9v8t {
-    padding-bottom: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingBottom_xxsmall_tablet__1hjdb9v8x {
-    padding-bottom: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingBottom_xsmall_tablet__1hjdb9v91 {
-    padding-bottom: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingBottom_small_tablet__1hjdb9v95 {
-    padding-bottom: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingBottom_medium_tablet__1hjdb9v99 {
-    padding-bottom: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingBottom_large_tablet__1hjdb9v9d {
-    padding-bottom: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingBottom_xlarge_tablet__1hjdb9v9h {
-    padding-bottom: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingBottom_xxlarge_tablet__1hjdb9v9l {
-    padding-bottom: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingBottom_xxxlarge_tablet__1hjdb9v9p {
-    padding-bottom: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingBottom_none_tablet__1hjdb9v9t {
-    padding-bottom: 0;
-  }
-  .sprinkles_paddingRight_gutter_tablet__1hjdb9v9x {
-    padding-right: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingRight_xxsmall_tablet__1hjdb9va1 {
-    padding-right: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingRight_xsmall_tablet__1hjdb9va5 {
-    padding-right: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingRight_small_tablet__1hjdb9va9 {
-    padding-right: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingRight_medium_tablet__1hjdb9vad {
-    padding-right: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingRight_large_tablet__1hjdb9vah {
-    padding-right: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingRight_xlarge_tablet__1hjdb9val {
-    padding-right: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingRight_xxlarge_tablet__1hjdb9vap {
-    padding-right: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingRight_xxxlarge_tablet__1hjdb9vat {
-    padding-right: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingRight_none_tablet__1hjdb9vax {
-    padding-right: 0;
-  }
-  .sprinkles_paddingLeft_gutter_tablet__1hjdb9vb1 {
-    padding-left: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingLeft_xxsmall_tablet__1hjdb9vb5 {
-    padding-left: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingLeft_xsmall_tablet__1hjdb9vb9 {
-    padding-left: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingLeft_small_tablet__1hjdb9vbd {
-    padding-left: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingLeft_medium_tablet__1hjdb9vbh {
-    padding-left: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingLeft_large_tablet__1hjdb9vbl {
-    padding-left: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingLeft_xlarge_tablet__1hjdb9vbp {
-    padding-left: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingLeft_xxlarge_tablet__1hjdb9vbt {
-    padding-left: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingLeft_xxxlarge_tablet__1hjdb9vbx {
-    padding-left: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingLeft_none_tablet__1hjdb9vc1 {
-    padding-left: 0;
-  }
-  .sprinkles_marginTop_gutter_tablet__1hjdb9vc5 {
-    margin-top: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginTop_xxsmall_tablet__1hjdb9vc9 {
-    margin-top: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginTop_xsmall_tablet__1hjdb9vcd {
-    margin-top: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginTop_small_tablet__1hjdb9vch {
-    margin-top: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginTop_medium_tablet__1hjdb9vcl {
-    margin-top: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginTop_large_tablet__1hjdb9vcp {
-    margin-top: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginTop_xlarge_tablet__1hjdb9vct {
-    margin-top: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginTop_xxlarge_tablet__1hjdb9vcx {
-    margin-top: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginTop_xxxlarge_tablet__1hjdb9vd1 {
-    margin-top: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginTop_none_tablet__1hjdb9vd5 {
-    margin-top: 0;
-  }
-  .sprinkles_marginBottom_gutter_tablet__1hjdb9vd9 {
-    margin-bottom: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginBottom_xxsmall_tablet__1hjdb9vdd {
-    margin-bottom: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginBottom_xsmall_tablet__1hjdb9vdh {
-    margin-bottom: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginBottom_small_tablet__1hjdb9vdl {
-    margin-bottom: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginBottom_medium_tablet__1hjdb9vdp {
-    margin-bottom: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginBottom_large_tablet__1hjdb9vdt {
-    margin-bottom: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginBottom_xlarge_tablet__1hjdb9vdx {
-    margin-bottom: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginBottom_xxlarge_tablet__1hjdb9ve1 {
-    margin-bottom: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginBottom_xxxlarge_tablet__1hjdb9ve5 {
-    margin-bottom: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginBottom_none_tablet__1hjdb9ve9 {
-    margin-bottom: 0;
-  }
-  .sprinkles_marginRight_gutter_tablet__1hjdb9ved {
-    margin-right: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginRight_xxsmall_tablet__1hjdb9veh {
-    margin-right: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginRight_xsmall_tablet__1hjdb9vel {
-    margin-right: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginRight_small_tablet__1hjdb9vep {
-    margin-right: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginRight_medium_tablet__1hjdb9vet {
-    margin-right: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginRight_large_tablet__1hjdb9vex {
-    margin-right: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginRight_xlarge_tablet__1hjdb9vf1 {
-    margin-right: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginRight_xxlarge_tablet__1hjdb9vf5 {
-    margin-right: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginRight_xxxlarge_tablet__1hjdb9vf9 {
-    margin-right: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginRight_none_tablet__1hjdb9vfd {
-    margin-right: 0;
-  }
-  .sprinkles_marginLeft_gutter_tablet__1hjdb9vfh {
-    margin-left: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginLeft_xxsmall_tablet__1hjdb9vfl {
-    margin-left: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginLeft_xsmall_tablet__1hjdb9vfp {
-    margin-left: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginLeft_small_tablet__1hjdb9vft {
-    margin-left: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginLeft_medium_tablet__1hjdb9vfx {
-    margin-left: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginLeft_large_tablet__1hjdb9vg1 {
-    margin-left: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginLeft_xlarge_tablet__1hjdb9vg5 {
-    margin-left: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginLeft_xxlarge_tablet__1hjdb9vg9 {
-    margin-left: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginLeft_xxxlarge_tablet__1hjdb9vgd {
-    margin-left: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginLeft_none_tablet__1hjdb9vgh {
-    margin-left: 0;
-  }
-  .sprinkles_alignItems_flexStart_tablet__1hjdb9vgl {
-    align-items: flex-start;
-  }
-  .sprinkles_alignItems_center_tablet__1hjdb9vgp {
-    align-items: center;
-  }
-  .sprinkles_alignItems_flexEnd_tablet__1hjdb9vgt {
-    align-items: flex-end;
-  }
-  .sprinkles_justifyContent_flexStart_tablet__1hjdb9vgx {
-    justify-content: flex-start;
-  }
-  .sprinkles_justifyContent_center_tablet__1hjdb9vh1 {
-    justify-content: center;
-  }
-  .sprinkles_justifyContent_flexEnd_tablet__1hjdb9vh5 {
-    justify-content: flex-end;
-  }
-  .sprinkles_justifyContent_spaceBetween_tablet__1hjdb9vh9 {
-    justify-content: space-between;
-  }
-  .sprinkles_flexDirection_row_tablet__1hjdb9vhd {
-    flex-direction: row;
-  }
-  .sprinkles_flexDirection_rowReverse_tablet__1hjdb9vhh {
-    flex-direction: row-reverse;
-  }
-  .sprinkles_flexDirection_column_tablet__1hjdb9vhl {
-    flex-direction: column;
-  }
-  .sprinkles_flexDirection_columnReverse_tablet__1hjdb9vhp {
-    flex-direction: column-reverse;
-  }
-  .sprinkles_flexWrap_wrap_tablet__1hjdb9vht {
-    flex-wrap: wrap;
-  }
-  .sprinkles_flexWrap_nowrap_tablet__1hjdb9vhx {
-    flex-wrap: nowrap;
-  }
-  .sprinkles_flexShrink_0_tablet__1hjdb9vi1 {
-    flex-shrink: 0;
-  }
-  .sprinkles_flexGrow_0_tablet__1hjdb9vi5 {
-    flex-grow: 0;
-  }
-  .sprinkles_flexGrow_1_tablet__1hjdb9vi9 {
-    flex-grow: 1;
-  }
-  .sprinkles_textAlign_left_tablet__1hjdb9vid {
-    text-align: left;
-  }
-  .sprinkles_textAlign_center_tablet__1hjdb9vih {
-    text-align: center;
-  }
-  .sprinkles_textAlign_right_tablet__1hjdb9vil {
-    text-align: right;
-  }
-}
-@media screen and (min-width: 992px) {
-  .sprinkles_display_none_desktop__1hjdb9v4y {
-    display: none;
-  }
-  .sprinkles_display_block_desktop__1hjdb9v52 {
-    display: block;
-  }
-  .sprinkles_display_inline_desktop__1hjdb9v56 {
-    display: inline;
-  }
-  .sprinkles_display_inlineBlock_desktop__1hjdb9v5a {
-    display: inline-block;
-  }
-  .sprinkles_display_flex_desktop__1hjdb9v5e {
-    display: flex;
-  }
-  .sprinkles_position_relative_desktop__1hjdb9v5i {
-    position: relative;
-  }
-  .sprinkles_position_absolute_desktop__1hjdb9v5m {
-    position: absolute;
-  }
-  .sprinkles_position_fixed_desktop__1hjdb9v5q {
-    position: fixed;
-  }
-  .sprinkles_position_sticky_desktop__1hjdb9v5u {
-    position: sticky;
-  }
-  .sprinkles_borderRadius_none_desktop__1hjdb9v5y {
-    border-radius: 0px;
-  }
-  .sprinkles_borderRadius_full_desktop__1hjdb9v62 {
-    border-radius: 9999px;
-  }
-  .sprinkles_borderRadius_small_desktop__1hjdb9v66 {
-    border-radius: var(--borderRadius-small__qhrpjvb);
-  }
-  .sprinkles_borderRadius_standard_desktop__1hjdb9v6a {
-    border-radius: var(--borderRadius-standard__qhrpjvc);
-  }
-  .sprinkles_borderRadius_large_desktop__1hjdb9v6e {
-    border-radius: var(--borderRadius-large__qhrpjvd);
-  }
-  .sprinkles_borderRadius_xlarge_desktop__1hjdb9v6i {
-    border-radius: var(--borderRadius-xlarge__qhrpjve);
-  }
-  .sprinkles_gap_gutter_desktop__1hjdb9v6m {
-    gap: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_gap_xxsmall_desktop__1hjdb9v6q {
-    gap: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_gap_xsmall_desktop__1hjdb9v6u {
-    gap: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_gap_small_desktop__1hjdb9v6y {
-    gap: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_gap_medium_desktop__1hjdb9v72 {
-    gap: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_gap_large_desktop__1hjdb9v76 {
-    gap: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_gap_xlarge_desktop__1hjdb9v7a {
-    gap: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_gap_xxlarge_desktop__1hjdb9v7e {
-    gap: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_gap_xxxlarge_desktop__1hjdb9v7i {
-    gap: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_gap_none_desktop__1hjdb9v7m {
-    gap: 0;
-  }
-  .sprinkles_paddingTop_gutter_desktop__1hjdb9v7q {
-    padding-top: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingTop_xxsmall_desktop__1hjdb9v7u {
-    padding-top: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingTop_xsmall_desktop__1hjdb9v7y {
-    padding-top: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingTop_small_desktop__1hjdb9v82 {
-    padding-top: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingTop_medium_desktop__1hjdb9v86 {
-    padding-top: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingTop_large_desktop__1hjdb9v8a {
-    padding-top: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingTop_xlarge_desktop__1hjdb9v8e {
-    padding-top: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingTop_xxlarge_desktop__1hjdb9v8i {
-    padding-top: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingTop_xxxlarge_desktop__1hjdb9v8m {
-    padding-top: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingTop_none_desktop__1hjdb9v8q {
-    padding-top: 0;
-  }
-  .sprinkles_paddingBottom_gutter_desktop__1hjdb9v8u {
-    padding-bottom: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingBottom_xxsmall_desktop__1hjdb9v8y {
-    padding-bottom: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingBottom_xsmall_desktop__1hjdb9v92 {
-    padding-bottom: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingBottom_small_desktop__1hjdb9v96 {
-    padding-bottom: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingBottom_medium_desktop__1hjdb9v9a {
-    padding-bottom: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingBottom_large_desktop__1hjdb9v9e {
-    padding-bottom: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingBottom_xlarge_desktop__1hjdb9v9i {
-    padding-bottom: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingBottom_xxlarge_desktop__1hjdb9v9m {
-    padding-bottom: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingBottom_xxxlarge_desktop__1hjdb9v9q {
-    padding-bottom: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingBottom_none_desktop__1hjdb9v9u {
-    padding-bottom: 0;
-  }
-  .sprinkles_paddingRight_gutter_desktop__1hjdb9v9y {
-    padding-right: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingRight_xxsmall_desktop__1hjdb9va2 {
-    padding-right: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingRight_xsmall_desktop__1hjdb9va6 {
-    padding-right: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingRight_small_desktop__1hjdb9vaa {
-    padding-right: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingRight_medium_desktop__1hjdb9vae {
-    padding-right: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingRight_large_desktop__1hjdb9vai {
-    padding-right: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingRight_xlarge_desktop__1hjdb9vam {
-    padding-right: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingRight_xxlarge_desktop__1hjdb9vaq {
-    padding-right: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingRight_xxxlarge_desktop__1hjdb9vau {
-    padding-right: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingRight_none_desktop__1hjdb9vay {
-    padding-right: 0;
-  }
-  .sprinkles_paddingLeft_gutter_desktop__1hjdb9vb2 {
-    padding-left: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingLeft_xxsmall_desktop__1hjdb9vb6 {
-    padding-left: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingLeft_xsmall_desktop__1hjdb9vba {
-    padding-left: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingLeft_small_desktop__1hjdb9vbe {
-    padding-left: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingLeft_medium_desktop__1hjdb9vbi {
-    padding-left: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingLeft_large_desktop__1hjdb9vbm {
-    padding-left: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingLeft_xlarge_desktop__1hjdb9vbq {
-    padding-left: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingLeft_xxlarge_desktop__1hjdb9vbu {
-    padding-left: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingLeft_xxxlarge_desktop__1hjdb9vby {
-    padding-left: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingLeft_none_desktop__1hjdb9vc2 {
-    padding-left: 0;
-  }
-  .sprinkles_marginTop_gutter_desktop__1hjdb9vc6 {
-    margin-top: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginTop_xxsmall_desktop__1hjdb9vca {
-    margin-top: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginTop_xsmall_desktop__1hjdb9vce {
-    margin-top: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginTop_small_desktop__1hjdb9vci {
-    margin-top: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginTop_medium_desktop__1hjdb9vcm {
-    margin-top: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginTop_large_desktop__1hjdb9vcq {
-    margin-top: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginTop_xlarge_desktop__1hjdb9vcu {
-    margin-top: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginTop_xxlarge_desktop__1hjdb9vcy {
-    margin-top: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginTop_xxxlarge_desktop__1hjdb9vd2 {
-    margin-top: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginTop_none_desktop__1hjdb9vd6 {
-    margin-top: 0;
-  }
-  .sprinkles_marginBottom_gutter_desktop__1hjdb9vda {
-    margin-bottom: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginBottom_xxsmall_desktop__1hjdb9vde {
-    margin-bottom: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginBottom_xsmall_desktop__1hjdb9vdi {
-    margin-bottom: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginBottom_small_desktop__1hjdb9vdm {
-    margin-bottom: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginBottom_medium_desktop__1hjdb9vdq {
-    margin-bottom: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginBottom_large_desktop__1hjdb9vdu {
-    margin-bottom: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginBottom_xlarge_desktop__1hjdb9vdy {
-    margin-bottom: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginBottom_xxlarge_desktop__1hjdb9ve2 {
-    margin-bottom: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginBottom_xxxlarge_desktop__1hjdb9ve6 {
-    margin-bottom: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginBottom_none_desktop__1hjdb9vea {
-    margin-bottom: 0;
-  }
-  .sprinkles_marginRight_gutter_desktop__1hjdb9vee {
-    margin-right: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginRight_xxsmall_desktop__1hjdb9vei {
-    margin-right: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginRight_xsmall_desktop__1hjdb9vem {
-    margin-right: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginRight_small_desktop__1hjdb9veq {
-    margin-right: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginRight_medium_desktop__1hjdb9veu {
-    margin-right: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginRight_large_desktop__1hjdb9vey {
-    margin-right: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginRight_xlarge_desktop__1hjdb9vf2 {
-    margin-right: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginRight_xxlarge_desktop__1hjdb9vf6 {
-    margin-right: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginRight_xxxlarge_desktop__1hjdb9vfa {
-    margin-right: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginRight_none_desktop__1hjdb9vfe {
-    margin-right: 0;
-  }
-  .sprinkles_marginLeft_gutter_desktop__1hjdb9vfi {
-    margin-left: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginLeft_xxsmall_desktop__1hjdb9vfm {
-    margin-left: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginLeft_xsmall_desktop__1hjdb9vfq {
-    margin-left: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginLeft_small_desktop__1hjdb9vfu {
-    margin-left: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginLeft_medium_desktop__1hjdb9vfy {
-    margin-left: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginLeft_large_desktop__1hjdb9vg2 {
-    margin-left: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginLeft_xlarge_desktop__1hjdb9vg6 {
-    margin-left: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginLeft_xxlarge_desktop__1hjdb9vga {
-    margin-left: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginLeft_xxxlarge_desktop__1hjdb9vge {
-    margin-left: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginLeft_none_desktop__1hjdb9vgi {
-    margin-left: 0;
-  }
-  .sprinkles_alignItems_flexStart_desktop__1hjdb9vgm {
-    align-items: flex-start;
-  }
-  .sprinkles_alignItems_center_desktop__1hjdb9vgq {
-    align-items: center;
-  }
-  .sprinkles_alignItems_flexEnd_desktop__1hjdb9vgu {
-    align-items: flex-end;
-  }
-  .sprinkles_justifyContent_flexStart_desktop__1hjdb9vgy {
-    justify-content: flex-start;
-  }
-  .sprinkles_justifyContent_center_desktop__1hjdb9vh2 {
-    justify-content: center;
-  }
-  .sprinkles_justifyContent_flexEnd_desktop__1hjdb9vh6 {
-    justify-content: flex-end;
-  }
-  .sprinkles_justifyContent_spaceBetween_desktop__1hjdb9vha {
-    justify-content: space-between;
-  }
-  .sprinkles_flexDirection_row_desktop__1hjdb9vhe {
-    flex-direction: row;
-  }
-  .sprinkles_flexDirection_rowReverse_desktop__1hjdb9vhi {
-    flex-direction: row-reverse;
-  }
-  .sprinkles_flexDirection_column_desktop__1hjdb9vhm {
-    flex-direction: column;
-  }
-  .sprinkles_flexDirection_columnReverse_desktop__1hjdb9vhq {
-    flex-direction: column-reverse;
-  }
-  .sprinkles_flexWrap_wrap_desktop__1hjdb9vhu {
-    flex-wrap: wrap;
-  }
-  .sprinkles_flexWrap_nowrap_desktop__1hjdb9vhy {
-    flex-wrap: nowrap;
-  }
-  .sprinkles_flexShrink_0_desktop__1hjdb9vi2 {
-    flex-shrink: 0;
-  }
-  .sprinkles_flexGrow_0_desktop__1hjdb9vi6 {
-    flex-grow: 0;
-  }
-  .sprinkles_flexGrow_1_desktop__1hjdb9via {
-    flex-grow: 1;
-  }
-  .sprinkles_textAlign_left_desktop__1hjdb9vie {
-    text-align: left;
-  }
-  .sprinkles_textAlign_center_desktop__1hjdb9vii {
-    text-align: center;
-  }
-  .sprinkles_textAlign_right_desktop__1hjdb9vim {
-    text-align: right;
-  }
-}
-@media screen and (min-width: 1200px) {
-  .sprinkles_display_none_wide__1hjdb9v4z {
-    display: none;
-  }
-  .sprinkles_display_block_wide__1hjdb9v53 {
-    display: block;
-  }
-  .sprinkles_display_inline_wide__1hjdb9v57 {
-    display: inline;
-  }
-  .sprinkles_display_inlineBlock_wide__1hjdb9v5b {
-    display: inline-block;
-  }
-  .sprinkles_display_flex_wide__1hjdb9v5f {
-    display: flex;
-  }
-  .sprinkles_position_relative_wide__1hjdb9v5j {
-    position: relative;
-  }
-  .sprinkles_position_absolute_wide__1hjdb9v5n {
-    position: absolute;
-  }
-  .sprinkles_position_fixed_wide__1hjdb9v5r {
-    position: fixed;
-  }
-  .sprinkles_position_sticky_wide__1hjdb9v5v {
-    position: sticky;
-  }
-  .sprinkles_borderRadius_none_wide__1hjdb9v5z {
-    border-radius: 0px;
-  }
-  .sprinkles_borderRadius_full_wide__1hjdb9v63 {
-    border-radius: 9999px;
-  }
-  .sprinkles_borderRadius_small_wide__1hjdb9v67 {
-    border-radius: var(--borderRadius-small__qhrpjvb);
-  }
-  .sprinkles_borderRadius_standard_wide__1hjdb9v6b {
-    border-radius: var(--borderRadius-standard__qhrpjvc);
-  }
-  .sprinkles_borderRadius_large_wide__1hjdb9v6f {
-    border-radius: var(--borderRadius-large__qhrpjvd);
-  }
-  .sprinkles_borderRadius_xlarge_wide__1hjdb9v6j {
-    border-radius: var(--borderRadius-xlarge__qhrpjve);
-  }
-  .sprinkles_gap_gutter_wide__1hjdb9v6n {
-    gap: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_gap_xxsmall_wide__1hjdb9v6r {
-    gap: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_gap_xsmall_wide__1hjdb9v6v {
-    gap: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_gap_small_wide__1hjdb9v6z {
-    gap: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_gap_medium_wide__1hjdb9v73 {
-    gap: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_gap_large_wide__1hjdb9v77 {
-    gap: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_gap_xlarge_wide__1hjdb9v7b {
-    gap: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_gap_xxlarge_wide__1hjdb9v7f {
-    gap: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_gap_xxxlarge_wide__1hjdb9v7j {
-    gap: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_gap_none_wide__1hjdb9v7n {
-    gap: 0;
-  }
-  .sprinkles_paddingTop_gutter_wide__1hjdb9v7r {
-    padding-top: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingTop_xxsmall_wide__1hjdb9v7v {
-    padding-top: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingTop_xsmall_wide__1hjdb9v7z {
-    padding-top: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingTop_small_wide__1hjdb9v83 {
-    padding-top: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingTop_medium_wide__1hjdb9v87 {
-    padding-top: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingTop_large_wide__1hjdb9v8b {
-    padding-top: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingTop_xlarge_wide__1hjdb9v8f {
-    padding-top: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingTop_xxlarge_wide__1hjdb9v8j {
-    padding-top: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingTop_xxxlarge_wide__1hjdb9v8n {
-    padding-top: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingTop_none_wide__1hjdb9v8r {
-    padding-top: 0;
-  }
-  .sprinkles_paddingBottom_gutter_wide__1hjdb9v8v {
-    padding-bottom: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingBottom_xxsmall_wide__1hjdb9v8z {
-    padding-bottom: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingBottom_xsmall_wide__1hjdb9v93 {
-    padding-bottom: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingBottom_small_wide__1hjdb9v97 {
-    padding-bottom: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingBottom_medium_wide__1hjdb9v9b {
-    padding-bottom: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingBottom_large_wide__1hjdb9v9f {
-    padding-bottom: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingBottom_xlarge_wide__1hjdb9v9j {
-    padding-bottom: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingBottom_xxlarge_wide__1hjdb9v9n {
-    padding-bottom: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingBottom_xxxlarge_wide__1hjdb9v9r {
-    padding-bottom: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingBottom_none_wide__1hjdb9v9v {
-    padding-bottom: 0;
-  }
-  .sprinkles_paddingRight_gutter_wide__1hjdb9v9z {
-    padding-right: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingRight_xxsmall_wide__1hjdb9va3 {
-    padding-right: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingRight_xsmall_wide__1hjdb9va7 {
-    padding-right: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingRight_small_wide__1hjdb9vab {
-    padding-right: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingRight_medium_wide__1hjdb9vaf {
-    padding-right: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingRight_large_wide__1hjdb9vaj {
-    padding-right: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingRight_xlarge_wide__1hjdb9van {
-    padding-right: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingRight_xxlarge_wide__1hjdb9var {
-    padding-right: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingRight_xxxlarge_wide__1hjdb9vav {
-    padding-right: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingRight_none_wide__1hjdb9vaz {
-    padding-right: 0;
-  }
-  .sprinkles_paddingLeft_gutter_wide__1hjdb9vb3 {
-    padding-left: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_paddingLeft_xxsmall_wide__1hjdb9vb7 {
-    padding-left: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_paddingLeft_xsmall_wide__1hjdb9vbb {
-    padding-left: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_paddingLeft_small_wide__1hjdb9vbf {
-    padding-left: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_paddingLeft_medium_wide__1hjdb9vbj {
-    padding-left: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_paddingLeft_large_wide__1hjdb9vbn {
-    padding-left: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_paddingLeft_xlarge_wide__1hjdb9vbr {
-    padding-left: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_paddingLeft_xxlarge_wide__1hjdb9vbv {
-    padding-left: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_paddingLeft_xxxlarge_wide__1hjdb9vbz {
-    padding-left: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_paddingLeft_none_wide__1hjdb9vc3 {
-    padding-left: 0;
-  }
-  .sprinkles_marginTop_gutter_wide__1hjdb9vc7 {
-    margin-top: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginTop_xxsmall_wide__1hjdb9vcb {
-    margin-top: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginTop_xsmall_wide__1hjdb9vcf {
-    margin-top: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginTop_small_wide__1hjdb9vcj {
-    margin-top: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginTop_medium_wide__1hjdb9vcn {
-    margin-top: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginTop_large_wide__1hjdb9vcr {
-    margin-top: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginTop_xlarge_wide__1hjdb9vcv {
-    margin-top: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginTop_xxlarge_wide__1hjdb9vcz {
-    margin-top: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginTop_xxxlarge_wide__1hjdb9vd3 {
-    margin-top: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginTop_none_wide__1hjdb9vd7 {
-    margin-top: 0;
-  }
-  .sprinkles_marginBottom_gutter_wide__1hjdb9vdb {
-    margin-bottom: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginBottom_xxsmall_wide__1hjdb9vdf {
-    margin-bottom: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginBottom_xsmall_wide__1hjdb9vdj {
-    margin-bottom: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginBottom_small_wide__1hjdb9vdn {
-    margin-bottom: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginBottom_medium_wide__1hjdb9vdr {
-    margin-bottom: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginBottom_large_wide__1hjdb9vdv {
-    margin-bottom: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginBottom_xlarge_wide__1hjdb9vdz {
-    margin-bottom: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginBottom_xxlarge_wide__1hjdb9ve3 {
-    margin-bottom: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginBottom_xxxlarge_wide__1hjdb9ve7 {
-    margin-bottom: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginBottom_none_wide__1hjdb9veb {
-    margin-bottom: 0;
-  }
-  .sprinkles_marginRight_gutter_wide__1hjdb9vef {
-    margin-right: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginRight_xxsmall_wide__1hjdb9vej {
-    margin-right: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginRight_xsmall_wide__1hjdb9ven {
-    margin-right: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginRight_small_wide__1hjdb9ver {
-    margin-right: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginRight_medium_wide__1hjdb9vev {
-    margin-right: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginRight_large_wide__1hjdb9vez {
-    margin-right: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginRight_xlarge_wide__1hjdb9vf3 {
-    margin-right: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginRight_xxlarge_wide__1hjdb9vf7 {
-    margin-right: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginRight_xxxlarge_wide__1hjdb9vfb {
-    margin-right: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginRight_none_wide__1hjdb9vff {
-    margin-right: 0;
-  }
-  .sprinkles_marginLeft_gutter_wide__1hjdb9vfj {
-    margin-left: var(--space-gutter__qhrpjv0);
-  }
-  .sprinkles_marginLeft_xxsmall_wide__1hjdb9vfn {
-    margin-left: var(--space-xxsmall__qhrpjv1);
-  }
-  .sprinkles_marginLeft_xsmall_wide__1hjdb9vfr {
-    margin-left: var(--space-xsmall__qhrpjv2);
-  }
-  .sprinkles_marginLeft_small_wide__1hjdb9vfv {
-    margin-left: var(--space-small__qhrpjv3);
-  }
-  .sprinkles_marginLeft_medium_wide__1hjdb9vfz {
-    margin-left: var(--space-medium__qhrpjv4);
-  }
-  .sprinkles_marginLeft_large_wide__1hjdb9vg3 {
-    margin-left: var(--space-large__qhrpjv5);
-  }
-  .sprinkles_marginLeft_xlarge_wide__1hjdb9vg7 {
-    margin-left: var(--space-xlarge__qhrpjv6);
-  }
-  .sprinkles_marginLeft_xxlarge_wide__1hjdb9vgb {
-    margin-left: var(--space-xxlarge__qhrpjv7);
-  }
-  .sprinkles_marginLeft_xxxlarge_wide__1hjdb9vgf {
-    margin-left: var(--space-xxxlarge__qhrpjv8);
-  }
-  .sprinkles_marginLeft_none_wide__1hjdb9vgj {
-    margin-left: 0;
-  }
-  .sprinkles_alignItems_flexStart_wide__1hjdb9vgn {
-    align-items: flex-start;
-  }
-  .sprinkles_alignItems_center_wide__1hjdb9vgr {
-    align-items: center;
-  }
-  .sprinkles_alignItems_flexEnd_wide__1hjdb9vgv {
-    align-items: flex-end;
-  }
-  .sprinkles_justifyContent_flexStart_wide__1hjdb9vgz {
-    justify-content: flex-start;
-  }
-  .sprinkles_justifyContent_center_wide__1hjdb9vh3 {
-    justify-content: center;
-  }
-  .sprinkles_justifyContent_flexEnd_wide__1hjdb9vh7 {
-    justify-content: flex-end;
-  }
-  .sprinkles_justifyContent_spaceBetween_wide__1hjdb9vhb {
-    justify-content: space-between;
-  }
-  .sprinkles_flexDirection_row_wide__1hjdb9vhf {
-    flex-direction: row;
-  }
-  .sprinkles_flexDirection_rowReverse_wide__1hjdb9vhj {
-    flex-direction: row-reverse;
-  }
-  .sprinkles_flexDirection_column_wide__1hjdb9vhn {
-    flex-direction: column;
-  }
-  .sprinkles_flexDirection_columnReverse_wide__1hjdb9vhr {
-    flex-direction: column-reverse;
-  }
-  .sprinkles_flexWrap_wrap_wide__1hjdb9vhv {
-    flex-wrap: wrap;
-  }
-  .sprinkles_flexWrap_nowrap_wide__1hjdb9vhz {
-    flex-wrap: nowrap;
-  }
-  .sprinkles_flexShrink_0_wide__1hjdb9vi3 {
-    flex-shrink: 0;
-  }
-  .sprinkles_flexGrow_0_wide__1hjdb9vi7 {
-    flex-grow: 0;
-  }
-  .sprinkles_flexGrow_1_wide__1hjdb9vib {
-    flex-grow: 1;
-  }
-  .sprinkles_textAlign_left_wide__1hjdb9vif {
-    text-align: left;
-  }
-  .sprinkles_textAlign_center_wide__1hjdb9vij {
-    text-align: center;
-  }
-  .sprinkles_textAlign_right_wide__1hjdb9vin {
-    text-align: right;
-  }
-}
-.capsize_capsizeStyle__1lwixuj4 {
-  font-size: var(--fontSize__1lwixuj0);
-  line-height: var(--lineHeight__1lwixuj1);
-}
-.capsize_capsizeStyle__1lwixuj4::before {
-  content: '';
-  margin-bottom: var(--capHeightTrim__1lwixuj2);
-  display: table;
-}
-.capsize_capsizeStyle__1lwixuj4::after {
-  content: '';
-  margin-top: var(--baselineTrim__1lwixuj3);
-  display: table;
-}
-.typography_fontFamily__co4djb0 {
-  font-family: var(--fontFamily__qhrpjv2w);
-}
-.typography_fontWeight_regular__co4djb1 {
-  font-weight: var(--textWeight-regular__qhrpjv46);
-}
-.typography_fontWeight_medium__co4djb2 {
-  font-weight: var(--textWeight-medium__qhrpjv47);
-}
-.typography_fontWeight_strong__co4djb3 {
-  font-weight: var(--textWeight-strong__qhrpjv48);
-}
-.typography_textSize_xsmall__co4djb4 {
-  --fontSize__1lwixuj0: var(--textSize-xsmall-mobile-fontSize__qhrpjv32);
-  --lineHeight__1lwixuj1: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
-  --capHeightTrim__1lwixuj2: var(--textSize-xsmall-mobile-capsizeTrims-capHeightTrim__qhrpjv35);
-  --baselineTrim__1lwixuj3: var(--textSize-xsmall-mobile-capsizeTrims-baselineTrim__qhrpjv36);
-}
-.typography_textSize_small__co4djb6 {
-  --fontSize__1lwixuj0: var(--textSize-small-mobile-fontSize__qhrpjv3c);
-  --lineHeight__1lwixuj1: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
-  --capHeightTrim__1lwixuj2: var(--textSize-small-mobile-capsizeTrims-capHeightTrim__qhrpjv3f);
-  --baselineTrim__1lwixuj3: var(--textSize-small-mobile-capsizeTrims-baselineTrim__qhrpjv3g);
-}
-.typography_textSize_standard__co4djb8 {
-  --fontSize__1lwixuj0: var(--textSize-standard-mobile-fontSize__qhrpjv3m);
-  --lineHeight__1lwixuj1: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
-  --capHeightTrim__1lwixuj2: var(--textSize-standard-mobile-capsizeTrims-capHeightTrim__qhrpjv3p);
-  --baselineTrim__1lwixuj3: var(--textSize-standard-mobile-capsizeTrims-baselineTrim__qhrpjv3q);
-}
-.typography_textSize_large__co4djba {
-  --fontSize__1lwixuj0: var(--textSize-large-mobile-fontSize__qhrpjv3w);
-  --lineHeight__1lwixuj1: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
-  --capHeightTrim__1lwixuj2: var(--textSize-large-mobile-capsizeTrims-capHeightTrim__qhrpjv3z);
-  --baselineTrim__1lwixuj3: var(--textSize-large-mobile-capsizeTrims-baselineTrim__qhrpjv40);
-}
-.typography_textSizeUntrimmed_xsmall__co4djbc {
-  font-size: var(--textSize-xsmall-mobile-fontSize__qhrpjv32);
-  line-height: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
-}
-.typography_textSizeUntrimmed_small__co4djbd {
-  font-size: var(--textSize-small-mobile-fontSize__qhrpjv3c);
-  line-height: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
-}
-.typography_textSizeUntrimmed_standard__co4djbe {
-  font-size: var(--textSize-standard-mobile-fontSize__qhrpjv3m);
-  line-height: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
-}
-.typography_textSizeUntrimmed_large__co4djbf {
-  font-size: var(--textSize-large-mobile-fontSize__qhrpjv3w);
-  line-height: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
-}
-.typography_headingWeight_weak__co4djbg {
-  font-weight: var(--headingWeight-weak__qhrpjv5d);
-}
-.typography_headingWeight_regular__co4djbh {
-  font-weight: var(--headingWeight-regular__qhrpjv5e);
-}
-.typography_heading_1__co4djbi {
-  --fontSize__1lwixuj0: var(--headingLevel-1-mobile-fontSize__qhrpjv49);
-  --lineHeight__1lwixuj1: var(--headingLevel-1-mobile-lineHeight__qhrpjv4a);
-  --capHeightTrim__1lwixuj2: var(--headingLevel-1-mobile-capsizeTrims-capHeightTrim__qhrpjv4c);
-  --baselineTrim__1lwixuj3: var(--headingLevel-1-mobile-capsizeTrims-baselineTrim__qhrpjv4d);
-}
-.typography_heading_2__co4djbk {
-  --fontSize__1lwixuj0: var(--headingLevel-2-mobile-fontSize__qhrpjv4j);
-  --lineHeight__1lwixuj1: var(--headingLevel-2-mobile-lineHeight__qhrpjv4k);
-  --capHeightTrim__1lwixuj2: var(--headingLevel-2-mobile-capsizeTrims-capHeightTrim__qhrpjv4m);
-  --baselineTrim__1lwixuj3: var(--headingLevel-2-mobile-capsizeTrims-baselineTrim__qhrpjv4n);
-}
-.typography_heading_3__co4djbm {
-  --fontSize__1lwixuj0: var(--headingLevel-3-mobile-fontSize__qhrpjv4t);
-  --lineHeight__1lwixuj1: var(--headingLevel-3-mobile-lineHeight__qhrpjv4u);
-  --capHeightTrim__1lwixuj2: var(--headingLevel-3-mobile-capsizeTrims-capHeightTrim__qhrpjv4w);
-  --baselineTrim__1lwixuj3: var(--headingLevel-3-mobile-capsizeTrims-baselineTrim__qhrpjv4x);
-}
-.typography_heading_4__co4djbo {
-  --fontSize__1lwixuj0: var(--headingLevel-4-mobile-fontSize__qhrpjv53);
-  --lineHeight__1lwixuj1: var(--headingLevel-4-mobile-lineHeight__qhrpjv54);
-  --capHeightTrim__1lwixuj2: var(--headingLevel-4-mobile-capsizeTrims-capHeightTrim__qhrpjv56);
-  --baselineTrim__1lwixuj3: var(--headingLevel-4-mobile-capsizeTrims-baselineTrim__qhrpjv57);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeTone_light__co4djb10 {
-  --critical__co4djbq: var(--foregroundColor-critical__qhrpjv19);
-  --caution__co4djbr: var(--foregroundColor-caution__qhrpjv17);
-  --info__co4djbs: var(--foregroundColor-info__qhrpjv1d);
-  --promote__co4djbt: var(--foregroundColor-promote__qhrpjv1o);
-  --positive__co4djbu: var(--foregroundColor-positive__qhrpjv1m);
-  --brandAccent__co4djbv: var(--foregroundColor-brandAccent__qhrpjv15);
-  --formAccent__co4djbw: var(--foregroundColor-formAccent__qhrpjv1b);
-  --neutral__co4djbx: var(--foregroundColor-neutral__qhrpjv1k);
-  --secondary__co4djby: var(--foregroundColor-secondary__qhrpjv1r);
-  --link__co4djbz: var(--foregroundColor-link__qhrpjv1f);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeTone_dark__co4djb11 {
-  --critical__co4djbq: var(--foregroundColor-criticalLight__qhrpjv1a);
-  --caution__co4djbr: var(--foregroundColor-cautionLight__qhrpjv18);
-  --info__co4djbs: var(--foregroundColor-infoLight__qhrpjv1e);
-  --promote__co4djbt: var(--foregroundColor-promoteLight__qhrpjv1p);
-  --positive__co4djbu: var(--foregroundColor-positiveLight__qhrpjv1n);
-  --brandAccent__co4djbv: var(--foregroundColor-brandAccentLight__qhrpjv16);
-  --formAccent__co4djbw: var(--foregroundColor-formAccentLight__qhrpjv1c);
-  --neutral__co4djbx: var(--foregroundColor-neutralInverted__qhrpjv1l);
-  --secondary__co4djby: var(--foregroundColor-secondaryInverted__qhrpjv1s);
-  --link__co4djbz: var(--foregroundColor-linkLight__qhrpjv1h);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeTone_light__co4djb12 {
-  --critical__co4djbq: var(--foregroundColor-critical__qhrpjv19);
-  --caution__co4djbr: var(--foregroundColor-caution__qhrpjv17);
-  --info__co4djbs: var(--foregroundColor-info__qhrpjv1d);
-  --promote__co4djbt: var(--foregroundColor-promote__qhrpjv1o);
-  --positive__co4djbu: var(--foregroundColor-positive__qhrpjv1m);
-  --brandAccent__co4djbv: var(--foregroundColor-brandAccent__qhrpjv15);
-  --formAccent__co4djbw: var(--foregroundColor-formAccent__qhrpjv1b);
-  --neutral__co4djbx: var(--foregroundColor-neutral__qhrpjv1k);
-  --secondary__co4djby: var(--foregroundColor-secondary__qhrpjv1r);
-  --link__co4djbz: var(--foregroundColor-link__qhrpjv1f);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeTone_dark__co4djb13 {
-  --critical__co4djbq: var(--foregroundColor-criticalLight__qhrpjv1a);
-  --caution__co4djbr: var(--foregroundColor-cautionLight__qhrpjv18);
-  --info__co4djbs: var(--foregroundColor-infoLight__qhrpjv1e);
-  --promote__co4djbt: var(--foregroundColor-promoteLight__qhrpjv1p);
-  --positive__co4djbu: var(--foregroundColor-positiveLight__qhrpjv1n);
-  --brandAccent__co4djbv: var(--foregroundColor-brandAccentLight__qhrpjv16);
-  --formAccent__co4djbw: var(--foregroundColor-formAccentLight__qhrpjv1c);
-  --neutral__co4djbx: var(--foregroundColor-neutralInverted__qhrpjv1l);
-  --secondary__co4djby: var(--foregroundColor-secondaryInverted__qhrpjv1s);
-  --link__co4djbz: var(--foregroundColor-linkLight__qhrpjv1h);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalLight__co4djb14 {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalSoft__co4djb15 {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalSoftActive__co4djb16 {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalSoftHover__co4djb17 {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_caution__co4djb18 {
-  --neutral__co4djbx: var(--caution__co4djbr);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_cautionLight__co4djb19 {
-  --neutral__co4djbx: var(--caution__co4djbr);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_positiveLight__co4djb1a {
-  --neutral__co4djbx: var(--positive__co4djbu);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_infoLight__co4djb1b {
-  --neutral__co4djbx: var(--info__co4djbs);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_promoteLight__co4djb1c {
-  --neutral__co4djbx: var(--promote__co4djbt);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalLight__co4djb1d {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalSoft__co4djb1e {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalSoftActive__co4djb1f {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalSoftHover__co4djb1g {
-  --neutral__co4djbx: var(--critical__co4djbq);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_caution__co4djb1h {
-  --neutral__co4djbx: var(--caution__co4djbr);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_cautionLight__co4djb1i {
-  --neutral__co4djbx: var(--caution__co4djbr);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_positiveLight__co4djb1j {
-  --neutral__co4djbx: var(--positive__co4djbu);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_infoLight__co4djb1k {
-  --neutral__co4djbx: var(--info__co4djbs);
-}
-html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_promoteLight__co4djb1l {
-  --neutral__co4djbx: var(--promote__co4djbt);
-}
-.typography_tone_critical__co4djb1m {
-  color: var(--critical__co4djbq);
-}
-.typography_tone_caution__co4djb1n {
-  color: var(--caution__co4djbr);
-}
-.typography_tone_info__co4djb1o {
-  color: var(--info__co4djbs);
-}
-.typography_tone_promote__co4djb1p {
-  color: var(--promote__co4djbt);
-}
-.typography_tone_positive__co4djb1q {
-  color: var(--positive__co4djbu);
-}
-.typography_tone_brandAccent__co4djb1r {
-  color: var(--brandAccent__co4djbv);
-}
-.typography_tone_formAccent__co4djb1s {
-  color: var(--formAccent__co4djbw);
-}
-.typography_tone_neutral__co4djb1t {
-  color: var(--neutral__co4djbx);
-}
-.typography_tone_secondary__co4djb1u {
-  color: var(--secondary__co4djby);
-}
-.typography_tone_link__co4djb1v {
-  color: var(--link__co4djbz);
-}
-.typography_touchableText_xsmall__co4djb1w {
-  padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-mobile-lineHeight__qhrpjv33)) / 2);
-  padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-mobile-lineHeight__qhrpjv33)) / 2);
-}
-.typography_touchableText_small__co4djb1x {
-  padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-mobile-lineHeight__qhrpjv3d)) / 2);
-  padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-mobile-lineHeight__qhrpjv3d)) / 2);
-}
-.typography_touchableText_standard__co4djb1y {
-  padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-mobile-lineHeight__qhrpjv3n)) / 2);
-  padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-mobile-lineHeight__qhrpjv3n)) / 2);
-}
-.typography_touchableText_large__co4djb1z {
-  padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-mobile-lineHeight__qhrpjv3x)) / 2);
-  padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-mobile-lineHeight__qhrpjv3x)) / 2);
-}
-@media screen and (min-width: 740px) {
-  .typography_textSize_xsmall__co4djb4 {
-    --fontSize__1lwixuj0: var(--textSize-xsmall-tablet-fontSize__qhrpjv37);
-    --lineHeight__1lwixuj1: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
-    --capHeightTrim__1lwixuj2: var(--textSize-xsmall-tablet-capsizeTrims-capHeightTrim__qhrpjv3a);
-    --baselineTrim__1lwixuj3: var(--textSize-xsmall-tablet-capsizeTrims-baselineTrim__qhrpjv3b);
-  }
-  .typography_textSize_small__co4djb6 {
-    --fontSize__1lwixuj0: var(--textSize-small-tablet-fontSize__qhrpjv3h);
-    --lineHeight__1lwixuj1: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
-    --capHeightTrim__1lwixuj2: var(--textSize-small-tablet-capsizeTrims-capHeightTrim__qhrpjv3k);
-    --baselineTrim__1lwixuj3: var(--textSize-small-tablet-capsizeTrims-baselineTrim__qhrpjv3l);
-  }
-  .typography_textSize_standard__co4djb8 {
-    --fontSize__1lwixuj0: var(--textSize-standard-tablet-fontSize__qhrpjv3r);
-    --lineHeight__1lwixuj1: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
-    --capHeightTrim__1lwixuj2: var(--textSize-standard-tablet-capsizeTrims-capHeightTrim__qhrpjv3u);
-    --baselineTrim__1lwixuj3: var(--textSize-standard-tablet-capsizeTrims-baselineTrim__qhrpjv3v);
-  }
-  .typography_textSize_large__co4djba {
-    --fontSize__1lwixuj0: var(--textSize-large-tablet-fontSize__qhrpjv41);
-    --lineHeight__1lwixuj1: var(--textSize-large-tablet-lineHeight__qhrpjv42);
-    --capHeightTrim__1lwixuj2: var(--textSize-large-tablet-capsizeTrims-capHeightTrim__qhrpjv44);
-    --baselineTrim__1lwixuj3: var(--textSize-large-tablet-capsizeTrims-baselineTrim__qhrpjv45);
-  }
-  .typography_textSizeUntrimmed_xsmall__co4djbc {
-    font-size: var(--textSize-xsmall-tablet-fontSize__qhrpjv37);
-    line-height: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
-  }
-  .typography_textSizeUntrimmed_small__co4djbd {
-    font-size: var(--textSize-small-tablet-fontSize__qhrpjv3h);
-    line-height: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
-  }
-  .typography_textSizeUntrimmed_standard__co4djbe {
-    font-size: var(--textSize-standard-tablet-fontSize__qhrpjv3r);
-    line-height: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
-  }
-  .typography_textSizeUntrimmed_large__co4djbf {
-    font-size: var(--textSize-large-tablet-fontSize__qhrpjv41);
-    line-height: var(--textSize-large-tablet-lineHeight__qhrpjv42);
-  }
-  .typography_heading_1__co4djbi {
-    --fontSize__1lwixuj0: var(--headingLevel-1-tablet-fontSize__qhrpjv4e);
-    --lineHeight__1lwixuj1: var(--headingLevel-1-tablet-lineHeight__qhrpjv4f);
-    --capHeightTrim__1lwixuj2: var(--headingLevel-1-tablet-capsizeTrims-capHeightTrim__qhrpjv4h);
-    --baselineTrim__1lwixuj3: var(--headingLevel-1-tablet-capsizeTrims-baselineTrim__qhrpjv4i);
-  }
-  .typography_heading_2__co4djbk {
-    --fontSize__1lwixuj0: var(--headingLevel-2-tablet-fontSize__qhrpjv4o);
-    --lineHeight__1lwixuj1: var(--headingLevel-2-tablet-lineHeight__qhrpjv4p);
-    --capHeightTrim__1lwixuj2: var(--headingLevel-2-tablet-capsizeTrims-capHeightTrim__qhrpjv4r);
-    --baselineTrim__1lwixuj3: var(--headingLevel-2-tablet-capsizeTrims-baselineTrim__qhrpjv4s);
-  }
-  .typography_heading_3__co4djbm {
-    --fontSize__1lwixuj0: var(--headingLevel-3-tablet-fontSize__qhrpjv4y);
-    --lineHeight__1lwixuj1: var(--headingLevel-3-tablet-lineHeight__qhrpjv4z);
-    --capHeightTrim__1lwixuj2: var(--headingLevel-3-tablet-capsizeTrims-capHeightTrim__qhrpjv51);
-    --baselineTrim__1lwixuj3: var(--headingLevel-3-tablet-capsizeTrims-baselineTrim__qhrpjv52);
-  }
-  .typography_heading_4__co4djbo {
-    --fontSize__1lwixuj0: var(--headingLevel-4-tablet-fontSize__qhrpjv58);
-    --lineHeight__1lwixuj1: var(--headingLevel-4-tablet-lineHeight__qhrpjv59);
-    --capHeightTrim__1lwixuj2: var(--headingLevel-4-tablet-capsizeTrims-capHeightTrim__qhrpjv5b);
-    --baselineTrim__1lwixuj3: var(--headingLevel-4-tablet-capsizeTrims-baselineTrim__qhrpjv5c);
-  }
-  .typography_touchableText_xsmall__co4djb1w {
-    padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-tablet-lineHeight__qhrpjv38)) / 2);
-    padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-tablet-lineHeight__qhrpjv38)) / 2);
-  }
-  .typography_touchableText_small__co4djb1x {
-    padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-tablet-lineHeight__qhrpjv3i)) / 2);
-    padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-tablet-lineHeight__qhrpjv3i)) / 2);
-  }
-  .typography_touchableText_standard__co4djb1y {
-    padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-tablet-lineHeight__qhrpjv3s)) / 2);
-    padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-tablet-lineHeight__qhrpjv3s)) / 2);
-  }
-  .typography_touchableText_large__co4djb1z {
-    padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-tablet-lineHeight__qhrpjv42)) / 2);
-    padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-tablet-lineHeight__qhrpjv42)) / 2);
-  }
-}
-.Divider_base__rgb1580 {
-  height: var(--borderWidth-standard__qhrpjvy);
-}
-.Divider_regular__rgb1583 {
-  background: var(--regular__rgb1581);
-}
-.Divider_strong__rgb1584 {
-  background: var(--strong__rgb1582);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Divider_lightModeWeight_light__rgb1585 {
-  --regular__rgb1581: var(--borderColor-neutralLight__qhrpjvt);
-  --strong__rgb1582: var(--borderColor-neutral__qhrpjvr);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Divider_lightModeWeight_dark__rgb1586 {
-  --regular__rgb1581: var(--borderColor-neutral__qhrpjvr);
-  --strong__rgb1582: var(--borderColor-neutralLight__qhrpjvt);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Divider_darkModeWeight_light__rgb1587 {
-  --regular__rgb1581: var(--borderColor-neutralLight__qhrpjvt);
-  --strong__rgb1582: var(--borderColor-neutral__qhrpjvr);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Divider_darkModeWeight_dark__rgb1588 {
-  --regular__rgb1581: var(--borderColor-neutral__qhrpjvr);
-  --strong__rgb1582: var(--borderColor-neutralLight__qhrpjvt);
-}
-.Spread_fitContent__19xp08d0 > * {
-  flex-basis: auto;
-  width: auto;
-}
-.Spread_maxWidth__19xp08d1 > * {
-  max-width: 100%;
-}
-.MaxLines_descenderCropFixForWebkitBox__1lw3qoe0 {
-  margin-bottom: -0.1em;
-}
-.MaxLines_base__1lw3qoe2 {
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow-wrap: break-word;
-}
-.MaxLines_descenderCropFixForWebkitBox__1lw3qoe0 .MaxLines_base__1lw3qoe2 {
-  padding-bottom: 0.1em;
-}
-@supports (display: -webkit-box) and (-webkit-line-clamp: 1) {
-  .MaxLines_multiLine__1lw3qoe4 {
-    white-space: initial;
-    display: -webkit-box;
-    -webkit-line-clamp: var(--lineLimit__1lw3qoe3);
-    -webkit-box-orient: vertical;
-  }
-}
-.virtualTouchable_virtualTouchable__9705do0 {
-  position: relative;
-}
-.virtualTouchable_virtualTouchable__9705do0::after {
-  content: "";
-  position: absolute;
-  min-height: 44px;
-  min-width: 44px;
-  height: 100%;
-  width: 100%;
-  transform: translate(-50%, -50%);
-  top: 50%;
-  left: 50%;
-}
-[data-braid-debug] .virtualTouchable_virtualTouchable__9705do0::after {
-  background: red;
-  opacity: 0.2;
-}
-.AccordionItem_focusRing__pr4mlf2 {
-  outline-offset: var(--space-xxsmall__qhrpjv1);
-}
-.icon_size__1ltfiyk0 {
-  width: 1.2em;
-  height: 1.2em;
-}
-.icon_cropToTextSize__1ltfiyk1 {
-  margin: -0.1em;
-}
-.icon_inlineCrop__1ltfiyk2 {
-  margin-top: -0.2em;
-  margin-bottom: -0.2em;
-}
-.icon_inline__1ltfiyk3 {
-  vertical-align: middle;
-}
-.icon_alignY_uppercase_none__1ltfiyk4 {
-  top: -0.105em;
-}
-.icon_alignY_uppercase_up__1ltfiyk5 {
-  top: -0.16499999999999998em;
-}
-.icon_alignY_uppercase_down__1ltfiyk6 {
-  top: -0.045em;
-}
-.icon_alignY_lowercase_none__1ltfiyk7 {
-  top: -0.065em;
-}
-.icon_alignY_lowercase_up__1ltfiyk8 {
-  top: -0.125em;
-}
-.icon_alignY_lowercase_down__1ltfiyk9 {
-  top: -0.0050000000000000044em;
-}
-.icon_blockWidths_xsmall__1ltfiyka {
-  width: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
-}
-.icon_blockWidths_small__1ltfiykb {
-  width: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
-}
-.icon_blockWidths_standard__1ltfiykc {
-  width: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
-}
-.icon_blockWidths_large__1ltfiykd {
-  width: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
-}
-@media screen and (min-width: 740px) {
-  .icon_blockWidths_xsmall__1ltfiyka {
-    width: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
-  }
-  .icon_blockWidths_small__1ltfiykb {
-    width: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
-  }
-  .icon_blockWidths_standard__1ltfiykc {
-    width: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
-  }
-  .icon_blockWidths_large__1ltfiykd {
-    width: var(--textSize-large-tablet-lineHeight__qhrpjv42);
-  }
-}
-.lineHeightContainer_lineHeightContainer_xsmall__pnbjt00 {
-  height: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
-}
-.lineHeightContainer_lineHeightContainer_small__pnbjt01 {
-  height: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
-}
-.lineHeightContainer_lineHeightContainer_standard__pnbjt02 {
-  height: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
-}
-.lineHeightContainer_lineHeightContainer_large__pnbjt03 {
-  height: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
-}
-@media screen and (min-width: 740px) {
-  .lineHeightContainer_lineHeightContainer_xsmall__pnbjt00 {
-    height: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
-  }
-  .lineHeightContainer_lineHeightContainer_small__pnbjt01 {
-    height: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
-  }
-  .lineHeightContainer_lineHeightContainer_standard__pnbjt02 {
-    height: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
-  }
-  .lineHeightContainer_lineHeightContainer_large__pnbjt03 {
-    height: var(--textSize-large-tablet-lineHeight__qhrpjv42);
-  }
-}
-.IconChevron_root__v2pdba0 {
-  transition: transform 0.3s ease;
-  transform-origin: 50% 50%;
-}
-.IconChevron_left__v2pdba1 {
-  transform: rotate(90deg);
-}
-.IconChevron_up__v2pdba2 {
-  transform: rotate(180deg);
-}
-.IconChevron_right__v2pdba3 {
-  transform: rotate(270deg);
-}
-.Inline_fitContentMobile__hkzz4h0 > * {
-  flex-basis: auto;
-  width: auto;
-  min-width: 0;
-}
-@media screen and (min-width: 740px) {
-  .Inline_fitContentTablet__hkzz4h1 > * {
-    flex-basis: auto;
-    width: auto;
-    min-width: 0;
-  }
-}
-@media screen and (min-width: 992px) {
-  .Inline_fitContentDesktop__hkzz4h2 > * {
-    flex-basis: auto;
-    width: auto;
-    min-width: 0;
-  }
-}
-@media screen and (min-width: 1200px) {
-  .Inline_fitContentWide__hkzz4h3 > * {
-    flex-basis: auto;
-    width: auto;
-    min-width: 0;
-  }
-}
-.Column_noSpaceBeforeFirstWhenCollapsed__1w6x3sw0:first-child {
-  padding-top: 0;
-}
-.Column_width_1\\/2__1w6x3sw1 {
-  flex-basis: 50%;
-}
-.Column_width_1\\/3__1w6x3sw2 {
-  flex-basis: 33.33333333333333%;
-}
-.Column_width_2\\/3__1w6x3sw3 {
-  flex-basis: 66.66666666666666%;
-}
-.Column_width_1\\/4__1w6x3sw4 {
-  flex-basis: 25%;
-}
-.Column_width_3\\/4__1w6x3sw5 {
-  flex-basis: 75%;
-}
-.Column_width_1\\/5__1w6x3sw6 {
-  flex-basis: 20%;
-}
-.Column_width_2\\/5__1w6x3sw7 {
-  flex-basis: 40%;
-}
-.Column_width_3\\/5__1w6x3sw8 {
-  flex-basis: 60%;
-}
-.Column_width_4\\/5__1w6x3sw9 {
-  flex-basis: 80%;
-}
-.negativeMargin_preventCollapsePseudo_top__1063ve10::before {
-  content: "";
-  display: table;
-}
-.negativeMargin_preventCollapsePseudo_bottom__1063ve11::after {
-  content: "";
-  display: table;
-}
-.negativeMargin_stylesForBreakpoint_gutter__1063ve12::before {
-  margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxsmall__1063ve13::before {
-  margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xsmall__1063ve14::before {
-  margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
-}
-.negativeMargin_stylesForBreakpoint_small__1063ve15::before {
-  margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
-}
-.negativeMargin_stylesForBreakpoint_medium__1063ve16::before {
-  margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
-}
-.negativeMargin_stylesForBreakpoint_large__1063ve17::before {
-  margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xlarge__1063ve18::before {
-  margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxlarge__1063ve19::before {
-  margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxxlarge__1063ve1a::before {
-  margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-}
-.negativeMargin_stylesForBreakpoint_none__1063ve1b::before {
-  margin-bottom: 0;
-}
-.negativeMargin_stylesForBreakpoint_gutter__1063ve116::after {
-  margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxsmall__1063ve117::after {
-  margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xsmall__1063ve118::after {
-  margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
-}
-.negativeMargin_stylesForBreakpoint_small__1063ve119::after {
-  margin-top: calc(var(--space-small__qhrpjv3) * -1);
-}
-.negativeMargin_stylesForBreakpoint_medium__1063ve11a::after {
-  margin-top: calc(var(--space-medium__qhrpjv4) * -1);
-}
-.negativeMargin_stylesForBreakpoint_large__1063ve11b::after {
-  margin-top: calc(var(--space-large__qhrpjv5) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xlarge__1063ve11c::after {
-  margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxlarge__1063ve11d::after {
-  margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxxlarge__1063ve11e::after {
-  margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-}
-.negativeMargin_stylesForBreakpoint_none__1063ve11f::after {
-  margin-top: 0;
-}
-.negativeMargin_stylesForBreakpoint_gutter__1063ve12a {
-  margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxsmall__1063ve12b {
-  margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xsmall__1063ve12c {
-  margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
-}
-.negativeMargin_stylesForBreakpoint_small__1063ve12d {
-  margin-left: calc(var(--space-small__qhrpjv3) * -1);
-}
-.negativeMargin_stylesForBreakpoint_medium__1063ve12e {
-  margin-left: calc(var(--space-medium__qhrpjv4) * -1);
-}
-.negativeMargin_stylesForBreakpoint_large__1063ve12f {
-  margin-left: calc(var(--space-large__qhrpjv5) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xlarge__1063ve12g {
-  margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxlarge__1063ve12h {
-  margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxxlarge__1063ve12i {
-  margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-}
-.negativeMargin_stylesForBreakpoint_none__1063ve12j {
-  margin-left: 0;
-}
-.negativeMargin_stylesForBreakpoint_gutter__1063ve13e {
-  margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxsmall__1063ve13f {
-  margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xsmall__1063ve13g {
-  margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
-}
-.negativeMargin_stylesForBreakpoint_small__1063ve13h {
-  margin-right: calc(var(--space-small__qhrpjv3) * -1);
-}
-.negativeMargin_stylesForBreakpoint_medium__1063ve13i {
-  margin-right: calc(var(--space-medium__qhrpjv4) * -1);
-}
-.negativeMargin_stylesForBreakpoint_large__1063ve13j {
-  margin-right: calc(var(--space-large__qhrpjv5) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xlarge__1063ve13k {
-  margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxlarge__1063ve13l {
-  margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
-}
-.negativeMargin_stylesForBreakpoint_xxxlarge__1063ve13m {
-  margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-}
-.negativeMargin_stylesForBreakpoint_none__1063ve13n {
-  margin-right: 0;
-}
-@media screen and (min-width: 740px) {
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve1c::before {
-    margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve1d::before {
-    margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve1e::before {
-    margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve1f::before {
-    margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve1g::before {
-    margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve1h::before {
-    margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve1i::before {
-    margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve1j::before {
-    margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve1k::before {
-    margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve1l::before {
-    margin-bottom: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve11g::after {
-    margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve11h::after {
-    margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve11i::after {
-    margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve11j::after {
-    margin-top: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve11k::after {
-    margin-top: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve11l::after {
-    margin-top: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve11m::after {
-    margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve11n::after {
-    margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve11o::after {
-    margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve11p::after {
-    margin-top: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve12k {
-    margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve12l {
-    margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve12m {
-    margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve12n {
-    margin-left: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve12o {
-    margin-left: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve12p {
-    margin-left: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve12q {
-    margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve12r {
-    margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve12s {
-    margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve12t {
-    margin-left: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve13o {
-    margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve13p {
-    margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve13q {
-    margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve13r {
-    margin-right: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve13s {
-    margin-right: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve13t {
-    margin-right: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve13u {
-    margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve13v {
-    margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve13w {
-    margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve13x {
-    margin-right: 0;
-  }
-}
-@media screen and (min-width: 992px) {
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve1m::before {
-    margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve1n::before {
-    margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve1o::before {
-    margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve1p::before {
-    margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve1q::before {
-    margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve1r::before {
-    margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve1s::before {
-    margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve1t::before {
-    margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve1u::before {
-    margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve1v::before {
-    margin-bottom: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve11q::after {
-    margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve11r::after {
-    margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve11s::after {
-    margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve11t::after {
-    margin-top: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve11u::after {
-    margin-top: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve11v::after {
-    margin-top: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve11w::after {
-    margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve11x::after {
-    margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve11y::after {
-    margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve11z::after {
-    margin-top: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve12u {
-    margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve12v {
-    margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve12w {
-    margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve12x {
-    margin-left: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve12y {
-    margin-left: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve12z {
-    margin-left: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve130 {
-    margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve131 {
-    margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve132 {
-    margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve133 {
-    margin-left: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve13y {
-    margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve13z {
-    margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve140 {
-    margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve141 {
-    margin-right: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve142 {
-    margin-right: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve143 {
-    margin-right: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve144 {
-    margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve145 {
-    margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve146 {
-    margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve147 {
-    margin-right: 0;
-  }
-}
-@media screen and (min-width: 1200px) {
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve1w::before {
-    margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve1x::before {
-    margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve1y::before {
-    margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve1z::before {
-    margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve110::before {
-    margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve111::before {
-    margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve112::before {
-    margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve113::before {
-    margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve114::before {
-    margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve115::before {
-    margin-bottom: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve120::after {
-    margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve121::after {
-    margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve122::after {
-    margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve123::after {
-    margin-top: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve124::after {
-    margin-top: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve125::after {
-    margin-top: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve126::after {
-    margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve127::after {
-    margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve128::after {
-    margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve129::after {
-    margin-top: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve134 {
-    margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve135 {
-    margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve136 {
-    margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve137 {
-    margin-left: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve138 {
-    margin-left: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve139 {
-    margin-left: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve13a {
-    margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve13b {
-    margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve13c {
-    margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve13d {
-    margin-left: 0;
-  }
-  .negativeMargin_stylesForBreakpoint_gutter__1063ve148 {
-    margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxsmall__1063ve149 {
-    margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xsmall__1063ve14a {
-    margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_small__1063ve14b {
-    margin-right: calc(var(--space-small__qhrpjv3) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_medium__1063ve14c {
-    margin-right: calc(var(--space-medium__qhrpjv4) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_large__1063ve14d {
-    margin-right: calc(var(--space-large__qhrpjv5) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xlarge__1063ve14e {
-    margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxlarge__1063ve14f {
-    margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve14g {
-    margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
-  }
-  .negativeMargin_stylesForBreakpoint_none__1063ve14h {
-    margin-right: 0;
-  }
-}
-.Alert_closeButton__1fve7fu0:focus .Alert_closeButtonHover__1fve7fu1, .Alert_closeButton__1fve7fu0:hover .Alert_closeButtonHover__1fve7fu1 {
-  opacity: 1;
-}
-.textAlignedToIcon_textAlignedToIcon_standard__u3vg1s0 {
-  padding-top: calc((var(--textSize-standard-mobile-lineHeight__qhrpjv3n) - var(--textSize-standard-mobile-capHeight__qhrpjv3o)) / 2);
-  padding-bottom: calc((var(--textSize-standard-mobile-lineHeight__qhrpjv3n) - var(--textSize-standard-mobile-capHeight__qhrpjv3o)) / 2);
-}
-@media screen and (min-width: 740px) {
-  .textAlignedToIcon_textAlignedToIcon_standard__u3vg1s0 {
-    padding-top: calc((var(--textSize-standard-tablet-lineHeight__qhrpjv3s) - var(--textSize-standard-tablet-capHeight__qhrpjv3t)) / 2);
-    padding-bottom: calc((var(--textSize-standard-tablet-lineHeight__qhrpjv3s) - var(--textSize-standard-tablet-capHeight__qhrpjv3t)) / 2);
-  }
-}
-.AvoidWidowIcon_nowrap__8ldtmt0 {
-  white-space: nowrap;
-}
-@keyframes Button_dot1__kmgydja {
-  14% {
-    opacity: 0;
-  }
-  15%,100% {
-    opacity: 1;
-  }
-}
-@keyframes Button_dot2__kmgydjb {
-  29% {
-    opacity: 0;
-  }
-  30%,100% {
-    opacity: 1;
-  }
-}
-@keyframes Button_dot3__kmgydjc {
-  44% {
-    opacity: 0;
-  }
-  45%,100% {
-    opacity: 1;
-  }
-}
-.Button_root__kmgydj0 {
-  text-decoration: none;
-  align-items: stretch;
-  outline-offset: 0;
-}
-.Button_root__kmgydj0:active .Button_activeAnimation__kmgydj2, .Button_forceActive__kmgydj1.Button_activeAnimation__kmgydj2 {
-  transform: var(--transform-touchable__qhrpjv5k);
-}
-.Button_root__kmgydj0:active .Button_activeOverlay__kmgydj3, .Button_forceActive__kmgydj1.Button_activeOverlay__kmgydj3 {
-  opacity: 1;
-}
-.Button_root__kmgydj0:hover:not(:disabled) .Button_hoverOverlay__kmgydj4 {
-  opacity: 1;
-}
-.Button_standard__kmgydj6 {
-  --capHeightToMinHeight__kmgydj5: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-mobile-capHeight__qhrpjv3o)) / 2);
-}
-.Button_small__kmgydj7 {
-  --capHeightToMinHeight__kmgydj5: calc(((var(--touchableSize__qhrpjv9) * 0.8) - var(--textSize-small-mobile-capHeight__qhrpjv3e)) / 2);
-}
-.Button_bleedVerticallyToCapHeight__kmgydj8 {
-  margin-top: calc(var(--capHeightToMinHeight__kmgydj5) * -1);
-  margin-bottom: calc(var(--capHeightToMinHeight__kmgydj5) * -1);
-}
-.Button_padToMinHeight__kmgydj9 {
-  padding-top: var(--capHeightToMinHeight__kmgydj5);
-  padding-bottom: var(--capHeightToMinHeight__kmgydj5);
-}
-.Button_loadingDot__kmgydjd {
-  animation-duration: 1s;
-  animation-iteration-count: infinite;
-  opacity: 0;
-}
-.Button_loadingDot__kmgydjd:nth-child(1) {
-  animation-name: Button_dot1__kmgydja;
-}
-.Button_loadingDot__kmgydjd:nth-child(2) {
-  animation-name: Button_dot2__kmgydjb;
-}
-.Button_loadingDot__kmgydjd:nth-child(3) {
-  animation-name: Button_dot3__kmgydjc;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Button_invertedBackgroundsLightMode_soft__kmgydje {
-  background: rgba(255,255,255,0.1);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Button_invertedBackgroundsLightMode_hover__kmgydjf {
-  background: rgba(255,255,255,0.15);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Button_invertedBackgroundsLightMode_active__kmgydjg {
-  background: rgba(255,255,255,0.15);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Button_invertedBackgroundsDarkMode_soft__kmgydjh {
-  background: rgba(255,255,255,0.1);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Button_invertedBackgroundsDarkMode_hover__kmgydji {
-  background: rgba(255,255,255,0.15);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Button_invertedBackgroundsDarkMode_active__kmgydjj {
-  background: rgba(255,255,255,0.15);
-}
-@media screen and (min-width: 740px) {
-  .Button_standard__kmgydj6 {
-    --capHeightToMinHeight__kmgydj5: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-tablet-capHeight__qhrpjv3t)) / 2);
-  }
-  .Button_small__kmgydj7 {
-    --capHeightToMinHeight__kmgydj5: calc(((var(--touchableSize__qhrpjv9) * 0.8) - var(--textSize-small-tablet-capHeight__qhrpjv3j)) / 2);
-  }
-}
-@keyframes Popover_popupAnimation__1yo0tp8a {
-  from {
-    opacity: 0;
-    transform: translateY(calc(var(--space-xxsmall__qhrpjv1) * var(--placementModifier__1yo0tp88, 1)));
-  }
-}
-.Popover_backdrop__1yo0tp80 {
-  width: 100vw;
-  height: 100vh;
-}
-.Popover_popoverPosition__1yo0tp87 {
-  --dynamicHeight__1yo0tp86: 100svh;
-  top: calc(var(--triggerVars_bottom__1yo0tp83) * 1px);
-  bottom: calc(var(--dynamicHeight__1yo0tp86, 100vh) - (var(--triggerVars_top__1yo0tp81) * 1px));
-  left: calc((var(--triggerVars_left__1yo0tp82) + var(--horizontalOffset__1yo0tp85)) * 1px);
-  right: calc((var(--triggerVars_right__1yo0tp84) + var(--horizontalOffset__1yo0tp85)) * 1px);
-}
-.Popover_invertPlacement__1yo0tp89 {
-  --placementModifier__1yo0tp88: -1;
-}
-.Popover_animation__1yo0tp8b {
-  animation-name: Popover_popupAnimation__1yo0tp8a;
-  animation-fill-mode: both;
-  animation-timing-function: ease;
-  animation-duration: 0.125s;
-  animation-delay: 15ms;
-}
-.Popover_delayVisibility__1yo0tp8c {
-  animation-delay: 250ms;
-}
-.TooltipRenderer_maxWidth__821e3y0 {
-  max-width: 260px;
-}
-.TooltipRenderer_overflowWrap__821e3y1 {
-  overflow-wrap: break-word;
-}
-.TooltipRenderer_translateZ0__821e3y2 {
-  transform: translateZ(0);
-}
-.TooltipRenderer_baseArrow__821e3y4 {
-  left: clamp(var(--space-medium__qhrpjv4), var(--horizontalOffset__821e3y3), calc(100% - var(--space-medium__qhrpjv4)));
-  transform: translateX(-50%);
-  visibility: hidden;
-}
-.TooltipRenderer_baseArrow__821e3y4:before {
-  content: '';
-  visibility: visible;
-  transform: rotate(45deg);
-}
-.TooltipRenderer_baseArrow__821e3y4, .TooltipRenderer_baseArrow__821e3y4::before {
-  width: calc(12px + (var(--borderRadius-small__qhrpjvb) * 2));
-  height: calc(12px + (var(--borderRadius-small__qhrpjvb) * 2));
-  position: absolute;
-  background: inherit;
-  border-radius: var(--borderRadius-small__qhrpjvb);
-}
-.TooltipRenderer_arrow_top__821e3y5 {
-  bottom: calc((12px / 2) * -1);
-}
-.TooltipRenderer_arrow_bottom__821e3y6 {
-  top: calc((12px / 2) * -1);
-}
-.ButtonIcon_button__11ol9k00:hover {
-  z-index: 1;
-}
-.ButtonIcon_button__11ol9k00::-moz-focus-inner {
-  border: 0;
-}
-.HiddenVisually_root__v7ph350 {
-  width: 1px;
-  height: 1px;
-  clip: rect(1px, 1px, 1px, 1px);
-  white-space: nowrap;
-}
-.Field_placeholderColor__klw7kj1::placeholder {
-  color: var(--foregroundColor-secondary__qhrpjv1r);
-}
-.Field_secondaryIconSpace__klw7kj2 {
-  padding-right: var(--touchableSize__qhrpjv9);
-}
-.Field_iconSpace__klw7kj3 {
-  padding-left: calc(var(--touchableSize__qhrpjv9) - 2px);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Field_hideBorderOnDarkBackgroundInLightMode__klw7kj4 {
-  opacity: 0;
-}
-.Field_field__klw7kj0:hover:not(:disabled) ~ .Field_hoverOverlay__klw7kj5, .Field_field__klw7kj0:focus ~ .Field_hoverOverlay__klw7kj5 {
-  opacity: 1;
-}
-.Field_verticalDivider__klw7kj6 {
-  width: var(--borderWidth-standard__qhrpjvy);
-  background: var(--borderColor-field__qhrpjvl);
-  opacity: 0.4;
-}
-.Autosuggest_backdrop__153m10i0 {
-  width: 100vw;
-  height: 100vh;
-  background: black;
-}
-.Autosuggest_backdropVisible__153m10i1 {
-  opacity: 0.4;
-}
-.Autosuggest_menu__153m10i2 {
-  max-height: calc((var(--touchableSize__qhrpjv9) * 6) + var(--space-xxsmall__qhrpjv1));
-  overflow-y: auto;
-}
-@media screen and (min-width: 740px) {
-  .Autosuggest_menu__153m10i2 {
-    max-height: calc((var(--touchableSize__qhrpjv9) * 8) + var(--space-xxsmall__qhrpjv1));
-  }
-}
-.Badge_inline__1r5hl7m0 {
-  display: inline-flex;
-  vertical-align: middle;
-  margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
-  margin-top: calc((var(--space-xxsmall__qhrpjv1) + .2em) * -1);
-}
-.Keyline_tone_promote__1kn7lf76 {
-  background: var(--promote__1kn7lf70);
-}
-.Keyline_tone_info__1kn7lf77 {
-  background: var(--info__1kn7lf71);
-}
-.Keyline_tone_positive__1kn7lf78 {
-  background: var(--positive__1kn7lf72);
-}
-.Keyline_tone_caution__1kn7lf79 {
-  background: var(--caution__1kn7lf73);
-}
-.Keyline_tone_critical__1kn7lf7a {
-  background: var(--critical__1kn7lf74);
-}
-.Keyline_tone_formAccent__1kn7lf7b {
-  background: var(--formAccent__1kn7lf75);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Keyline_lightMode_light__1kn7lf7c {
-  --promote__1kn7lf70: var(--borderColor-promote__qhrpjvw);
-  --info__1kn7lf71: var(--borderColor-info__qhrpjvp);
-  --positive__1kn7lf72: var(--borderColor-positive__qhrpjvu);
-  --caution__1kn7lf73: var(--borderColor-caution__qhrpjvh);
-  --critical__1kn7lf74: var(--borderColor-critical__qhrpjvj);
-  --formAccent__1kn7lf75: var(--borderColor-formAccent__qhrpjvn);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Keyline_lightMode_dark__1kn7lf7d {
-  --promote__1kn7lf70: var(--borderColor-promoteLight__qhrpjvx);
-  --info__1kn7lf71: var(--borderColor-infoLight__qhrpjvq);
-  --positive__1kn7lf72: var(--borderColor-positiveLight__qhrpjvv);
-  --caution__1kn7lf73: var(--borderColor-cautionLight__qhrpjvi);
-  --critical__1kn7lf74: var(--borderColor-criticalLight__qhrpjvk);
-  --formAccent__1kn7lf75: var(--borderColor-formAccentLight__qhrpjvo);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Keyline_darkMode_light__1kn7lf7e {
-  --promote__1kn7lf70: var(--borderColor-promote__qhrpjvw);
-  --info__1kn7lf71: var(--borderColor-info__qhrpjvp);
-  --positive__1kn7lf72: var(--borderColor-positive__qhrpjvu);
-  --caution__1kn7lf73: var(--borderColor-caution__qhrpjvh);
-  --critical__1kn7lf74: var(--borderColor-critical__qhrpjvj);
-  --formAccent__1kn7lf75: var(--borderColor-formAccent__qhrpjvn);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Keyline_darkMode_dark__1kn7lf7f {
-  --promote__1kn7lf70: var(--borderColor-promoteLight__qhrpjvx);
-  --info__1kn7lf71: var(--borderColor-infoLight__qhrpjvq);
-  --positive__1kn7lf72: var(--borderColor-positiveLight__qhrpjvv);
-  --caution__1kn7lf73: var(--borderColor-cautionLight__qhrpjvi);
-  --critical__1kn7lf74: var(--borderColor-criticalLight__qhrpjvk);
-  --formAccent__1kn7lf75: var(--borderColor-formAccentLight__qhrpjvo);
-}
-.Keyline_noRadiusOnRight__1kn7lf7g {
-  border-top-right-radius: 0 !important;
-  border-bottom-right-radius: 0 !important;
-}
-.Keyline_largestWidth__1kn7lf7h {
-  width: var(--borderRadius-xlarge__qhrpjve);
-}
-.Keyline_width__1kn7lf7i {
-  width: var(--grid__qhrpjva);
-}
-.InlineField_sizeVars_standard__1b4ltjx2 {
-  --fieldSize__1b4ltjx0: var(--inlineFieldSize-standard__qhrpjv5g);
-  --labelCapHeight__1b4ltjx1: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
-}
-.InlineField_sizeVars_small__1b4ltjx3 {
-  --fieldSize__1b4ltjx0: var(--inlineFieldSize-small__qhrpjv5h);
-  --labelCapHeight__1b4ltjx1: var(--textSize-small-mobile-capHeight__qhrpjv3e);
-}
-.InlineField_realField__1b4ltjx4 {
-  width: 44px;
-  height: 44px;
-  top: calc(((44px - var(--fieldSize__1b4ltjx0)) / 2) * -1);
-  left: calc(((44px - var(--fieldSize__1b4ltjx0)) / 2) * -1);
-}
-[data-braid-debug] .InlineField_realField__1b4ltjx4 {
-  background: red;
-  opacity: 0.2;
-}
-.InlineField_fakeField__1b4ltjx5 {
-  height: var(--fieldSize__1b4ltjx0);
-  width: var(--fieldSize__1b4ltjx0);
-  outline: var(--focusRingSize__qhrpjv10) solid transparent;
-  transition: outline-color .125s ease;
-}
-.InlineField_realField__1b4ltjx4[type="checkbox"]:checked ~ .InlineField_fakeField__1b4ltjx5 {
-  background: transparent;
-}
-.InlineField_realField__1b4ltjx4:focus-visible ~ .InlineField_fakeField__1b4ltjx5 {
-  outline-color: var(--borderColor-focus__qhrpjvm);
-}
-.InlineField_labelOffset__1b4ltjx6 {
-  padding-top: calc((var(--fieldSize__1b4ltjx0) - var(--labelCapHeight__1b4ltjx1)) / 2);
-}
-.InlineField_realField__1b4ltjx4:checked ~ * .InlineField_children__1b4ltjx8,
-  .InlineField_realField__1b4ltjx4.InlineField_isMixed__1b4ltjx7 ~ * .InlineField_children__1b4ltjx8 {
-  display: block;
-  z-index: 1;
-}
-.InlineField_realField__1b4ltjx4:checked + .InlineField_fakeField__1b4ltjx5 > .InlineField_selected__1b4ltjx9,
-  .InlineField_realField__1b4ltjx4.InlineField_isMixed__1b4ltjx7 + .InlineField_fakeField__1b4ltjx5 > .InlineField_selected__1b4ltjx9 {
-  opacity: 1;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .InlineField_hideBorderOnDarkBackgroundInLightMode__1b4ltjxa {
-  opacity: 0;
-}
-.InlineField_realField__1b4ltjx4:hover:not(:checked):not(.InlineField_isMixed__1b4ltjx7):not(:disabled) + .InlineField_fakeField__1b4ltjx5 > .InlineField_hoverOverlay__1b4ltjxb,
-  .InlineField_realField__1b4ltjx4:focus:not(.InlineField_isMixed__1b4ltjx7) + .InlineField_fakeField__1b4ltjx5 > .InlineField_hoverOverlay__1b4ltjxb {
-  opacity: 1;
-}
-.InlineField_hoverOverlay__1b4ltjxb > .InlineField_indicator__1b4ltjxc {
-  opacity: 0.2;
-}
-.InlineField_disabledRadioIndicator__1b4ltjxd {
-  opacity: 0.3;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .InlineField_disabledRadioIndicator__1b4ltjxd {
-  background-color: var(--foregroundColor-secondary__qhrpjv1r);
-}
-html.sprinkles_darkMode__1hjdb9v11 .InlineField_disabledRadioIndicator__1b4ltjxd {
-  background-color: var(--foregroundColor-secondaryInverted__qhrpjv1s);
-}
-.InlineField_checkboxScale__1b4ltjxe {
-  transform: scale(0.85);
-}
-.InlineField_realField__1b4ltjx4:active + .InlineField_fakeField__1b4ltjx5 > * > .InlineField_checkboxScale__1b4ltjxe {
-  transform: scale(0.75);
-}
-.InlineField_radioScale__1b4ltjxf {
-  transform: scale(0.6);
-}
-.InlineField_realField__1b4ltjx4:active + .InlineField_fakeField__1b4ltjx5 > * > .InlineField_radioScale__1b4ltjxf {
-  transform: scale(0.5);
-}
-@media screen and (min-width: 740px) {
-  .InlineField_sizeVars_standard__1b4ltjx2 {
-    --labelCapHeight__1b4ltjx1: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
-  }
-  .InlineField_sizeVars_small__1b4ltjx3 {
-    --labelCapHeight__1b4ltjx1: var(--textSize-small-tablet-capHeight__qhrpjv3j);
-  }
-}
-.ContentBlock_marginAuto__1xx6jv80 {
-  margin: 0 auto;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Modal_backdrop__13n71fr2 {
-  background: rgba(0, 0, 0, 0.4);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Modal_backdrop__13n71fr2 {
-  background: rgba(0, 0, 0, 0.6);
-}
-.Modal_rightAnimation__13n71fr4 {
-  opacity: 1;
-  transform: translateX(110%);
-}
-.Modal_leftAnimation__13n71fr5 {
-  opacity: 1;
-  transform: translateX(-110%);
-}
-.Modal_centerAnimation__13n71fr6 {
-  transform: scale(.8);
-}
-.Modal_horizontalTransition__13n71fr7 {
-  transition: transform .3s cubic-bezier(0.4, 0, 0, 1), opacity .3s cubic-bezier(0.4, 0, 0, 1);
-}
-.Modal_pointerEventsAll__13n71fr9 {
-  pointer-events: all;
-}
-.Modal_viewportHeight__13n71frd {
-  max-height: var(--fullHeightVar__13n71frb);
-}
-.Modal_maxSize_center__13n71fre {
-  --gutterSizeVar__13n71fra: var(--space-xsmall__qhrpjv2);
-  max-height: calc(var(--fullHeightVar__13n71frb) - (var(--gutterSizeVar__13n71fra) * 2));
-  max-width: calc(var(--fullWidthVar__13n71frc) - (var(--gutterSizeVar__13n71fra) * 2));
-}
-.Modal_modalContainer__13n71frf {
-  --fullHeightVar__13n71frb: 100vh;
-  --fullWidthVar__13n71frc: 100vw;
-  max-height: var(--fullHeightVar__13n71frb);
-  max-width: var(--fullWidthVar__13n71frc);
-}
-.Modal_headingRoot__13n71frg {
-  overflow-wrap: break-word;
-}
-.Modal_closeIconOffset__13n71frh {
-  top: -5px;
-  right: -5px;
-}
-@media screen and (prefers-reduced-motion) {
-  .Modal_reducedMotion__13n71fr3 {
-    transform: none !important;
-  }
-}
-@media screen and (min-width: 740px) {
-  .Modal_rightAnimation__13n71fr4 {
-    opacity: 0;
-    transform: translateX(40px);
-  }
-  .Modal_leftAnimation__13n71fr5 {
-    opacity: 0;
-    transform: translateX(-40px);
-  }
-  .Modal_horizontalTransition__13n71fr7 {
-    transition: transform .175s cubic-bezier(0.4, 0, 0, 1), opacity .175s cubic-bezier(0.4, 0, 0, 1);
-  }
-  .Modal_maxSize_center__13n71fre {
-    --gutterSizeVar__13n71fra: var(--space-gutter__qhrpjv0);
-  }
-}
-@media screen and (min-width: 992px) {
-  .Modal_maxSize_center__13n71fre {
-    --gutterSizeVar__13n71fra: var(--space-xlarge__qhrpjv6);
-  }
-}
-@supports (height: 1dvh) {
-  .Modal_modalContainer__13n71frf {
-    --fullHeightVar__13n71frb: 100dvh;
-    --fullWidthVar__13n71frc: 100dvw;
-  }
-}
-.TextLink_base__beoo42 {
-  color: var(--color__beoo40);
-  text-decoration: var(--linkDecoration__qhrpjv5f);
-  text-decoration-thickness: 0.08em;
-  text-underline-offset: 3px;
-  outline-offset: 0.2em;
-  border-radius: var(--borderRadius-small__qhrpjvb);
-}
-.TextLink_base__beoo42:hover {
-  color: var(--colorHover__beoo41);
-  text-decoration: underline;
-  text-decoration-thickness: 0.08em;
-}
-.TextLink_base__beoo42:focus-visible {
-  color: var(--colorHover__beoo41);
-}
-.TextLink_weakLink__beoo43 {
-  --color__beoo40: inherit;
-  --colorHover__beoo41: inherit;
-  text-decoration: underline;
-  text-decoration-thickness: 0.08em;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_regularLinkLightMode_light__beoo44 {
-  --color__beoo40: var(--foregroundColor-link__qhrpjv1f);
-  --colorHover__beoo41: var(--foregroundColor-linkHover__qhrpjv1g);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_regularLinkLightMode_dark__beoo45 {
-  --color__beoo40: var(--foregroundColor-linkLight__qhrpjv1h);
-  --colorHover__beoo41: var(--foregroundColor-linkLight__qhrpjv1h);
-}
-html.sprinkles_darkMode__1hjdb9v11 .TextLink_regularLinkDarkMode_light__beoo46 {
-  --color__beoo40: var(--foregroundColor-link__qhrpjv1f);
-  --colorHover__beoo41: var(--foregroundColor-linkHover__qhrpjv1g);
-}
-html.sprinkles_darkMode__1hjdb9v11 .TextLink_regularLinkDarkMode_dark__beoo47 {
-  --color__beoo40: var(--foregroundColor-linkLight__qhrpjv1h);
-  --colorHover__beoo41: var(--foregroundColor-linkLight__qhrpjv1h);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_visitedLightMode_light__beoo48:visited {
-  color: var(--foregroundColor-linkVisited__qhrpjv1i);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_visitedLightMode_dark__beoo49:visited {
-  color: var(--foregroundColor-linkLightVisited__qhrpjv1j);
-}
-html.sprinkles_darkMode__1hjdb9v11 .TextLink_visitedDarkMode_light__beoo4a:visited {
-  color: var(--foregroundColor-linkVisited__qhrpjv1i);
-}
-html.sprinkles_darkMode__1hjdb9v11 .TextLink_visitedDarkMode_dark__beoo4b:visited {
-  color: var(--foregroundColor-linkLightVisited__qhrpjv1j);
-}
-.Dropdown_field__gz3fci0 {
-  padding-right: var(--touchableSize__qhrpjv9);
-}
-@media print {
-  .Hidden_hiddenOnPrint__1mw96wl0 {
-    display: none !important;
-  }
-}
-.List_currentColor__1an15sm0 {
-  background: currentColor;
-}
-.List_large__1an15sm1 {
-  width: 5px;
-  height: 5px;
-}
-.List_standard__1an15sm2 {
-  width: 4px;
-  height: 4px;
-}
-.List_xsmall__1an15sm3 {
-  width: 3px;
-  height: 3px;
-}
-.List_minCharacterWidth__1an15sm4 {
-  min-width: 1.4ch;
-}
-.List_minCharacterWidth__1an15sm5 {
-  min-width: 2.4ch;
-}
-.List_trimGutter__1an15sm6 {
-  margin-right: -0.4ch;
-}
-@keyframes Loader_bounce__e5c4uh9 {
-  33% {
-    transform: translateY(-1.4em);
-  }
-  66% {
-    transform: translateY(1.4em);
-  }
-}
-@keyframes Loader_fade__e5c4uhd {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-.Loader_rootSize_xsmall__e5c4uh0 {
-  height: var(--textSize-xsmall-mobile-capHeight__qhrpjv34);
-}
-.Loader_rootSize_small__e5c4uh1 {
-  height: var(--textSize-small-mobile-capHeight__qhrpjv3e);
-}
-.Loader_rootSize_standard__e5c4uh2 {
-  height: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
-}
-.Loader_rootSize_large__e5c4uh3 {
-  height: var(--textSize-large-mobile-capHeight__qhrpjv3y);
-}
-.Loader_size_xsmall__e5c4uh4 {
-  height: var(--textSize-xsmall-mobile-fontSize__qhrpjv32);
-}
-.Loader_size_small__e5c4uh5 {
-  height: var(--textSize-small-mobile-fontSize__qhrpjv3c);
-}
-.Loader_size_standard__e5c4uh6 {
-  height: var(--textSize-standard-mobile-fontSize__qhrpjv3m);
-}
-.Loader_size_large__e5c4uh7 {
-  height: var(--textSize-large-mobile-fontSize__qhrpjv3w);
-}
-.Loader_currentColor__e5c4uh8 {
-  fill: currentcolor;
-}
-.Loader_bounceAnimation__e5c4uha {
-  animation-name: Loader_bounce__e5c4uh9;
-  animation-fill-mode: both;
-  animation-iteration-count: infinite;
-  animation-timing-function: ease-in-out;
-  animation-duration: 0.6s;
-}
-.Loader_circle__e5c4uhb {
-  transform: translateY(1.4em);
-}
-.Loader_circle__e5c4uhb:nth-child(1) {
-  animation-delay: 140ms;
-}
-.Loader_circle__e5c4uhb:nth-child(2) {
-  animation-delay: 70ms;
-}
-.Loader_delay__e5c4uhe {
-  opacity: 0;
-  animation-name: Loader_fade__e5c4uhd;
-  animation-iteration-count: 1;
-  animation-fill-mode: forwards;
-  animation-timing-function: ease-in;
-  animation-duration: 0.25s;
-  animation-delay: 800ms;
-}
-@media screen and (min-width: 740px) {
-  .Loader_rootSize_xsmall__e5c4uh0 {
-    height: var(--textSize-xsmall-tablet-capHeight__qhrpjv39);
-  }
-  .Loader_rootSize_small__e5c4uh1 {
-    height: var(--textSize-small-tablet-capHeight__qhrpjv3j);
-  }
-  .Loader_rootSize_standard__e5c4uh2 {
-    height: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
-  }
-  .Loader_rootSize_large__e5c4uh3 {
-    height: var(--textSize-large-tablet-capHeight__qhrpjv43);
-  }
-  .Loader_size_xsmall__e5c4uh4 {
-    height: var(--textSize-xsmall-tablet-fontSize__qhrpjv37);
-  }
-  .Loader_size_small__e5c4uh5 {
-    height: var(--textSize-small-tablet-fontSize__qhrpjv3h);
-  }
-  .Loader_size_standard__e5c4uh6 {
-    height: var(--textSize-standard-tablet-fontSize__qhrpjv3r);
-  }
-  .Loader_size_large__e5c4uh7 {
-    height: var(--textSize-large-tablet-fontSize__qhrpjv41);
-  }
-}
-.ScrollContainer_container__1aqz9r10 {
-  -webkit-overflow-scrolling: touch;
-  -webkit-mask-composite: destination-in;
-  mask-composite: intersect;
-}
-.ScrollContainer_hideScrollbar__1aqz9r11 {
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-.ScrollContainer_hideScrollbar__1aqz9r11::-webkit-scrollbar {
-  width: 0;
-  height: 0;
-}
-.ScrollContainer_fadeSize_small__1aqz9r13 {
-  --scrollOverlaySize__1aqz9r12: 40px;
-}
-.ScrollContainer_fadeSize_medium__1aqz9r14 {
-  --scrollOverlaySize__1aqz9r12: 60px;
-}
-.ScrollContainer_fadeSize_large__1aqz9r15 {
-  --scrollOverlaySize__1aqz9r12: 80px;
-}
-.ScrollContainer_direction_horizontal__1aqz9r16 {
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: fit-content;
-}
-.ScrollContainer_direction_vertical__1aqz9r17 {
-  overflow-x: hidden;
-  overflow-y: auto;
-}
-.ScrollContainer_direction_all__1aqz9r18 {
-  overflow: auto;
-}
-.ScrollContainer_mask__1aqz9r1d {
-  mask-image: linear-gradient(to bottom, transparent 0, black var(--top__1aqz9r1b, 0)),linear-gradient(to right, transparent 0, black var(--left__1aqz9r19, 0)),linear-gradient(to left, transparent 0, black var(--right__1aqz9r1a, 0)),linear-gradient(to top, transparent 0, black var(--bottom__1aqz9r1c, 0));
-}
-.ScrollContainer_maskLeft__1aqz9r1e {
-  --left__1aqz9r19: var(--scrollOverlaySize__1aqz9r12);
-}
-.ScrollContainer_maskRight__1aqz9r1f {
-  --right__1aqz9r1a: var(--scrollOverlaySize__1aqz9r12);
-}
-.ScrollContainer_maskTop__1aqz9r1g {
-  --top__1aqz9r1b: var(--scrollOverlaySize__1aqz9r12);
-}
-.ScrollContainer_maskBottom__1aqz9r1h {
-  --bottom__1aqz9r1c: var(--scrollOverlaySize__1aqz9r12);
-}
-.MenuRenderer_backdrop__p34lbl1 {
-  width: 100vw;
-  height: 100vh;
-}
-.MenuRenderer_menuPosition__p34lbl6 {
-  top: var(--triggerVars_bottom__p34lbl4);
-  bottom: var(--triggerVars_top__p34lbl2);
-  left: var(--triggerVars_left__p34lbl3);
-  right: var(--triggerVars_right__p34lbl5);
-}
-.MenuRenderer_baseWidth__p34lbl8 {
-  width: calc(var(--widthVar__p34lbl7) / 4);
-}
-.MenuRenderer_width_small__p34lbl9 {
-  --widthVar__p34lbl7: var(--contentWidth-small__qhrpjv12);
-}
-.MenuRenderer_width_medium__p34lbla {
-  --widthVar__p34lbl7: var(--contentWidth-medium__qhrpjv13);
-}
-.MenuRenderer_width_large__p34lblb {
-  --widthVar__p34lbl7: var(--contentWidth-large__qhrpjv14);
-}
-.MenuRenderer_menuHeightLimit__p34lblc {
-  max-height: calc((var(--touchableSize__qhrpjv9) * 9.5) + (var(--menuYPadding__p34lbl0) * 2));
-}
-.useMenuItem_menuItem__wz3nke0::-moz-focus-inner {
-  border: 0;
-}
-.useMenuItem_menuItemLeftSlot__wz3nke1 {
-  height: 0px;
-}
-.MenuItemCheckbox_checkboxSize__17whdqr2 {
-  --menuItemCapHeight__17whdqr0: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
-  --crop__17whdqr1: calc(((var(--inlineFieldSize-small__qhrpjv5h) - var(--menuItemCapHeight__17whdqr0)) / 2) * -1);
-  height: var(--inlineFieldSize-small__qhrpjv5h);
-  width: var(--inlineFieldSize-small__qhrpjv5h);
-  margin-top: var(--crop__17whdqr1);
-  margin-bottom: var(--crop__17whdqr1);
-}
-@media screen and (min-width: 740px) {
-  .MenuItemCheckbox_checkboxSize__17whdqr2 {
-    --menuItemCapHeight__17whdqr0: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
-  }
-}
-.OverflowMenu_wrapperPositioning__18ydm7f0 {
-  margin: -1px -6px;
-}
-.MonthPicker_nativeInput__1xbm4s00::-webkit-inner-spin-button, .MonthPicker_nativeInput__1xbm4s00::-webkit-calendar-picker-indicator, .MonthPicker_nativeInput__1xbm4s00::-webkit-clear-button {
-  display: none;
-  -webkit-appearance: none;
-}
-.Page_fullHeight__7puj9a1 {
-  min-height: var(--heightLimit__7puj9a0, 100vh);
-}
-.Pagination_focusRing__oms9uc1 {
-  outline-offset: 0;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Pagination_lightModeCurrentKeyline__oms9uc3 {
-  opacity: 0.3;
-}
-html.sprinkles_darkMode__1hjdb9v11 .Pagination_darkModeCurrentKeyline__oms9uc4 {
-  opacity: 0.3;
-}
-.Pagination_current__oms9uc5 {
-  opacity: 0.075;
-}
-.Pagination_hover__oms9uc2:hover .Pagination_background__oms9uc6:not(.Pagination_current__oms9uc5) {
-  opacity: 0.5;
-}
-.Rating_inlineFlex__nkq5400 {
-  display: inline-flex;
-  gap: 1px;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_tone_formAccent__6woprh2 {
-  --highlightVar__6woprh1: var(--borderColor-formAccent__qhrpjvn);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Stepper_tone_formAccent__6woprh2 {
-  --highlightVar__6woprh1: var(--borderColor-formAccentLight__qhrpjvo);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_tone_neutral__6woprh3 {
-  --highlightVar__6woprh1: var(--borderColor-neutral__qhrpjvr);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Stepper_tone_neutral__6woprh3 {
-  --highlightVar__6woprh1: var(--borderColor-neutralLight__qhrpjvt);
-}
-.Stepper_step__6woprh4 {
-  outline: none;
-  text-align: left;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_step__6woprh4 {
-  --baseColourVar__6woprh0: var(--borderColor-neutralLight__qhrpjvt);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Stepper_step__6woprh4 {
-  --baseColourVar__6woprh0: var(--borderColor-neutral__qhrpjvr);
-}
-.Stepper_indicator__6woprh6 {
-  height: var(--inlineFieldSize-small__qhrpjv5h);
-  width: var(--inlineFieldSize-small__qhrpjv5h);
-  color: var(--baseColourVar__6woprh0);
-}
-.Stepper_stretch__6woprh7 {
-  flex: 1;
-}
-.Stepper_highlight__6woprh9 {
-  color: var(--highlightVar__6woprh1);
-}
-.Stepper_inner__6woprhd {
-  fill: currentcolor;
-  transform-origin: 50% 50%;
-  transform: scale(0);
-}
-.Stepper_active__6woprhb > .Stepper_inner__6woprhd {
-  transform: scale(1);
-  opacity: 1;
-}
-.Stepper_complete__6woprha > .Stepper_inner__6woprhd {
-  transform: scale(2.1);
-  opacity: 1;
-}
-.Stepper_tick__6woprhf {
-  transition-delay: .1s;
-  transform-origin: 50% 50%;
-}
-:not(.Stepper_complete__6woprha) > .Stepper_tick__6woprhf {
-  opacity: 0;
-  transition-delay: 0s;
-  transform: scale(.5) rotate(50deg);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_tick__6woprhf {
-  fill: var(--foregroundColor-neutralInverted__qhrpjv1l);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Stepper_tick__6woprhf {
-  fill: var(--foregroundColor-neutral__qhrpjv1k);
-}
-.Stepper_progressTrack__6woprhg {
-  background: repeating-linear-gradient(90deg, var(--baseColourVar__6woprh0), var(--baseColourVar__6woprh0) 2px, transparent 2px, transparent 4px);
-  height: var(--borderWidth-large__qhrpjvz);
-  width: calc((100% - var(--inlineFieldSize-small__qhrpjv5h)) - (var(--space-xxsmall__qhrpjv1) * 2));
-  top: calc((var(--inlineFieldSize-small__qhrpjv5h) - var(--borderWidth-large__qhrpjvz)) / 2);
-  left: calc(var(--inlineFieldSize-small__qhrpjv5h) + var(--space-xxsmall__qhrpjv1));
-}
-.Stepper_progressLine__6woprhi {
-  background: var(--highlightVar__6woprh1);
-  transition: transform .2s ease;
-}
-.Stepper_progressUnfilled__6woprhj {
-  transform: translateX(-101%);
-}
-.Stepper_indicatorContainer__6woprhk {
-  outline: var(--focusRingSize__qhrpjv10) solid transparent;
-  width: var(--inlineFieldSize-small__qhrpjv5h);
-  transition: var(--transition-fast__qhrpjv5i), outline-color .125s ease;
-}
-.Stepper_step__6woprh4:focus-visible .Stepper_indicatorContainer__6woprhk {
-  outline-color: var(--borderColor-focus__qhrpjvm);
-  transform: scale(1.2);
-}
-.Stepper_step__6woprh4:active .Stepper_indicatorContainer__6woprhk {
-  transform: var(--transform-touchable__qhrpjv5k);
-}
-@media screen and (min-width: 740px) {
-  .Stepper_stretchLastAboveTablet__6woprh8 {
-    flex: 1;
-  }
-  .Stepper_progressTrackCentered__6woprhh {
-    left: calc((50% + (var(--inlineFieldSize-small__qhrpjv5h) / 2)) + var(--space-xxsmall__qhrpjv1));
-  }
-}
-.Table_table__y0v62q1 {
-  border-collapse: separate;
-  border: var(--borderWidth-standard__qhrpjvy) solid var(--borderColor__y0v62q0);
-  font-variant-numeric: tabular-nums;
-  word-break: break-word;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Table_table__y0v62q1 {
-  --borderColor__y0v62q0: var(--borderColor-neutralLight__qhrpjvt);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Table_table__y0v62q1 {
-  --borderColor__y0v62q0: var(--borderColor-neutral__qhrpjvr);
-}
-.Table_row__y0v62q4:not(:last-child) > .Table_cell__y0v62q5 {
-  border-bottom: 1px solid var(--borderColor__y0v62q0);
-}
-.Table_tableSection__y0v62q3:not(.Table_tableHeader__y0v62q2) > .Table_row__y0v62q4 > .Table_headCell__y0v62q6:not(:first-child) {
-  border-left: 1px solid var(--borderColor__y0v62q0);
-}
-.Table_tableSection__y0v62q3:not(.Table_tableHeader__y0v62q2) > .Table_row__y0v62q4 > .Table_headCell__y0v62q6:not(:last-child) {
-  border-right: 1px solid var(--borderColor__y0v62q0);
-}
-.Table_tableSection__y0v62q3:not(:first-child) > .Table_row__y0v62q4:first-child > .Table_cell__y0v62q5 {
-  border-top: var(--borderWidth-standard__qhrpjvy) solid var(--borderColor__y0v62q0);
-}
-.Table_alignY_center__y0v62q7 {
-  vertical-align: middle;
-}
-.Table_alignY_top__y0v62q8 {
-  vertical-align: top;
-}
-.Table_nowrap__y0v62q9 {
-  white-space: nowrap;
-}
-.Table_softWidth__y0v62qb {
-  width: var(--softWidthVar__y0v62qa);
-}
-.Table_minWidth__y0v62qd {
-  min-width: var(--minWidthVar__y0v62qc);
-}
-.Table_maxWidth__y0v62qf {
-  max-width: var(--maxWidthVar__y0v62qe);
-}
-@media screen and (min-width: 740px) {
-  .Table_showOnTablet__y0v62qg {
-    display: table-cell;
-  }
-}
-@media screen and (min-width: 992px) {
-  .Table_showOnDesktop__y0v62qh {
-    display: table-cell;
-  }
-}
-@media screen and (min-width: 1200px) {
-  .Table_showOnWide__y0v62qi {
-    display: table-cell;
-  }
-}
-.Tabs_tab__wez1qd0::-moz-focus-inner {
-  border: 0;
-}
-.Tabs_tab__wez1qd0:hover .Tabs_hoveredTab__wez1qd1 {
-  opacity: 1;
-}
-.Tabs_nowrap__wez1qd2 {
-  white-space: nowrap;
-}
-.Tabs_scroll__wez1qd3 {
-  -webkit-overflow-scrolling: touch;
-  overflow-x: auto;
-  overflow-y: hidden;
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-.Tabs_scroll__wez1qd3::-webkit-scrollbar {
-  width: 0;
-  height: 0;
-}
-.Tabs_mask__wez1qd4 {
-  mask-image: linear-gradient(90deg, rgba(0,0,0,1) 0, rgba(0,0,0,1) calc(100% - 80px), rgba(0,0,0,0) 100%);
-}
-.Tabs_marginAuto__wez1qd5 {
-  margin-left: auto;
-  margin-right: auto;
-}
-.Tabs_tabFocusRing__wez1qd6 {
-  outline-offset: calc(var(--focusRingSize__qhrpjv10) * -1);
-}
-.Tabs_tabUnderline__wez1qdb {
-  --underlineRadius__wez1qd9: calc(var(--borderRadius-small__qhrpjvb) / var(--underlineScale__wez1qda));
-  --underlineScale__wez1qda: calc(var(--underlineWidth__wez1qd8) / 100);
-  height: var(--borderWidth-large__qhrpjvz);
-  border-top-left-radius: var(--underlineRadius__wez1qd9);
-  border-top-right-radius: var(--underlineRadius__wez1qd9);
-  width: 100px;
-  transform-origin: 0 0;
-  transition: transform .3s ease;
-  transform: translateZ(0) translateX(calc(var(--underlineLeft__wez1qd7) * 1px)) scaleX(var(--underlineScale__wez1qda));
-}
-html.sprinkles_darkMode__1hjdb9v11 .Tabs_tabUnderlineActiveDarkMode__wez1qdc {
-  background: var(--borderColor-formAccentLight__qhrpjvo);
-}
-.Tabs_divider__wez1qde {
-  height: var(--borderWidth-standard__qhrpjvy);
-}
-.Tag_clearGutter__1jrpwfo0 {
-  padding-left: 1px;
-}
-.Highlight_root__cnytm1 {
-  padding: 0 2px;
-  margin: 0 -2px;
-  text-decoration: underline;
-  text-decoration-style: wavy;
-  text-decoration-skip-ink: none;
-  text-decoration-thickness: 2px;
-  text-underline-offset: 2px;
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Highlight_critical__cnytm2 {
-  text-decoration-color: var(--borderColor-critical__qhrpjvj);
-  background: var(--backgroundColor-criticalLight__qhrpjv27);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Highlight_critical__cnytm2 {
-  text-decoration-color: var(--borderColor-criticalLight__qhrpjvk);
-}
-.Highlight_caution__cnytm3 {
-  text-decoration-color: var(--borderColor-caution__qhrpjvh);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Highlight_caution__cnytm3 {
-  background: var(--backgroundColor-cautionLight__qhrpjv23);
-}
-.Textarea_field__ak2u6d0 {
-  resize: vertical;
-  background: transparent;
-  min-height: calc(var(--grid__qhrpjva) * 15);
-}
-.Textarea_highlights__ak2u6d1 {
-  color: transparent !important;
-  word-break: break-word;
-  white-space: pre-wrap;
-}
-.Textarea_highlights__ak2u6d1:after {
-  content: "\\A";
-}
-.TextDropdown_select__pu1g620 {
-  min-height: 44px;
-  min-width: 44px;
-  height: 100%;
-  width: 100%;
-  transform: translate(-50%, -50%);
-  top: 50%;
-  left: 50%;
-}
-[data-braid-debug] .TextDropdown_select__pu1g620 {
-  background: red;
-  opacity: 0.2;
-}
-.TextDropdown_focusRing__pu1g622 {
-  outline: var(--focusRingSize__qhrpjv10) solid transparent;
-  transition: outline-color .125s ease;
-  outline-offset: var(--space-xxsmall__qhrpjv1);
-}
-.TextDropdown_select__pu1g620:focus-visible ~ .TextDropdown_focusRing__pu1g622 {
-  outline-color: var(--borderColor-focus__qhrpjvm);
-}
-.Tiles_tiles__5j02iv5 {
-  --columns__5j02iv0: var(--mobileColumnsVar__5j02iv1);
-  display: grid;
-  grid-template-columns: repeat(var(--columns__5j02iv0), 1fr);
-}
-.Tiles_tiles__5j02iv5 > * {
-  min-width: 0;
-}
-@media screen and (min-width: 740px) {
-  .Tiles_tiles__5j02iv5 {
-    --columns__5j02iv0: var(--tabletColumnsVar__5j02iv2);
-  }
-}
-@media screen and (min-width: 992px) {
-  .Tiles_tiles__5j02iv5 {
-    --columns__5j02iv0: var(--desktopColumnsVar__5j02iv3);
-  }
-}
-@media screen and (min-width: 1200px) {
-  .Tiles_tiles__5j02iv5 {
-    --columns__5j02iv0: var(--wideColumnsVar__5j02iv4);
-  }
-}
-.Toggle_bleedToCapHeight_standard__158h80u0 {
-  height: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
-}
-.Toggle_bleedToCapHeight_small__158h80u1 {
-  height: var(--textSize-small-mobile-capHeight__qhrpjv3e);
-}
-.Toggle_root__158h80u2:hover {
-  z-index: 1;
-}
-.Toggle_realField__158h80u3 {
-  height: 44px;
-}
-[data-braid-debug] .Toggle_realField__158h80u3 {
-  background: red;
-  opacity: 0.2;
-}
-.Toggle_realFieldPosition_standard__158h80u4 {
-  top: calc(((44px - var(--inlineFieldSize-standard__qhrpjv5g)) / 2) * -1);
-}
-.Toggle_realFieldPosition_small__158h80u5 {
-  top: calc(((44px - var(--inlineFieldSize-small__qhrpjv5h)) / 2) * -1);
-}
-.Toggle_fieldSize_standard__158h80u6 {
-  width: calc(var(--inlineFieldSize-standard__qhrpjv5g) * 1.6);
-}
-.Toggle_fieldSize_small__158h80u7 {
-  width: calc(var(--inlineFieldSize-small__qhrpjv5h) * 1.6);
-}
-.Toggle_slideContainerSize_standard__158h80u9 {
-  height: var(--inlineFieldSize-standard__qhrpjv5g);
-}
-.Toggle_slideContainerSize_small__158h80ua {
-  height: var(--inlineFieldSize-small__qhrpjv5h);
-}
-.Toggle_slideTrack_standard__158h80ub {
-  height: calc(var(--inlineFieldSize-standard__qhrpjv5g) - var(--grid__qhrpjva));
-}
-.Toggle_slideTrack_small__158h80uc {
-  height: calc(var(--inlineFieldSize-small__qhrpjv5h) - var(--grid__qhrpjva));
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Toggle_slideTrackBgLightMode_light__158h80ud {
-  background: rgba(0,0,0,0.08);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Toggle_slideTrackBgLightMode_dark__158h80ue {
-  background: rgba(255,255,255,0.12);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Toggle_slideTrackBgDarkMode_light__158h80uf {
-  background: rgba(0,0,0,0.08);
-}
-html.sprinkles_darkMode__1hjdb9v11 .Toggle_slideTrackBgDarkMode_dark__158h80ug {
-  background: rgba(255,255,255,0.12);
-}
-.Toggle_slideTrackMask__158h80uh {
-  -webkit-mask-image: -webkit-radial-gradient(white, black);
-}
-.Toggle_realField__158h80u3:not(:checked) + .Toggle_slideContainer__158h80u8 .Toggle_slideTrackSelected__158h80ui {
-  transform: translateX(calc(var(--touchableSize__qhrpjv9) * -1));
-}
-.Toggle_slider_standard__158h80uj {
-  outline: var(--focusRingSize__qhrpjv10) solid transparent;
-  height: var(--inlineFieldSize-standard__qhrpjv5g);
-  width: var(--inlineFieldSize-standard__qhrpjv5g);
-  transition: var(--transition-fast__qhrpjv5i), outline-color .125s ease;
-}
-.Toggle_realField__158h80u3:focus-visible + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
-  outline-color: var(--borderColor-focus__qhrpjvm);
-}
-.Toggle_realField__158h80u3:active + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
-  transform: translateX(calc((var(--inlineFieldSize-standard__qhrpjv5g) * 0.12) * -1));
-}
-.Toggle_realField__158h80u3:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
-  transform: translateX(calc((var(--inlineFieldSize-standard__qhrpjv5g) * 1.6) - var(--inlineFieldSize-standard__qhrpjv5g)));
-}
-.Toggle_realField__158h80u3:active:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
-  transform: translateX(calc(((var(--inlineFieldSize-standard__qhrpjv5g) * 1.6) - var(--inlineFieldSize-standard__qhrpjv5g)) + (var(--inlineFieldSize-standard__qhrpjv5g) * 0.12)));
-}
-.Toggle_slider_small__158h80uk {
-  outline: var(--focusRingSize__qhrpjv10) solid transparent;
-  height: var(--inlineFieldSize-small__qhrpjv5h);
-  width: var(--inlineFieldSize-small__qhrpjv5h);
-  transition: var(--transition-fast__qhrpjv5i), outline-color .125s ease;
-}
-.Toggle_realField__158h80u3:focus-visible + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
-  outline-color: var(--borderColor-focus__qhrpjvm);
-}
-.Toggle_realField__158h80u3:active + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
-  transform: translateX(calc((var(--inlineFieldSize-small__qhrpjv5h) * 0.12) * -1));
-}
-.Toggle_realField__158h80u3:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
-  transform: translateX(calc((var(--inlineFieldSize-small__qhrpjv5h) * 1.6) - var(--inlineFieldSize-small__qhrpjv5h)));
-}
-.Toggle_realField__158h80u3:active:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
-  transform: translateX(calc(((var(--inlineFieldSize-small__qhrpjv5h) * 1.6) - var(--inlineFieldSize-small__qhrpjv5h)) + (var(--inlineFieldSize-small__qhrpjv5h) * 0.12)));
-}
-.Toggle_sliderThumbOutlineFix__158h80ul {
-  transform: scale(1.04);
-}
-html:not(.sprinkles_darkMode__1hjdb9v11) .Toggle_hideBorderOnDarkBackgroundInLightMode__158h80um {
-  opacity: 0;
-}
-.Toggle_realField__158h80u3:hover:not(:disabled) + .Toggle_slideContainer__158h80u8 .Toggle_hoverOverlay__158h80un,
-  .Toggle_realField__158h80u3:focus + .Toggle_slideContainer__158h80u8 .Toggle_hoverOverlay__158h80un {
-  opacity: 1;
-}
-@media screen and (min-width: 740px) {
-  .Toggle_bleedToCapHeight_standard__158h80u0 {
-    height: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
-  }
-  .Toggle_bleedToCapHeight_small__158h80u1 {
-    height: var(--textSize-small-tablet-capHeight__qhrpjv3j);
-  }
-}
-.Toast_toast__1nhoi470 {
-  pointer-events: all;
-}
-.Toast_collapsed__1nhoi471 .Toast_collapsedToastContent__1nhoi472 {
-  opacity: 0;
-}
-.Toaster_toaster__103l6ur0 {
-  left: 0;
-  right: 0;
-  margin-inline: auto;
-  bottom: var(--space-xsmall__qhrpjv2);
-  max-width: min(var(--contentWidth-xsmall__qhrpjv11), calc(100vw - (2 * var(--space-small__qhrpjv3))));
-}
-.IconArrow_root__1igczit0 {
-  transition: transform 0.3s ease;
-  transform-origin: 50% 50%;
-}
-.IconArrow_flip__1igczit1 {
-  transform: rotateX(180deg);
-}
-.IconArrow_rotate__1igczit3 {
-  transform: scaleX(var(--mirrorVar__1igczit2, 1)) rotate(90deg);
-}
-.IconArrow_mirror__1igczit4 {
-  --mirrorVar__1igczit2: -1;
-}
-.IconThumb_root__fympft0 {
-  transition: transform 0.3s ease;
-  transform-origin: 50% 50%;
-}
-.IconThumb_down__fympft1 {
-  transform: rotate(180deg);
-}
-.seekJobs_seekJobs__1fmskxf0 {
-  --space-gutter__qhrpjv0: 24px;
-  --space-xxsmall__qhrpjv1: 8px;
-  --space-xsmall__qhrpjv2: 12px;
-  --space-small__qhrpjv3: 16px;
-  --space-medium__qhrpjv4: 24px;
-  --space-large__qhrpjv5: 32px;
-  --space-xlarge__qhrpjv6: 48px;
-  --space-xxlarge__qhrpjv7: 64px;
-  --space-xxxlarge__qhrpjv8: 96px;
-  --touchableSize__qhrpjv9: 48px;
-  --grid__qhrpjva: 4px;
-  --borderRadius-small__qhrpjvb: 4px;
-  --borderRadius-standard__qhrpjvc: 8px;
-  --borderRadius-large__qhrpjvd: 16px;
-  --borderRadius-xlarge__qhrpjve: 24px;
-  --borderColor-brandAccent__qhrpjvf: #E60278;
-  --borderColor-brandAccentLight__qhrpjvg: #F8B1DC;
-  --borderColor-caution__qhrpjvh: #FDC221;
-  --borderColor-cautionLight__qhrpjvi: #FEE384;
-  --borderColor-critical__qhrpjvj: #B91E1E;
-  --borderColor-criticalLight__qhrpjvk: #FB999A;
-  --borderColor-field__qhrpjvl: #838FA5;
-  --borderColor-focus__qhrpjvm: rgba(153,191,247,0.7);
-  --borderColor-formAccent__qhrpjvn: #1E47A9;
-  --borderColor-formAccentLight__qhrpjvo: #99BFF7;
-  --borderColor-info__qhrpjvp: #1D559D;
-  --borderColor-infoLight__qhrpjvq: #98C9F1;
-  --borderColor-neutral__qhrpjvr: #2E3849;
-  --borderColor-neutralLight__qhrpjvt: #EAECF1;
-  --borderColor-neutralInverted__qhrpjvs: #fff;
-  --borderColor-positive__qhrpjvu: #12784F;
-  --borderColor-positiveLight__qhrpjvv: #8BDEC5;
-  --borderColor-promote__qhrpjvw: #7F35A9;
-  --borderColor-promoteLight__qhrpjvx: #E1B2F5;
-  --borderWidth-standard__qhrpjvy: 2px;
-  --borderWidth-large__qhrpjvz: 4px;
-  --focusRingSize__qhrpjv10: 6px;
-  --contentWidth-xsmall__qhrpjv11: 400px;
-  --contentWidth-small__qhrpjv12: 660px;
-  --contentWidth-medium__qhrpjv13: 940px;
-  --contentWidth-large__qhrpjv14: 1280px;
-  --foregroundColor-brandAccent__qhrpjv15: #E60278;
-  --foregroundColor-brandAccentLight__qhrpjv16: #F8B1DC;
-  --foregroundColor-caution__qhrpjv17: #723D02;
-  --foregroundColor-cautionLight__qhrpjv18: #FEE384;
-  --foregroundColor-critical__qhrpjv19: #B91E1E;
-  --foregroundColor-criticalLight__qhrpjv1a: #FB999A;
-  --foregroundColor-formAccent__qhrpjv1b: #1E47A9;
-  --foregroundColor-formAccentLight__qhrpjv1c: #99BFF7;
-  --foregroundColor-info__qhrpjv1d: #1D559D;
-  --foregroundColor-infoLight__qhrpjv1e: #98C9F1;
-  --foregroundColor-link__qhrpjv1f: #2E3849;
-  --foregroundColor-linkLight__qhrpjv1h: #fff;
-  --foregroundColor-linkHover__qhrpjv1g: #2E3849;
-  --foregroundColor-linkVisited__qhrpjv1i: #5B2084;
-  --foregroundColor-linkLightVisited__qhrpjv1j: #F0D6FA;
-  --foregroundColor-neutral__qhrpjv1k: #2E3849;
-  --foregroundColor-neutralInverted__qhrpjv1l: #fff;
-  --foregroundColor-positive__qhrpjv1m: #12784F;
-  --foregroundColor-positiveLight__qhrpjv1n: #8BDEC5;
-  --foregroundColor-promote__qhrpjv1o: #7F35A9;
-  --foregroundColor-promoteLight__qhrpjv1p: #E1B2F5;
-  --foregroundColor-rating__qhrpjv1q: #E60278;
-  --foregroundColor-secondary__qhrpjv1r: #5A6881;
-  --foregroundColor-secondaryInverted__qhrpjv1s: rgba(255,255,255,0.65);
-  --backgroundColor-body__qhrpjv1t: #fff;
-  --backgroundColor-bodyDark__qhrpjv1u: #1C2330;
-  --backgroundColor-brand__qhrpjv1v: #051A49;
-  --backgroundColor-brandAccent__qhrpjv1w: #E60278;
-  --backgroundColor-brandAccentActive__qhrpjv1x: #cd026b;
-  --backgroundColor-brandAccentHover__qhrpjv1y: #fd0585;
-  --backgroundColor-brandAccentSoft__qhrpjv1z: #FEEFFA;
-  --backgroundColor-brandAccentSoftActive__qhrpjv20: #fdd7f3;
-  --backgroundColor-brandAccentSoftHover__qhrpjv21: #fde3f6;
-  --backgroundColor-caution__qhrpjv22: #FDC221;
-  --backgroundColor-cautionLight__qhrpjv23: #FEF8DE;
-  --backgroundColor-critical__qhrpjv24: #B91E1E;
-  --backgroundColor-criticalActive__qhrpjv25: #a31a1a;
-  --backgroundColor-criticalHover__qhrpjv26: #db1616;
-  --backgroundColor-criticalLight__qhrpjv27: #FFE3E2;
-  --backgroundColor-criticalSoft__qhrpjv28: #FEF3F3;
-  --backgroundColor-criticalSoftActive__qhrpjv29: #fcdbdb;
-  --backgroundColor-criticalSoftHover__qhrpjv2a: #fde7e7;
-  --backgroundColor-formAccent__qhrpjv2b: #1E47A9;
-  --backgroundColor-formAccentActive__qhrpjv2c: #1a3e93;
-  --backgroundColor-formAccentHover__qhrpjv2d: #2455c9;
-  --backgroundColor-formAccentSoft__qhrpjv2e: #F0F7FE;
-  --backgroundColor-formAccentSoftActive__qhrpjv2f: #d8eafc;
-  --backgroundColor-formAccentSoftHover__qhrpjv2g: #e4f1fd;
-  --backgroundColor-info__qhrpjv2h: #1D559D;
-  --backgroundColor-infoLight__qhrpjv2i: #E3F2FB;
-  --backgroundColor-neutral__qhrpjv2j: #2E3849;
-  --backgroundColor-neutralActive__qhrpjv2k: #242c39;
-  --backgroundColor-neutralHover__qhrpjv2l: #384459;
-  --backgroundColor-neutralLight__qhrpjv2m: #F3F5F7;
-  --backgroundColor-neutralSoft__qhrpjv2n: #F3F5F7;
-  --backgroundColor-neutralSoftActive__qhrpjv2o: #e4e8ed;
-  --backgroundColor-neutralSoftHover__qhrpjv2p: #ebeff2;
-  --backgroundColor-positive__qhrpjv2q: #12784F;
-  --backgroundColor-positiveLight__qhrpjv2r: #E2F7F1;
-  --backgroundColor-promote__qhrpjv2s: #7F35A9;
-  --backgroundColor-promoteLight__qhrpjv2t: #F9EBFD;
-  --backgroundColor-surface__qhrpjv2u: #fff;
-  --backgroundColor-surfaceDark__qhrpjv2v: #1C2330;
-  --fontFamily__qhrpjv2w: SeekSans, "SeekSans Fallback", Arial, Tahoma, sans-serif;
-  --fontMetrics-capHeight__qhrpjv2x: 783;
-  --fontMetrics-ascent__qhrpjv2y: 1057;
-  --fontMetrics-descent__qhrpjv2z: -274;
-  --fontMetrics-lineGap__qhrpjv30: 0;
-  --fontMetrics-unitsPerEm__qhrpjv31: 1000;
-  --textSize-large-mobile-fontSize__qhrpjv3w: 18px;
-  --textSize-large-mobile-lineHeight__qhrpjv3x: 27.094px;
-  --textSize-large-mobile-capHeight__qhrpjv3y: 14.094px;
-  --textSize-large-mobile-capsizeTrims-capHeightTrim__qhrpjv3z: -0.3611em;
-  --textSize-large-mobile-capsizeTrims-baselineTrim__qhrpjv40: -0.3611em;
-  --textSize-large-tablet-fontSize__qhrpjv41: 18px;
-  --textSize-large-tablet-lineHeight__qhrpjv42: 27.094px;
-  --textSize-large-tablet-capHeight__qhrpjv43: 14.094px;
-  --textSize-large-tablet-capsizeTrims-capHeightTrim__qhrpjv44: -0.3611em;
-  --textSize-large-tablet-capsizeTrims-baselineTrim__qhrpjv45: -0.3611em;
-  --textSize-standard-mobile-fontSize__qhrpjv3m: 16px;
-  --textSize-standard-mobile-lineHeight__qhrpjv3n: 24.528px;
-  --textSize-standard-mobile-capHeight__qhrpjv3o: 12.528px;
-  --textSize-standard-mobile-capsizeTrims-capHeightTrim__qhrpjv3p: -0.375em;
-  --textSize-standard-mobile-capsizeTrims-baselineTrim__qhrpjv3q: -0.375em;
-  --textSize-standard-tablet-fontSize__qhrpjv3r: 16px;
-  --textSize-standard-tablet-lineHeight__qhrpjv3s: 24.528px;
-  --textSize-standard-tablet-capHeight__qhrpjv3t: 12.528px;
-  --textSize-standard-tablet-capsizeTrims-capHeightTrim__qhrpjv3u: -0.375em;
-  --textSize-standard-tablet-capsizeTrims-baselineTrim__qhrpjv3v: -0.375em;
-  --textSize-small-mobile-fontSize__qhrpjv3c: 14px;
-  --textSize-small-mobile-lineHeight__qhrpjv3d: 20.962px;
-  --textSize-small-mobile-capHeight__qhrpjv3e: 10.962px;
-  --textSize-small-mobile-capsizeTrims-capHeightTrim__qhrpjv3f: -0.3571em;
-  --textSize-small-mobile-capsizeTrims-baselineTrim__qhrpjv3g: -0.3571em;
-  --textSize-small-tablet-fontSize__qhrpjv3h: 14px;
-  --textSize-small-tablet-lineHeight__qhrpjv3i: 20.962px;
-  --textSize-small-tablet-capHeight__qhrpjv3j: 10.962px;
-  --textSize-small-tablet-capsizeTrims-capHeightTrim__qhrpjv3k: -0.3571em;
-  --textSize-small-tablet-capsizeTrims-baselineTrim__qhrpjv3l: -0.3571em;
-  --textSize-xsmall-mobile-fontSize__qhrpjv32: 12px;
-  --textSize-xsmall-mobile-lineHeight__qhrpjv33: 18.396px;
-  --textSize-xsmall-mobile-capHeight__qhrpjv34: 9.396px;
-  --textSize-xsmall-mobile-capsizeTrims-capHeightTrim__qhrpjv35: -0.375em;
-  --textSize-xsmall-mobile-capsizeTrims-baselineTrim__qhrpjv36: -0.375em;
-  --textSize-xsmall-tablet-fontSize__qhrpjv37: 12px;
-  --textSize-xsmall-tablet-lineHeight__qhrpjv38: 18.396px;
-  --textSize-xsmall-tablet-capHeight__qhrpjv39: 9.396px;
-  --textSize-xsmall-tablet-capsizeTrims-capHeightTrim__qhrpjv3a: -0.375em;
-  --textSize-xsmall-tablet-capsizeTrims-baselineTrim__qhrpjv3b: -0.375em;
-  --textWeight-regular__qhrpjv46: 400;
-  --textWeight-medium__qhrpjv47: 600;
-  --textWeight-strong__qhrpjv48: 700;
-  --headingLevel-1-mobile-fontSize__qhrpjv49: 28px;
-  --headingLevel-1-mobile-lineHeight__qhrpjv4a: 32.924px;
-  --headingLevel-1-mobile-capHeight__qhrpjv4b: 21.924px;
-  --headingLevel-1-mobile-capsizeTrims-capHeightTrim__qhrpjv4c: -0.1964em;
-  --headingLevel-1-mobile-capsizeTrims-baselineTrim__qhrpjv4d: -0.1964em;
-  --headingLevel-1-tablet-fontSize__qhrpjv4e: 36px;
-  --headingLevel-1-tablet-lineHeight__qhrpjv4f: 42.188px;
-  --headingLevel-1-tablet-capHeight__qhrpjv4g: 28.188px;
-  --headingLevel-1-tablet-capsizeTrims-capHeightTrim__qhrpjv4h: -0.1944em;
-  --headingLevel-1-tablet-capsizeTrims-baselineTrim__qhrpjv4i: -0.1944em;
-  --headingLevel-2-mobile-fontSize__qhrpjv4j: 24px;
-  --headingLevel-2-mobile-lineHeight__qhrpjv4k: 29.792px;
-  --headingLevel-2-mobile-capHeight__qhrpjv4l: 18.792px;
-  --headingLevel-2-mobile-capsizeTrims-capHeightTrim__qhrpjv4m: -0.2292em;
-  --headingLevel-2-mobile-capsizeTrims-baselineTrim__qhrpjv4n: -0.2292em;
-  --headingLevel-2-tablet-fontSize__qhrpjv4o: 30px;
-  --headingLevel-2-tablet-lineHeight__qhrpjv4p: 36.49px;
-  --headingLevel-2-tablet-capHeight__qhrpjv4q: 23.49px;
-  --headingLevel-2-tablet-capsizeTrims-capHeightTrim__qhrpjv4r: -0.2167em;
-  --headingLevel-2-tablet-capsizeTrims-baselineTrim__qhrpjv4s: -0.2167em;
-  --headingLevel-3-mobile-fontSize__qhrpjv4t: 22px;
-  --headingLevel-3-mobile-lineHeight__qhrpjv4u: 27.226px;
-  --headingLevel-3-mobile-capHeight__qhrpjv4v: 17.226px;
-  --headingLevel-3-mobile-capsizeTrims-capHeightTrim__qhrpjv4w: -0.2273em;
-  --headingLevel-3-mobile-capsizeTrims-baselineTrim__qhrpjv4x: -0.2273em;
-  --headingLevel-3-tablet-fontSize__qhrpjv4y: 24px;
-  --headingLevel-3-tablet-lineHeight__qhrpjv4z: 29.792px;
-  --headingLevel-3-tablet-capHeight__qhrpjv50: 18.792px;
-  --headingLevel-3-tablet-capsizeTrims-capHeightTrim__qhrpjv51: -0.2292em;
-  --headingLevel-3-tablet-capsizeTrims-baselineTrim__qhrpjv52: -0.2292em;
-  --headingLevel-4-mobile-fontSize__qhrpjv53: 20px;
-  --headingLevel-4-mobile-lineHeight__qhrpjv54: 24.66px;
-  --headingLevel-4-mobile-capHeight__qhrpjv55: 15.66px;
-  --headingLevel-4-mobile-capsizeTrims-capHeightTrim__qhrpjv56: -0.225em;
-  --headingLevel-4-mobile-capsizeTrims-baselineTrim__qhrpjv57: -0.225em;
-  --headingLevel-4-tablet-fontSize__qhrpjv58: 20px;
-  --headingLevel-4-tablet-lineHeight__qhrpjv59: 24.66px;
-  --headingLevel-4-tablet-capHeight__qhrpjv5a: 15.66px;
-  --headingLevel-4-tablet-capsizeTrims-capHeightTrim__qhrpjv5b: -0.225em;
-  --headingLevel-4-tablet-capsizeTrims-baselineTrim__qhrpjv5c: -0.225em;
-  --headingWeight-weak__qhrpjv5d: 400;
-  --headingWeight-regular__qhrpjv5e: 600;
-  --linkDecoration__qhrpjv5f: underline;
-  --inlineFieldSize-standard__qhrpjv5g: 24px;
-  --inlineFieldSize-small__qhrpjv5h: 20px;
-  --transition-fast__qhrpjv5i: transform .125s ease, opacity .125s ease;
-  --transition-touchable__qhrpjv5j: transform 0.2s cubic-bezier(0.02, 1.505, 0.745, 1.235);
-  --transform-touchable__qhrpjv5k: scale(0.95);
-  --shadow-small__qhrpjv5l: 0 0 4px 0 rgba(28,35,48,0.08), 0 4px 8px -2px rgba(28,35,48,0.08);
-  --shadow-medium__qhrpjv5m: 0 0 8px 0 rgba(28,35,48,0.08), 0 8px 16px -4px rgba(28,35,48,0.08);
-  --shadow-large__qhrpjv5n: 0 0 12px 0 rgba(28,35,48,0.08), 0 12px 24px -6px rgba(28,35,48,0.08);
-}
-.App_vanillaBox__inn18b0 {
-  --backgroundColor__zv7nmx0: blueviolet;
-  background-color: var(--backgroundColor__zv7nmx0);
-  color: white;
-  font-size: 20px;
-  padding: 100px;
-}
-    </style>
-    <script type="module">
-      import { injectIntoGlobalHook } from "/@react-refresh";
-injectIntoGlobalHook(window);
-window.$RefreshReg$ = () => {};
-window.$RefreshSig$ = () => (type) => type;
-    </script>
-    <script
-      type="module"
-      src="/@vite/client"
-    >
-    </script>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <script>
-      window.SKU_SITE = 'seekAnz';
-    </script>
-    <script
-      type="module"
-      src="/@id/__x00__/index.html?html-proxy&index=0.js"
-    >
-    </script>
-    <script
-      type="module"
-      src="/@id/__x00__/index.html?html-proxy&index=1.js"
-    >
-    </script>
-  </head>
-  <body>
-    <div id="app">
-      <style type="text/css">
-        html,body{margin:0;padding:0;background:#fff}
-            html.sprinkles_darkMode__1hjdb9v11,html.sprinkles_darkMode__1hjdb9v11 body{color-scheme:dark;background:#1C2330}
-      </style>
-      <div class="seekJobs_seekJobs__1fmskxf0 typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13">
-        <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSizeTrimmed_standard__co4djb9 typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
-          Hello
-          seekAnz
-          <span class="reset_base__yw2qws0 sprinkles_display_inlineBlock_mobile__1hjdb9v58">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewbox="0 0 24 24"
-              xml:space="preserve"
-              focusable="false"
-              fill="currentColor"
-              width="16"
-              height="16"
-              class="reset_base__yw2qws0 IconChevron_root__v2pdba0 sprinkles_display_inlineBlock_mobile__1hjdb9v58 sprinkles_position_relative_mobile__1hjdb9v5g icon_size__1ltfiyk0 icon_inlineCrop__1ltfiyk2 icon_inline__1ltfiyk3 icon_alignY_uppercase_none__1ltfiyk4"
-              aria-hidden="true"
-            >
-              <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
-              </path>
-            </svg>
-          </span>
-        </span>
-        <div class="reset_base__yw2qws0 sprinkles_paddingBottom_gutter_mobile__1hjdb9v8s sprinkles_paddingTop_gutter_mobile__1hjdb9v7o sprinkles_paddingLeft_gutter_mobile__1hjdb9vb0 sprinkles_paddingRight_gutter_mobile__1hjdb9v9w sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_large_mobile__1hjdb9v6c sprinkles_textAlign_left_mobile__1hjdb9vic sprinkles_boxShadow_borderNeutralLight_lightMode__1hjdb9v4k sprinkles_boxShadow_borderNeutral_darkMode__1hjdb9v4d typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13 sprinkles_background_surface_lightMode__1hjdb9v34 sprinkles_background_surfaceDark_darkMode__1hjdb9v37">
-          <div class="reset_base__yw2qws0 sprinkles_position_relative_mobile__1hjdb9v5g">
-            <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c sprinkles_textAlign_left_mobile__1hjdb9vic">
-              <input
-                class="reset_base__yw2qws0 reset_input__yw2qwse reset_field__yw2qws9 reset_block__yw2qws1 reset_appearance__yw2qws6 reset_transparent__yw2qws7 reset_focusVisible__yw2qws8 reset_input__yw2qwsd sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_zIndex_1__1hjdb9v9 sprinkles_cursor_pointer__1hjdb9vi sprinkles_opacity_0__1hjdb9v7 InlineField_realField__1b4ltjx4 InlineField_sizeVars_standard__1b4ltjx2"
-                type="checkbox"
-                id="id_1"
-                aria-checked="false"
-              >
-              <div class="reset_base__yw2qws0 sprinkles_flexShrink_0_mobile__1hjdb9vi0 sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_standard_mobile__1hjdb9v68 InlineField_fakeField__1b4ltjx5 InlineField_sizeVars_standard__1b4ltjx2 typography_lightModeTone_light__co4djb10  sprinkles_background_surface_lightMode__1hjdb9v34">
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_selected__1b4ltjx9 typography_lightModeTone_dark__co4djb11 typography_darkModeTone_dark__co4djb13 sprinkles_background_formAccent_lightMode__1hjdb9v22 sprinkles_background_formAccent_darkMode__1hjdb9v23">
-                  <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_boxShadow_borderField_lightMode__1hjdb9v3y sprinkles_boxShadow_borderField_darkMode__1hjdb9v3z">
-                </span>
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 sprinkles_boxShadow_borderCritical_lightMode__1hjdb9v3q sprinkles_boxShadow_borderCriticalLight_darkMode__1hjdb9v3v">
-                </span>
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_hoverOverlay__1b4ltjxb sprinkles_boxShadow_borderFormAccent_lightMode__1hjdb9v40 sprinkles_boxShadow_borderFormAccentLight_darkMode__1hjdb9v45">
-                  <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-              </div>
-              <div class="reset_base__yw2qws0 sprinkles_paddingLeft_xsmall_mobile__1hjdb9vb8 sprinkles_flexGrow_1_mobile__1hjdb9vi8">
-                <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c InlineField_sizeVars_standard__1b4ltjx2 InlineField_labelOffset__1b4ltjx6">
-                  <label
-                    class="reset_base__yw2qws0 sprinkles_userSelect_none__1hjdb9v4 sprinkles_display_block_mobile__1hjdb9v50 sprinkles_cursor_pointer__1hjdb9vi virtualTouchable_virtualTouchable__9705do0"
-                    for="id_1"
-                  >
-                    <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSizeTrimmed_standard__co4djb9 typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
-                      This is a checkbox
-                    </span>
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="reset_base__yw2qws0 App_vanillaBox__inn18b0">
-          🧁 Vanilla content
-          Initial
-        </div>
-      </div>
-    </div>
-    <script
-      type="module"
-      src="{cwd}/packages/sku/dist/services/vite/entries/vite-client.js"
-    >
-    </script>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"site":"seekAnz"}
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -4548,14 +4548,4837 @@
+@@ -1,4707 +1,9530 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <style
+       type="text/css"
+       data-vanilla-extract-inline-dev-css
+     >
+       .reset_base__yw2qws0 {
+   margin: 0;
+   padding: 0;
+   border: 0;
+   box-sizing: border-box;
+   font-size: 100%;
+   font: inherit;
+   vertical-align: baseline;
+   -webkit-tap-highlight-color: transparent;
+ }
+ .reset_block__yw2qws1 {
+   display: block;
+ }
+ .reset_body__yw2qws2 {
+   line-height: 1;
+ }
+ .reset_list__yw2qws3 {
+   list-style: none;
+ }
+ .reset_quote__yw2qws4 {
+   quotes: none;
+ }
+ .reset_quote__yw2qws4:before, .reset_quote__yw2qws4:after {
+   content: '';
+ }
+ .reset_table__yw2qws5 {
+   border-collapse: collapse;
+   border-spacing: 0;
+ }
+ .reset_appearance__yw2qws6 {
+   appearance: none;
+ }
+ .reset_transparent__yw2qws7 {
+   background-color: transparent;
+ }
+ .reset_focusVisible__yw2qws8 {
+   outline: var(--focusRingSize__qhrpjv10) solid transparent;
+   transition: outline-color .125s ease;
+ }
+ .reset_focusVisible__yw2qws8:focus-visible {
+   outline-color: var(--borderColor-focus__qhrpjvm);
+ }
+ .reset_mark__yw2qwsa {
+   color: inherit;
+ }
+ .reset_select__yw2qwsb:disabled {
+   opacity: 1;
+ }
+ .reset_select__yw2qwsb::-ms-expand {
+   display: none;
+ }
+ .reset_input__yw2qwsd[type="number"] {
+   -moz-appearance: textfield;
+ }
+ .reset_input__yw2qwsd[type="number"]::-webkit-inner-spin-button,.reset_input__yw2qwsd[type="number"]::-webkit-outer-spin-button {
+   -webkit-appearance: none;
+   margin: 0;
+ }
+ .reset_input__yw2qwsd::-ms-clear {
+   display: none;
+ }
+ .reset_input__yw2qwsd::-webkit-search-cancel-button {
+   -webkit-appearance: none;
+ }
+ .reset_a__yw2qwsg {
+   text-decoration: none;
+   color: inherit;
+ }
+ .sprinkles_overflow_hidden__1hjdb9v0 {
+   overflow: hidden;
+ }
+ .sprinkles_overflow_scroll__1hjdb9v1 {
+   overflow: scroll;
+ }
+ .sprinkles_overflow_visible__1hjdb9v2 {
+   overflow: visible;
+ }
+ .sprinkles_overflow_auto__1hjdb9v3 {
+   overflow: auto;
+ }
+ .sprinkles_userSelect_none__1hjdb9v4 {
+   user-select: none;
+ }
+ .sprinkles_outline_none__1hjdb9v5 {
+   outline: none;
+ }
+ .sprinkles_outline_focus__1hjdb9v6 {
+   outline: var(--focusRingSize__qhrpjv10) solid transparent;
+   transition: outline-color .125s ease;
+ }
+ .sprinkles_outline_focus__1hjdb9v6:focus-visible {
+   outline-color: var(--borderColor-focus__qhrpjvm);
+ }
+ .sprinkles_opacity_0__1hjdb9v7 {
+   opacity: 0;
+ }
+ .sprinkles_zIndex_0__1hjdb9v8 {
+   z-index: 0;
+ }
+ .sprinkles_zIndex_1__1hjdb9v9 {
+   z-index: 1;
+ }
+ .sprinkles_zIndex_2__1hjdb9va {
+   z-index: 2;
+ }
+ .sprinkles_zIndex_dropdownBackdrop__1hjdb9vb {
+   z-index: 90;
+ }
+ .sprinkles_zIndex_dropdown__1hjdb9vc {
+   z-index: 100;
+ }
+ .sprinkles_zIndex_sticky__1hjdb9vd {
+   z-index: 200;
+ }
+ .sprinkles_zIndex_modalBackdrop__1hjdb9ve {
+   z-index: 290;
+ }
+ .sprinkles_zIndex_modal__1hjdb9vf {
+   z-index: 300;
+ }
+ .sprinkles_zIndex_notification__1hjdb9vg {
+   z-index: 400;
+ }
+ .sprinkles_cursor_default__1hjdb9vh {
+   cursor: default;
+ }
+ .sprinkles_cursor_pointer__1hjdb9vi {
+   cursor: pointer;
+ }
+ .sprinkles_pointerEvents_none__1hjdb9vj {
+   pointer-events: none;
+ }
+ .sprinkles_top_0__1hjdb9vk {
+   top: 0;
+ }
+ .sprinkles_bottom_0__1hjdb9vl {
+   bottom: 0;
+ }
+ .sprinkles_left_0__1hjdb9vm {
+   left: 0;
+ }
+ .sprinkles_right_0__1hjdb9vn {
+   right: 0;
+ }
+ .sprinkles_height_full__1hjdb9vo {
+   height: 100%;
+ }
+ .sprinkles_height_touchable__1hjdb9vp {
+   height: var(--touchableSize__qhrpjv9);
+ }
+ .sprinkles_width_full__1hjdb9vq {
+   width: 100%;
+ }
+ .sprinkles_width_touchable__1hjdb9vr {
+   width: var(--touchableSize__qhrpjv9);
+ }
+ .sprinkles_minWidth_0__1hjdb9vs {
+   min-width: 0%;
+ }
+ .sprinkles_maxWidth_xsmall__1hjdb9vt {
+   max-width: var(--contentWidth-xsmall__qhrpjv11);
+ }
+ .sprinkles_maxWidth_small__1hjdb9vu {
+   max-width: var(--contentWidth-small__qhrpjv12);
+ }
+ .sprinkles_maxWidth_medium__1hjdb9vv {
+   max-width: var(--contentWidth-medium__qhrpjv13);
+ }
+ .sprinkles_maxWidth_large__1hjdb9vw {
+   max-width: var(--contentWidth-large__qhrpjv14);
+ }
+ .sprinkles_maxWidth_content__1hjdb9vx {
+   max-width: fit-content;
+ }
+ .sprinkles_transition_fast__1hjdb9vy {
+   transition: var(--transition-fast__qhrpjv5i);
+ }
+ .sprinkles_transition_touchable__1hjdb9vz {
+   transition: var(--transition-touchable__qhrpjv5j);
+ }
+ .sprinkles_transform_touchable_active__1hjdb9v10:active {
+   transform: var(--transform-touchable__qhrpjv5k);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_body_lightMode__1hjdb9v12 {
+   background: var(--backgroundColor-body__qhrpjv1t);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_body_darkMode__1hjdb9v13 {
+   background: var(--backgroundColor-body__qhrpjv1t);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_bodyDark_lightMode__1hjdb9v14 {
+   background: var(--backgroundColor-bodyDark__qhrpjv1u);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_bodyDark_darkMode__1hjdb9v15 {
+   background: var(--backgroundColor-bodyDark__qhrpjv1u);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brand_lightMode__1hjdb9v16 {
+   background: var(--backgroundColor-brand__qhrpjv1v);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brand_darkMode__1hjdb9v17 {
+   background: var(--backgroundColor-brand__qhrpjv1v);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccent_lightMode__1hjdb9v18 {
+   background: var(--backgroundColor-brandAccent__qhrpjv1w);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccent_darkMode__1hjdb9v19 {
+   background: var(--backgroundColor-brandAccent__qhrpjv1w);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentActive_lightMode__1hjdb9v1a {
+   background: var(--backgroundColor-brandAccentActive__qhrpjv1x);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentActive_darkMode__1hjdb9v1b {
+   background: var(--backgroundColor-brandAccentActive__qhrpjv1x);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentHover_lightMode__1hjdb9v1c {
+   background: var(--backgroundColor-brandAccentHover__qhrpjv1y);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentHover_darkMode__1hjdb9v1d {
+   background: var(--backgroundColor-brandAccentHover__qhrpjv1y);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentSoft_lightMode__1hjdb9v1e {
+   background: var(--backgroundColor-brandAccentSoft__qhrpjv1z);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentSoft_darkMode__1hjdb9v1f {
+   background: var(--backgroundColor-brandAccentSoft__qhrpjv1z);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentSoftActive_lightMode__1hjdb9v1g {
+   background: var(--backgroundColor-brandAccentSoftActive__qhrpjv20);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentSoftActive_darkMode__1hjdb9v1h {
+   background: var(--backgroundColor-brandAccentSoftActive__qhrpjv20);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_brandAccentSoftHover_lightMode__1hjdb9v1i {
+   background: var(--backgroundColor-brandAccentSoftHover__qhrpjv21);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_brandAccentSoftHover_darkMode__1hjdb9v1j {
+   background: var(--backgroundColor-brandAccentSoftHover__qhrpjv21);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_caution_lightMode__1hjdb9v1k {
+   background: var(--backgroundColor-caution__qhrpjv22);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_caution_darkMode__1hjdb9v1l {
+   background: var(--backgroundColor-caution__qhrpjv22);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_cautionLight_lightMode__1hjdb9v1m {
+   background: var(--backgroundColor-cautionLight__qhrpjv23);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_cautionLight_darkMode__1hjdb9v1n {
+   background: var(--backgroundColor-cautionLight__qhrpjv23);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_critical_lightMode__1hjdb9v1o {
+   background: var(--backgroundColor-critical__qhrpjv24);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_critical_darkMode__1hjdb9v1p {
+   background: var(--backgroundColor-critical__qhrpjv24);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalActive_lightMode__1hjdb9v1q {
+   background: var(--backgroundColor-criticalActive__qhrpjv25);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalActive_darkMode__1hjdb9v1r {
+   background: var(--backgroundColor-criticalActive__qhrpjv25);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalHover_lightMode__1hjdb9v1s {
+   background: var(--backgroundColor-criticalHover__qhrpjv26);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalHover_darkMode__1hjdb9v1t {
+   background: var(--backgroundColor-criticalHover__qhrpjv26);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalLight_lightMode__1hjdb9v1u {
+   background: var(--backgroundColor-criticalLight__qhrpjv27);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalLight_darkMode__1hjdb9v1v {
+   background: var(--backgroundColor-criticalLight__qhrpjv27);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalSoft_lightMode__1hjdb9v1w {
+   background: var(--backgroundColor-criticalSoft__qhrpjv28);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalSoft_darkMode__1hjdb9v1x {
+   background: var(--backgroundColor-criticalSoft__qhrpjv28);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalSoftActive_lightMode__1hjdb9v1y {
+   background: var(--backgroundColor-criticalSoftActive__qhrpjv29);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalSoftActive_darkMode__1hjdb9v1z {
+   background: var(--backgroundColor-criticalSoftActive__qhrpjv29);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_criticalSoftHover_lightMode__1hjdb9v20 {
+   background: var(--backgroundColor-criticalSoftHover__qhrpjv2a);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_criticalSoftHover_darkMode__1hjdb9v21 {
+   background: var(--backgroundColor-criticalSoftHover__qhrpjv2a);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccent_lightMode__1hjdb9v22 {
+   background: var(--backgroundColor-formAccent__qhrpjv2b);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccent_darkMode__1hjdb9v23 {
+   background: var(--backgroundColor-formAccent__qhrpjv2b);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentActive_lightMode__1hjdb9v24 {
+   background: var(--backgroundColor-formAccentActive__qhrpjv2c);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentActive_darkMode__1hjdb9v25 {
+   background: var(--backgroundColor-formAccentActive__qhrpjv2c);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentHover_lightMode__1hjdb9v26 {
+   background: var(--backgroundColor-formAccentHover__qhrpjv2d);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentHover_darkMode__1hjdb9v27 {
+   background: var(--backgroundColor-formAccentHover__qhrpjv2d);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentSoft_lightMode__1hjdb9v28 {
+   background: var(--backgroundColor-formAccentSoft__qhrpjv2e);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentSoft_darkMode__1hjdb9v29 {
+   background: var(--backgroundColor-formAccentSoft__qhrpjv2e);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentSoftActive_lightMode__1hjdb9v2a {
+   background: var(--backgroundColor-formAccentSoftActive__qhrpjv2f);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentSoftActive_darkMode__1hjdb9v2b {
+   background: var(--backgroundColor-formAccentSoftActive__qhrpjv2f);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_formAccentSoftHover_lightMode__1hjdb9v2c {
+   background: var(--backgroundColor-formAccentSoftHover__qhrpjv2g);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_formAccentSoftHover_darkMode__1hjdb9v2d {
+   background: var(--backgroundColor-formAccentSoftHover__qhrpjv2g);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_info_lightMode__1hjdb9v2e {
+   background: var(--backgroundColor-info__qhrpjv2h);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_info_darkMode__1hjdb9v2f {
+   background: var(--backgroundColor-info__qhrpjv2h);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_infoLight_lightMode__1hjdb9v2g {
+   background: var(--backgroundColor-infoLight__qhrpjv2i);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_infoLight_darkMode__1hjdb9v2h {
+   background: var(--backgroundColor-infoLight__qhrpjv2i);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutral_lightMode__1hjdb9v2i {
+   background: var(--backgroundColor-neutral__qhrpjv2j);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutral_darkMode__1hjdb9v2j {
+   background: var(--backgroundColor-neutral__qhrpjv2j);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralActive_lightMode__1hjdb9v2k {
+   background: var(--backgroundColor-neutralActive__qhrpjv2k);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralActive_darkMode__1hjdb9v2l {
+   background: var(--backgroundColor-neutralActive__qhrpjv2k);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralHover_lightMode__1hjdb9v2m {
+   background: var(--backgroundColor-neutralHover__qhrpjv2l);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralHover_darkMode__1hjdb9v2n {
+   background: var(--backgroundColor-neutralHover__qhrpjv2l);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralLight_lightMode__1hjdb9v2o {
+   background: var(--backgroundColor-neutralLight__qhrpjv2m);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralLight_darkMode__1hjdb9v2p {
+   background: var(--backgroundColor-neutralLight__qhrpjv2m);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralSoft_lightMode__1hjdb9v2q {
+   background: var(--backgroundColor-neutralSoft__qhrpjv2n);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralSoft_darkMode__1hjdb9v2r {
+   background: var(--backgroundColor-neutralSoft__qhrpjv2n);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralSoftActive_lightMode__1hjdb9v2s {
+   background: var(--backgroundColor-neutralSoftActive__qhrpjv2o);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralSoftActive_darkMode__1hjdb9v2t {
+   background: var(--backgroundColor-neutralSoftActive__qhrpjv2o);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_neutralSoftHover_lightMode__1hjdb9v2u {
+   background: var(--backgroundColor-neutralSoftHover__qhrpjv2p);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_neutralSoftHover_darkMode__1hjdb9v2v {
+   background: var(--backgroundColor-neutralSoftHover__qhrpjv2p);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_positive_lightMode__1hjdb9v2w {
+   background: var(--backgroundColor-positive__qhrpjv2q);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_positive_darkMode__1hjdb9v2x {
+   background: var(--backgroundColor-positive__qhrpjv2q);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_positiveLight_lightMode__1hjdb9v2y {
+   background: var(--backgroundColor-positiveLight__qhrpjv2r);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_positiveLight_darkMode__1hjdb9v2z {
+   background: var(--backgroundColor-positiveLight__qhrpjv2r);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_promote_lightMode__1hjdb9v30 {
+   background: var(--backgroundColor-promote__qhrpjv2s);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_promote_darkMode__1hjdb9v31 {
+   background: var(--backgroundColor-promote__qhrpjv2s);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_promoteLight_lightMode__1hjdb9v32 {
+   background: var(--backgroundColor-promoteLight__qhrpjv2t);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_promoteLight_darkMode__1hjdb9v33 {
+   background: var(--backgroundColor-promoteLight__qhrpjv2t);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_surface_lightMode__1hjdb9v34 {
+   background: var(--backgroundColor-surface__qhrpjv2u);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_surface_darkMode__1hjdb9v35 {
+   background: var(--backgroundColor-surface__qhrpjv2u);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_background_surfaceDark_lightMode__1hjdb9v36 {
+   background: var(--backgroundColor-surfaceDark__qhrpjv2v);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_background_surfaceDark_darkMode__1hjdb9v37 {
+   background: var(--backgroundColor-surfaceDark__qhrpjv2v);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_small_lightMode__1hjdb9v38 {
+   box-shadow: var(--shadow-small__qhrpjv5l);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_small_darkMode__1hjdb9v39 {
+   box-shadow: var(--shadow-small__qhrpjv5l);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_medium_lightMode__1hjdb9v3a {
+   box-shadow: var(--shadow-medium__qhrpjv5m);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_medium_darkMode__1hjdb9v3b {
+   box-shadow: var(--shadow-medium__qhrpjv5m);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_large_lightMode__1hjdb9v3c {
+   box-shadow: var(--shadow-large__qhrpjv5n);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_large_darkMode__1hjdb9v3d {
+   box-shadow: var(--shadow-large__qhrpjv5n);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccent_lightMode__1hjdb9v3e {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccent__qhrpjvf);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccent_darkMode__1hjdb9v3f {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccent__qhrpjvf);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccentLight_lightMode__1hjdb9v3g {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccentLight__qhrpjvg);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccentLight_darkMode__1hjdb9v3h {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-brandAccentLight__qhrpjvg);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccentLarge_lightMode__1hjdb9v3i {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccent__qhrpjvf);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccentLarge_darkMode__1hjdb9v3j {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccent__qhrpjvf);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderBrandAccentLightLarge_lightMode__1hjdb9v3k {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccentLight__qhrpjvg);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderBrandAccentLightLarge_darkMode__1hjdb9v3l {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-brandAccentLight__qhrpjvg);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCaution_lightMode__1hjdb9v3m {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-caution__qhrpjvh);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCaution_darkMode__1hjdb9v3n {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-caution__qhrpjvh);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCautionLight_lightMode__1hjdb9v3o {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-cautionLight__qhrpjvi);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCautionLight_darkMode__1hjdb9v3p {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-cautionLight__qhrpjvi);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCritical_lightMode__1hjdb9v3q {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-critical__qhrpjvj);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCritical_darkMode__1hjdb9v3r {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-critical__qhrpjvj);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCriticalLarge_lightMode__1hjdb9v3s {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-critical__qhrpjvj);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCriticalLarge_darkMode__1hjdb9v3t {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-critical__qhrpjvj);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCriticalLight_lightMode__1hjdb9v3u {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-criticalLight__qhrpjvk);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCriticalLight_darkMode__1hjdb9v3v {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-criticalLight__qhrpjvk);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderCriticalLightLarge_lightMode__1hjdb9v3w {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-criticalLight__qhrpjvk);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderCriticalLightLarge_darkMode__1hjdb9v3x {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-criticalLight__qhrpjvk);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderField_lightMode__1hjdb9v3y {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-field__qhrpjvl);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderField_darkMode__1hjdb9v3z {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-field__qhrpjvl);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccent_lightMode__1hjdb9v40 {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccent__qhrpjvn);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccent_darkMode__1hjdb9v41 {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccent__qhrpjvn);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccentLarge_lightMode__1hjdb9v42 {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccent__qhrpjvn);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccentLarge_darkMode__1hjdb9v43 {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccent__qhrpjvn);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccentLight_lightMode__1hjdb9v44 {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccentLight_darkMode__1hjdb9v45 {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderFormAccentLightLarge_lightMode__1hjdb9v46 {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderFormAccentLightLarge_darkMode__1hjdb9v47 {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderInfo_lightMode__1hjdb9v48 {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-info__qhrpjvp);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderInfo_darkMode__1hjdb9v49 {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-info__qhrpjvp);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderInfoLight_lightMode__1hjdb9v4a {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-infoLight__qhrpjvq);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderInfoLight_darkMode__1hjdb9v4b {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-infoLight__qhrpjvq);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutral_lightMode__1hjdb9v4c {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutral__qhrpjvr);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutral_darkMode__1hjdb9v4d {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutral__qhrpjvr);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralLarge_lightMode__1hjdb9v4e {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutral__qhrpjvr);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralLarge_darkMode__1hjdb9v4f {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutral__qhrpjvr);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralInverted_lightMode__1hjdb9v4g {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralInverted__qhrpjvs);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralInverted_darkMode__1hjdb9v4h {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralInverted__qhrpjvs);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralInvertedLarge_lightMode__1hjdb9v4i {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutralInverted__qhrpjvs);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralInvertedLarge_darkMode__1hjdb9v4j {
+   box-shadow: inset 0 0 0 var(--borderWidth-large__qhrpjvz) var(--borderColor-neutralInverted__qhrpjvs);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderNeutralLight_lightMode__1hjdb9v4k {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralLight__qhrpjvt);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderNeutralLight_darkMode__1hjdb9v4l {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-neutralLight__qhrpjvt);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPositive_lightMode__1hjdb9v4m {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positive__qhrpjvu);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPositive_darkMode__1hjdb9v4n {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positive__qhrpjvu);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPositiveLight_lightMode__1hjdb9v4o {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positiveLight__qhrpjvv);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPositiveLight_darkMode__1hjdb9v4p {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-positiveLight__qhrpjvv);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPromote_lightMode__1hjdb9v4q {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promote__qhrpjvw);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPromote_darkMode__1hjdb9v4r {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promote__qhrpjvw);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_borderPromoteLight_lightMode__1hjdb9v4s {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promoteLight__qhrpjvx);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_borderPromoteLight_darkMode__1hjdb9v4t {
+   box-shadow: inset 0 0 0 var(--borderWidth-standard__qhrpjvy) var(--borderColor-promoteLight__qhrpjvx);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .sprinkles_boxShadow_outlineFocus_lightMode__1hjdb9v4u {
+   box-shadow: 0 0 0 var(--focusRingSize__qhrpjv10) var(--borderColor-focus__qhrpjvm);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .sprinkles_boxShadow_outlineFocus_darkMode__1hjdb9v4v {
+   box-shadow: 0 0 0 var(--focusRingSize__qhrpjv10) var(--borderColor-focus__qhrpjvm);
+ }
+ .sprinkles_display_none_mobile__1hjdb9v4w {
+   display: none;
+ }
+ .sprinkles_display_block_mobile__1hjdb9v50 {
+   display: block;
+ }
+ .sprinkles_display_inline_mobile__1hjdb9v54 {
+   display: inline;
+ }
+ .sprinkles_display_inlineBlock_mobile__1hjdb9v58 {
+   display: inline-block;
+ }
+ .sprinkles_display_flex_mobile__1hjdb9v5c {
+   display: flex;
+ }
+ .sprinkles_position_relative_mobile__1hjdb9v5g {
+   position: relative;
+ }
+ .sprinkles_position_absolute_mobile__1hjdb9v5k {
+   position: absolute;
+ }
+ .sprinkles_position_fixed_mobile__1hjdb9v5o {
+   position: fixed;
+ }
+ .sprinkles_position_sticky_mobile__1hjdb9v5s {
+   position: sticky;
+ }
+ .sprinkles_borderRadius_none_mobile__1hjdb9v5w {
+   border-radius: 0px;
+ }
+ .sprinkles_borderRadius_full_mobile__1hjdb9v60 {
+   border-radius: 9999px;
+ }
+ .sprinkles_borderRadius_small_mobile__1hjdb9v64 {
+   border-radius: var(--borderRadius-small__qhrpjvb);
+ }
+ .sprinkles_borderRadius_standard_mobile__1hjdb9v68 {
+   border-radius: var(--borderRadius-standard__qhrpjvc);
+ }
+ .sprinkles_borderRadius_large_mobile__1hjdb9v6c {
+   border-radius: var(--borderRadius-large__qhrpjvd);
+ }
+ .sprinkles_borderRadius_xlarge_mobile__1hjdb9v6g {
+   border-radius: var(--borderRadius-xlarge__qhrpjve);
+ }
+ .sprinkles_gap_gutter_mobile__1hjdb9v6k {
+   gap: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_gap_xxsmall_mobile__1hjdb9v6o {
+   gap: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_gap_xsmall_mobile__1hjdb9v6s {
+   gap: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_gap_small_mobile__1hjdb9v6w {
+   gap: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_gap_medium_mobile__1hjdb9v70 {
+   gap: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_gap_large_mobile__1hjdb9v74 {
+   gap: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_gap_xlarge_mobile__1hjdb9v78 {
+   gap: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_gap_xxlarge_mobile__1hjdb9v7c {
+   gap: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_gap_xxxlarge_mobile__1hjdb9v7g {
+   gap: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_gap_none_mobile__1hjdb9v7k {
+   gap: 0;
+ }
+ .sprinkles_paddingTop_gutter_mobile__1hjdb9v7o {
+   padding-top: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_paddingTop_xxsmall_mobile__1hjdb9v7s {
+   padding-top: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_paddingTop_xsmall_mobile__1hjdb9v7w {
+   padding-top: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_paddingTop_small_mobile__1hjdb9v80 {
+   padding-top: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_paddingTop_medium_mobile__1hjdb9v84 {
+   padding-top: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_paddingTop_large_mobile__1hjdb9v88 {
+   padding-top: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_paddingTop_xlarge_mobile__1hjdb9v8c {
+   padding-top: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_paddingTop_xxlarge_mobile__1hjdb9v8g {
+   padding-top: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_paddingTop_xxxlarge_mobile__1hjdb9v8k {
+   padding-top: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_paddingTop_none_mobile__1hjdb9v8o {
+   padding-top: 0;
+ }
+ .sprinkles_paddingBottom_gutter_mobile__1hjdb9v8s {
+   padding-bottom: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_paddingBottom_xxsmall_mobile__1hjdb9v8w {
+   padding-bottom: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_paddingBottom_xsmall_mobile__1hjdb9v90 {
+   padding-bottom: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_paddingBottom_small_mobile__1hjdb9v94 {
+   padding-bottom: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_paddingBottom_medium_mobile__1hjdb9v98 {
+   padding-bottom: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_paddingBottom_large_mobile__1hjdb9v9c {
+   padding-bottom: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_paddingBottom_xlarge_mobile__1hjdb9v9g {
+   padding-bottom: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_paddingBottom_xxlarge_mobile__1hjdb9v9k {
+   padding-bottom: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_paddingBottom_xxxlarge_mobile__1hjdb9v9o {
+   padding-bottom: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_paddingBottom_none_mobile__1hjdb9v9s {
+   padding-bottom: 0;
+ }
+ .sprinkles_paddingRight_gutter_mobile__1hjdb9v9w {
+   padding-right: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_paddingRight_xxsmall_mobile__1hjdb9va0 {
+   padding-right: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_paddingRight_xsmall_mobile__1hjdb9va4 {
+   padding-right: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_paddingRight_small_mobile__1hjdb9va8 {
+   padding-right: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_paddingRight_medium_mobile__1hjdb9vac {
+   padding-right: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_paddingRight_large_mobile__1hjdb9vag {
+   padding-right: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_paddingRight_xlarge_mobile__1hjdb9vak {
+   padding-right: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_paddingRight_xxlarge_mobile__1hjdb9vao {
+   padding-right: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_paddingRight_xxxlarge_mobile__1hjdb9vas {
+   padding-right: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_paddingRight_none_mobile__1hjdb9vaw {
+   padding-right: 0;
+ }
+ .sprinkles_paddingLeft_gutter_mobile__1hjdb9vb0 {
+   padding-left: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_paddingLeft_xxsmall_mobile__1hjdb9vb4 {
+   padding-left: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_paddingLeft_xsmall_mobile__1hjdb9vb8 {
+   padding-left: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_paddingLeft_small_mobile__1hjdb9vbc {
+   padding-left: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_paddingLeft_medium_mobile__1hjdb9vbg {
+   padding-left: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_paddingLeft_large_mobile__1hjdb9vbk {
+   padding-left: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_paddingLeft_xlarge_mobile__1hjdb9vbo {
+   padding-left: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_paddingLeft_xxlarge_mobile__1hjdb9vbs {
+   padding-left: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_paddingLeft_xxxlarge_mobile__1hjdb9vbw {
+   padding-left: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_paddingLeft_none_mobile__1hjdb9vc0 {
+   padding-left: 0;
+ }
+ .sprinkles_marginTop_gutter_mobile__1hjdb9vc4 {
+   margin-top: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_marginTop_xxsmall_mobile__1hjdb9vc8 {
+   margin-top: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_marginTop_xsmall_mobile__1hjdb9vcc {
+   margin-top: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_marginTop_small_mobile__1hjdb9vcg {
+   margin-top: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_marginTop_medium_mobile__1hjdb9vck {
+   margin-top: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_marginTop_large_mobile__1hjdb9vco {
+   margin-top: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_marginTop_xlarge_mobile__1hjdb9vcs {
+   margin-top: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_marginTop_xxlarge_mobile__1hjdb9vcw {
+   margin-top: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_marginTop_xxxlarge_mobile__1hjdb9vd0 {
+   margin-top: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_marginTop_none_mobile__1hjdb9vd4 {
+   margin-top: 0;
+ }
+ .sprinkles_marginBottom_gutter_mobile__1hjdb9vd8 {
+   margin-bottom: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_marginBottom_xxsmall_mobile__1hjdb9vdc {
+   margin-bottom: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_marginBottom_xsmall_mobile__1hjdb9vdg {
+   margin-bottom: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_marginBottom_small_mobile__1hjdb9vdk {
+   margin-bottom: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_marginBottom_medium_mobile__1hjdb9vdo {
+   margin-bottom: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_marginBottom_large_mobile__1hjdb9vds {
+   margin-bottom: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_marginBottom_xlarge_mobile__1hjdb9vdw {
+   margin-bottom: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_marginBottom_xxlarge_mobile__1hjdb9ve0 {
+   margin-bottom: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_marginBottom_xxxlarge_mobile__1hjdb9ve4 {
+   margin-bottom: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_marginBottom_none_mobile__1hjdb9ve8 {
+   margin-bottom: 0;
+ }
+ .sprinkles_marginRight_gutter_mobile__1hjdb9vec {
+   margin-right: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_marginRight_xxsmall_mobile__1hjdb9veg {
+   margin-right: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_marginRight_xsmall_mobile__1hjdb9vek {
+   margin-right: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_marginRight_small_mobile__1hjdb9veo {
+   margin-right: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_marginRight_medium_mobile__1hjdb9ves {
+   margin-right: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_marginRight_large_mobile__1hjdb9vew {
+   margin-right: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_marginRight_xlarge_mobile__1hjdb9vf0 {
+   margin-right: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_marginRight_xxlarge_mobile__1hjdb9vf4 {
+   margin-right: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_marginRight_xxxlarge_mobile__1hjdb9vf8 {
+   margin-right: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_marginRight_none_mobile__1hjdb9vfc {
+   margin-right: 0;
+ }
+ .sprinkles_marginLeft_gutter_mobile__1hjdb9vfg {
+   margin-left: var(--space-gutter__qhrpjv0);
+ }
+ .sprinkles_marginLeft_xxsmall_mobile__1hjdb9vfk {
+   margin-left: var(--space-xxsmall__qhrpjv1);
+ }
+ .sprinkles_marginLeft_xsmall_mobile__1hjdb9vfo {
+   margin-left: var(--space-xsmall__qhrpjv2);
+ }
+ .sprinkles_marginLeft_small_mobile__1hjdb9vfs {
+   margin-left: var(--space-small__qhrpjv3);
+ }
+ .sprinkles_marginLeft_medium_mobile__1hjdb9vfw {
+   margin-left: var(--space-medium__qhrpjv4);
+ }
+ .sprinkles_marginLeft_large_mobile__1hjdb9vg0 {
+   margin-left: var(--space-large__qhrpjv5);
+ }
+ .sprinkles_marginLeft_xlarge_mobile__1hjdb9vg4 {
+   margin-left: var(--space-xlarge__qhrpjv6);
+ }
+ .sprinkles_marginLeft_xxlarge_mobile__1hjdb9vg8 {
+   margin-left: var(--space-xxlarge__qhrpjv7);
+ }
+ .sprinkles_marginLeft_xxxlarge_mobile__1hjdb9vgc {
+   margin-left: var(--space-xxxlarge__qhrpjv8);
+ }
+ .sprinkles_marginLeft_none_mobile__1hjdb9vgg {
+   margin-left: 0;
+ }
+ .sprinkles_alignItems_flexStart_mobile__1hjdb9vgk {
+   align-items: flex-start;
+ }
+ .sprinkles_alignItems_center_mobile__1hjdb9vgo {
+   align-items: center;
+ }
+ .sprinkles_alignItems_flexEnd_mobile__1hjdb9vgs {
+   align-items: flex-end;
+ }
+ .sprinkles_justifyContent_flexStart_mobile__1hjdb9vgw {
+   justify-content: flex-start;
+ }
+ .sprinkles_justifyContent_center_mobile__1hjdb9vh0 {
+   justify-content: center;
+ }
+ .sprinkles_justifyContent_flexEnd_mobile__1hjdb9vh4 {
+   justify-content: flex-end;
+ }
+ .sprinkles_justifyContent_spaceBetween_mobile__1hjdb9vh8 {
+   justify-content: space-between;
+ }
+ .sprinkles_flexDirection_row_mobile__1hjdb9vhc {
+   flex-direction: row;
+ }
+ .sprinkles_flexDirection_rowReverse_mobile__1hjdb9vhg {
+   flex-direction: row-reverse;
+ }
+ .sprinkles_flexDirection_column_mobile__1hjdb9vhk {
+   flex-direction: column;
+ }
+ .sprinkles_flexDirection_columnReverse_mobile__1hjdb9vho {
+   flex-direction: column-reverse;
+ }
+ .sprinkles_flexWrap_wrap_mobile__1hjdb9vhs {
+   flex-wrap: wrap;
+ }
+ .sprinkles_flexWrap_nowrap_mobile__1hjdb9vhw {
+   flex-wrap: nowrap;
+ }
+ .sprinkles_flexShrink_0_mobile__1hjdb9vi0 {
+   flex-shrink: 0;
+ }
+ .sprinkles_flexGrow_0_mobile__1hjdb9vi4 {
+   flex-grow: 0;
+ }
+ .sprinkles_flexGrow_1_mobile__1hjdb9vi8 {
+   flex-grow: 1;
+ }
+ .sprinkles_textAlign_left_mobile__1hjdb9vic {
+   text-align: left;
+ }
+ .sprinkles_textAlign_center_mobile__1hjdb9vig {
+   text-align: center;
+ }
+ .sprinkles_textAlign_right_mobile__1hjdb9vik {
+   text-align: right;
+ }
+ @media screen and (min-width: 740px) {
+   .sprinkles_display_none_tablet__1hjdb9v4x {
+     display: none;
+   }
+   .sprinkles_display_block_tablet__1hjdb9v51 {
+     display: block;
+   }
+   .sprinkles_display_inline_tablet__1hjdb9v55 {
+     display: inline;
+   }
+   .sprinkles_display_inlineBlock_tablet__1hjdb9v59 {
+     display: inline-block;
+   }
+   .sprinkles_display_flex_tablet__1hjdb9v5d {
+     display: flex;
+   }
+   .sprinkles_position_relative_tablet__1hjdb9v5h {
+     position: relative;
+   }
+   .sprinkles_position_absolute_tablet__1hjdb9v5l {
+     position: absolute;
+   }
+   .sprinkles_position_fixed_tablet__1hjdb9v5p {
+     position: fixed;
+   }
+   .sprinkles_position_sticky_tablet__1hjdb9v5t {
+     position: sticky;
+   }
+   .sprinkles_borderRadius_none_tablet__1hjdb9v5x {
+     border-radius: 0px;
+   }
+   .sprinkles_borderRadius_full_tablet__1hjdb9v61 {
+     border-radius: 9999px;
+   }
+   .sprinkles_borderRadius_small_tablet__1hjdb9v65 {
+     border-radius: var(--borderRadius-small__qhrpjvb);
+   }
+   .sprinkles_borderRadius_standard_tablet__1hjdb9v69 {
+     border-radius: var(--borderRadius-standard__qhrpjvc);
+   }
+   .sprinkles_borderRadius_large_tablet__1hjdb9v6d {
+     border-radius: var(--borderRadius-large__qhrpjvd);
+   }
+   .sprinkles_borderRadius_xlarge_tablet__1hjdb9v6h {
+     border-radius: var(--borderRadius-xlarge__qhrpjve);
+   }
+   .sprinkles_gap_gutter_tablet__1hjdb9v6l {
+     gap: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_gap_xxsmall_tablet__1hjdb9v6p {
+     gap: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_gap_xsmall_tablet__1hjdb9v6t {
+     gap: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_gap_small_tablet__1hjdb9v6x {
+     gap: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_gap_medium_tablet__1hjdb9v71 {
+     gap: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_gap_large_tablet__1hjdb9v75 {
+     gap: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_gap_xlarge_tablet__1hjdb9v79 {
+     gap: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_gap_xxlarge_tablet__1hjdb9v7d {
+     gap: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_gap_xxxlarge_tablet__1hjdb9v7h {
+     gap: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_gap_none_tablet__1hjdb9v7l {
+     gap: 0;
+   }
+   .sprinkles_paddingTop_gutter_tablet__1hjdb9v7p {
+     padding-top: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingTop_xxsmall_tablet__1hjdb9v7t {
+     padding-top: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingTop_xsmall_tablet__1hjdb9v7x {
+     padding-top: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingTop_small_tablet__1hjdb9v81 {
+     padding-top: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingTop_medium_tablet__1hjdb9v85 {
+     padding-top: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingTop_large_tablet__1hjdb9v89 {
+     padding-top: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingTop_xlarge_tablet__1hjdb9v8d {
+     padding-top: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingTop_xxlarge_tablet__1hjdb9v8h {
+     padding-top: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingTop_xxxlarge_tablet__1hjdb9v8l {
+     padding-top: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingTop_none_tablet__1hjdb9v8p {
+     padding-top: 0;
+   }
+   .sprinkles_paddingBottom_gutter_tablet__1hjdb9v8t {
+     padding-bottom: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingBottom_xxsmall_tablet__1hjdb9v8x {
+     padding-bottom: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingBottom_xsmall_tablet__1hjdb9v91 {
+     padding-bottom: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingBottom_small_tablet__1hjdb9v95 {
+     padding-bottom: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingBottom_medium_tablet__1hjdb9v99 {
+     padding-bottom: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingBottom_large_tablet__1hjdb9v9d {
+     padding-bottom: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingBottom_xlarge_tablet__1hjdb9v9h {
+     padding-bottom: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingBottom_xxlarge_tablet__1hjdb9v9l {
+     padding-bottom: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingBottom_xxxlarge_tablet__1hjdb9v9p {
+     padding-bottom: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingBottom_none_tablet__1hjdb9v9t {
+     padding-bottom: 0;
+   }
+   .sprinkles_paddingRight_gutter_tablet__1hjdb9v9x {
+     padding-right: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingRight_xxsmall_tablet__1hjdb9va1 {
+     padding-right: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingRight_xsmall_tablet__1hjdb9va5 {
+     padding-right: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingRight_small_tablet__1hjdb9va9 {
+     padding-right: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingRight_medium_tablet__1hjdb9vad {
+     padding-right: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingRight_large_tablet__1hjdb9vah {
+     padding-right: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingRight_xlarge_tablet__1hjdb9val {
+     padding-right: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingRight_xxlarge_tablet__1hjdb9vap {
+     padding-right: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingRight_xxxlarge_tablet__1hjdb9vat {
+     padding-right: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingRight_none_tablet__1hjdb9vax {
+     padding-right: 0;
+   }
+   .sprinkles_paddingLeft_gutter_tablet__1hjdb9vb1 {
+     padding-left: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingLeft_xxsmall_tablet__1hjdb9vb5 {
+     padding-left: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingLeft_xsmall_tablet__1hjdb9vb9 {
+     padding-left: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingLeft_small_tablet__1hjdb9vbd {
+     padding-left: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingLeft_medium_tablet__1hjdb9vbh {
+     padding-left: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingLeft_large_tablet__1hjdb9vbl {
+     padding-left: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingLeft_xlarge_tablet__1hjdb9vbp {
+     padding-left: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingLeft_xxlarge_tablet__1hjdb9vbt {
+     padding-left: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingLeft_xxxlarge_tablet__1hjdb9vbx {
+     padding-left: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingLeft_none_tablet__1hjdb9vc1 {
+     padding-left: 0;
+   }
+   .sprinkles_marginTop_gutter_tablet__1hjdb9vc5 {
+     margin-top: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginTop_xxsmall_tablet__1hjdb9vc9 {
+     margin-top: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginTop_xsmall_tablet__1hjdb9vcd {
+     margin-top: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginTop_small_tablet__1hjdb9vch {
+     margin-top: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginTop_medium_tablet__1hjdb9vcl {
+     margin-top: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginTop_large_tablet__1hjdb9vcp {
+     margin-top: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginTop_xlarge_tablet__1hjdb9vct {
+     margin-top: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginTop_xxlarge_tablet__1hjdb9vcx {
+     margin-top: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginTop_xxxlarge_tablet__1hjdb9vd1 {
+     margin-top: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginTop_none_tablet__1hjdb9vd5 {
+     margin-top: 0;
+   }
+   .sprinkles_marginBottom_gutter_tablet__1hjdb9vd9 {
+     margin-bottom: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginBottom_xxsmall_tablet__1hjdb9vdd {
+     margin-bottom: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginBottom_xsmall_tablet__1hjdb9vdh {
+     margin-bottom: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginBottom_small_tablet__1hjdb9vdl {
+     margin-bottom: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginBottom_medium_tablet__1hjdb9vdp {
+     margin-bottom: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginBottom_large_tablet__1hjdb9vdt {
+     margin-bottom: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginBottom_xlarge_tablet__1hjdb9vdx {
+     margin-bottom: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginBottom_xxlarge_tablet__1hjdb9ve1 {
+     margin-bottom: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginBottom_xxxlarge_tablet__1hjdb9ve5 {
+     margin-bottom: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginBottom_none_tablet__1hjdb9ve9 {
+     margin-bottom: 0;
+   }
+   .sprinkles_marginRight_gutter_tablet__1hjdb9ved {
+     margin-right: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginRight_xxsmall_tablet__1hjdb9veh {
+     margin-right: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginRight_xsmall_tablet__1hjdb9vel {
+     margin-right: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginRight_small_tablet__1hjdb9vep {
+     margin-right: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginRight_medium_tablet__1hjdb9vet {
+     margin-right: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginRight_large_tablet__1hjdb9vex {
+     margin-right: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginRight_xlarge_tablet__1hjdb9vf1 {
+     margin-right: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginRight_xxlarge_tablet__1hjdb9vf5 {
+     margin-right: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginRight_xxxlarge_tablet__1hjdb9vf9 {
+     margin-right: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginRight_none_tablet__1hjdb9vfd {
+     margin-right: 0;
+   }
+   .sprinkles_marginLeft_gutter_tablet__1hjdb9vfh {
+     margin-left: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginLeft_xxsmall_tablet__1hjdb9vfl {
+     margin-left: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginLeft_xsmall_tablet__1hjdb9vfp {
+     margin-left: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginLeft_small_tablet__1hjdb9vft {
+     margin-left: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginLeft_medium_tablet__1hjdb9vfx {
+     margin-left: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginLeft_large_tablet__1hjdb9vg1 {
+     margin-left: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginLeft_xlarge_tablet__1hjdb9vg5 {
+     margin-left: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginLeft_xxlarge_tablet__1hjdb9vg9 {
+     margin-left: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginLeft_xxxlarge_tablet__1hjdb9vgd {
+     margin-left: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginLeft_none_tablet__1hjdb9vgh {
+     margin-left: 0;
+   }
+   .sprinkles_alignItems_flexStart_tablet__1hjdb9vgl {
+     align-items: flex-start;
+   }
+   .sprinkles_alignItems_center_tablet__1hjdb9vgp {
+     align-items: center;
+   }
+   .sprinkles_alignItems_flexEnd_tablet__1hjdb9vgt {
+     align-items: flex-end;
+   }
+   .sprinkles_justifyContent_flexStart_tablet__1hjdb9vgx {
+     justify-content: flex-start;
+   }
+   .sprinkles_justifyContent_center_tablet__1hjdb9vh1 {
+     justify-content: center;
+   }
+   .sprinkles_justifyContent_flexEnd_tablet__1hjdb9vh5 {
+     justify-content: flex-end;
+   }
+   .sprinkles_justifyContent_spaceBetween_tablet__1hjdb9vh9 {
+     justify-content: space-between;
+   }
+   .sprinkles_flexDirection_row_tablet__1hjdb9vhd {
+     flex-direction: row;
+   }
+   .sprinkles_flexDirection_rowReverse_tablet__1hjdb9vhh {
+     flex-direction: row-reverse;
+   }
+   .sprinkles_flexDirection_column_tablet__1hjdb9vhl {
+     flex-direction: column;
+   }
+   .sprinkles_flexDirection_columnReverse_tablet__1hjdb9vhp {
+     flex-direction: column-reverse;
+   }
+   .sprinkles_flexWrap_wrap_tablet__1hjdb9vht {
+     flex-wrap: wrap;
+   }
+   .sprinkles_flexWrap_nowrap_tablet__1hjdb9vhx {
+     flex-wrap: nowrap;
+   }
+   .sprinkles_flexShrink_0_tablet__1hjdb9vi1 {
+     flex-shrink: 0;
+   }
+   .sprinkles_flexGrow_0_tablet__1hjdb9vi5 {
+     flex-grow: 0;
+   }
+   .sprinkles_flexGrow_1_tablet__1hjdb9vi9 {
+     flex-grow: 1;
+   }
+   .sprinkles_textAlign_left_tablet__1hjdb9vid {
+     text-align: left;
+   }
+   .sprinkles_textAlign_center_tablet__1hjdb9vih {
+     text-align: center;
+   }
+   .sprinkles_textAlign_right_tablet__1hjdb9vil {
+     text-align: right;
+   }
+ }
+ @media screen and (min-width: 992px) {
+   .sprinkles_display_none_desktop__1hjdb9v4y {
+     display: none;
+   }
+   .sprinkles_display_block_desktop__1hjdb9v52 {
+     display: block;
+   }
+   .sprinkles_display_inline_desktop__1hjdb9v56 {
+     display: inline;
+   }
+   .sprinkles_display_inlineBlock_desktop__1hjdb9v5a {
+     display: inline-block;
+   }
+   .sprinkles_display_flex_desktop__1hjdb9v5e {
+     display: flex;
+   }
+   .sprinkles_position_relative_desktop__1hjdb9v5i {
+     position: relative;
+   }
+   .sprinkles_position_absolute_desktop__1hjdb9v5m {
+     position: absolute;
+   }
+   .sprinkles_position_fixed_desktop__1hjdb9v5q {
+     position: fixed;
+   }
+   .sprinkles_position_sticky_desktop__1hjdb9v5u {
+     position: sticky;
+   }
+   .sprinkles_borderRadius_none_desktop__1hjdb9v5y {
+     border-radius: 0px;
+   }
+   .sprinkles_borderRadius_full_desktop__1hjdb9v62 {
+     border-radius: 9999px;
+   }
+   .sprinkles_borderRadius_small_desktop__1hjdb9v66 {
+     border-radius: var(--borderRadius-small__qhrpjvb);
+   }
+   .sprinkles_borderRadius_standard_desktop__1hjdb9v6a {
+     border-radius: var(--borderRadius-standard__qhrpjvc);
+   }
+   .sprinkles_borderRadius_large_desktop__1hjdb9v6e {
+     border-radius: var(--borderRadius-large__qhrpjvd);
+   }
+   .sprinkles_borderRadius_xlarge_desktop__1hjdb9v6i {
+     border-radius: var(--borderRadius-xlarge__qhrpjve);
+   }
+   .sprinkles_gap_gutter_desktop__1hjdb9v6m {
+     gap: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_gap_xxsmall_desktop__1hjdb9v6q {
+     gap: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_gap_xsmall_desktop__1hjdb9v6u {
+     gap: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_gap_small_desktop__1hjdb9v6y {
+     gap: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_gap_medium_desktop__1hjdb9v72 {
+     gap: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_gap_large_desktop__1hjdb9v76 {
+     gap: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_gap_xlarge_desktop__1hjdb9v7a {
+     gap: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_gap_xxlarge_desktop__1hjdb9v7e {
+     gap: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_gap_xxxlarge_desktop__1hjdb9v7i {
+     gap: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_gap_none_desktop__1hjdb9v7m {
+     gap: 0;
+   }
+   .sprinkles_paddingTop_gutter_desktop__1hjdb9v7q {
+     padding-top: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingTop_xxsmall_desktop__1hjdb9v7u {
+     padding-top: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingTop_xsmall_desktop__1hjdb9v7y {
+     padding-top: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingTop_small_desktop__1hjdb9v82 {
+     padding-top: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingTop_medium_desktop__1hjdb9v86 {
+     padding-top: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingTop_large_desktop__1hjdb9v8a {
+     padding-top: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingTop_xlarge_desktop__1hjdb9v8e {
+     padding-top: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingTop_xxlarge_desktop__1hjdb9v8i {
+     padding-top: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingTop_xxxlarge_desktop__1hjdb9v8m {
+     padding-top: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingTop_none_desktop__1hjdb9v8q {
+     padding-top: 0;
+   }
+   .sprinkles_paddingBottom_gutter_desktop__1hjdb9v8u {
+     padding-bottom: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingBottom_xxsmall_desktop__1hjdb9v8y {
+     padding-bottom: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingBottom_xsmall_desktop__1hjdb9v92 {
+     padding-bottom: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingBottom_small_desktop__1hjdb9v96 {
+     padding-bottom: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingBottom_medium_desktop__1hjdb9v9a {
+     padding-bottom: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingBottom_large_desktop__1hjdb9v9e {
+     padding-bottom: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingBottom_xlarge_desktop__1hjdb9v9i {
+     padding-bottom: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingBottom_xxlarge_desktop__1hjdb9v9m {
+     padding-bottom: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingBottom_xxxlarge_desktop__1hjdb9v9q {
+     padding-bottom: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingBottom_none_desktop__1hjdb9v9u {
+     padding-bottom: 0;
+   }
+   .sprinkles_paddingRight_gutter_desktop__1hjdb9v9y {
+     padding-right: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingRight_xxsmall_desktop__1hjdb9va2 {
+     padding-right: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingRight_xsmall_desktop__1hjdb9va6 {
+     padding-right: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingRight_small_desktop__1hjdb9vaa {
+     padding-right: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingRight_medium_desktop__1hjdb9vae {
+     padding-right: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingRight_large_desktop__1hjdb9vai {
+     padding-right: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingRight_xlarge_desktop__1hjdb9vam {
+     padding-right: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingRight_xxlarge_desktop__1hjdb9vaq {
+     padding-right: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingRight_xxxlarge_desktop__1hjdb9vau {
+     padding-right: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingRight_none_desktop__1hjdb9vay {
+     padding-right: 0;
+   }
+   .sprinkles_paddingLeft_gutter_desktop__1hjdb9vb2 {
+     padding-left: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingLeft_xxsmall_desktop__1hjdb9vb6 {
+     padding-left: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingLeft_xsmall_desktop__1hjdb9vba {
+     padding-left: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingLeft_small_desktop__1hjdb9vbe {
+     padding-left: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingLeft_medium_desktop__1hjdb9vbi {
+     padding-left: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingLeft_large_desktop__1hjdb9vbm {
+     padding-left: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingLeft_xlarge_desktop__1hjdb9vbq {
+     padding-left: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingLeft_xxlarge_desktop__1hjdb9vbu {
+     padding-left: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingLeft_xxxlarge_desktop__1hjdb9vby {
+     padding-left: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingLeft_none_desktop__1hjdb9vc2 {
+     padding-left: 0;
+   }
+   .sprinkles_marginTop_gutter_desktop__1hjdb9vc6 {
+     margin-top: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginTop_xxsmall_desktop__1hjdb9vca {
+     margin-top: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginTop_xsmall_desktop__1hjdb9vce {
+     margin-top: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginTop_small_desktop__1hjdb9vci {
+     margin-top: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginTop_medium_desktop__1hjdb9vcm {
+     margin-top: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginTop_large_desktop__1hjdb9vcq {
+     margin-top: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginTop_xlarge_desktop__1hjdb9vcu {
+     margin-top: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginTop_xxlarge_desktop__1hjdb9vcy {
+     margin-top: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginTop_xxxlarge_desktop__1hjdb9vd2 {
+     margin-top: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginTop_none_desktop__1hjdb9vd6 {
+     margin-top: 0;
+   }
+   .sprinkles_marginBottom_gutter_desktop__1hjdb9vda {
+     margin-bottom: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginBottom_xxsmall_desktop__1hjdb9vde {
+     margin-bottom: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginBottom_xsmall_desktop__1hjdb9vdi {
+     margin-bottom: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginBottom_small_desktop__1hjdb9vdm {
+     margin-bottom: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginBottom_medium_desktop__1hjdb9vdq {
+     margin-bottom: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginBottom_large_desktop__1hjdb9vdu {
+     margin-bottom: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginBottom_xlarge_desktop__1hjdb9vdy {
+     margin-bottom: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginBottom_xxlarge_desktop__1hjdb9ve2 {
+     margin-bottom: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginBottom_xxxlarge_desktop__1hjdb9ve6 {
+     margin-bottom: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginBottom_none_desktop__1hjdb9vea {
+     margin-bottom: 0;
+   }
+   .sprinkles_marginRight_gutter_desktop__1hjdb9vee {
+     margin-right: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginRight_xxsmall_desktop__1hjdb9vei {
+     margin-right: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginRight_xsmall_desktop__1hjdb9vem {
+     margin-right: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginRight_small_desktop__1hjdb9veq {
+     margin-right: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginRight_medium_desktop__1hjdb9veu {
+     margin-right: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginRight_large_desktop__1hjdb9vey {
+     margin-right: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginRight_xlarge_desktop__1hjdb9vf2 {
+     margin-right: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginRight_xxlarge_desktop__1hjdb9vf6 {
+     margin-right: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginRight_xxxlarge_desktop__1hjdb9vfa {
+     margin-right: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginRight_none_desktop__1hjdb9vfe {
+     margin-right: 0;
+   }
+   .sprinkles_marginLeft_gutter_desktop__1hjdb9vfi {
+     margin-left: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginLeft_xxsmall_desktop__1hjdb9vfm {
+     margin-left: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginLeft_xsmall_desktop__1hjdb9vfq {
+     margin-left: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginLeft_small_desktop__1hjdb9vfu {
+     margin-left: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginLeft_medium_desktop__1hjdb9vfy {
+     margin-left: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginLeft_large_desktop__1hjdb9vg2 {
+     margin-left: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginLeft_xlarge_desktop__1hjdb9vg6 {
+     margin-left: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginLeft_xxlarge_desktop__1hjdb9vga {
+     margin-left: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginLeft_xxxlarge_desktop__1hjdb9vge {
+     margin-left: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginLeft_none_desktop__1hjdb9vgi {
+     margin-left: 0;
+   }
+   .sprinkles_alignItems_flexStart_desktop__1hjdb9vgm {
+     align-items: flex-start;
+   }
+   .sprinkles_alignItems_center_desktop__1hjdb9vgq {
+     align-items: center;
+   }
+   .sprinkles_alignItems_flexEnd_desktop__1hjdb9vgu {
+     align-items: flex-end;
+   }
+   .sprinkles_justifyContent_flexStart_desktop__1hjdb9vgy {
+     justify-content: flex-start;
+   }
+   .sprinkles_justifyContent_center_desktop__1hjdb9vh2 {
+     justify-content: center;
+   }
+   .sprinkles_justifyContent_flexEnd_desktop__1hjdb9vh6 {
+     justify-content: flex-end;
+   }
+   .sprinkles_justifyContent_spaceBetween_desktop__1hjdb9vha {
+     justify-content: space-between;
+   }
+   .sprinkles_flexDirection_row_desktop__1hjdb9vhe {
+     flex-direction: row;
+   }
+   .sprinkles_flexDirection_rowReverse_desktop__1hjdb9vhi {
+     flex-direction: row-reverse;
+   }
+   .sprinkles_flexDirection_column_desktop__1hjdb9vhm {
+     flex-direction: column;
+   }
+   .sprinkles_flexDirection_columnReverse_desktop__1hjdb9vhq {
+     flex-direction: column-reverse;
+   }
+   .sprinkles_flexWrap_wrap_desktop__1hjdb9vhu {
+     flex-wrap: wrap;
+   }
+   .sprinkles_flexWrap_nowrap_desktop__1hjdb9vhy {
+     flex-wrap: nowrap;
+   }
+   .sprinkles_flexShrink_0_desktop__1hjdb9vi2 {
+     flex-shrink: 0;
+   }
+   .sprinkles_flexGrow_0_desktop__1hjdb9vi6 {
+     flex-grow: 0;
+   }
+   .sprinkles_flexGrow_1_desktop__1hjdb9via {
+     flex-grow: 1;
+   }
+   .sprinkles_textAlign_left_desktop__1hjdb9vie {
+     text-align: left;
+   }
+   .sprinkles_textAlign_center_desktop__1hjdb9vii {
+     text-align: center;
+   }
+   .sprinkles_textAlign_right_desktop__1hjdb9vim {
+     text-align: right;
+   }
+ }
+ @media screen and (min-width: 1200px) {
+   .sprinkles_display_none_wide__1hjdb9v4z {
+     display: none;
+   }
+   .sprinkles_display_block_wide__1hjdb9v53 {
+     display: block;
+   }
+   .sprinkles_display_inline_wide__1hjdb9v57 {
+     display: inline;
+   }
+   .sprinkles_display_inlineBlock_wide__1hjdb9v5b {
+     display: inline-block;
+   }
+   .sprinkles_display_flex_wide__1hjdb9v5f {
+     display: flex;
+   }
+   .sprinkles_position_relative_wide__1hjdb9v5j {
+     position: relative;
+   }
+   .sprinkles_position_absolute_wide__1hjdb9v5n {
+     position: absolute;
+   }
+   .sprinkles_position_fixed_wide__1hjdb9v5r {
+     position: fixed;
+   }
+   .sprinkles_position_sticky_wide__1hjdb9v5v {
+     position: sticky;
+   }
+   .sprinkles_borderRadius_none_wide__1hjdb9v5z {
+     border-radius: 0px;
+   }
+   .sprinkles_borderRadius_full_wide__1hjdb9v63 {
+     border-radius: 9999px;
+   }
+   .sprinkles_borderRadius_small_wide__1hjdb9v67 {
+     border-radius: var(--borderRadius-small__qhrpjvb);
+   }
+   .sprinkles_borderRadius_standard_wide__1hjdb9v6b {
+     border-radius: var(--borderRadius-standard__qhrpjvc);
+   }
+   .sprinkles_borderRadius_large_wide__1hjdb9v6f {
+     border-radius: var(--borderRadius-large__qhrpjvd);
+   }
+   .sprinkles_borderRadius_xlarge_wide__1hjdb9v6j {
+     border-radius: var(--borderRadius-xlarge__qhrpjve);
+   }
+   .sprinkles_gap_gutter_wide__1hjdb9v6n {
+     gap: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_gap_xxsmall_wide__1hjdb9v6r {
+     gap: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_gap_xsmall_wide__1hjdb9v6v {
+     gap: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_gap_small_wide__1hjdb9v6z {
+     gap: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_gap_medium_wide__1hjdb9v73 {
+     gap: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_gap_large_wide__1hjdb9v77 {
+     gap: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_gap_xlarge_wide__1hjdb9v7b {
+     gap: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_gap_xxlarge_wide__1hjdb9v7f {
+     gap: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_gap_xxxlarge_wide__1hjdb9v7j {
+     gap: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_gap_none_wide__1hjdb9v7n {
+     gap: 0;
+   }
+   .sprinkles_paddingTop_gutter_wide__1hjdb9v7r {
+     padding-top: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingTop_xxsmall_wide__1hjdb9v7v {
+     padding-top: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingTop_xsmall_wide__1hjdb9v7z {
+     padding-top: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingTop_small_wide__1hjdb9v83 {
+     padding-top: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingTop_medium_wide__1hjdb9v87 {
+     padding-top: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingTop_large_wide__1hjdb9v8b {
+     padding-top: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingTop_xlarge_wide__1hjdb9v8f {
+     padding-top: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingTop_xxlarge_wide__1hjdb9v8j {
+     padding-top: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingTop_xxxlarge_wide__1hjdb9v8n {
+     padding-top: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingTop_none_wide__1hjdb9v8r {
+     padding-top: 0;
+   }
+   .sprinkles_paddingBottom_gutter_wide__1hjdb9v8v {
+     padding-bottom: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingBottom_xxsmall_wide__1hjdb9v8z {
+     padding-bottom: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingBottom_xsmall_wide__1hjdb9v93 {
+     padding-bottom: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingBottom_small_wide__1hjdb9v97 {
+     padding-bottom: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingBottom_medium_wide__1hjdb9v9b {
+     padding-bottom: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingBottom_large_wide__1hjdb9v9f {
+     padding-bottom: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingBottom_xlarge_wide__1hjdb9v9j {
+     padding-bottom: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingBottom_xxlarge_wide__1hjdb9v9n {
+     padding-bottom: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingBottom_xxxlarge_wide__1hjdb9v9r {
+     padding-bottom: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingBottom_none_wide__1hjdb9v9v {
+     padding-bottom: 0;
+   }
+   .sprinkles_paddingRight_gutter_wide__1hjdb9v9z {
+     padding-right: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingRight_xxsmall_wide__1hjdb9va3 {
+     padding-right: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingRight_xsmall_wide__1hjdb9va7 {
+     padding-right: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingRight_small_wide__1hjdb9vab {
+     padding-right: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingRight_medium_wide__1hjdb9vaf {
+     padding-right: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingRight_large_wide__1hjdb9vaj {
+     padding-right: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingRight_xlarge_wide__1hjdb9van {
+     padding-right: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingRight_xxlarge_wide__1hjdb9var {
+     padding-right: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingRight_xxxlarge_wide__1hjdb9vav {
+     padding-right: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingRight_none_wide__1hjdb9vaz {
+     padding-right: 0;
+   }
+   .sprinkles_paddingLeft_gutter_wide__1hjdb9vb3 {
+     padding-left: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_paddingLeft_xxsmall_wide__1hjdb9vb7 {
+     padding-left: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_paddingLeft_xsmall_wide__1hjdb9vbb {
+     padding-left: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_paddingLeft_small_wide__1hjdb9vbf {
+     padding-left: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_paddingLeft_medium_wide__1hjdb9vbj {
+     padding-left: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_paddingLeft_large_wide__1hjdb9vbn {
+     padding-left: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_paddingLeft_xlarge_wide__1hjdb9vbr {
+     padding-left: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_paddingLeft_xxlarge_wide__1hjdb9vbv {
+     padding-left: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_paddingLeft_xxxlarge_wide__1hjdb9vbz {
+     padding-left: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_paddingLeft_none_wide__1hjdb9vc3 {
+     padding-left: 0;
+   }
+   .sprinkles_marginTop_gutter_wide__1hjdb9vc7 {
+     margin-top: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginTop_xxsmall_wide__1hjdb9vcb {
+     margin-top: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginTop_xsmall_wide__1hjdb9vcf {
+     margin-top: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginTop_small_wide__1hjdb9vcj {
+     margin-top: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginTop_medium_wide__1hjdb9vcn {
+     margin-top: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginTop_large_wide__1hjdb9vcr {
+     margin-top: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginTop_xlarge_wide__1hjdb9vcv {
+     margin-top: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginTop_xxlarge_wide__1hjdb9vcz {
+     margin-top: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginTop_xxxlarge_wide__1hjdb9vd3 {
+     margin-top: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginTop_none_wide__1hjdb9vd7 {
+     margin-top: 0;
+   }
+   .sprinkles_marginBottom_gutter_wide__1hjdb9vdb {
+     margin-bottom: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginBottom_xxsmall_wide__1hjdb9vdf {
+     margin-bottom: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginBottom_xsmall_wide__1hjdb9vdj {
+     margin-bottom: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginBottom_small_wide__1hjdb9vdn {
+     margin-bottom: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginBottom_medium_wide__1hjdb9vdr {
+     margin-bottom: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginBottom_large_wide__1hjdb9vdv {
+     margin-bottom: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginBottom_xlarge_wide__1hjdb9vdz {
+     margin-bottom: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginBottom_xxlarge_wide__1hjdb9ve3 {
+     margin-bottom: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginBottom_xxxlarge_wide__1hjdb9ve7 {
+     margin-bottom: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginBottom_none_wide__1hjdb9veb {
+     margin-bottom: 0;
+   }
+   .sprinkles_marginRight_gutter_wide__1hjdb9vef {
+     margin-right: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginRight_xxsmall_wide__1hjdb9vej {
+     margin-right: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginRight_xsmall_wide__1hjdb9ven {
+     margin-right: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginRight_small_wide__1hjdb9ver {
+     margin-right: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginRight_medium_wide__1hjdb9vev {
+     margin-right: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginRight_large_wide__1hjdb9vez {
+     margin-right: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginRight_xlarge_wide__1hjdb9vf3 {
+     margin-right: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginRight_xxlarge_wide__1hjdb9vf7 {
+     margin-right: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginRight_xxxlarge_wide__1hjdb9vfb {
+     margin-right: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginRight_none_wide__1hjdb9vff {
+     margin-right: 0;
+   }
+   .sprinkles_marginLeft_gutter_wide__1hjdb9vfj {
+     margin-left: var(--space-gutter__qhrpjv0);
+   }
+   .sprinkles_marginLeft_xxsmall_wide__1hjdb9vfn {
+     margin-left: var(--space-xxsmall__qhrpjv1);
+   }
+   .sprinkles_marginLeft_xsmall_wide__1hjdb9vfr {
+     margin-left: var(--space-xsmall__qhrpjv2);
+   }
+   .sprinkles_marginLeft_small_wide__1hjdb9vfv {
+     margin-left: var(--space-small__qhrpjv3);
+   }
+   .sprinkles_marginLeft_medium_wide__1hjdb9vfz {
+     margin-left: var(--space-medium__qhrpjv4);
+   }
+   .sprinkles_marginLeft_large_wide__1hjdb9vg3 {
+     margin-left: var(--space-large__qhrpjv5);
+   }
+   .sprinkles_marginLeft_xlarge_wide__1hjdb9vg7 {
+     margin-left: var(--space-xlarge__qhrpjv6);
+   }
+   .sprinkles_marginLeft_xxlarge_wide__1hjdb9vgb {
+     margin-left: var(--space-xxlarge__qhrpjv7);
+   }
+   .sprinkles_marginLeft_xxxlarge_wide__1hjdb9vgf {
+     margin-left: var(--space-xxxlarge__qhrpjv8);
+   }
+   .sprinkles_marginLeft_none_wide__1hjdb9vgj {
+     margin-left: 0;
+   }
+   .sprinkles_alignItems_flexStart_wide__1hjdb9vgn {
+     align-items: flex-start;
+   }
+   .sprinkles_alignItems_center_wide__1hjdb9vgr {
+     align-items: center;
+   }
+   .sprinkles_alignItems_flexEnd_wide__1hjdb9vgv {
+     align-items: flex-end;
+   }
+   .sprinkles_justifyContent_flexStart_wide__1hjdb9vgz {
+     justify-content: flex-start;
+   }
+   .sprinkles_justifyContent_center_wide__1hjdb9vh3 {
+     justify-content: center;
+   }
+   .sprinkles_justifyContent_flexEnd_wide__1hjdb9vh7 {
+     justify-content: flex-end;
+   }
+   .sprinkles_justifyContent_spaceBetween_wide__1hjdb9vhb {
+     justify-content: space-between;
+   }
+   .sprinkles_flexDirection_row_wide__1hjdb9vhf {
+     flex-direction: row;
+   }
+   .sprinkles_flexDirection_rowReverse_wide__1hjdb9vhj {
+     flex-direction: row-reverse;
+   }
+   .sprinkles_flexDirection_column_wide__1hjdb9vhn {
+     flex-direction: column;
+   }
+   .sprinkles_flexDirection_columnReverse_wide__1hjdb9vhr {
+     flex-direction: column-reverse;
+   }
+   .sprinkles_flexWrap_wrap_wide__1hjdb9vhv {
+     flex-wrap: wrap;
+   }
+   .sprinkles_flexWrap_nowrap_wide__1hjdb9vhz {
+     flex-wrap: nowrap;
+   }
+   .sprinkles_flexShrink_0_wide__1hjdb9vi3 {
+     flex-shrink: 0;
+   }
+   .sprinkles_flexGrow_0_wide__1hjdb9vi7 {
+     flex-grow: 0;
+   }
+   .sprinkles_flexGrow_1_wide__1hjdb9vib {
+     flex-grow: 1;
+   }
+   .sprinkles_textAlign_left_wide__1hjdb9vif {
+     text-align: left;
+   }
+   .sprinkles_textAlign_center_wide__1hjdb9vij {
+     text-align: center;
+   }
+   .sprinkles_textAlign_right_wide__1hjdb9vin {
+     text-align: right;
+   }
+ }
+ .capsize_capsizeStyle__1lwixuj4 {
+   font-size: var(--fontSize__1lwixuj0);
+   line-height: var(--lineHeight__1lwixuj1);
+ }
+ .capsize_capsizeStyle__1lwixuj4::before {
+   content: '';
+   margin-bottom: var(--capHeightTrim__1lwixuj2);
+   display: table;
+ }
+ .capsize_capsizeStyle__1lwixuj4::after {
+   content: '';
+   margin-top: var(--baselineTrim__1lwixuj3);
+   display: table;
+ }
+ .typography_fontFamily__co4djb0 {
+   font-family: var(--fontFamily__qhrpjv2w);
+ }
+ .typography_fontWeight_regular__co4djb1 {
+   font-weight: var(--textWeight-regular__qhrpjv46);
+ }
+ .typography_fontWeight_medium__co4djb2 {
+   font-weight: var(--textWeight-medium__qhrpjv47);
+ }
+ .typography_fontWeight_strong__co4djb3 {
+   font-weight: var(--textWeight-strong__qhrpjv48);
+ }
+ .typography_textSize_xsmall__co4djb4 {
+   --fontSize__1lwixuj0: var(--textSize-xsmall-mobile-fontSize__qhrpjv32);
+   --lineHeight__1lwixuj1: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
+   --capHeightTrim__1lwixuj2: var(--textSize-xsmall-mobile-capsizeTrims-capHeightTrim__qhrpjv35);
+   --baselineTrim__1lwixuj3: var(--textSize-xsmall-mobile-capsizeTrims-baselineTrim__qhrpjv36);
+ }
+ .typography_textSize_small__co4djb6 {
+   --fontSize__1lwixuj0: var(--textSize-small-mobile-fontSize__qhrpjv3c);
+   --lineHeight__1lwixuj1: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
+   --capHeightTrim__1lwixuj2: var(--textSize-small-mobile-capsizeTrims-capHeightTrim__qhrpjv3f);
+   --baselineTrim__1lwixuj3: var(--textSize-small-mobile-capsizeTrims-baselineTrim__qhrpjv3g);
+ }
+ .typography_textSize_standard__co4djb8 {
+   --fontSize__1lwixuj0: var(--textSize-standard-mobile-fontSize__qhrpjv3m);
+   --lineHeight__1lwixuj1: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
+   --capHeightTrim__1lwixuj2: var(--textSize-standard-mobile-capsizeTrims-capHeightTrim__qhrpjv3p);
+   --baselineTrim__1lwixuj3: var(--textSize-standard-mobile-capsizeTrims-baselineTrim__qhrpjv3q);
+ }
+ .typography_textSize_large__co4djba {
+   --fontSize__1lwixuj0: var(--textSize-large-mobile-fontSize__qhrpjv3w);
+   --lineHeight__1lwixuj1: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
+   --capHeightTrim__1lwixuj2: var(--textSize-large-mobile-capsizeTrims-capHeightTrim__qhrpjv3z);
+   --baselineTrim__1lwixuj3: var(--textSize-large-mobile-capsizeTrims-baselineTrim__qhrpjv40);
+ }
+ .typography_textSizeUntrimmed_xsmall__co4djbc {
+   font-size: var(--textSize-xsmall-mobile-fontSize__qhrpjv32);
+   line-height: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
+ }
+ .typography_textSizeUntrimmed_small__co4djbd {
+   font-size: var(--textSize-small-mobile-fontSize__qhrpjv3c);
+   line-height: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
+ }
+ .typography_textSizeUntrimmed_standard__co4djbe {
+   font-size: var(--textSize-standard-mobile-fontSize__qhrpjv3m);
+   line-height: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
+ }
+ .typography_textSizeUntrimmed_large__co4djbf {
+   font-size: var(--textSize-large-mobile-fontSize__qhrpjv3w);
+   line-height: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
+ }
+ .typography_headingWeight_weak__co4djbg {
+   font-weight: var(--headingWeight-weak__qhrpjv5d);
+ }
+ .typography_headingWeight_regular__co4djbh {
+   font-weight: var(--headingWeight-regular__qhrpjv5e);
+ }
+ .typography_heading_1__co4djbi {
+   --fontSize__1lwixuj0: var(--headingLevel-1-mobile-fontSize__qhrpjv49);
+   --lineHeight__1lwixuj1: var(--headingLevel-1-mobile-lineHeight__qhrpjv4a);
+   --capHeightTrim__1lwixuj2: var(--headingLevel-1-mobile-capsizeTrims-capHeightTrim__qhrpjv4c);
+   --baselineTrim__1lwixuj3: var(--headingLevel-1-mobile-capsizeTrims-baselineTrim__qhrpjv4d);
+ }
+ .typography_heading_2__co4djbk {
+   --fontSize__1lwixuj0: var(--headingLevel-2-mobile-fontSize__qhrpjv4j);
+   --lineHeight__1lwixuj1: var(--headingLevel-2-mobile-lineHeight__qhrpjv4k);
+   --capHeightTrim__1lwixuj2: var(--headingLevel-2-mobile-capsizeTrims-capHeightTrim__qhrpjv4m);
+   --baselineTrim__1lwixuj3: var(--headingLevel-2-mobile-capsizeTrims-baselineTrim__qhrpjv4n);
+ }
+ .typography_heading_3__co4djbm {
+   --fontSize__1lwixuj0: var(--headingLevel-3-mobile-fontSize__qhrpjv4t);
+   --lineHeight__1lwixuj1: var(--headingLevel-3-mobile-lineHeight__qhrpjv4u);
+   --capHeightTrim__1lwixuj2: var(--headingLevel-3-mobile-capsizeTrims-capHeightTrim__qhrpjv4w);
+   --baselineTrim__1lwixuj3: var(--headingLevel-3-mobile-capsizeTrims-baselineTrim__qhrpjv4x);
+ }
+ .typography_heading_4__co4djbo {
+   --fontSize__1lwixuj0: var(--headingLevel-4-mobile-fontSize__qhrpjv53);
+   --lineHeight__1lwixuj1: var(--headingLevel-4-mobile-lineHeight__qhrpjv54);
+   --capHeightTrim__1lwixuj2: var(--headingLevel-4-mobile-capsizeTrims-capHeightTrim__qhrpjv56);
+   --baselineTrim__1lwixuj3: var(--headingLevel-4-mobile-capsizeTrims-baselineTrim__qhrpjv57);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeTone_light__co4djb10 {
+   --critical__co4djbq: var(--foregroundColor-critical__qhrpjv19);
+   --caution__co4djbr: var(--foregroundColor-caution__qhrpjv17);
+   --info__co4djbs: var(--foregroundColor-info__qhrpjv1d);
+   --promote__co4djbt: var(--foregroundColor-promote__qhrpjv1o);
+   --positive__co4djbu: var(--foregroundColor-positive__qhrpjv1m);
+   --brandAccent__co4djbv: var(--foregroundColor-brandAccent__qhrpjv15);
+   --formAccent__co4djbw: var(--foregroundColor-formAccent__qhrpjv1b);
+   --neutral__co4djbx: var(--foregroundColor-neutral__qhrpjv1k);
+   --secondary__co4djby: var(--foregroundColor-secondary__qhrpjv1r);
+   --link__co4djbz: var(--foregroundColor-link__qhrpjv1f);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeTone_dark__co4djb11 {
+   --critical__co4djbq: var(--foregroundColor-criticalLight__qhrpjv1a);
+   --caution__co4djbr: var(--foregroundColor-cautionLight__qhrpjv18);
+   --info__co4djbs: var(--foregroundColor-infoLight__qhrpjv1e);
+   --promote__co4djbt: var(--foregroundColor-promoteLight__qhrpjv1p);
+   --positive__co4djbu: var(--foregroundColor-positiveLight__qhrpjv1n);
+   --brandAccent__co4djbv: var(--foregroundColor-brandAccentLight__qhrpjv16);
+   --formAccent__co4djbw: var(--foregroundColor-formAccentLight__qhrpjv1c);
+   --neutral__co4djbx: var(--foregroundColor-neutralInverted__qhrpjv1l);
+   --secondary__co4djby: var(--foregroundColor-secondaryInverted__qhrpjv1s);
+   --link__co4djbz: var(--foregroundColor-linkLight__qhrpjv1h);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeTone_light__co4djb12 {
+   --critical__co4djbq: var(--foregroundColor-critical__qhrpjv19);
+   --caution__co4djbr: var(--foregroundColor-caution__qhrpjv17);
+   --info__co4djbs: var(--foregroundColor-info__qhrpjv1d);
+   --promote__co4djbt: var(--foregroundColor-promote__qhrpjv1o);
+   --positive__co4djbu: var(--foregroundColor-positive__qhrpjv1m);
+   --brandAccent__co4djbv: var(--foregroundColor-brandAccent__qhrpjv15);
+   --formAccent__co4djbw: var(--foregroundColor-formAccent__qhrpjv1b);
+   --neutral__co4djbx: var(--foregroundColor-neutral__qhrpjv1k);
+   --secondary__co4djby: var(--foregroundColor-secondary__qhrpjv1r);
+   --link__co4djbz: var(--foregroundColor-link__qhrpjv1f);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeTone_dark__co4djb13 {
+   --critical__co4djbq: var(--foregroundColor-criticalLight__qhrpjv1a);
+   --caution__co4djbr: var(--foregroundColor-cautionLight__qhrpjv18);
+   --info__co4djbs: var(--foregroundColor-infoLight__qhrpjv1e);
+   --promote__co4djbt: var(--foregroundColor-promoteLight__qhrpjv1p);
+   --positive__co4djbu: var(--foregroundColor-positiveLight__qhrpjv1n);
+   --brandAccent__co4djbv: var(--foregroundColor-brandAccentLight__qhrpjv16);
+   --formAccent__co4djbw: var(--foregroundColor-formAccentLight__qhrpjv1c);
+   --neutral__co4djbx: var(--foregroundColor-neutralInverted__qhrpjv1l);
+   --secondary__co4djby: var(--foregroundColor-secondaryInverted__qhrpjv1s);
+   --link__co4djbz: var(--foregroundColor-linkLight__qhrpjv1h);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalLight__co4djb14 {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalSoft__co4djb15 {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalSoftActive__co4djb16 {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_criticalSoftHover__co4djb17 {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_caution__co4djb18 {
+   --neutral__co4djbx: var(--caution__co4djbr);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_cautionLight__co4djb19 {
+   --neutral__co4djbx: var(--caution__co4djbr);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_positiveLight__co4djb1a {
+   --neutral__co4djbx: var(--positive__co4djbu);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_infoLight__co4djb1b {
+   --neutral__co4djbx: var(--info__co4djbs);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .typography_lightModeNeutralOverride_promoteLight__co4djb1c {
+   --neutral__co4djbx: var(--promote__co4djbt);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalLight__co4djb1d {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalSoft__co4djb1e {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalSoftActive__co4djb1f {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_criticalSoftHover__co4djb1g {
+   --neutral__co4djbx: var(--critical__co4djbq);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_caution__co4djb1h {
+   --neutral__co4djbx: var(--caution__co4djbr);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_cautionLight__co4djb1i {
+   --neutral__co4djbx: var(--caution__co4djbr);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_positiveLight__co4djb1j {
+   --neutral__co4djbx: var(--positive__co4djbu);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_infoLight__co4djb1k {
+   --neutral__co4djbx: var(--info__co4djbs);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .typography_darkModeNeutralOverride_promoteLight__co4djb1l {
+   --neutral__co4djbx: var(--promote__co4djbt);
+ }
+ .typography_tone_critical__co4djb1m {
+   color: var(--critical__co4djbq);
+ }
+ .typography_tone_caution__co4djb1n {
+   color: var(--caution__co4djbr);
+ }
+ .typography_tone_info__co4djb1o {
+   color: var(--info__co4djbs);
+ }
+ .typography_tone_promote__co4djb1p {
+   color: var(--promote__co4djbt);
+ }
+ .typography_tone_positive__co4djb1q {
+   color: var(--positive__co4djbu);
+ }
+ .typography_tone_brandAccent__co4djb1r {
+   color: var(--brandAccent__co4djbv);
+ }
+ .typography_tone_formAccent__co4djb1s {
+   color: var(--formAccent__co4djbw);
+ }
+ .typography_tone_neutral__co4djb1t {
+   color: var(--neutral__co4djbx);
+ }
+ .typography_tone_secondary__co4djb1u {
+   color: var(--secondary__co4djby);
+ }
+ .typography_tone_link__co4djb1v {
+   color: var(--link__co4djbz);
+ }
+ .typography_touchableText_xsmall__co4djb1w {
+   padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-mobile-lineHeight__qhrpjv33)) / 2);
+   padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-mobile-lineHeight__qhrpjv33)) / 2);
+ }
+ .typography_touchableText_small__co4djb1x {
+   padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-mobile-lineHeight__qhrpjv3d)) / 2);
+   padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-mobile-lineHeight__qhrpjv3d)) / 2);
+ }
+ .typography_touchableText_standard__co4djb1y {
+   padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-mobile-lineHeight__qhrpjv3n)) / 2);
+   padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-mobile-lineHeight__qhrpjv3n)) / 2);
+ }
+ .typography_touchableText_large__co4djb1z {
+   padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-mobile-lineHeight__qhrpjv3x)) / 2);
+   padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-mobile-lineHeight__qhrpjv3x)) / 2);
+ }
+ @media screen and (min-width: 740px) {
+   .typography_textSize_xsmall__co4djb4 {
+     --fontSize__1lwixuj0: var(--textSize-xsmall-tablet-fontSize__qhrpjv37);
+     --lineHeight__1lwixuj1: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
+     --capHeightTrim__1lwixuj2: var(--textSize-xsmall-tablet-capsizeTrims-capHeightTrim__qhrpjv3a);
+     --baselineTrim__1lwixuj3: var(--textSize-xsmall-tablet-capsizeTrims-baselineTrim__qhrpjv3b);
+   }
+   .typography_textSize_small__co4djb6 {
+     --fontSize__1lwixuj0: var(--textSize-small-tablet-fontSize__qhrpjv3h);
+     --lineHeight__1lwixuj1: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
+     --capHeightTrim__1lwixuj2: var(--textSize-small-tablet-capsizeTrims-capHeightTrim__qhrpjv3k);
+     --baselineTrim__1lwixuj3: var(--textSize-small-tablet-capsizeTrims-baselineTrim__qhrpjv3l);
+   }
+   .typography_textSize_standard__co4djb8 {
+     --fontSize__1lwixuj0: var(--textSize-standard-tablet-fontSize__qhrpjv3r);
+     --lineHeight__1lwixuj1: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
+     --capHeightTrim__1lwixuj2: var(--textSize-standard-tablet-capsizeTrims-capHeightTrim__qhrpjv3u);
+     --baselineTrim__1lwixuj3: var(--textSize-standard-tablet-capsizeTrims-baselineTrim__qhrpjv3v);
+   }
+   .typography_textSize_large__co4djba {
+     --fontSize__1lwixuj0: var(--textSize-large-tablet-fontSize__qhrpjv41);
+     --lineHeight__1lwixuj1: var(--textSize-large-tablet-lineHeight__qhrpjv42);
+     --capHeightTrim__1lwixuj2: var(--textSize-large-tablet-capsizeTrims-capHeightTrim__qhrpjv44);
+     --baselineTrim__1lwixuj3: var(--textSize-large-tablet-capsizeTrims-baselineTrim__qhrpjv45);
+   }
+   .typography_textSizeUntrimmed_xsmall__co4djbc {
+     font-size: var(--textSize-xsmall-tablet-fontSize__qhrpjv37);
+     line-height: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
+   }
+   .typography_textSizeUntrimmed_small__co4djbd {
+     font-size: var(--textSize-small-tablet-fontSize__qhrpjv3h);
+     line-height: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
+   }
+   .typography_textSizeUntrimmed_standard__co4djbe {
+     font-size: var(--textSize-standard-tablet-fontSize__qhrpjv3r);
+     line-height: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
+   }
+   .typography_textSizeUntrimmed_large__co4djbf {
+     font-size: var(--textSize-large-tablet-fontSize__qhrpjv41);
+     line-height: var(--textSize-large-tablet-lineHeight__qhrpjv42);
+   }
+   .typography_heading_1__co4djbi {
+     --fontSize__1lwixuj0: var(--headingLevel-1-tablet-fontSize__qhrpjv4e);
+     --lineHeight__1lwixuj1: var(--headingLevel-1-tablet-lineHeight__qhrpjv4f);
+     --capHeightTrim__1lwixuj2: var(--headingLevel-1-tablet-capsizeTrims-capHeightTrim__qhrpjv4h);
+     --baselineTrim__1lwixuj3: var(--headingLevel-1-tablet-capsizeTrims-baselineTrim__qhrpjv4i);
+   }
+   .typography_heading_2__co4djbk {
+     --fontSize__1lwixuj0: var(--headingLevel-2-tablet-fontSize__qhrpjv4o);
+     --lineHeight__1lwixuj1: var(--headingLevel-2-tablet-lineHeight__qhrpjv4p);
+     --capHeightTrim__1lwixuj2: var(--headingLevel-2-tablet-capsizeTrims-capHeightTrim__qhrpjv4r);
+     --baselineTrim__1lwixuj3: var(--headingLevel-2-tablet-capsizeTrims-baselineTrim__qhrpjv4s);
+   }
+   .typography_heading_3__co4djbm {
+     --fontSize__1lwixuj0: var(--headingLevel-3-tablet-fontSize__qhrpjv4y);
+     --lineHeight__1lwixuj1: var(--headingLevel-3-tablet-lineHeight__qhrpjv4z);
+     --capHeightTrim__1lwixuj2: var(--headingLevel-3-tablet-capsizeTrims-capHeightTrim__qhrpjv51);
+     --baselineTrim__1lwixuj3: var(--headingLevel-3-tablet-capsizeTrims-baselineTrim__qhrpjv52);
+   }
+   .typography_heading_4__co4djbo {
+     --fontSize__1lwixuj0: var(--headingLevel-4-tablet-fontSize__qhrpjv58);
+     --lineHeight__1lwixuj1: var(--headingLevel-4-tablet-lineHeight__qhrpjv59);
+     --capHeightTrim__1lwixuj2: var(--headingLevel-4-tablet-capsizeTrims-capHeightTrim__qhrpjv5b);
+     --baselineTrim__1lwixuj3: var(--headingLevel-4-tablet-capsizeTrims-baselineTrim__qhrpjv5c);
+   }
+   .typography_touchableText_xsmall__co4djb1w {
+     padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-tablet-lineHeight__qhrpjv38)) / 2);
+     padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-xsmall-tablet-lineHeight__qhrpjv38)) / 2);
+   }
+   .typography_touchableText_small__co4djb1x {
+     padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-tablet-lineHeight__qhrpjv3i)) / 2);
+     padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-small-tablet-lineHeight__qhrpjv3i)) / 2);
+   }
+   .typography_touchableText_standard__co4djb1y {
+     padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-tablet-lineHeight__qhrpjv3s)) / 2);
+     padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-tablet-lineHeight__qhrpjv3s)) / 2);
+   }
+   .typography_touchableText_large__co4djb1z {
+     padding-top: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-tablet-lineHeight__qhrpjv42)) / 2);
+     padding-bottom: calc((var(--touchableSize__qhrpjv9) - var(--textSize-large-tablet-lineHeight__qhrpjv42)) / 2);
+   }
+ }
+ .Divider_base__rgb1580 {
+   height: var(--borderWidth-standard__qhrpjvy);
+ }
+ .Divider_regular__rgb1583 {
+   background: var(--regular__rgb1581);
+ }
+ .Divider_strong__rgb1584 {
+   background: var(--strong__rgb1582);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Divider_lightModeWeight_light__rgb1585 {
+   --regular__rgb1581: var(--borderColor-neutralLight__qhrpjvt);
+   --strong__rgb1582: var(--borderColor-neutral__qhrpjvr);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Divider_lightModeWeight_dark__rgb1586 {
+   --regular__rgb1581: var(--borderColor-neutral__qhrpjvr);
+   --strong__rgb1582: var(--borderColor-neutralLight__qhrpjvt);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Divider_darkModeWeight_light__rgb1587 {
+   --regular__rgb1581: var(--borderColor-neutralLight__qhrpjvt);
+   --strong__rgb1582: var(--borderColor-neutral__qhrpjvr);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Divider_darkModeWeight_dark__rgb1588 {
+   --regular__rgb1581: var(--borderColor-neutral__qhrpjvr);
+   --strong__rgb1582: var(--borderColor-neutralLight__qhrpjvt);
+ }
+ .Spread_fitContent__19xp08d0 > * {
+   flex-basis: auto;
+   width: auto;
+ }
+ .Spread_maxWidth__19xp08d1 > * {
+   max-width: 100%;
+ }
+ .MaxLines_descenderCropFixForWebkitBox__1lw3qoe0 {
+   margin-bottom: -0.1em;
+ }
+ .MaxLines_base__1lw3qoe2 {
+   text-overflow: ellipsis;
+   white-space: nowrap;
+   overflow-wrap: break-word;
+ }
+ .MaxLines_descenderCropFixForWebkitBox__1lw3qoe0 .MaxLines_base__1lw3qoe2 {
+   padding-bottom: 0.1em;
+ }
+ @supports (display: -webkit-box) and (-webkit-line-clamp: 1) {
+   .MaxLines_multiLine__1lw3qoe4 {
+     white-space: initial;
+     display: -webkit-box;
+     -webkit-line-clamp: var(--lineLimit__1lw3qoe3);
+     -webkit-box-orient: vertical;
+   }
+ }
+ .virtualTouchable_virtualTouchable__9705do0 {
+   position: relative;
+ }
+ .virtualTouchable_virtualTouchable__9705do0::after {
+   content: "";
+   position: absolute;
+   min-height: 44px;
+   min-width: 44px;
+   height: 100%;
+   width: 100%;
+   transform: translate(-50%, -50%);
+   top: 50%;
+   left: 50%;
+ }
+ [data-braid-debug] .virtualTouchable_virtualTouchable__9705do0::after {
+   background: red;
+   opacity: 0.2;
+ }
+ .AccordionItem_focusRing__pr4mlf2 {
+   outline-offset: var(--space-xxsmall__qhrpjv1);
+ }
+ .icon_size__1ltfiyk0 {
+   width: 1.2em;
+   height: 1.2em;
+ }
+ .icon_cropToTextSize__1ltfiyk1 {
+   margin: -0.1em;
+ }
+ .icon_inlineCrop__1ltfiyk2 {
+   margin-top: -0.2em;
+   margin-bottom: -0.2em;
+ }
+ .icon_inline__1ltfiyk3 {
+   vertical-align: middle;
+ }
+ .icon_alignY_uppercase_none__1ltfiyk4 {
+   top: -0.105em;
+ }
+ .icon_alignY_uppercase_up__1ltfiyk5 {
+   top: -0.16499999999999998em;
+ }
+ .icon_alignY_uppercase_down__1ltfiyk6 {
+   top: -0.045em;
+ }
+ .icon_alignY_lowercase_none__1ltfiyk7 {
+   top: -0.065em;
+ }
+ .icon_alignY_lowercase_up__1ltfiyk8 {
+   top: -0.125em;
+ }
+ .icon_alignY_lowercase_down__1ltfiyk9 {
+   top: -0.0050000000000000044em;
+ }
+ .icon_blockWidths_xsmall__1ltfiyka {
+   width: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
+ }
+ .icon_blockWidths_small__1ltfiykb {
+   width: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
+ }
+ .icon_blockWidths_standard__1ltfiykc {
+   width: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
+ }
+ .icon_blockWidths_large__1ltfiykd {
+   width: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
+ }
+ @media screen and (min-width: 740px) {
+   .icon_blockWidths_xsmall__1ltfiyka {
+     width: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
+   }
+   .icon_blockWidths_small__1ltfiykb {
+     width: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
+   }
+   .icon_blockWidths_standard__1ltfiykc {
+     width: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
+   }
+   .icon_blockWidths_large__1ltfiykd {
+     width: var(--textSize-large-tablet-lineHeight__qhrpjv42);
+   }
+ }
+ .lineHeightContainer_lineHeightContainer_xsmall__pnbjt00 {
+   height: var(--textSize-xsmall-mobile-lineHeight__qhrpjv33);
+ }
+ .lineHeightContainer_lineHeightContainer_small__pnbjt01 {
+   height: var(--textSize-small-mobile-lineHeight__qhrpjv3d);
+ }
+ .lineHeightContainer_lineHeightContainer_standard__pnbjt02 {
+   height: var(--textSize-standard-mobile-lineHeight__qhrpjv3n);
+ }
+ .lineHeightContainer_lineHeightContainer_large__pnbjt03 {
+   height: var(--textSize-large-mobile-lineHeight__qhrpjv3x);
+ }
+ @media screen and (min-width: 740px) {
+   .lineHeightContainer_lineHeightContainer_xsmall__pnbjt00 {
+     height: var(--textSize-xsmall-tablet-lineHeight__qhrpjv38);
+   }
+   .lineHeightContainer_lineHeightContainer_small__pnbjt01 {
+     height: var(--textSize-small-tablet-lineHeight__qhrpjv3i);
+   }
+   .lineHeightContainer_lineHeightContainer_standard__pnbjt02 {
+     height: var(--textSize-standard-tablet-lineHeight__qhrpjv3s);
+   }
+   .lineHeightContainer_lineHeightContainer_large__pnbjt03 {
+     height: var(--textSize-large-tablet-lineHeight__qhrpjv42);
+   }
+ }
+ .IconChevron_root__v2pdba0 {
+   transition: transform 0.3s ease;
+   transform-origin: 50% 50%;
+ }
+ .IconChevron_left__v2pdba1 {
+   transform: rotate(90deg);
+ }
+ .IconChevron_up__v2pdba2 {
+   transform: rotate(180deg);
+ }
+ .IconChevron_right__v2pdba3 {
+   transform: rotate(270deg);
+ }
+ .Inline_fitContentMobile__hkzz4h0 > * {
+   flex-basis: auto;
+   width: auto;
+   min-width: 0;
+ }
+ @media screen and (min-width: 740px) {
+   .Inline_fitContentTablet__hkzz4h1 > * {
+     flex-basis: auto;
+     width: auto;
+     min-width: 0;
+   }
+ }
+ @media screen and (min-width: 992px) {
+   .Inline_fitContentDesktop__hkzz4h2 > * {
+     flex-basis: auto;
+     width: auto;
+     min-width: 0;
+   }
+ }
+ @media screen and (min-width: 1200px) {
+   .Inline_fitContentWide__hkzz4h3 > * {
+     flex-basis: auto;
+     width: auto;
+     min-width: 0;
+   }
+ }
+ .Column_noSpaceBeforeFirstWhenCollapsed__1w6x3sw0:first-child {
+   padding-top: 0;
+ }
+ .Column_width_1\\/2__1w6x3sw1 {
+   flex-basis: 50%;
+ }
+ .Column_width_1\\/3__1w6x3sw2 {
+   flex-basis: 33.33333333333333%;
+ }
+ .Column_width_2\\/3__1w6x3sw3 {
+   flex-basis: 66.66666666666666%;
+ }
+ .Column_width_1\\/4__1w6x3sw4 {
+   flex-basis: 25%;
+ }
+ .Column_width_3\\/4__1w6x3sw5 {
+   flex-basis: 75%;
+ }
+ .Column_width_1\\/5__1w6x3sw6 {
+   flex-basis: 20%;
+ }
+ .Column_width_2\\/5__1w6x3sw7 {
+   flex-basis: 40%;
+ }
+ .Column_width_3\\/5__1w6x3sw8 {
+   flex-basis: 60%;
+ }
+ .Column_width_4\\/5__1w6x3sw9 {
+   flex-basis: 80%;
+ }
+ .negativeMargin_preventCollapsePseudo_top__1063ve10::before {
+   content: "";
+   display: table;
+ }
+ .negativeMargin_preventCollapsePseudo_bottom__1063ve11::after {
+   content: "";
+   display: table;
+ }
+ .negativeMargin_stylesForBreakpoint_gutter__1063ve12::before {
+   margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxsmall__1063ve13::before {
+   margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xsmall__1063ve14::before {
+   margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_small__1063ve15::before {
+   margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_medium__1063ve16::before {
+   margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_large__1063ve17::before {
+   margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xlarge__1063ve18::before {
+   margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxlarge__1063ve19::before {
+   margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve1a::before {
+   margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_none__1063ve1b::before {
+   margin-bottom: 0;
+ }
+ .negativeMargin_stylesForBreakpoint_gutter__1063ve116::after {
+   margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxsmall__1063ve117::after {
+   margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xsmall__1063ve118::after {
+   margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_small__1063ve119::after {
+   margin-top: calc(var(--space-small__qhrpjv3) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_medium__1063ve11a::after {
+   margin-top: calc(var(--space-medium__qhrpjv4) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_large__1063ve11b::after {
+   margin-top: calc(var(--space-large__qhrpjv5) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xlarge__1063ve11c::after {
+   margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxlarge__1063ve11d::after {
+   margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve11e::after {
+   margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_none__1063ve11f::after {
+   margin-top: 0;
+ }
+ .negativeMargin_stylesForBreakpoint_gutter__1063ve12a {
+   margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxsmall__1063ve12b {
+   margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xsmall__1063ve12c {
+   margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_small__1063ve12d {
+   margin-left: calc(var(--space-small__qhrpjv3) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_medium__1063ve12e {
+   margin-left: calc(var(--space-medium__qhrpjv4) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_large__1063ve12f {
+   margin-left: calc(var(--space-large__qhrpjv5) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xlarge__1063ve12g {
+   margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxlarge__1063ve12h {
+   margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve12i {
+   margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_none__1063ve12j {
+   margin-left: 0;
+ }
+ .negativeMargin_stylesForBreakpoint_gutter__1063ve13e {
+   margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxsmall__1063ve13f {
+   margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xsmall__1063ve13g {
+   margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_small__1063ve13h {
+   margin-right: calc(var(--space-small__qhrpjv3) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_medium__1063ve13i {
+   margin-right: calc(var(--space-medium__qhrpjv4) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_large__1063ve13j {
+   margin-right: calc(var(--space-large__qhrpjv5) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xlarge__1063ve13k {
+   margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxlarge__1063ve13l {
+   margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve13m {
+   margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+ }
+ .negativeMargin_stylesForBreakpoint_none__1063ve13n {
+   margin-right: 0;
+ }
+ @media screen and (min-width: 740px) {
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve1c::before {
+     margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve1d::before {
+     margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve1e::before {
+     margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve1f::before {
+     margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve1g::before {
+     margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve1h::before {
+     margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve1i::before {
+     margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve1j::before {
+     margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve1k::before {
+     margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve1l::before {
+     margin-bottom: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve11g::after {
+     margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve11h::after {
+     margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve11i::after {
+     margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve11j::after {
+     margin-top: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve11k::after {
+     margin-top: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve11l::after {
+     margin-top: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve11m::after {
+     margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve11n::after {
+     margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve11o::after {
+     margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve11p::after {
+     margin-top: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve12k {
+     margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve12l {
+     margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve12m {
+     margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve12n {
+     margin-left: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve12o {
+     margin-left: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve12p {
+     margin-left: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve12q {
+     margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve12r {
+     margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve12s {
+     margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve12t {
+     margin-left: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve13o {
+     margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve13p {
+     margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve13q {
+     margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve13r {
+     margin-right: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve13s {
+     margin-right: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve13t {
+     margin-right: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve13u {
+     margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve13v {
+     margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve13w {
+     margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve13x {
+     margin-right: 0;
+   }
+ }
+ @media screen and (min-width: 992px) {
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve1m::before {
+     margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve1n::before {
+     margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve1o::before {
+     margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve1p::before {
+     margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve1q::before {
+     margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve1r::before {
+     margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve1s::before {
+     margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve1t::before {
+     margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve1u::before {
+     margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve1v::before {
+     margin-bottom: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve11q::after {
+     margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve11r::after {
+     margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve11s::after {
+     margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve11t::after {
+     margin-top: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve11u::after {
+     margin-top: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve11v::after {
+     margin-top: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve11w::after {
+     margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve11x::after {
+     margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve11y::after {
+     margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve11z::after {
+     margin-top: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve12u {
+     margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve12v {
+     margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve12w {
+     margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve12x {
+     margin-left: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve12y {
+     margin-left: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve12z {
+     margin-left: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve130 {
+     margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve131 {
+     margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve132 {
+     margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve133 {
+     margin-left: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve13y {
+     margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve13z {
+     margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve140 {
+     margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve141 {
+     margin-right: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve142 {
+     margin-right: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve143 {
+     margin-right: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve144 {
+     margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve145 {
+     margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve146 {
+     margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve147 {
+     margin-right: 0;
+   }
+ }
+ @media screen and (min-width: 1200px) {
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve1w::before {
+     margin-bottom: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve1x::before {
+     margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve1y::before {
+     margin-bottom: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve1z::before {
+     margin-bottom: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve110::before {
+     margin-bottom: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve111::before {
+     margin-bottom: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve112::before {
+     margin-bottom: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve113::before {
+     margin-bottom: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve114::before {
+     margin-bottom: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve115::before {
+     margin-bottom: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve120::after {
+     margin-top: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve121::after {
+     margin-top: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve122::after {
+     margin-top: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve123::after {
+     margin-top: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve124::after {
+     margin-top: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve125::after {
+     margin-top: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve126::after {
+     margin-top: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve127::after {
+     margin-top: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve128::after {
+     margin-top: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve129::after {
+     margin-top: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve134 {
+     margin-left: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve135 {
+     margin-left: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve136 {
+     margin-left: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve137 {
+     margin-left: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve138 {
+     margin-left: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve139 {
+     margin-left: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve13a {
+     margin-left: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve13b {
+     margin-left: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve13c {
+     margin-left: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve13d {
+     margin-left: 0;
+   }
+   .negativeMargin_stylesForBreakpoint_gutter__1063ve148 {
+     margin-right: calc(var(--space-gutter__qhrpjv0) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxsmall__1063ve149 {
+     margin-right: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xsmall__1063ve14a {
+     margin-right: calc(var(--space-xsmall__qhrpjv2) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_small__1063ve14b {
+     margin-right: calc(var(--space-small__qhrpjv3) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_medium__1063ve14c {
+     margin-right: calc(var(--space-medium__qhrpjv4) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_large__1063ve14d {
+     margin-right: calc(var(--space-large__qhrpjv5) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xlarge__1063ve14e {
+     margin-right: calc(var(--space-xlarge__qhrpjv6) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxlarge__1063ve14f {
+     margin-right: calc(var(--space-xxlarge__qhrpjv7) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_xxxlarge__1063ve14g {
+     margin-right: calc(var(--space-xxxlarge__qhrpjv8) * -1);
+   }
+   .negativeMargin_stylesForBreakpoint_none__1063ve14h {
+     margin-right: 0;
+   }
+ }
+ .Alert_closeButton__1fve7fu0:focus .Alert_closeButtonHover__1fve7fu1, .Alert_closeButton__1fve7fu0:hover .Alert_closeButtonHover__1fve7fu1 {
+   opacity: 1;
+ }
+ .textAlignedToIcon_textAlignedToIcon_standard__u3vg1s0 {
+   padding-top: calc((var(--textSize-standard-mobile-lineHeight__qhrpjv3n) - var(--textSize-standard-mobile-capHeight__qhrpjv3o)) / 2);
+   padding-bottom: calc((var(--textSize-standard-mobile-lineHeight__qhrpjv3n) - var(--textSize-standard-mobile-capHeight__qhrpjv3o)) / 2);
+ }
+ @media screen and (min-width: 740px) {
+   .textAlignedToIcon_textAlignedToIcon_standard__u3vg1s0 {
+     padding-top: calc((var(--textSize-standard-tablet-lineHeight__qhrpjv3s) - var(--textSize-standard-tablet-capHeight__qhrpjv3t)) / 2);
+     padding-bottom: calc((var(--textSize-standard-tablet-lineHeight__qhrpjv3s) - var(--textSize-standard-tablet-capHeight__qhrpjv3t)) / 2);
+   }
+ }
+ .AvoidWidowIcon_nowrap__8ldtmt0 {
+   white-space: nowrap;
+ }
+ @keyframes Button_dot1__kmgydja {
+   14% {
+     opacity: 0;
+   }
+   15%,100% {
+     opacity: 1;
+   }
+ }
+ @keyframes Button_dot2__kmgydjb {
+   29% {
+     opacity: 0;
+   }
+   30%,100% {
+     opacity: 1;
+   }
+ }
+ @keyframes Button_dot3__kmgydjc {
+   44% {
+     opacity: 0;
+   }
+   45%,100% {
+     opacity: 1;
+   }
+ }
+ .Button_root__kmgydj0 {
+   text-decoration: none;
+   align-items: stretch;
+   outline-offset: 0;
+ }
+ .Button_root__kmgydj0:active .Button_activeAnimation__kmgydj2, .Button_forceActive__kmgydj1.Button_activeAnimation__kmgydj2 {
+   transform: var(--transform-touchable__qhrpjv5k);
+ }
+ .Button_root__kmgydj0:active .Button_activeOverlay__kmgydj3, .Button_forceActive__kmgydj1.Button_activeOverlay__kmgydj3 {
+   opacity: 1;
+ }
+ .Button_root__kmgydj0:hover:not(:disabled) .Button_hoverOverlay__kmgydj4 {
+   opacity: 1;
+ }
+ .Button_standard__kmgydj6 {
+   --capHeightToMinHeight__kmgydj5: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-mobile-capHeight__qhrpjv3o)) / 2);
+ }
+ .Button_small__kmgydj7 {
+   --capHeightToMinHeight__kmgydj5: calc(((var(--touchableSize__qhrpjv9) * 0.8) - var(--textSize-small-mobile-capHeight__qhrpjv3e)) / 2);
+ }
+ .Button_bleedVerticallyToCapHeight__kmgydj8 {
+   margin-top: calc(var(--capHeightToMinHeight__kmgydj5) * -1);
+   margin-bottom: calc(var(--capHeightToMinHeight__kmgydj5) * -1);
+ }
+ .Button_padToMinHeight__kmgydj9 {
+   padding-top: var(--capHeightToMinHeight__kmgydj5);
+   padding-bottom: var(--capHeightToMinHeight__kmgydj5);
+ }
+ .Button_loadingDot__kmgydjd {
+   animation-duration: 1s;
+   animation-iteration-count: infinite;
+   opacity: 0;
+ }
+ .Button_loadingDot__kmgydjd:nth-child(1) {
+   animation-name: Button_dot1__kmgydja;
+ }
+ .Button_loadingDot__kmgydjd:nth-child(2) {
+   animation-name: Button_dot2__kmgydjb;
+ }
+ .Button_loadingDot__kmgydjd:nth-child(3) {
+   animation-name: Button_dot3__kmgydjc;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Button_invertedBackgroundsLightMode_soft__kmgydje {
+   background: rgba(255,255,255,0.1);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Button_invertedBackgroundsLightMode_hover__kmgydjf {
+   background: rgba(255,255,255,0.15);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Button_invertedBackgroundsLightMode_active__kmgydjg {
+   background: rgba(255,255,255,0.15);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Button_invertedBackgroundsDarkMode_soft__kmgydjh {
+   background: rgba(255,255,255,0.1);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Button_invertedBackgroundsDarkMode_hover__kmgydji {
+   background: rgba(255,255,255,0.15);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Button_invertedBackgroundsDarkMode_active__kmgydjj {
+   background: rgba(255,255,255,0.15);
+ }
+ @media screen and (min-width: 740px) {
+   .Button_standard__kmgydj6 {
+     --capHeightToMinHeight__kmgydj5: calc((var(--touchableSize__qhrpjv9) - var(--textSize-standard-tablet-capHeight__qhrpjv3t)) / 2);
+   }
+   .Button_small__kmgydj7 {
+     --capHeightToMinHeight__kmgydj5: calc(((var(--touchableSize__qhrpjv9) * 0.8) - var(--textSize-small-tablet-capHeight__qhrpjv3j)) / 2);
+   }
+ }
+ @keyframes Popover_popupAnimation__1yo0tp8a {
+   from {
+     opacity: 0;
+     transform: translateY(calc(var(--space-xxsmall__qhrpjv1) * var(--placementModifier__1yo0tp88, 1)));
+   }
+ }
+ .Popover_backdrop__1yo0tp80 {
+   width: 100vw;
+   height: 100vh;
+ }
+ .Popover_popoverPosition__1yo0tp87 {
+   --dynamicHeight__1yo0tp86: 100svh;
+   top: calc(var(--triggerVars_bottom__1yo0tp83) * 1px);
+   bottom: calc(var(--dynamicHeight__1yo0tp86, 100vh) - (var(--triggerVars_top__1yo0tp81) * 1px));
+   left: calc((var(--triggerVars_left__1yo0tp82) + var(--horizontalOffset__1yo0tp85)) * 1px);
+   right: calc((var(--triggerVars_right__1yo0tp84) + var(--horizontalOffset__1yo0tp85)) * 1px);
+ }
+ .Popover_invertPlacement__1yo0tp89 {
+   --placementModifier__1yo0tp88: -1;
+ }
+ .Popover_animation__1yo0tp8b {
+   animation-name: Popover_popupAnimation__1yo0tp8a;
+   animation-fill-mode: both;
+   animation-timing-function: ease;
+   animation-duration: 0.125s;
+   animation-delay: 15ms;
+ }
+ .Popover_delayVisibility__1yo0tp8c {
+   animation-delay: 250ms;
+ }
+ .TooltipRenderer_maxWidth__821e3y0 {
+   max-width: 260px;
+ }
+ .TooltipRenderer_overflowWrap__821e3y1 {
+   overflow-wrap: break-word;
+ }
+ .TooltipRenderer_translateZ0__821e3y2 {
+   transform: translateZ(0);
+ }
+ .TooltipRenderer_baseArrow__821e3y4 {
+   left: clamp(var(--space-medium__qhrpjv4), var(--horizontalOffset__821e3y3), calc(100% - var(--space-medium__qhrpjv4)));
+   transform: translateX(-50%);
+   visibility: hidden;
+ }
+ .TooltipRenderer_baseArrow__821e3y4:before {
+   content: '';
+   visibility: visible;
+   transform: rotate(45deg);
+ }
+ .TooltipRenderer_baseArrow__821e3y4, .TooltipRenderer_baseArrow__821e3y4::before {
+   width: calc(12px + (var(--borderRadius-small__qhrpjvb) * 2));
+   height: calc(12px + (var(--borderRadius-small__qhrpjvb) * 2));
+   position: absolute;
+   background: inherit;
+   border-radius: var(--borderRadius-small__qhrpjvb);
+ }
+ .TooltipRenderer_arrow_top__821e3y5 {
+   bottom: calc((12px / 2) * -1);
+ }
+ .TooltipRenderer_arrow_bottom__821e3y6 {
+   top: calc((12px / 2) * -1);
+ }
+ .ButtonIcon_button__11ol9k00:hover {
+   z-index: 1;
+ }
+ .ButtonIcon_button__11ol9k00::-moz-focus-inner {
+   border: 0;
+ }
+ .HiddenVisually_root__v7ph350 {
+   width: 1px;
+   height: 1px;
+   clip: rect(1px, 1px, 1px, 1px);
+   white-space: nowrap;
+ }
+ .Field_placeholderColor__klw7kj1::placeholder {
+   color: var(--foregroundColor-secondary__qhrpjv1r);
+ }
+ .Field_secondaryIconSpace__klw7kj2 {
+   padding-right: var(--touchableSize__qhrpjv9);
+ }
+ .Field_iconSpace__klw7kj3 {
+   padding-left: calc(var(--touchableSize__qhrpjv9) - 2px);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Field_hideBorderOnDarkBackgroundInLightMode__klw7kj4 {
+   opacity: 0;
+ }
+ .Field_field__klw7kj0:hover:not(:disabled) ~ .Field_hoverOverlay__klw7kj5, .Field_field__klw7kj0:focus ~ .Field_hoverOverlay__klw7kj5 {
+   opacity: 1;
+ }
+ .Field_verticalDivider__klw7kj6 {
+   width: var(--borderWidth-standard__qhrpjvy);
+   background: var(--borderColor-field__qhrpjvl);
+   opacity: 0.4;
+ }
+ .Autosuggest_backdrop__153m10i0 {
+   width: 100vw;
+   height: 100vh;
+   background: black;
+ }
+ .Autosuggest_backdropVisible__153m10i1 {
+   opacity: 0.4;
+ }
+ .Autosuggest_menu__153m10i2 {
+   max-height: calc((var(--touchableSize__qhrpjv9) * 6) + var(--space-xxsmall__qhrpjv1));
+   overflow-y: auto;
+ }
+ @media screen and (min-width: 740px) {
+   .Autosuggest_menu__153m10i2 {
+     max-height: calc((var(--touchableSize__qhrpjv9) * 8) + var(--space-xxsmall__qhrpjv1));
+   }
+ }
+ .Badge_inline__1r5hl7m0 {
+   display: inline-flex;
+   vertical-align: middle;
+   margin-bottom: calc(var(--space-xxsmall__qhrpjv1) * -1);
+   margin-top: calc((var(--space-xxsmall__qhrpjv1) + .2em) * -1);
+ }
+ .Keyline_tone_promote__1kn7lf76 {
+   background: var(--promote__1kn7lf70);
+ }
+ .Keyline_tone_info__1kn7lf77 {
+   background: var(--info__1kn7lf71);
+ }
+ .Keyline_tone_positive__1kn7lf78 {
+   background: var(--positive__1kn7lf72);
+ }
+ .Keyline_tone_caution__1kn7lf79 {
+   background: var(--caution__1kn7lf73);
+ }
+ .Keyline_tone_critical__1kn7lf7a {
+   background: var(--critical__1kn7lf74);
+ }
+ .Keyline_tone_formAccent__1kn7lf7b {
+   background: var(--formAccent__1kn7lf75);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Keyline_lightMode_light__1kn7lf7c {
+   --promote__1kn7lf70: var(--borderColor-promote__qhrpjvw);
+   --info__1kn7lf71: var(--borderColor-info__qhrpjvp);
+   --positive__1kn7lf72: var(--borderColor-positive__qhrpjvu);
+   --caution__1kn7lf73: var(--borderColor-caution__qhrpjvh);
+   --critical__1kn7lf74: var(--borderColor-critical__qhrpjvj);
+   --formAccent__1kn7lf75: var(--borderColor-formAccent__qhrpjvn);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Keyline_lightMode_dark__1kn7lf7d {
+   --promote__1kn7lf70: var(--borderColor-promoteLight__qhrpjvx);
+   --info__1kn7lf71: var(--borderColor-infoLight__qhrpjvq);
+   --positive__1kn7lf72: var(--borderColor-positiveLight__qhrpjvv);
+   --caution__1kn7lf73: var(--borderColor-cautionLight__qhrpjvi);
+   --critical__1kn7lf74: var(--borderColor-criticalLight__qhrpjvk);
+   --formAccent__1kn7lf75: var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Keyline_darkMode_light__1kn7lf7e {
+   --promote__1kn7lf70: var(--borderColor-promote__qhrpjvw);
+   --info__1kn7lf71: var(--borderColor-info__qhrpjvp);
+   --positive__1kn7lf72: var(--borderColor-positive__qhrpjvu);
+   --caution__1kn7lf73: var(--borderColor-caution__qhrpjvh);
+   --critical__1kn7lf74: var(--borderColor-critical__qhrpjvj);
+   --formAccent__1kn7lf75: var(--borderColor-formAccent__qhrpjvn);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Keyline_darkMode_dark__1kn7lf7f {
+   --promote__1kn7lf70: var(--borderColor-promoteLight__qhrpjvx);
+   --info__1kn7lf71: var(--borderColor-infoLight__qhrpjvq);
+   --positive__1kn7lf72: var(--borderColor-positiveLight__qhrpjvv);
+   --caution__1kn7lf73: var(--borderColor-cautionLight__qhrpjvi);
+   --critical__1kn7lf74: var(--borderColor-criticalLight__qhrpjvk);
+   --formAccent__1kn7lf75: var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ .Keyline_noRadiusOnRight__1kn7lf7g {
+   border-top-right-radius: 0 !important;
+   border-bottom-right-radius: 0 !important;
+ }
+ .Keyline_largestWidth__1kn7lf7h {
+   width: var(--borderRadius-xlarge__qhrpjve);
+ }
+ .Keyline_width__1kn7lf7i {
+   width: var(--grid__qhrpjva);
+ }
+ .InlineField_sizeVars_standard__1b4ltjx2 {
+   --fieldSize__1b4ltjx0: var(--inlineFieldSize-standard__qhrpjv5g);
+   --labelCapHeight__1b4ltjx1: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
+ }
+ .InlineField_sizeVars_small__1b4ltjx3 {
+   --fieldSize__1b4ltjx0: var(--inlineFieldSize-small__qhrpjv5h);
+   --labelCapHeight__1b4ltjx1: var(--textSize-small-mobile-capHeight__qhrpjv3e);
+ }
+ .InlineField_realField__1b4ltjx4 {
+   width: 44px;
+   height: 44px;
+   top: calc(((44px - var(--fieldSize__1b4ltjx0)) / 2) * -1);
+   left: calc(((44px - var(--fieldSize__1b4ltjx0)) / 2) * -1);
+ }
+ [data-braid-debug] .InlineField_realField__1b4ltjx4 {
+   background: red;
+   opacity: 0.2;
+ }
+ .InlineField_fakeField__1b4ltjx5 {
+   height: var(--fieldSize__1b4ltjx0);
+   width: var(--fieldSize__1b4ltjx0);
+   outline: var(--focusRingSize__qhrpjv10) solid transparent;
+   transition: outline-color .125s ease;
+ }
+ .InlineField_realField__1b4ltjx4[type="checkbox"]:checked ~ .InlineField_fakeField__1b4ltjx5 {
+   background: transparent;
+ }
+ .InlineField_realField__1b4ltjx4:focus-visible ~ .InlineField_fakeField__1b4ltjx5 {
+   outline-color: var(--borderColor-focus__qhrpjvm);
+ }
+ .InlineField_labelOffset__1b4ltjx6 {
+   padding-top: calc((var(--fieldSize__1b4ltjx0) - var(--labelCapHeight__1b4ltjx1)) / 2);
+ }
+ .InlineField_realField__1b4ltjx4:checked ~ * .InlineField_children__1b4ltjx8,
+   .InlineField_realField__1b4ltjx4.InlineField_isMixed__1b4ltjx7 ~ * .InlineField_children__1b4ltjx8 {
+   display: block;
+   z-index: 1;
+ }
+ .InlineField_realField__1b4ltjx4:checked + .InlineField_fakeField__1b4ltjx5 > .InlineField_selected__1b4ltjx9,
+   .InlineField_realField__1b4ltjx4.InlineField_isMixed__1b4ltjx7 + .InlineField_fakeField__1b4ltjx5 > .InlineField_selected__1b4ltjx9 {
+   opacity: 1;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .InlineField_hideBorderOnDarkBackgroundInLightMode__1b4ltjxa {
+   opacity: 0;
+ }
+ .InlineField_realField__1b4ltjx4:hover:not(:checked):not(.InlineField_isMixed__1b4ltjx7):not(:disabled) + .InlineField_fakeField__1b4ltjx5 > .InlineField_hoverOverlay__1b4ltjxb,
+   .InlineField_realField__1b4ltjx4:focus:not(.InlineField_isMixed__1b4ltjx7) + .InlineField_fakeField__1b4ltjx5 > .InlineField_hoverOverlay__1b4ltjxb {
+   opacity: 1;
+ }
+ .InlineField_hoverOverlay__1b4ltjxb > .InlineField_indicator__1b4ltjxc {
+   opacity: 0.2;
+ }
+ .InlineField_disabledRadioIndicator__1b4ltjxd {
+   opacity: 0.3;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .InlineField_disabledRadioIndicator__1b4ltjxd {
+   background-color: var(--foregroundColor-secondary__qhrpjv1r);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .InlineField_disabledRadioIndicator__1b4ltjxd {
+   background-color: var(--foregroundColor-secondaryInverted__qhrpjv1s);
+ }
+ .InlineField_checkboxScale__1b4ltjxe {
+   transform: scale(0.85);
+ }
+ .InlineField_realField__1b4ltjx4:active + .InlineField_fakeField__1b4ltjx5 > * > .InlineField_checkboxScale__1b4ltjxe {
+   transform: scale(0.75);
+ }
+ .InlineField_radioScale__1b4ltjxf {
+   transform: scale(0.6);
+ }
+ .InlineField_realField__1b4ltjx4:active + .InlineField_fakeField__1b4ltjx5 > * > .InlineField_radioScale__1b4ltjxf {
+   transform: scale(0.5);
+ }
+ @media screen and (min-width: 740px) {
+   .InlineField_sizeVars_standard__1b4ltjx2 {
+     --labelCapHeight__1b4ltjx1: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
+   }
+   .InlineField_sizeVars_small__1b4ltjx3 {
+     --labelCapHeight__1b4ltjx1: var(--textSize-small-tablet-capHeight__qhrpjv3j);
+   }
+ }
+ .ContentBlock_marginAuto__1xx6jv80 {
+   margin: 0 auto;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Modal_backdrop__13n71fr2 {
+   background: rgba(0, 0, 0, 0.4);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Modal_backdrop__13n71fr2 {
+   background: rgba(0, 0, 0, 0.6);
+ }
+ .Modal_rightAnimation__13n71fr4 {
+   opacity: 1;
+   transform: translateX(110%);
+ }
+ .Modal_leftAnimation__13n71fr5 {
+   opacity: 1;
+   transform: translateX(-110%);
+ }
+ .Modal_centerAnimation__13n71fr6 {
+   transform: scale(.8);
+ }
+ .Modal_horizontalTransition__13n71fr7 {
+   transition: transform .3s cubic-bezier(0.4, 0, 0, 1), opacity .3s cubic-bezier(0.4, 0, 0, 1);
+ }
+ .Modal_pointerEventsAll__13n71fr9 {
+   pointer-events: all;
+ }
+ .Modal_viewportHeight__13n71frd {
+   max-height: var(--fullHeightVar__13n71frb);
+ }
+ .Modal_maxSize_center__13n71fre {
+   --gutterSizeVar__13n71fra: var(--space-xsmall__qhrpjv2);
+   max-height: calc(var(--fullHeightVar__13n71frb) - (var(--gutterSizeVar__13n71fra) * 2));
+   max-width: calc(var(--fullWidthVar__13n71frc) - (var(--gutterSizeVar__13n71fra) * 2));
+ }
+ .Modal_modalContainer__13n71frf {
+   --fullHeightVar__13n71frb: 100vh;
+   --fullWidthVar__13n71frc: 100vw;
+   max-height: var(--fullHeightVar__13n71frb);
+   max-width: var(--fullWidthVar__13n71frc);
+ }
+ .Modal_headingRoot__13n71frg {
+   overflow-wrap: break-word;
+ }
+ .Modal_closeIconOffset__13n71frh {
+   top: -5px;
+   right: -5px;
+ }
+ @media screen and (prefers-reduced-motion) {
+   .Modal_reducedMotion__13n71fr3 {
+     transform: none !important;
+   }
+ }
+ @media screen and (min-width: 740px) {
+   .Modal_rightAnimation__13n71fr4 {
+     opacity: 0;
+     transform: translateX(40px);
+   }
+   .Modal_leftAnimation__13n71fr5 {
+     opacity: 0;
+     transform: translateX(-40px);
+   }
+   .Modal_horizontalTransition__13n71fr7 {
+     transition: transform .175s cubic-bezier(0.4, 0, 0, 1), opacity .175s cubic-bezier(0.4, 0, 0, 1);
+   }
+   .Modal_maxSize_center__13n71fre {
+     --gutterSizeVar__13n71fra: var(--space-gutter__qhrpjv0);
+   }
+ }
+ @media screen and (min-width: 992px) {
+   .Modal_maxSize_center__13n71fre {
+     --gutterSizeVar__13n71fra: var(--space-xlarge__qhrpjv6);
+   }
+ }
+ @supports (height: 1dvh) {
+   .Modal_modalContainer__13n71frf {
+     --fullHeightVar__13n71frb: 100dvh;
+     --fullWidthVar__13n71frc: 100dvw;
+   }
+ }
+ .TextLink_base__beoo42 {
+   color: var(--color__beoo40);
+   text-decoration: var(--linkDecoration__qhrpjv5f);
+   text-decoration-thickness: 0.08em;
+   text-underline-offset: 3px;
+   outline-offset: 0.2em;
+   border-radius: var(--borderRadius-small__qhrpjvb);
+ }
+ .TextLink_base__beoo42:hover {
+   color: var(--colorHover__beoo41);
+   text-decoration: underline;
+   text-decoration-thickness: 0.08em;
+ }
+ .TextLink_base__beoo42:focus-visible {
+   color: var(--colorHover__beoo41);
+ }
+ .TextLink_weakLink__beoo43 {
+   --color__beoo40: inherit;
+   --colorHover__beoo41: inherit;
+   text-decoration: underline;
+   text-decoration-thickness: 0.08em;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_regularLinkLightMode_light__beoo44 {
+   --color__beoo40: var(--foregroundColor-link__qhrpjv1f);
+   --colorHover__beoo41: var(--foregroundColor-linkHover__qhrpjv1g);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_regularLinkLightMode_dark__beoo45 {
+   --color__beoo40: var(--foregroundColor-linkLight__qhrpjv1h);
+   --colorHover__beoo41: var(--foregroundColor-linkLight__qhrpjv1h);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .TextLink_regularLinkDarkMode_light__beoo46 {
+   --color__beoo40: var(--foregroundColor-link__qhrpjv1f);
+   --colorHover__beoo41: var(--foregroundColor-linkHover__qhrpjv1g);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .TextLink_regularLinkDarkMode_dark__beoo47 {
+   --color__beoo40: var(--foregroundColor-linkLight__qhrpjv1h);
+   --colorHover__beoo41: var(--foregroundColor-linkLight__qhrpjv1h);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_visitedLightMode_light__beoo48:visited {
+   color: var(--foregroundColor-linkVisited__qhrpjv1i);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .TextLink_visitedLightMode_dark__beoo49:visited {
+   color: var(--foregroundColor-linkLightVisited__qhrpjv1j);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .TextLink_visitedDarkMode_light__beoo4a:visited {
+   color: var(--foregroundColor-linkVisited__qhrpjv1i);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .TextLink_visitedDarkMode_dark__beoo4b:visited {
+   color: var(--foregroundColor-linkLightVisited__qhrpjv1j);
+ }
+ .Dropdown_field__gz3fci0 {
+   padding-right: var(--touchableSize__qhrpjv9);
+ }
+ @media print {
+   .Hidden_hiddenOnPrint__1mw96wl0 {
+     display: none !important;
+   }
+ }
+ .List_currentColor__1an15sm0 {
+   background: currentColor;
+ }
+ .List_large__1an15sm1 {
+   width: 5px;
+   height: 5px;
+ }
+ .List_standard__1an15sm2 {
+   width: 4px;
+   height: 4px;
+ }
+ .List_xsmall__1an15sm3 {
+   width: 3px;
+   height: 3px;
+ }
+ .List_minCharacterWidth__1an15sm4 {
+   min-width: 1.4ch;
+ }
+ .List_minCharacterWidth__1an15sm5 {
+   min-width: 2.4ch;
+ }
+ .List_trimGutter__1an15sm6 {
+   margin-right: -0.4ch;
+ }
+ @keyframes Loader_bounce__e5c4uh9 {
+   33% {
+     transform: translateY(-1.4em);
+   }
+   66% {
+     transform: translateY(1.4em);
+   }
+ }
+ @keyframes Loader_fade__e5c4uhd {
+   from {
+     opacity: 0;
+   }
+   to {
+     opacity: 1;
+   }
+ }
+ .Loader_rootSize_xsmall__e5c4uh0 {
+   height: var(--textSize-xsmall-mobile-capHeight__qhrpjv34);
+ }
+ .Loader_rootSize_small__e5c4uh1 {
+   height: var(--textSize-small-mobile-capHeight__qhrpjv3e);
+ }
+ .Loader_rootSize_standard__e5c4uh2 {
+   height: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
+ }
+ .Loader_rootSize_large__e5c4uh3 {
+   height: var(--textSize-large-mobile-capHeight__qhrpjv3y);
+ }
+ .Loader_size_xsmall__e5c4uh4 {
+   height: var(--textSize-xsmall-mobile-fontSize__qhrpjv32);
+ }
+ .Loader_size_small__e5c4uh5 {
+   height: var(--textSize-small-mobile-fontSize__qhrpjv3c);
+ }
+ .Loader_size_standard__e5c4uh6 {
+   height: var(--textSize-standard-mobile-fontSize__qhrpjv3m);
+ }
+ .Loader_size_large__e5c4uh7 {
+   height: var(--textSize-large-mobile-fontSize__qhrpjv3w);
+ }
+ .Loader_currentColor__e5c4uh8 {
+   fill: currentcolor;
+ }
+ .Loader_bounceAnimation__e5c4uha {
+   animation-name: Loader_bounce__e5c4uh9;
+   animation-fill-mode: both;
+   animation-iteration-count: infinite;
+   animation-timing-function: ease-in-out;
+   animation-duration: 0.6s;
+ }
+ .Loader_circle__e5c4uhb {
+   transform: translateY(1.4em);
+ }
+ .Loader_circle__e5c4uhb:nth-child(1) {
+   animation-delay: 140ms;
+ }
+ .Loader_circle__e5c4uhb:nth-child(2) {
+   animation-delay: 70ms;
+ }
+ .Loader_delay__e5c4uhe {
+   opacity: 0;
+   animation-name: Loader_fade__e5c4uhd;
+   animation-iteration-count: 1;
+   animation-fill-mode: forwards;
+   animation-timing-function: ease-in;
+   animation-duration: 0.25s;
+   animation-delay: 800ms;
+ }
+ @media screen and (min-width: 740px) {
+   .Loader_rootSize_xsmall__e5c4uh0 {
+     height: var(--textSize-xsmall-tablet-capHeight__qhrpjv39);
+   }
+   .Loader_rootSize_small__e5c4uh1 {
+     height: var(--textSize-small-tablet-capHeight__qhrpjv3j);
+   }
+   .Loader_rootSize_standard__e5c4uh2 {
+     height: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
+   }
+   .Loader_rootSize_large__e5c4uh3 {
+     height: var(--textSize-large-tablet-capHeight__qhrpjv43);
+   }
+   .Loader_size_xsmall__e5c4uh4 {
+     height: var(--textSize-xsmall-tablet-fontSize__qhrpjv37);
+   }
+   .Loader_size_small__e5c4uh5 {
+     height: var(--textSize-small-tablet-fontSize__qhrpjv3h);
+   }
+   .Loader_size_standard__e5c4uh6 {
+     height: var(--textSize-standard-tablet-fontSize__qhrpjv3r);
+   }
+   .Loader_size_large__e5c4uh7 {
+     height: var(--textSize-large-tablet-fontSize__qhrpjv41);
+   }
+ }
+ .ScrollContainer_container__1aqz9r10 {
+   -webkit-overflow-scrolling: touch;
+   -webkit-mask-composite: destination-in;
+   mask-composite: intersect;
+ }
+ .ScrollContainer_hideScrollbar__1aqz9r11 {
+   scrollbar-width: none;
+   -ms-overflow-style: none;
+ }
+ .ScrollContainer_hideScrollbar__1aqz9r11::-webkit-scrollbar {
+   width: 0;
+   height: 0;
+ }
+ .ScrollContainer_fadeSize_small__1aqz9r13 {
+   --scrollOverlaySize__1aqz9r12: 40px;
+ }
+ .ScrollContainer_fadeSize_medium__1aqz9r14 {
+   --scrollOverlaySize__1aqz9r12: 60px;
+ }
+ .ScrollContainer_fadeSize_large__1aqz9r15 {
+   --scrollOverlaySize__1aqz9r12: 80px;
+ }
+ .ScrollContainer_direction_horizontal__1aqz9r16 {
+   overflow-x: auto;
+   overflow-y: hidden;
+   min-height: fit-content;
+ }
+ .ScrollContainer_direction_vertical__1aqz9r17 {
+   overflow-x: hidden;
+   overflow-y: auto;
+ }
+ .ScrollContainer_direction_all__1aqz9r18 {
+   overflow: auto;
+ }
+ .ScrollContainer_mask__1aqz9r1d {
+   mask-image: linear-gradient(to bottom, transparent 0, black var(--top__1aqz9r1b, 0)),linear-gradient(to right, transparent 0, black var(--left__1aqz9r19, 0)),linear-gradient(to left, transparent 0, black var(--right__1aqz9r1a, 0)),linear-gradient(to top, transparent 0, black var(--bottom__1aqz9r1c, 0));
+ }
+ .ScrollContainer_maskLeft__1aqz9r1e {
+   --left__1aqz9r19: var(--scrollOverlaySize__1aqz9r12);
+ }
+ .ScrollContainer_maskRight__1aqz9r1f {
+   --right__1aqz9r1a: var(--scrollOverlaySize__1aqz9r12);
+ }
+ .ScrollContainer_maskTop__1aqz9r1g {
+   --top__1aqz9r1b: var(--scrollOverlaySize__1aqz9r12);
+ }
+ .ScrollContainer_maskBottom__1aqz9r1h {
+   --bottom__1aqz9r1c: var(--scrollOverlaySize__1aqz9r12);
+ }
+ .MenuRenderer_backdrop__p34lbl1 {
+   width: 100vw;
+   height: 100vh;
+ }
+ .MenuRenderer_menuPosition__p34lbl6 {
+   top: var(--triggerVars_bottom__p34lbl4);
+   bottom: var(--triggerVars_top__p34lbl2);
+   left: var(--triggerVars_left__p34lbl3);
+   right: var(--triggerVars_right__p34lbl5);
+ }
+ .MenuRenderer_baseWidth__p34lbl8 {
+   width: calc(var(--widthVar__p34lbl7) / 4);
+ }
+ .MenuRenderer_width_small__p34lbl9 {
+   --widthVar__p34lbl7: var(--contentWidth-small__qhrpjv12);
+ }
+ .MenuRenderer_width_medium__p34lbla {
+   --widthVar__p34lbl7: var(--contentWidth-medium__qhrpjv13);
+ }
+ .MenuRenderer_width_large__p34lblb {
+   --widthVar__p34lbl7: var(--contentWidth-large__qhrpjv14);
+ }
+ .MenuRenderer_menuHeightLimit__p34lblc {
+   max-height: calc((var(--touchableSize__qhrpjv9) * 9.5) + (var(--menuYPadding__p34lbl0) * 2));
+ }
+ .useMenuItem_menuItem__wz3nke0::-moz-focus-inner {
+   border: 0;
+ }
+ .useMenuItem_menuItemLeftSlot__wz3nke1 {
+   height: 0px;
+ }
+ .MenuItemCheckbox_checkboxSize__17whdqr2 {
+   --menuItemCapHeight__17whdqr0: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
+   --crop__17whdqr1: calc(((var(--inlineFieldSize-small__qhrpjv5h) - var(--menuItemCapHeight__17whdqr0)) / 2) * -1);
+   height: var(--inlineFieldSize-small__qhrpjv5h);
+   width: var(--inlineFieldSize-small__qhrpjv5h);
+   margin-top: var(--crop__17whdqr1);
+   margin-bottom: var(--crop__17whdqr1);
+ }
+ @media screen and (min-width: 740px) {
+   .MenuItemCheckbox_checkboxSize__17whdqr2 {
+     --menuItemCapHeight__17whdqr0: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
+   }
+ }
+ .OverflowMenu_wrapperPositioning__18ydm7f0 {
+   margin: -1px -6px;
+ }
+ .MonthPicker_nativeInput__1xbm4s00::-webkit-inner-spin-button, .MonthPicker_nativeInput__1xbm4s00::-webkit-calendar-picker-indicator, .MonthPicker_nativeInput__1xbm4s00::-webkit-clear-button {
+   display: none;
+   -webkit-appearance: none;
+ }
+ .Page_fullHeight__7puj9a1 {
+   min-height: var(--heightLimit__7puj9a0, 100vh);
+ }
+ .Pagination_focusRing__oms9uc1 {
+   outline-offset: 0;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Pagination_lightModeCurrentKeyline__oms9uc3 {
+   opacity: 0.3;
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Pagination_darkModeCurrentKeyline__oms9uc4 {
+   opacity: 0.3;
+ }
+ .Pagination_current__oms9uc5 {
+   opacity: 0.075;
+ }
+ .Pagination_hover__oms9uc2:hover .Pagination_background__oms9uc6:not(.Pagination_current__oms9uc5) {
+   opacity: 0.5;
+ }
+ .Rating_inlineFlex__nkq5400 {
+   display: inline-flex;
+   gap: 1px;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_tone_formAccent__6woprh2 {
+   --highlightVar__6woprh1: var(--borderColor-formAccent__qhrpjvn);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Stepper_tone_formAccent__6woprh2 {
+   --highlightVar__6woprh1: var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_tone_neutral__6woprh3 {
+   --highlightVar__6woprh1: var(--borderColor-neutral__qhrpjvr);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Stepper_tone_neutral__6woprh3 {
+   --highlightVar__6woprh1: var(--borderColor-neutralLight__qhrpjvt);
+ }
+ .Stepper_step__6woprh4 {
+   outline: none;
+   text-align: left;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_step__6woprh4 {
+   --baseColourVar__6woprh0: var(--borderColor-neutralLight__qhrpjvt);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Stepper_step__6woprh4 {
+   --baseColourVar__6woprh0: var(--borderColor-neutral__qhrpjvr);
+ }
+ .Stepper_indicator__6woprh6 {
+   height: var(--inlineFieldSize-small__qhrpjv5h);
+   width: var(--inlineFieldSize-small__qhrpjv5h);
+   color: var(--baseColourVar__6woprh0);
+ }
+ .Stepper_stretch__6woprh7 {
+   flex: 1;
+ }
+ .Stepper_highlight__6woprh9 {
+   color: var(--highlightVar__6woprh1);
+ }
+ .Stepper_inner__6woprhd {
+   fill: currentcolor;
+   transform-origin: 50% 50%;
+   transform: scale(0);
+ }
+ .Stepper_active__6woprhb > .Stepper_inner__6woprhd {
+   transform: scale(1);
+   opacity: 1;
+ }
+ .Stepper_complete__6woprha > .Stepper_inner__6woprhd {
+   transform: scale(2.1);
+   opacity: 1;
+ }
+ .Stepper_tick__6woprhf {
+   transition-delay: .1s;
+   transform-origin: 50% 50%;
+ }
+ :not(.Stepper_complete__6woprha) > .Stepper_tick__6woprhf {
+   opacity: 0;
+   transition-delay: 0s;
+   transform: scale(.5) rotate(50deg);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Stepper_tick__6woprhf {
+   fill: var(--foregroundColor-neutralInverted__qhrpjv1l);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Stepper_tick__6woprhf {
+   fill: var(--foregroundColor-neutral__qhrpjv1k);
+ }
+ .Stepper_progressTrack__6woprhg {
+   background: repeating-linear-gradient(90deg, var(--baseColourVar__6woprh0), var(--baseColourVar__6woprh0) 2px, transparent 2px, transparent 4px);
+   height: var(--borderWidth-large__qhrpjvz);
+   width: calc((100% - var(--inlineFieldSize-small__qhrpjv5h)) - (var(--space-xxsmall__qhrpjv1) * 2));
+   top: calc((var(--inlineFieldSize-small__qhrpjv5h) - var(--borderWidth-large__qhrpjvz)) / 2);
+   left: calc(var(--inlineFieldSize-small__qhrpjv5h) + var(--space-xxsmall__qhrpjv1));
+ }
+ .Stepper_progressLine__6woprhi {
+   background: var(--highlightVar__6woprh1);
+   transition: transform .2s ease;
+ }
+ .Stepper_progressUnfilled__6woprhj {
+   transform: translateX(-101%);
+ }
+ .Stepper_indicatorContainer__6woprhk {
+   outline: var(--focusRingSize__qhrpjv10) solid transparent;
+   width: var(--inlineFieldSize-small__qhrpjv5h);
+   transition: var(--transition-fast__qhrpjv5i), outline-color .125s ease;
+ }
+ .Stepper_step__6woprh4:focus-visible .Stepper_indicatorContainer__6woprhk {
+   outline-color: var(--borderColor-focus__qhrpjvm);
+   transform: scale(1.2);
+ }
+ .Stepper_step__6woprh4:active .Stepper_indicatorContainer__6woprhk {
+   transform: var(--transform-touchable__qhrpjv5k);
+ }
+ @media screen and (min-width: 740px) {
+   .Stepper_stretchLastAboveTablet__6woprh8 {
+     flex: 1;
+   }
+   .Stepper_progressTrackCentered__6woprhh {
+     left: calc((50% + (var(--inlineFieldSize-small__qhrpjv5h) / 2)) + var(--space-xxsmall__qhrpjv1));
+   }
+ }
+ .Table_table__y0v62q1 {
+   border-collapse: separate;
+   border: var(--borderWidth-standard__qhrpjvy) solid var(--borderColor__y0v62q0);
+   font-variant-numeric: tabular-nums;
+   word-break: break-word;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Table_table__y0v62q1 {
+   --borderColor__y0v62q0: var(--borderColor-neutralLight__qhrpjvt);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Table_table__y0v62q1 {
+   --borderColor__y0v62q0: var(--borderColor-neutral__qhrpjvr);
+ }
+ .Table_row__y0v62q4:not(:last-child) > .Table_cell__y0v62q5 {
+   border-bottom: 1px solid var(--borderColor__y0v62q0);
+ }
+ .Table_tableSection__y0v62q3:not(.Table_tableHeader__y0v62q2) > .Table_row__y0v62q4 > .Table_headCell__y0v62q6:not(:first-child) {
+   border-left: 1px solid var(--borderColor__y0v62q0);
+ }
+ .Table_tableSection__y0v62q3:not(.Table_tableHeader__y0v62q2) > .Table_row__y0v62q4 > .Table_headCell__y0v62q6:not(:last-child) {
+   border-right: 1px solid var(--borderColor__y0v62q0);
+ }
+ .Table_tableSection__y0v62q3:not(:first-child) > .Table_row__y0v62q4:first-child > .Table_cell__y0v62q5 {
+   border-top: var(--borderWidth-standard__qhrpjvy) solid var(--borderColor__y0v62q0);
+ }
+ .Table_alignY_center__y0v62q7 {
+   vertical-align: middle;
+ }
+ .Table_alignY_top__y0v62q8 {
+   vertical-align: top;
+ }
+ .Table_nowrap__y0v62q9 {
+   white-space: nowrap;
+ }
+ .Table_softWidth__y0v62qb {
+   width: var(--softWidthVar__y0v62qa);
+ }
+ .Table_minWidth__y0v62qd {
+   min-width: var(--minWidthVar__y0v62qc);
+ }
+ .Table_maxWidth__y0v62qf {
+   max-width: var(--maxWidthVar__y0v62qe);
+ }
+ @media screen and (min-width: 740px) {
+   .Table_showOnTablet__y0v62qg {
+     display: table-cell;
+   }
+ }
+ @media screen and (min-width: 992px) {
+   .Table_showOnDesktop__y0v62qh {
+     display: table-cell;
+   }
+ }
+ @media screen and (min-width: 1200px) {
+   .Table_showOnWide__y0v62qi {
+     display: table-cell;
+   }
+ }
+ .Tabs_tab__wez1qd0::-moz-focus-inner {
+   border: 0;
+ }
+ .Tabs_tab__wez1qd0:hover .Tabs_hoveredTab__wez1qd1 {
+   opacity: 1;
+ }
+ .Tabs_nowrap__wez1qd2 {
+   white-space: nowrap;
+ }
+ .Tabs_scroll__wez1qd3 {
+   -webkit-overflow-scrolling: touch;
+   overflow-x: auto;
+   overflow-y: hidden;
+   scrollbar-width: none;
+   -ms-overflow-style: none;
+ }
+ .Tabs_scroll__wez1qd3::-webkit-scrollbar {
+   width: 0;
+   height: 0;
+ }
+ .Tabs_mask__wez1qd4 {
+   mask-image: linear-gradient(90deg, rgba(0,0,0,1) 0, rgba(0,0,0,1) calc(100% - 80px), rgba(0,0,0,0) 100%);
+ }
+ .Tabs_marginAuto__wez1qd5 {
+   margin-left: auto;
+   margin-right: auto;
+ }
+ .Tabs_tabFocusRing__wez1qd6 {
+   outline-offset: calc(var(--focusRingSize__qhrpjv10) * -1);
+ }
+ .Tabs_tabUnderline__wez1qdb {
+   --underlineRadius__wez1qd9: calc(var(--borderRadius-small__qhrpjvb) / var(--underlineScale__wez1qda));
+   --underlineScale__wez1qda: calc(var(--underlineWidth__wez1qd8) / 100);
+   height: var(--borderWidth-large__qhrpjvz);
+   border-top-left-radius: var(--underlineRadius__wez1qd9);
+   border-top-right-radius: var(--underlineRadius__wez1qd9);
+   width: 100px;
+   transform-origin: 0 0;
+   transition: transform .3s ease;
+   transform: translateZ(0) translateX(calc(var(--underlineLeft__wez1qd7) * 1px)) scaleX(var(--underlineScale__wez1qda));
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Tabs_tabUnderlineActiveDarkMode__wez1qdc {
+   background: var(--borderColor-formAccentLight__qhrpjvo);
+ }
+ .Tabs_divider__wez1qde {
+   height: var(--borderWidth-standard__qhrpjvy);
+ }
+ .Tag_clearGutter__1jrpwfo0 {
+   padding-left: 1px;
+ }
+ .Highlight_root__cnytm1 {
+   padding: 0 2px;
+   margin: 0 -2px;
+   text-decoration: underline;
+   text-decoration-style: wavy;
+   text-decoration-skip-ink: none;
+   text-decoration-thickness: 2px;
+   text-underline-offset: 2px;
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Highlight_critical__cnytm2 {
+   text-decoration-color: var(--borderColor-critical__qhrpjvj);
+   background: var(--backgroundColor-criticalLight__qhrpjv27);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Highlight_critical__cnytm2 {
+   text-decoration-color: var(--borderColor-criticalLight__qhrpjvk);
+ }
+ .Highlight_caution__cnytm3 {
+   text-decoration-color: var(--borderColor-caution__qhrpjvh);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Highlight_caution__cnytm3 {
+   background: var(--backgroundColor-cautionLight__qhrpjv23);
+ }
+ .Textarea_field__ak2u6d0 {
+   resize: vertical;
+   background: transparent;
+   min-height: calc(var(--grid__qhrpjva) * 15);
+ }
+ .Textarea_highlights__ak2u6d1 {
+   color: transparent !important;
+   word-break: break-word;
+   white-space: pre-wrap;
+ }
+ .Textarea_highlights__ak2u6d1:after {
+   content: "\\A";
+ }
+ .TextDropdown_select__pu1g620 {
+   min-height: 44px;
+   min-width: 44px;
+   height: 100%;
+   width: 100%;
+   transform: translate(-50%, -50%);
+   top: 50%;
+   left: 50%;
+ }
+ [data-braid-debug] .TextDropdown_select__pu1g620 {
+   background: red;
+   opacity: 0.2;
+ }
+ .TextDropdown_focusRing__pu1g622 {
+   outline: var(--focusRingSize__qhrpjv10) solid transparent;
+   transition: outline-color .125s ease;
+   outline-offset: var(--space-xxsmall__qhrpjv1);
+ }
+ .TextDropdown_select__pu1g620:focus-visible ~ .TextDropdown_focusRing__pu1g622 {
+   outline-color: var(--borderColor-focus__qhrpjvm);
+ }
+ .Tiles_tiles__5j02iv5 {
+   --columns__5j02iv0: var(--mobileColumnsVar__5j02iv1);
+   display: grid;
+   grid-template-columns: repeat(var(--columns__5j02iv0), 1fr);
+ }
+ .Tiles_tiles__5j02iv5 > * {
+   min-width: 0;
+ }
+ @media screen and (min-width: 740px) {
+   .Tiles_tiles__5j02iv5 {
+     --columns__5j02iv0: var(--tabletColumnsVar__5j02iv2);
+   }
+ }
+ @media screen and (min-width: 992px) {
+   .Tiles_tiles__5j02iv5 {
+     --columns__5j02iv0: var(--desktopColumnsVar__5j02iv3);
+   }
+ }
+ @media screen and (min-width: 1200px) {
+   .Tiles_tiles__5j02iv5 {
+     --columns__5j02iv0: var(--wideColumnsVar__5j02iv4);
+   }
+ }
+ .Toggle_bleedToCapHeight_standard__158h80u0 {
+   height: var(--textSize-standard-mobile-capHeight__qhrpjv3o);
+ }
+ .Toggle_bleedToCapHeight_small__158h80u1 {
+   height: var(--textSize-small-mobile-capHeight__qhrpjv3e);
+ }
+ .Toggle_root__158h80u2:hover {
+   z-index: 1;
+ }
+ .Toggle_realField__158h80u3 {
+   height: 44px;
+ }
+ [data-braid-debug] .Toggle_realField__158h80u3 {
+   background: red;
+   opacity: 0.2;
+ }
+ .Toggle_realFieldPosition_standard__158h80u4 {
+   top: calc(((44px - var(--inlineFieldSize-standard__qhrpjv5g)) / 2) * -1);
+ }
+ .Toggle_realFieldPosition_small__158h80u5 {
+   top: calc(((44px - var(--inlineFieldSize-small__qhrpjv5h)) / 2) * -1);
+ }
+ .Toggle_fieldSize_standard__158h80u6 {
+   width: calc(var(--inlineFieldSize-standard__qhrpjv5g) * 1.6);
+ }
+ .Toggle_fieldSize_small__158h80u7 {
+   width: calc(var(--inlineFieldSize-small__qhrpjv5h) * 1.6);
+ }
+ .Toggle_slideContainerSize_standard__158h80u9 {
+   height: var(--inlineFieldSize-standard__qhrpjv5g);
+ }
+ .Toggle_slideContainerSize_small__158h80ua {
+   height: var(--inlineFieldSize-small__qhrpjv5h);
+ }
+ .Toggle_slideTrack_standard__158h80ub {
+   height: calc(var(--inlineFieldSize-standard__qhrpjv5g) - var(--grid__qhrpjva));
+ }
+ .Toggle_slideTrack_small__158h80uc {
+   height: calc(var(--inlineFieldSize-small__qhrpjv5h) - var(--grid__qhrpjva));
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Toggle_slideTrackBgLightMode_light__158h80ud {
+   background: rgba(0,0,0,0.08);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Toggle_slideTrackBgLightMode_dark__158h80ue {
+   background: rgba(255,255,255,0.12);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Toggle_slideTrackBgDarkMode_light__158h80uf {
+   background: rgba(0,0,0,0.08);
+ }
+ html.sprinkles_darkMode__1hjdb9v11 .Toggle_slideTrackBgDarkMode_dark__158h80ug {
+   background: rgba(255,255,255,0.12);
+ }
+ .Toggle_slideTrackMask__158h80uh {
+   -webkit-mask-image: -webkit-radial-gradient(white, black);
+ }
+ .Toggle_realField__158h80u3:not(:checked) + .Toggle_slideContainer__158h80u8 .Toggle_slideTrackSelected__158h80ui {
+   transform: translateX(calc(var(--touchableSize__qhrpjv9) * -1));
+ }
+ .Toggle_slider_standard__158h80uj {
+   outline: var(--focusRingSize__qhrpjv10) solid transparent;
+   height: var(--inlineFieldSize-standard__qhrpjv5g);
+   width: var(--inlineFieldSize-standard__qhrpjv5g);
+   transition: var(--transition-fast__qhrpjv5i), outline-color .125s ease;
+ }
+ .Toggle_realField__158h80u3:focus-visible + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
+   outline-color: var(--borderColor-focus__qhrpjvm);
+ }
+ .Toggle_realField__158h80u3:active + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
+   transform: translateX(calc((var(--inlineFieldSize-standard__qhrpjv5g) * 0.12) * -1));
+ }
+ .Toggle_realField__158h80u3:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
+   transform: translateX(calc((var(--inlineFieldSize-standard__qhrpjv5g) * 1.6) - var(--inlineFieldSize-standard__qhrpjv5g)));
+ }
+ .Toggle_realField__158h80u3:active:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_standard__158h80uj {
+   transform: translateX(calc(((var(--inlineFieldSize-standard__qhrpjv5g) * 1.6) - var(--inlineFieldSize-standard__qhrpjv5g)) + (var(--inlineFieldSize-standard__qhrpjv5g) * 0.12)));
+ }
+ .Toggle_slider_small__158h80uk {
+   outline: var(--focusRingSize__qhrpjv10) solid transparent;
+   height: var(--inlineFieldSize-small__qhrpjv5h);
+   width: var(--inlineFieldSize-small__qhrpjv5h);
+   transition: var(--transition-fast__qhrpjv5i), outline-color .125s ease;
+ }
+ .Toggle_realField__158h80u3:focus-visible + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
+   outline-color: var(--borderColor-focus__qhrpjvm);
+ }
+ .Toggle_realField__158h80u3:active + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
+   transform: translateX(calc((var(--inlineFieldSize-small__qhrpjv5h) * 0.12) * -1));
+ }
+ .Toggle_realField__158h80u3:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
+   transform: translateX(calc((var(--inlineFieldSize-small__qhrpjv5h) * 1.6) - var(--inlineFieldSize-small__qhrpjv5h)));
+ }
+ .Toggle_realField__158h80u3:active:checked + .Toggle_slideContainer__158h80u8 .Toggle_slider_small__158h80uk {
+   transform: translateX(calc(((var(--inlineFieldSize-small__qhrpjv5h) * 1.6) - var(--inlineFieldSize-small__qhrpjv5h)) + (var(--inlineFieldSize-small__qhrpjv5h) * 0.12)));
+ }
+ .Toggle_sliderThumbOutlineFix__158h80ul {
+   transform: scale(1.04);
+ }
+ html:not(.sprinkles_darkMode__1hjdb9v11) .Toggle_hideBorderOnDarkBackgroundInLightMode__158h80um {
+   opacity: 0;
+ }
+ .Toggle_realField__158h80u3:hover:not(:disabled) + .Toggle_slideContainer__158h80u8 .Toggle_hoverOverlay__158h80un,
+   .Toggle_realField__158h80u3:focus + .Toggle_slideContainer__158h80u8 .Toggle_hoverOverlay__158h80un {
+   opacity: 1;
+ }
+ @media screen and (min-width: 740px) {
+   .Toggle_bleedToCapHeight_standard__158h80u0 {
+     height: var(--textSize-standard-tablet-capHeight__qhrpjv3t);
+   }
+   .Toggle_bleedToCapHeight_small__158h80u1 {
+     height: var(--textSize-small-tablet-capHeight__qhrpjv3j);
+   }
+ }
+ .Toast_toast__1nhoi470 {
+   pointer-events: all;
+ }
+ .Toast_collapsed__1nhoi471 .Toast_collapsedToastContent__1nhoi472 {
+   opacity: 0;
+ }
+ .Toaster_toaster__103l6ur0 {
+   left: 0;
+   right: 0;
+   margin-inline: auto;
+   bottom: var(--space-xsmall__qhrpjv2);
+   max-width: min(var(--contentWidth-xsmall__qhrpjv11), calc(100vw - (2 * var(--space-small__qhrpjv3))));
+ }
+ .IconArrow_root__1igczit0 {
+   transition: transform 0.3s ease;
+   transform-origin: 50% 50%;
+ }
+ .IconArrow_flip__1igczit1 {
+   transform: rotateX(180deg);
+ }
+ .IconArrow_rotate__1igczit3 {
+   transform: scaleX(var(--mirrorVar__1igczit2, 1)) rotate(90deg);
+ }
+ .IconArrow_mirror__1igczit4 {
+   --mirrorVar__1igczit2: -1;
+ }
+ .IconThumb_root__fympft0 {
+   transition: transform 0.3s ease;
+   transform-origin: 50% 50%;
+ }
+ .IconThumb_down__fympft1 {
+   transform: rotate(180deg);
+ }
+ .seekJobs_seekJobs__1fmskxf0 {
+   --space-gutter__qhrpjv0: 24px;
+   --space-xxsmall__qhrpjv1: 8px;
+   --space-xsmall__qhrpjv2: 12px;
+   --space-small__qhrpjv3: 16px;
+   --space-medium__qhrpjv4: 24px;
+   --space-large__qhrpjv5: 32px;
+   --space-xlarge__qhrpjv6: 48px;
+   --space-xxlarge__qhrpjv7: 64px;
+   --space-xxxlarge__qhrpjv8: 96px;
+   --touchableSize__qhrpjv9: 48px;
+   --grid__qhrpjva: 4px;
+   --borderRadius-small__qhrpjvb: 4px;
+   --borderRadius-standard__qhrpjvc: 8px;
+   --borderRadius-large__qhrpjvd: 16px;
+   --borderRadius-xlarge__qhrpjve: 24px;
+   --borderColor-brandAccent__qhrpjvf: #E60278;
+   --borderColor-brandAccentLight__qhrpjvg: #F8B1DC;
+   --borderColor-caution__qhrpjvh: #FDC221;
+   --borderColor-cautionLight__qhrpjvi: #FEE384;
+   --borderColor-critical__qhrpjvj: #B91E1E;
+   --borderColor-criticalLight__qhrpjvk: #FB999A;
+   --borderColor-field__qhrpjvl: #838FA5;
+   --borderColor-focus__qhrpjvm: rgba(153,191,247,0.7);
+   --borderColor-formAccent__qhrpjvn: #1E47A9;
+   --borderColor-formAccentLight__qhrpjvo: #99BFF7;
+   --borderColor-info__qhrpjvp: #1D559D;
+   --borderColor-infoLight__qhrpjvq: #98C9F1;
+   --borderColor-neutral__qhrpjvr: #2E3849;
+   --borderColor-neutralLight__qhrpjvt: #EAECF1;
+   --borderColor-neutralInverted__qhrpjvs: #fff;
+   --borderColor-positive__qhrpjvu: #12784F;
+   --borderColor-positiveLight__qhrpjvv: #8BDEC5;
+   --borderColor-promote__qhrpjvw: #7F35A9;
+   --borderColor-promoteLight__qhrpjvx: #E1B2F5;
+   --borderWidth-standard__qhrpjvy: 2px;
+   --borderWidth-large__qhrpjvz: 4px;
+   --focusRingSize__qhrpjv10: 6px;
+   --contentWidth-xsmall__qhrpjv11: 400px;
+   --contentWidth-small__qhrpjv12: 660px;
+   --contentWidth-medium__qhrpjv13: 940px;
+   --contentWidth-large__qhrpjv14: 1280px;
+   --foregroundColor-brandAccent__qhrpjv15: #E60278;
+   --foregroundColor-brandAccentLight__qhrpjv16: #F8B1DC;
+   --foregroundColor-caution__qhrpjv17: #723D02;
+   --foregroundColor-cautionLight__qhrpjv18: #FEE384;
+   --foregroundColor-critical__qhrpjv19: #B91E1E;
+   --foregroundColor-criticalLight__qhrpjv1a: #FB999A;
+   --foregroundColor-formAccent__qhrpjv1b: #1E47A9;
+   --foregroundColor-formAccentLight__qhrpjv1c: #99BFF7;
+   --foregroundColor-info__qhrpjv1d: #1D559D;
+   --foregroundColor-infoLight__qhrpjv1e: #98C9F1;
+   --foregroundColor-link__qhrpjv1f: #2E3849;
+   --foregroundColor-linkLight__qhrpjv1h: #fff;
+   --foregroundColor-linkHover__qhrpjv1g: #2E3849;
+   --foregroundColor-linkVisited__qhrpjv1i: #5B2084;
+   --foregroundColor-linkLightVisited__qhrpjv1j: #F0D6FA;
+   --foregroundColor-neutral__qhrpjv1k: #2E3849;
+   --foregroundColor-neutralInverted__qhrpjv1l: #fff;
+   --foregroundColor-positive__qhrpjv1m: #12784F;
+   --foregroundColor-positiveLight__qhrpjv1n: #8BDEC5;
+   --foregroundColor-promote__qhrpjv1o: #7F35A9;
+   --foregroundColor-promoteLight__qhrpjv1p: #E1B2F5;
+   --foregroundColor-rating__qhrpjv1q: #E60278;
+   --foregroundColor-secondary__qhrpjv1r: #5A6881;
+   --foregroundColor-secondaryInverted__qhrpjv1s: rgba(255,255,255,0.65);
+   --backgroundColor-body__qhrpjv1t: #fff;
+   --backgroundColor-bodyDark__qhrpjv1u: #1C2330;
+   --backgroundColor-brand__qhrpjv1v: #051A49;
+   --backgroundColor-brandAccent__qhrpjv1w: #E60278;
+   --backgroundColor-brandAccentActive__qhrpjv1x: #cd026b;
+   --backgroundColor-brandAccentHover__qhrpjv1y: #fd0585;
+   --backgroundColor-brandAccentSoft__qhrpjv1z: #FEEFFA;
+   --backgroundColor-brandAccentSoftActive__qhrpjv20: #fdd7f3;
+   --backgroundColor-brandAccentSoftHover__qhrpjv21: #fde3f6;
+   --backgroundColor-caution__qhrpjv22: #FDC221;
+   --backgroundColor-cautionLight__qhrpjv23: #FEF8DE;
+   --backgroundColor-critical__qhrpjv24: #B91E1E;
+   --backgroundColor-criticalActive__qhrpjv25: #a31a1a;
+   --backgroundColor-criticalHover__qhrpjv26: #db1616;
+   --backgroundColor-criticalLight__qhrpjv27: #FFE3E2;
+   --backgroundColor-criticalSoft__qhrpjv28: #FEF3F3;
+   --backgroundColor-criticalSoftActive__qhrpjv29: #fcdbdb;
+   --backgroundColor-criticalSoftHover__qhrpjv2a: #fde7e7;
+   --backgroundColor-formAccent__qhrpjv2b: #1E47A9;
+   --backgroundColor-formAccentActive__qhrpjv2c: #1a3e93;
+   --backgroundColor-formAccentHover__qhrpjv2d: #2455c9;
+   --backgroundColor-formAccentSoft__qhrpjv2e: #F0F7FE;
+   --backgroundColor-formAccentSoftActive__qhrpjv2f: #d8eafc;
+   --backgroundColor-formAccentSoftHover__qhrpjv2g: #e4f1fd;
+   --backgroundColor-info__qhrpjv2h: #1D559D;
+   --backgroundColor-infoLight__qhrpjv2i: #E3F2FB;
+   --backgroundColor-neutral__qhrpjv2j: #2E3849;
+   --backgroundColor-neutralActive__qhrpjv2k: #242c39;
+   --backgroundColor-neutralHover__qhrpjv2l: #384459;
+   --backgroundColor-neutralLight__qhrpjv2m: #F3F5F7;
+   --backgroundColor-neutralSoft__qhrpjv2n: #F3F5F7;
+   --backgroundColor-neutralSoftActive__qhrpjv2o: #e4e8ed;
+   --backgroundColor-neutralSoftHover__qhrpjv2p: #ebeff2;
+   --backgroundColor-positive__qhrpjv2q: #12784F;
+   --backgroundColor-positiveLight__qhrpjv2r: #E2F7F1;
+   --backgroundColor-promote__qhrpjv2s: #7F35A9;
+   --backgroundColor-promoteLight__qhrpjv2t: #F9EBFD;
+   --backgroundColor-surface__qhrpjv2u: #fff;
+   --backgroundColor-surfaceDark__qhrpjv2v: #1C2330;
+   --fontFamily__qhrpjv2w: SeekSans, "SeekSans Fallback", Arial, Tahoma, sans-serif;
+   --fontMetrics-capHeight__qhrpjv2x: 783;
+   --fontMetrics-ascent__qhrpjv2y: 1057;
+   --fontMetrics-descent__qhrpjv2z: -274;
+   --fontMetrics-lineGap__qhrpjv30: 0;
+   --fontMetrics-unitsPerEm__qhrpjv31: 1000;
+   --textSize-large-mobile-fontSize__qhrpjv3w: 18px;
+   --textSize-large-mobile-lineHeight__qhrpjv3x: 27.094px;
+   --textSize-large-mobile-capHeight__qhrpjv3y: 14.094px;
+   --textSize-large-mobile-capsizeTrims-capHeightTrim__qhrpjv3z: -0.3611em;
+   --textSize-large-mobile-capsizeTrims-baselineTrim__qhrpjv40: -0.3611em;
+   --textSize-large-tablet-fontSize__qhrpjv41: 18px;
+   --textSize-large-tablet-lineHeight__qhrpjv42: 27.094px;
+   --textSize-large-tablet-capHeight__qhrpjv43: 14.094px;
+   --textSize-large-tablet-capsizeTrims-capHeightTrim__qhrpjv44: -0.3611em;
+   --textSize-large-tablet-capsizeTrims-baselineTrim__qhrpjv45: -0.3611em;
+   --textSize-standard-mobile-fontSize__qhrpjv3m: 16px;
+   --textSize-standard-mobile-lineHeight__qhrpjv3n: 24.528px;
+   --textSize-standard-mobile-capHeight__qhrpjv3o: 12.528px;
+   --textSize-standard-mobile-capsizeTrims-capHeightTrim__qhrpjv3p: -0.375em;
+   --textSize-standard-mobile-capsizeTrims-baselineTrim__qhrpjv3q: -0.375em;
+   --textSize-standard-tablet-fontSize__qhrpjv3r: 16px;
+   --textSize-standard-tablet-lineHeight__qhrpjv3s: 24.528px;
+   --textSize-standard-tablet-capHeight__qhrpjv3t: 12.528px;
+   --textSize-standard-tablet-capsizeTrims-capHeightTrim__qhrpjv3u: -0.375em;
+   --textSize-standard-tablet-capsizeTrims-baselineTrim__qhrpjv3v: -0.375em;
+   --textSize-small-mobile-fontSize__qhrpjv3c: 14px;
+   --textSize-small-mobile-lineHeight__qhrpjv3d: 20.962px;
+   --textSize-small-mobile-capHeight__qhrpjv3e: 10.962px;
+   --textSize-small-mobile-capsizeTrims-capHeightTrim__qhrpjv3f: -0.3571em;
+   --textSize-small-mobile-capsizeTrims-baselineTrim__qhrpjv3g: -0.3571em;
+   --textSize-small-tablet-fontSize__qhrpjv3h: 14px;
+   --textSize-small-tablet-lineHeight__qhrpjv3i: 20.962px;
+   --textSize-small-tablet-capHeight__qhrpjv3j: 10.962px;
+   --textSize-small-tablet-capsizeTrims-capHeightTrim__qhrpjv3k: -0.3571em;
+   --textSize-small-tablet-capsizeTrims-baselineTrim__qhrpjv3l: -0.3571em;
+   --textSize-xsmall-mobile-fontSize__qhrpjv32: 12px;
+   --textSize-xsmall-mobile-lineHeight__qhrpjv33: 18.396px;
+   --textSize-xsmall-mobile-capHeight__qhrpjv34: 9.396px;
+   --textSize-xsmall-mobile-capsizeTrims-capHeightTrim__qhrpjv35: -0.375em;
+   --textSize-xsmall-mobile-capsizeTrims-baselineTrim__qhrpjv36: -0.375em;
+   --textSize-xsmall-tablet-fontSize__qhrpjv37: 12px;
+   --textSize-xsmall-tablet-lineHeight__qhrpjv38: 18.396px;
+   --textSize-xsmall-tablet-capHeight__qhrpjv39: 9.396px;
+   --textSize-xsmall-tablet-capsizeTrims-capHeightTrim__qhrpjv3a: -0.375em;
+   --textSize-xsmall-tablet-capsizeTrims-baselineTrim__qhrpjv3b: -0.375em;
+   --textWeight-regular__qhrpjv46: 400;
+   --textWeight-medium__qhrpjv47: 600;
+   --textWeight-strong__qhrpjv48: 700;
+   --headingLevel-1-mobile-fontSize__qhrpjv49: 28px;
+   --headingLevel-1-mobile-lineHeight__qhrpjv4a: 32.924px;
+   --headingLevel-1-mobile-capHeight__qhrpjv4b: 21.924px;
+   --headingLevel-1-mobile-capsizeTrims-capHeightTrim__qhrpjv4c: -0.1964em;
+   --headingLevel-1-mobile-capsizeTrims-baselineTrim__qhrpjv4d: -0.1964em;
+   --headingLevel-1-tablet-fontSize__qhrpjv4e: 36px;
+   --headingLevel-1-tablet-lineHeight__qhrpjv4f: 42.188px;
+   --headingLevel-1-tablet-capHeight__qhrpjv4g: 28.188px;
+   --headingLevel-1-tablet-capsizeTrims-capHeightTrim__qhrpjv4h: -0.1944em;
+   --headingLevel-1-tablet-capsizeTrims-baselineTrim__qhrpjv4i: -0.1944em;
+   --headingLevel-2-mobile-fontSize__qhrpjv4j: 24px;
+   --headingLevel-2-mobile-lineHeight__qhrpjv4k: 29.792px;
+   --headingLevel-2-mobile-capHeight__qhrpjv4l: 18.792px;
+   --headingLevel-2-mobile-capsizeTrims-capHeightTrim__qhrpjv4m: -0.2292em;
+   --headingLevel-2-mobile-capsizeTrims-baselineTrim__qhrpjv4n: -0.2292em;
+   --headingLevel-2-tablet-fontSize__qhrpjv4o: 30px;
+   --headingLevel-2-tablet-lineHeight__qhrpjv4p: 36.49px;
+   --headingLevel-2-tablet-capHeight__qhrpjv4q: 23.49px;
+   --headingLevel-2-tablet-capsizeTrims-capHeightTrim__qhrpjv4r: -0.2167em;
+   --headingLevel-2-tablet-capsizeTrims-baselineTrim__qhrpjv4s: -0.2167em;
+   --headingLevel-3-mobile-fontSize__qhrpjv4t: 22px;
+   --headingLevel-3-mobile-lineHeight__qhrpjv4u: 27.226px;
+   --headingLevel-3-mobile-capHeight__qhrpjv4v: 17.226px;
+   --headingLevel-3-mobile-capsizeTrims-capHeightTrim__qhrpjv4w: -0.2273em;
+   --headingLevel-3-mobile-capsizeTrims-baselineTrim__qhrpjv4x: -0.2273em;
+   --headingLevel-3-tablet-fontSize__qhrpjv4y: 24px;
+   --headingLevel-3-tablet-lineHeight__qhrpjv4z: 29.792px;
+   --headingLevel-3-tablet-capHeight__qhrpjv50: 18.792px;
+   --headingLevel-3-tablet-capsizeTrims-capHeightTrim__qhrpjv51: -0.2292em;
+   --headingLevel-3-tablet-capsizeTrims-baselineTrim__qhrpjv52: -0.2292em;
+   --headingLevel-4-mobile-fontSize__qhrpjv53: 20px;
+   --headingLevel-4-mobile-lineHeight__qhrpjv54: 24.66px;
+   --headingLevel-4-mobile-capHeight__qhrpjv55: 15.66px;
+   --headingLevel-4-mobile-capsizeTrims-capHeightTrim__qhrpjv56: -0.225em;
+   --headingLevel-4-mobile-capsizeTrims-baselineTrim__qhrpjv57: -0.225em;
+   --headingLevel-4-tablet-fontSize__qhrpjv58: 20px;
+   --headingLevel-4-tablet-lineHeight__qhrpjv59: 24.66px;
+   --headingLevel-4-tablet-capHeight__qhrpjv5a: 15.66px;
+   --headingLevel-4-tablet-capsizeTrims-capHeightTrim__qhrpjv5b: -0.225em;
+   --headingLevel-4-tablet-capsizeTrims-baselineTrim__qhrpjv5c: -0.225em;
+   --headingWeight-weak__qhrpjv5d: 400;
+   --headingWeight-regular__qhrpjv5e: 600;
+   --linkDecoration__qhrpjv5f: underline;
+   --inlineFieldSize-standard__qhrpjv5g: 24px;
+   --inlineFieldSize-small__qhrpjv5h: 20px;
+   --transition-fast__qhrpjv5i: transform .125s ease, opacity .125s ease;
+   --transition-touchable__qhrpjv5j: transform 0.2s cubic-bezier(0.02, 1.505, 0.745, 1.235);
+   --transform-touchable__qhrpjv5k: scale(0.95);
+   --shadow-small__qhrpjv5l: 0 0 4px 0 rgba(28,35,48,0.08), 0 4px 8px -2px rgba(28,35,48,0.08);
+   --shadow-medium__qhrpjv5m: 0 0 8px 0 rgba(28,35,48,0.08), 0 8px 16px -4px rgba(28,35,48,0.08);
+   --shadow-large__qhrpjv5n: 0 0 12px 0 rgba(28,35,48,0.08), 0 12px 24px -6px rgba(28,35,48,0.08);
+ }
+ .App_vanillaBox__inn18b0 {
+   --backgroundColor__zv7nmx0: blueviolet;
+   background-color: var(--backgroundColor__zv7nmx0);
+   color: white;
+   font-size: 20px;
+   padding: 100px;
+ }
+     </style>
+     <script type="module">
+       import { injectIntoGlobalHook } from "/@react-refresh";
+ injectIntoGlobalHook(window);
+ window.$RefreshReg$ = () => {};
+ window.$RefreshSig$ = () => (type) => type;
+     </script>
+     <script
+       type="module"
+       src="/@vite/client"
+     >
+     </script>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <script>
+       window.SKU_SITE = 'seekAnz';
      </script>
      <script
        type="module"
@@ -22457,7 +22260,132 @@ POST HYDRATE DIFFS:
    </head>
    <body>
      <div id="app">
-@@ -4688,7 +9511,7 @@
+       <style type="text/css">
+         html,body{margin:0;padding:0;background:#fff}
+             html.sprinkles_darkMode__1hjdb9v11,html.sprinkles_darkMode__1hjdb9v11 body{color-scheme:dark;background:#1C2330}
+       </style>
+       <div class="seekJobs_seekJobs__1fmskxf0 typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13">
+         <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSizeTrimmed_standard__co4djb9 typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
+           Hello
+           seekAnz
+           <span class="reset_base__yw2qws0 sprinkles_display_inlineBlock_mobile__1hjdb9v58">
+             <svg
+               xmlns="http://www.w3.org/2000/svg"
+               viewbox="0 0 24 24"
+               xml:space="preserve"
+               focusable="false"
+               fill="currentColor"
+               width="16"
+               height="16"
+               class="reset_base__yw2qws0 IconChevron_root__v2pdba0 sprinkles_display_inlineBlock_mobile__1hjdb9v58 sprinkles_position_relative_mobile__1hjdb9v5g icon_size__1ltfiyk0 icon_inlineCrop__1ltfiyk2 icon_inline__1ltfiyk3 icon_alignY_uppercase_none__1ltfiyk4"
+               aria-hidden="true"
+             >
+               <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
+               </path>
+             </svg>
+           </span>
+         </span>
+         <div class="reset_base__yw2qws0 sprinkles_paddingBottom_gutter_mobile__1hjdb9v8s sprinkles_paddingTop_gutter_mobile__1hjdb9v7o sprinkles_paddingLeft_gutter_mobile__1hjdb9vb0 sprinkles_paddingRight_gutter_mobile__1hjdb9v9w sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_large_mobile__1hjdb9v6c sprinkles_textAlign_left_mobile__1hjdb9vic sprinkles_boxShadow_borderNeutralLight_lightMode__1hjdb9v4k sprinkles_boxShadow_borderNeutral_darkMode__1hjdb9v4d typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13 sprinkles_background_surface_lightMode__1hjdb9v34 sprinkles_background_surfaceDark_darkMode__1hjdb9v37">
+           <div class="reset_base__yw2qws0 sprinkles_position_relative_mobile__1hjdb9v5g">
+             <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c sprinkles_textAlign_left_mobile__1hjdb9vic">
+               <input
+                 class="reset_base__yw2qws0 reset_input__yw2qwse reset_field__yw2qws9 reset_block__yw2qws1 reset_appearance__yw2qws6 reset_transparent__yw2qws7 reset_focusVisible__yw2qws8 reset_input__yw2qwsd sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_zIndex_1__1hjdb9v9 sprinkles_cursor_pointer__1hjdb9vi sprinkles_opacity_0__1hjdb9v7 InlineField_realField__1b4ltjx4 InlineField_sizeVars_standard__1b4ltjx2"
+                 type="checkbox"
+                 id="id_1"
+                 aria-checked="false"
+               >
+               <div class="reset_base__yw2qws0 sprinkles_flexShrink_0_mobile__1hjdb9vi0 sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_standard_mobile__1hjdb9v68 InlineField_fakeField__1b4ltjx5 InlineField_sizeVars_standard__1b4ltjx2 typography_lightModeTone_light__co4djb10  sprinkles_background_surface_lightMode__1hjdb9v34">
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_selected__1b4ltjx9 typography_lightModeTone_dark__co4djb11 typography_darkModeTone_dark__co4djb13 sprinkles_background_formAccent_lightMode__1hjdb9v22 sprinkles_background_formAccent_darkMode__1hjdb9v23">
+                   <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_boxShadow_borderField_lightMode__1hjdb9v3y sprinkles_boxShadow_borderField_darkMode__1hjdb9v3z">
+                 </span>
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 sprinkles_boxShadow_borderCritical_lightMode__1hjdb9v3q sprinkles_boxShadow_borderCriticalLight_darkMode__1hjdb9v3v">
+                 </span>
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_hoverOverlay__1b4ltjxb sprinkles_boxShadow_borderFormAccent_lightMode__1hjdb9v40 sprinkles_boxShadow_borderFormAccentLight_darkMode__1hjdb9v45">
+                   <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+               </div>
+               <div class="reset_base__yw2qws0 sprinkles_paddingLeft_xsmall_mobile__1hjdb9vb8 sprinkles_flexGrow_1_mobile__1hjdb9vi8">
+                 <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c InlineField_sizeVars_standard__1b4ltjx2 InlineField_labelOffset__1b4ltjx6">
+                   <label
+                     class="reset_base__yw2qws0 sprinkles_userSelect_none__1hjdb9v4 sprinkles_display_block_mobile__1hjdb9v50 sprinkles_cursor_pointer__1hjdb9vi virtualTouchable_virtualTouchable__9705do0"
+                     for="id_1"
+                   >
+                     <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSizeTrimmed_standard__co4djb9 typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
+                       This is a checkbox
+                     </span>
+                   </label>
+                 </div>
+               </div>
+             </div>
+           </div>
          </div>
          <div class="reset_base__yw2qws0 App_vanillaBox__inn18b0">
            🧁 Vanilla content
@@ -22466,6 +22394,20 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
+     <script
+       type="module"
+       src="{cwd}/packages/sku/dist/services/vite/entries/vite-client.js"
+     >
+     </script>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"site":"seekAnz"}
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`braid-design-system > bundler webpack > build > should generate the expected files 1`] = `
@@ -25308,210 +25250,170 @@ html._1hjdb9v11 ._1b4ltjxd {
 `;
 
 exports[`braid-design-system > bundler webpack > build > should return built jobStreet site 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="stylesheet"
-      href="/2-5e85940d0a687009caed.css"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/main.js"
-    >
-    <script>
-      window.SKU_SITE = 'jobStreet';
-    </script>
-  </head>
-  <body>
-    <div id="app">
-      <style type="text/css">
-        html,body{margin:0;padding:0;background:#fff}
-            html._1hjdb9v11,html._1hjdb9v11 body{color-scheme:dark;background:#1C2330}
-      </style>
-      <div class="_1fmskxf0 co4djb10 co4djb13">
-        <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb8 _1lwixuj4">
-          Hello
-          jobStreet
-          <span class="yw2qws0 _1hjdb9v58">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewbox="0 0 24 24"
-              xml:space="preserve"
-              focusable="false"
-              fill="currentColor"
-              width="16"
-              height="16"
-              class="yw2qws0 v2pdba0 _1hjdb9v58 _1hjdb9v5g _1ltfiyk0 _1ltfiyk2 _1ltfiyk3 _1ltfiyk4"
-              aria-hidden="true"
-            >
-              <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
-              </path>
-            </svg>
-          </span>
-        </span>
-        <div class="yw2qws0 _1hjdb9v8s _1hjdb9v7o _1hjdb9vb0 _1hjdb9v9w _1hjdb9v5g _1hjdb9v6c _1hjdb9vic _1hjdb9v4k _1hjdb9v4d co4djb10 co4djb13 _1hjdb9v34 _1hjdb9v37">
-          <div class="yw2qws0 _1hjdb9v5g">
-            <div class="yw2qws0 _1hjdb9v5c _1hjdb9vic">
-              <input
-                class="yw2qws0 yw2qws1 yw2qws6 yw2qws7 yw2qws8 yw2qwsd _1hjdb9v5k _1hjdb9v9 _1hjdb9vi _1hjdb9v7 _1b4ltjx4 _1b4ltjx2"
-                type="checkbox"
-                id="id_1"
-                aria-checked="false"
-              >
-              <div class="yw2qws0 _1hjdb9vi0 _1hjdb9v5g _1hjdb9v68 _1b4ltjx5 _1b4ltjx2 co4djb10  _1hjdb9v34">
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjx9 co4djb11 co4djb13 _1hjdb9v22 _1hjdb9v23">
-                  <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v3y _1hjdb9v3z">
-                </span>
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1hjdb9v3q _1hjdb9v3v">
-                </span>
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjxb _1hjdb9v40 _1hjdb9v45">
-                  <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-              </div>
-              <div class="yw2qws0 _1hjdb9vb8 _1hjdb9vi8">
-                <div class="yw2qws0 _1hjdb9v5c _1b4ltjx2 _1b4ltjx6">
-                  <label
-                    class="yw2qws0 _1hjdb9v4 _1hjdb9v50 _1hjdb9vi _9705do0"
-                    for="id_1"
-                  >
-                    <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb8 _1lwixuj4">
-                      This is a checkbox
-                    </span>
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="yw2qws0 inn18b0">
-          🧁 Vanilla content
-          Initial
-        </div>
-      </div>
-    </div>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"site":"jobStreet"}
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      []
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":[]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/main.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -161,7 +161,7 @@
+@@ -1,199 +1,199 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="stylesheet"
+       href="/2-5e85940d0a687009caed.css"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/main.js"
+     >
+     <script>
+       window.SKU_SITE = 'jobStreet';
+     </script>
+   </head>
+   <body>
+     <div id="app">
+       <style type="text/css">
+         html,body{margin:0;padding:0;background:#fff}
+             html._1hjdb9v11,html._1hjdb9v11 body{color-scheme:dark;background:#1C2330}
+       </style>
+       <div class="_1fmskxf0 co4djb10 co4djb13">
+         <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb8 _1lwixuj4">
+           Hello
+           jobStreet
+           <span class="yw2qws0 _1hjdb9v58">
+             <svg
+               xmlns="http://www.w3.org/2000/svg"
+               viewbox="0 0 24 24"
+               xml:space="preserve"
+               focusable="false"
+               fill="currentColor"
+               width="16"
+               height="16"
+               class="yw2qws0 v2pdba0 _1hjdb9v58 _1hjdb9v5g _1ltfiyk0 _1ltfiyk2 _1ltfiyk3 _1ltfiyk4"
+               aria-hidden="true"
+             >
+               <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
+               </path>
+             </svg>
+           </span>
+         </span>
+         <div class="yw2qws0 _1hjdb9v8s _1hjdb9v7o _1hjdb9vb0 _1hjdb9v9w _1hjdb9v5g _1hjdb9v6c _1hjdb9vic _1hjdb9v4k _1hjdb9v4d co4djb10 co4djb13 _1hjdb9v34 _1hjdb9v37">
+           <div class="yw2qws0 _1hjdb9v5g">
+             <div class="yw2qws0 _1hjdb9v5c _1hjdb9vic">
+               <input
+                 class="yw2qws0 yw2qws1 yw2qws6 yw2qws7 yw2qws8 yw2qwsd _1hjdb9v5k _1hjdb9v9 _1hjdb9vi _1hjdb9v7 _1b4ltjx4 _1b4ltjx2"
+                 type="checkbox"
+                 id="id_1"
+                 aria-checked="false"
+               >
+               <div class="yw2qws0 _1hjdb9vi0 _1hjdb9v5g _1hjdb9v68 _1b4ltjx5 _1b4ltjx2 co4djb10  _1hjdb9v34">
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjx9 co4djb11 co4djb13 _1hjdb9v22 _1hjdb9v23">
+                   <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v3y _1hjdb9v3z">
+                 </span>
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1hjdb9v3q _1hjdb9v3v">
+                 </span>
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjxb _1hjdb9v40 _1hjdb9v45">
+                   <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+               </div>
+               <div class="yw2qws0 _1hjdb9vb8 _1hjdb9vi8">
+                 <div class="yw2qws0 _1hjdb9v5c _1b4ltjx2 _1b4ltjx6">
+                   <label
+                     class="yw2qws0 _1hjdb9v4 _1hjdb9v50 _1hjdb9vi _9705do0"
+                     for="id_1"
+                   >
+                     <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb8 _1lwixuj4">
+                       This is a checkbox
+                     </span>
+                   </label>
+                 </div>
+               </div>
+             </div>
+           </div>
          </div>
          <div class="yw2qws0 inn18b0">
            🧁 Vanilla content
@@ -25520,213 +25422,206 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"site":"jobStreet"}
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/main.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`braid-design-system > bundler webpack > build > should return built seekAnz site 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="stylesheet"
-      href="/2-5e85940d0a687009caed.css"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/main.js"
-    >
-    <script>
-      window.SKU_SITE = 'seekAnz';
-    </script>
-  </head>
-  <body>
-    <div id="app">
-      <style type="text/css">
-        html,body{margin:0;padding:0;background:#fff}
-            html._1hjdb9v11,html._1hjdb9v11 body{color-scheme:dark;background:#1C2330}
-      </style>
-      <div class="_1fmskxf0 co4djb10 co4djb13">
-        <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb8 _1lwixuj4">
-          Hello
-          seekAnz
-          <span class="yw2qws0 _1hjdb9v58">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewbox="0 0 24 24"
-              xml:space="preserve"
-              focusable="false"
-              fill="currentColor"
-              width="16"
-              height="16"
-              class="yw2qws0 v2pdba0 _1hjdb9v58 _1hjdb9v5g _1ltfiyk0 _1ltfiyk2 _1ltfiyk3 _1ltfiyk4"
-              aria-hidden="true"
-            >
-              <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
-              </path>
-            </svg>
-          </span>
-        </span>
-        <div class="yw2qws0 _1hjdb9v8s _1hjdb9v7o _1hjdb9vb0 _1hjdb9v9w _1hjdb9v5g _1hjdb9v6c _1hjdb9vic _1hjdb9v4k _1hjdb9v4d co4djb10 co4djb13 _1hjdb9v34 _1hjdb9v37">
-          <div class="yw2qws0 _1hjdb9v5g">
-            <div class="yw2qws0 _1hjdb9v5c _1hjdb9vic">
-              <input
-                class="yw2qws0 yw2qws1 yw2qws6 yw2qws7 yw2qws8 yw2qwsd _1hjdb9v5k _1hjdb9v9 _1hjdb9vi _1hjdb9v7 _1b4ltjx4 _1b4ltjx2"
-                type="checkbox"
-                id="id_1"
-                aria-checked="false"
-              >
-              <div class="yw2qws0 _1hjdb9vi0 _1hjdb9v5g _1hjdb9v68 _1b4ltjx5 _1b4ltjx2 co4djb10  _1hjdb9v34">
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjx9 co4djb11 co4djb13 _1hjdb9v22 _1hjdb9v23">
-                  <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v3y _1hjdb9v3z">
-                </span>
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1hjdb9v3q _1hjdb9v3v">
-                </span>
-                <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjxb _1hjdb9v40 _1hjdb9v45">
-                  <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-              </div>
-              <div class="yw2qws0 _1hjdb9vb8 _1hjdb9vi8">
-                <div class="yw2qws0 _1hjdb9v5c _1b4ltjx2 _1b4ltjx6">
-                  <label
-                    class="yw2qws0 _1hjdb9v4 _1hjdb9v50 _1hjdb9vi _9705do0"
-                    for="id_1"
-                  >
-                    <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb8 _1lwixuj4">
-                      This is a checkbox
-                    </span>
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="yw2qws0 inn18b0">
-          🧁 Vanilla content
-          Initial
-        </div>
-      </div>
-    </div>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"site":"seekAnz"}
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      []
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":[]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/main.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -161,7 +161,7 @@
+@@ -1,199 +1,199 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="stylesheet"
+       href="/2-5e85940d0a687009caed.css"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/main.js"
+     >
+     <script>
+       window.SKU_SITE = 'seekAnz';
+     </script>
+   </head>
+   <body>
+     <div id="app">
+       <style type="text/css">
+         html,body{margin:0;padding:0;background:#fff}
+             html._1hjdb9v11,html._1hjdb9v11 body{color-scheme:dark;background:#1C2330}
+       </style>
+       <div class="_1fmskxf0 co4djb10 co4djb13">
+         <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb8 _1lwixuj4">
+           Hello
+           seekAnz
+           <span class="yw2qws0 _1hjdb9v58">
+             <svg
+               xmlns="http://www.w3.org/2000/svg"
+               viewbox="0 0 24 24"
+               xml:space="preserve"
+               focusable="false"
+               fill="currentColor"
+               width="16"
+               height="16"
+               class="yw2qws0 v2pdba0 _1hjdb9v58 _1hjdb9v5g _1ltfiyk0 _1ltfiyk2 _1ltfiyk3 _1ltfiyk4"
+               aria-hidden="true"
+             >
+               <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
+               </path>
+             </svg>
+           </span>
+         </span>
+         <div class="yw2qws0 _1hjdb9v8s _1hjdb9v7o _1hjdb9vb0 _1hjdb9v9w _1hjdb9v5g _1hjdb9v6c _1hjdb9vic _1hjdb9v4k _1hjdb9v4d co4djb10 co4djb13 _1hjdb9v34 _1hjdb9v37">
+           <div class="yw2qws0 _1hjdb9v5g">
+             <div class="yw2qws0 _1hjdb9v5c _1hjdb9vic">
+               <input
+                 class="yw2qws0 yw2qws1 yw2qws6 yw2qws7 yw2qws8 yw2qwsd _1hjdb9v5k _1hjdb9v9 _1hjdb9vi _1hjdb9v7 _1b4ltjx4 _1b4ltjx2"
+                 type="checkbox"
+                 id="id_1"
+                 aria-checked="false"
+               >
+               <div class="yw2qws0 _1hjdb9vi0 _1hjdb9v5g _1hjdb9v68 _1b4ltjx5 _1b4ltjx2 co4djb10  _1hjdb9v34">
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjx9 co4djb11 co4djb13 _1hjdb9v22 _1hjdb9v23">
+                   <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v3y _1hjdb9v3z">
+                 </span>
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1hjdb9v3q _1hjdb9v3v">
+                 </span>
+                 <span class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vj _1hjdb9v68 _1hjdb9vy _1hjdb9v7 _1b4ltjxb _1hjdb9v40 _1hjdb9v45">
+                   <div class="yw2qws0 _1hjdb9vo _1hjdb9vy _1hjdb9v5g _1b4ltjxc _1b4ltjxe">
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy _1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="yw2qws0 _1hjdb9vk _1hjdb9vl _1hjdb9vm _1hjdb9vn _1hjdb9v5k _1hjdb9vy">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="yw2qws0 _1hjdb9vq _1hjdb9vo _1hjdb9v50 co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+               </div>
+               <div class="yw2qws0 _1hjdb9vb8 _1hjdb9vi8">
+                 <div class="yw2qws0 _1hjdb9v5c _1b4ltjx2 _1b4ltjx6">
+                   <label
+                     class="yw2qws0 _1hjdb9v4 _1hjdb9v50 _1hjdb9vi _9705do0"
+                     for="id_1"
+                   >
+                     <span class="yw2qws0 _1hjdb9v50 co4djb0 co4djb1 co4djb1t co4djb8 _1lwixuj4">
+                       This is a checkbox
+                     </span>
+                   </label>
+                 </div>
+               </div>
+             </div>
+           </div>
          </div>
          <div class="yw2qws0 inn18b0">
            🧁 Vanilla content
@@ -25735,225 +25630,212 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"site":"seekAnz"}
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/main.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`braid-design-system > bundler webpack > start > should return development jobStreet site 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="stylesheet"
-      href="/2.css"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/2.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/main.js"
-    >
-    <script>
-      window.SKU_SITE = 'jobStreet';
-    </script>
-  </head>
-  <body>
-    <div id="app">
-      <style type="text/css">
-        html,body{margin:0;padding:0;background:#fff}
-            html.sprinkles_darkMode__1hjdb9v11,html.sprinkles_darkMode__1hjdb9v11 body{color-scheme:dark;background:#1C2330}
-      </style>
-      <div class="seekJobs_seekJobs__1fmskxf0 typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13">
-        <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
-          Hello
-          jobStreet
-          <span class="reset_base__yw2qws0 sprinkles_display_inlineBlock_mobile__1hjdb9v58">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewbox="0 0 24 24"
-              xml:space="preserve"
-              focusable="false"
-              fill="currentColor"
-              width="16"
-              height="16"
-              class="reset_base__yw2qws0 IconChevron_root__v2pdba0 sprinkles_display_inlineBlock_mobile__1hjdb9v58 sprinkles_position_relative_mobile__1hjdb9v5g icon_size__1ltfiyk0 icon_inlineCrop__1ltfiyk2 icon_inline__1ltfiyk3 icon_alignY_uppercase_none__1ltfiyk4"
-              aria-hidden="true"
-            >
-              <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
-              </path>
-            </svg>
-          </span>
-        </span>
-        <div class="reset_base__yw2qws0 sprinkles_paddingBottom_gutter_mobile__1hjdb9v8s sprinkles_paddingTop_gutter_mobile__1hjdb9v7o sprinkles_paddingLeft_gutter_mobile__1hjdb9vb0 sprinkles_paddingRight_gutter_mobile__1hjdb9v9w sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_large_mobile__1hjdb9v6c sprinkles_textAlign_left_mobile__1hjdb9vic sprinkles_boxShadow_borderNeutralLight_lightMode__1hjdb9v4k sprinkles_boxShadow_borderNeutral_darkMode__1hjdb9v4d typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13 sprinkles_background_surface_lightMode__1hjdb9v34 sprinkles_background_surfaceDark_darkMode__1hjdb9v37">
-          <div class="reset_base__yw2qws0 sprinkles_position_relative_mobile__1hjdb9v5g">
-            <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c sprinkles_textAlign_left_mobile__1hjdb9vic">
-              <input
-                class="reset_base__yw2qws0 reset_block__yw2qws1 reset_appearance__yw2qws6 reset_transparent__yw2qws7 reset_focusVisible__yw2qws8 reset_input__yw2qwsd sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_zIndex_1__1hjdb9v9 sprinkles_cursor_pointer__1hjdb9vi sprinkles_opacity_0__1hjdb9v7 InlineField_realField__1b4ltjx4 InlineField_sizeVars_standard__1b4ltjx2"
-                type="checkbox"
-                id="id_1"
-                aria-checked="false"
-              >
-              <div class="reset_base__yw2qws0 sprinkles_flexShrink_0_mobile__1hjdb9vi0 sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_standard_mobile__1hjdb9v68 InlineField_fakeField__1b4ltjx5 InlineField_sizeVars_standard__1b4ltjx2 typography_lightModeTone_light__co4djb10  sprinkles_background_surface_lightMode__1hjdb9v34">
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_selected__1b4ltjx9 typography_lightModeTone_dark__co4djb11 typography_darkModeTone_dark__co4djb13 sprinkles_background_formAccent_lightMode__1hjdb9v22 sprinkles_background_formAccent_darkMode__1hjdb9v23">
-                  <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_boxShadow_borderField_lightMode__1hjdb9v3y sprinkles_boxShadow_borderField_darkMode__1hjdb9v3z">
-                </span>
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 sprinkles_boxShadow_borderCritical_lightMode__1hjdb9v3q sprinkles_boxShadow_borderCriticalLight_darkMode__1hjdb9v3v">
-                </span>
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_hoverOverlay__1b4ltjxb sprinkles_boxShadow_borderFormAccent_lightMode__1hjdb9v40 sprinkles_boxShadow_borderFormAccentLight_darkMode__1hjdb9v45">
-                  <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-              </div>
-              <div class="reset_base__yw2qws0 sprinkles_paddingLeft_xsmall_mobile__1hjdb9vb8 sprinkles_flexGrow_1_mobile__1hjdb9vi8">
-                <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c InlineField_sizeVars_standard__1b4ltjx2 InlineField_labelOffset__1b4ltjx6">
-                  <label
-                    class="reset_base__yw2qws0 sprinkles_userSelect_none__1hjdb9v4 sprinkles_display_block_mobile__1hjdb9v50 sprinkles_cursor_pointer__1hjdb9vi virtualTouchable_virtualTouchable__9705do0"
-                    for="id_1"
-                  >
-                    <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
-                      This is a checkbox
-                    </span>
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="reset_base__yw2qws0 App_vanillaBox__inn18b0">
-          🧁 Vanilla content
-          Initial
-        </div>
-      </div>
-    </div>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"site":"jobStreet"}
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      []
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":[]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/2.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/main.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -167,7 +167,7 @@
+@@ -1,211 +1,211 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="stylesheet"
+       href="/2.css"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/2.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/main.js"
+     >
+     <script>
+       window.SKU_SITE = 'jobStreet';
+     </script>
+   </head>
+   <body>
+     <div id="app">
+       <style type="text/css">
+         html,body{margin:0;padding:0;background:#fff}
+             html.sprinkles_darkMode__1hjdb9v11,html.sprinkles_darkMode__1hjdb9v11 body{color-scheme:dark;background:#1C2330}
+       </style>
+       <div class="seekJobs_seekJobs__1fmskxf0 typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13">
+         <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
+           Hello
+           jobStreet
+           <span class="reset_base__yw2qws0 sprinkles_display_inlineBlock_mobile__1hjdb9v58">
+             <svg
+               xmlns="http://www.w3.org/2000/svg"
+               viewbox="0 0 24 24"
+               xml:space="preserve"
+               focusable="false"
+               fill="currentColor"
+               width="16"
+               height="16"
+               class="reset_base__yw2qws0 IconChevron_root__v2pdba0 sprinkles_display_inlineBlock_mobile__1hjdb9v58 sprinkles_position_relative_mobile__1hjdb9v5g icon_size__1ltfiyk0 icon_inlineCrop__1ltfiyk2 icon_inline__1ltfiyk3 icon_alignY_uppercase_none__1ltfiyk4"
+               aria-hidden="true"
+             >
+               <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
+               </path>
+             </svg>
+           </span>
+         </span>
+         <div class="reset_base__yw2qws0 sprinkles_paddingBottom_gutter_mobile__1hjdb9v8s sprinkles_paddingTop_gutter_mobile__1hjdb9v7o sprinkles_paddingLeft_gutter_mobile__1hjdb9vb0 sprinkles_paddingRight_gutter_mobile__1hjdb9v9w sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_large_mobile__1hjdb9v6c sprinkles_textAlign_left_mobile__1hjdb9vic sprinkles_boxShadow_borderNeutralLight_lightMode__1hjdb9v4k sprinkles_boxShadow_borderNeutral_darkMode__1hjdb9v4d typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13 sprinkles_background_surface_lightMode__1hjdb9v34 sprinkles_background_surfaceDark_darkMode__1hjdb9v37">
+           <div class="reset_base__yw2qws0 sprinkles_position_relative_mobile__1hjdb9v5g">
+             <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c sprinkles_textAlign_left_mobile__1hjdb9vic">
+               <input
+                 class="reset_base__yw2qws0 reset_block__yw2qws1 reset_appearance__yw2qws6 reset_transparent__yw2qws7 reset_focusVisible__yw2qws8 reset_input__yw2qwsd sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_zIndex_1__1hjdb9v9 sprinkles_cursor_pointer__1hjdb9vi sprinkles_opacity_0__1hjdb9v7 InlineField_realField__1b4ltjx4 InlineField_sizeVars_standard__1b4ltjx2"
+                 type="checkbox"
+                 id="id_1"
+                 aria-checked="false"
+               >
+               <div class="reset_base__yw2qws0 sprinkles_flexShrink_0_mobile__1hjdb9vi0 sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_standard_mobile__1hjdb9v68 InlineField_fakeField__1b4ltjx5 InlineField_sizeVars_standard__1b4ltjx2 typography_lightModeTone_light__co4djb10  sprinkles_background_surface_lightMode__1hjdb9v34">
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_selected__1b4ltjx9 typography_lightModeTone_dark__co4djb11 typography_darkModeTone_dark__co4djb13 sprinkles_background_formAccent_lightMode__1hjdb9v22 sprinkles_background_formAccent_darkMode__1hjdb9v23">
+                   <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_boxShadow_borderField_lightMode__1hjdb9v3y sprinkles_boxShadow_borderField_darkMode__1hjdb9v3z">
+                 </span>
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 sprinkles_boxShadow_borderCritical_lightMode__1hjdb9v3q sprinkles_boxShadow_borderCriticalLight_darkMode__1hjdb9v3v">
+                 </span>
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_hoverOverlay__1b4ltjxb sprinkles_boxShadow_borderFormAccent_lightMode__1hjdb9v40 sprinkles_boxShadow_borderFormAccentLight_darkMode__1hjdb9v45">
+                   <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+               </div>
+               <div class="reset_base__yw2qws0 sprinkles_paddingLeft_xsmall_mobile__1hjdb9vb8 sprinkles_flexGrow_1_mobile__1hjdb9vi8">
+                 <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c InlineField_sizeVars_standard__1b4ltjx2 InlineField_labelOffset__1b4ltjx6">
+                   <label
+                     class="reset_base__yw2qws0 sprinkles_userSelect_none__1hjdb9v4 sprinkles_display_block_mobile__1hjdb9v50 sprinkles_cursor_pointer__1hjdb9vi virtualTouchable_virtualTouchable__9705do0"
+                     for="id_1"
+                   >
+                     <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
+                       This is a checkbox
+                     </span>
+                   </label>
+                 </div>
+               </div>
+             </div>
+           </div>
          </div>
          <div class="reset_base__yw2qws0 App_vanillaBox__inn18b0">
            🧁 Vanilla content
@@ -25962,225 +25844,218 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"site":"jobStreet"}
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/2.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/main.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`braid-design-system > bundler webpack > start > should return development seekAnz site 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="stylesheet"
-      href="/2.css"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/2.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/main.js"
-    >
-    <script>
-      window.SKU_SITE = 'seekAnz';
-    </script>
-  </head>
-  <body>
-    <div id="app">
-      <style type="text/css">
-        html,body{margin:0;padding:0;background:#fff}
-            html.sprinkles_darkMode__1hjdb9v11,html.sprinkles_darkMode__1hjdb9v11 body{color-scheme:dark;background:#1C2330}
-      </style>
-      <div class="seekJobs_seekJobs__1fmskxf0 typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13">
-        <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
-          Hello
-          seekAnz
-          <span class="reset_base__yw2qws0 sprinkles_display_inlineBlock_mobile__1hjdb9v58">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewbox="0 0 24 24"
-              xml:space="preserve"
-              focusable="false"
-              fill="currentColor"
-              width="16"
-              height="16"
-              class="reset_base__yw2qws0 IconChevron_root__v2pdba0 sprinkles_display_inlineBlock_mobile__1hjdb9v58 sprinkles_position_relative_mobile__1hjdb9v5g icon_size__1ltfiyk0 icon_inlineCrop__1ltfiyk2 icon_inline__1ltfiyk3 icon_alignY_uppercase_none__1ltfiyk4"
-              aria-hidden="true"
-            >
-              <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
-              </path>
-            </svg>
-          </span>
-        </span>
-        <div class="reset_base__yw2qws0 sprinkles_paddingBottom_gutter_mobile__1hjdb9v8s sprinkles_paddingTop_gutter_mobile__1hjdb9v7o sprinkles_paddingLeft_gutter_mobile__1hjdb9vb0 sprinkles_paddingRight_gutter_mobile__1hjdb9v9w sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_large_mobile__1hjdb9v6c sprinkles_textAlign_left_mobile__1hjdb9vic sprinkles_boxShadow_borderNeutralLight_lightMode__1hjdb9v4k sprinkles_boxShadow_borderNeutral_darkMode__1hjdb9v4d typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13 sprinkles_background_surface_lightMode__1hjdb9v34 sprinkles_background_surfaceDark_darkMode__1hjdb9v37">
-          <div class="reset_base__yw2qws0 sprinkles_position_relative_mobile__1hjdb9v5g">
-            <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c sprinkles_textAlign_left_mobile__1hjdb9vic">
-              <input
-                class="reset_base__yw2qws0 reset_block__yw2qws1 reset_appearance__yw2qws6 reset_transparent__yw2qws7 reset_focusVisible__yw2qws8 reset_input__yw2qwsd sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_zIndex_1__1hjdb9v9 sprinkles_cursor_pointer__1hjdb9vi sprinkles_opacity_0__1hjdb9v7 InlineField_realField__1b4ltjx4 InlineField_sizeVars_standard__1b4ltjx2"
-                type="checkbox"
-                id="id_1"
-                aria-checked="false"
-              >
-              <div class="reset_base__yw2qws0 sprinkles_flexShrink_0_mobile__1hjdb9vi0 sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_standard_mobile__1hjdb9v68 InlineField_fakeField__1b4ltjx5 InlineField_sizeVars_standard__1b4ltjx2 typography_lightModeTone_light__co4djb10  sprinkles_background_surface_lightMode__1hjdb9v34">
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_selected__1b4ltjx9 typography_lightModeTone_dark__co4djb11 typography_darkModeTone_dark__co4djb13 sprinkles_background_formAccent_lightMode__1hjdb9v22 sprinkles_background_formAccent_darkMode__1hjdb9v23">
-                  <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_boxShadow_borderField_lightMode__1hjdb9v3y sprinkles_boxShadow_borderField_darkMode__1hjdb9v3z">
-                </span>
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 sprinkles_boxShadow_borderCritical_lightMode__1hjdb9v3q sprinkles_boxShadow_borderCriticalLight_darkMode__1hjdb9v3v">
-                </span>
-                <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_hoverOverlay__1b4ltjxb sprinkles_boxShadow_borderFormAccent_lightMode__1hjdb9v40 sprinkles_boxShadow_borderFormAccentLight_darkMode__1hjdb9v45">
-                  <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
-                        </path>
-                      </svg>
-                    </div>
-                    <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewbox="0 0 24 24"
-                        xml:space="preserve"
-                        focusable="false"
-                        fill="currentColor"
-                        width="16"
-                        height="16"
-                        class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
-                        aria-hidden="true"
-                      >
-                        <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
-                        </path>
-                      </svg>
-                    </div>
-                  </div>
-                </span>
-              </div>
-              <div class="reset_base__yw2qws0 sprinkles_paddingLeft_xsmall_mobile__1hjdb9vb8 sprinkles_flexGrow_1_mobile__1hjdb9vi8">
-                <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c InlineField_sizeVars_standard__1b4ltjx2 InlineField_labelOffset__1b4ltjx6">
-                  <label
-                    class="reset_base__yw2qws0 sprinkles_userSelect_none__1hjdb9v4 sprinkles_display_block_mobile__1hjdb9v50 sprinkles_cursor_pointer__1hjdb9vi virtualTouchable_virtualTouchable__9705do0"
-                    for="id_1"
-                  >
-                    <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
-                      This is a checkbox
-                    </span>
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="reset_base__yw2qws0 App_vanillaBox__inn18b0">
-          🧁 Vanilla content
-          Initial
-        </div>
-      </div>
-    </div>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"site":"seekAnz"}
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      []
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":[]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/2.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/main.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -167,7 +167,7 @@
+@@ -1,211 +1,211 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="stylesheet"
+       href="/2.css"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/2.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/main.js"
+     >
+     <script>
+       window.SKU_SITE = 'seekAnz';
+     </script>
+   </head>
+   <body>
+     <div id="app">
+       <style type="text/css">
+         html,body{margin:0;padding:0;background:#fff}
+             html.sprinkles_darkMode__1hjdb9v11,html.sprinkles_darkMode__1hjdb9v11 body{color-scheme:dark;background:#1C2330}
+       </style>
+       <div class="seekJobs_seekJobs__1fmskxf0 typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13">
+         <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
+           Hello
+           seekAnz
+           <span class="reset_base__yw2qws0 sprinkles_display_inlineBlock_mobile__1hjdb9v58">
+             <svg
+               xmlns="http://www.w3.org/2000/svg"
+               viewbox="0 0 24 24"
+               xml:space="preserve"
+               focusable="false"
+               fill="currentColor"
+               width="16"
+               height="16"
+               class="reset_base__yw2qws0 IconChevron_root__v2pdba0 sprinkles_display_inlineBlock_mobile__1hjdb9v58 sprinkles_position_relative_mobile__1hjdb9v5g icon_size__1ltfiyk0 icon_inlineCrop__1ltfiyk2 icon_inline__1ltfiyk3 icon_alignY_uppercase_none__1ltfiyk4"
+               aria-hidden="true"
+             >
+               <path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z">
+               </path>
+             </svg>
+           </span>
+         </span>
+         <div class="reset_base__yw2qws0 sprinkles_paddingBottom_gutter_mobile__1hjdb9v8s sprinkles_paddingTop_gutter_mobile__1hjdb9v7o sprinkles_paddingLeft_gutter_mobile__1hjdb9vb0 sprinkles_paddingRight_gutter_mobile__1hjdb9v9w sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_large_mobile__1hjdb9v6c sprinkles_textAlign_left_mobile__1hjdb9vic sprinkles_boxShadow_borderNeutralLight_lightMode__1hjdb9v4k sprinkles_boxShadow_borderNeutral_darkMode__1hjdb9v4d typography_lightModeTone_light__co4djb10 typography_darkModeTone_dark__co4djb13 sprinkles_background_surface_lightMode__1hjdb9v34 sprinkles_background_surfaceDark_darkMode__1hjdb9v37">
+           <div class="reset_base__yw2qws0 sprinkles_position_relative_mobile__1hjdb9v5g">
+             <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c sprinkles_textAlign_left_mobile__1hjdb9vic">
+               <input
+                 class="reset_base__yw2qws0 reset_block__yw2qws1 reset_appearance__yw2qws6 reset_transparent__yw2qws7 reset_focusVisible__yw2qws8 reset_input__yw2qwsd sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_zIndex_1__1hjdb9v9 sprinkles_cursor_pointer__1hjdb9vi sprinkles_opacity_0__1hjdb9v7 InlineField_realField__1b4ltjx4 InlineField_sizeVars_standard__1b4ltjx2"
+                 type="checkbox"
+                 id="id_1"
+                 aria-checked="false"
+               >
+               <div class="reset_base__yw2qws0 sprinkles_flexShrink_0_mobile__1hjdb9vi0 sprinkles_position_relative_mobile__1hjdb9v5g sprinkles_borderRadius_standard_mobile__1hjdb9v68 InlineField_fakeField__1b4ltjx5 InlineField_sizeVars_standard__1b4ltjx2 typography_lightModeTone_light__co4djb10  sprinkles_background_surface_lightMode__1hjdb9v34">
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_selected__1b4ltjx9 typography_lightModeTone_dark__co4djb11 typography_darkModeTone_dark__co4djb13 sprinkles_background_formAccent_lightMode__1hjdb9v22 sprinkles_background_formAccent_darkMode__1hjdb9v23">
+                   <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_neutral__co4djb1t"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_boxShadow_borderField_lightMode__1hjdb9v3y sprinkles_boxShadow_borderField_darkMode__1hjdb9v3z">
+                 </span>
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 sprinkles_boxShadow_borderCritical_lightMode__1hjdb9v3q sprinkles_boxShadow_borderCriticalLight_darkMode__1hjdb9v3v">
+                 </span>
+                 <span class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_pointerEvents_none__1hjdb9vj sprinkles_borderRadius_standard_mobile__1hjdb9v68 sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7 InlineField_hoverOverlay__1b4ltjxb sprinkles_boxShadow_borderFormAccent_lightMode__1hjdb9v40 sprinkles_boxShadow_borderFormAccentLight_darkMode__1hjdb9v45">
+                   <div class="reset_base__yw2qws0 sprinkles_height_full__1hjdb9vo sprinkles_transition_fast__1hjdb9vy sprinkles_position_relative_mobile__1hjdb9v5g InlineField_indicator__1b4ltjxc InlineField_checkboxScale__1b4ltjxe">
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy sprinkles_opacity_0__1hjdb9v7">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z">
+                         </path>
+                       </svg>
+                     </div>
+                     <div class="reset_base__yw2qws0 sprinkles_top_0__1hjdb9vk sprinkles_bottom_0__1hjdb9vl sprinkles_left_0__1hjdb9vm sprinkles_right_0__1hjdb9vn sprinkles_position_absolute_mobile__1hjdb9v5k sprinkles_transition_fast__1hjdb9vy">
+                       <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewbox="0 0 24 24"
+                         xml:space="preserve"
+                         focusable="false"
+                         fill="currentColor"
+                         width="16"
+                         height="16"
+                         class="reset_base__yw2qws0 sprinkles_width_full__1hjdb9vq sprinkles_height_full__1hjdb9vo sprinkles_display_block_mobile__1hjdb9v50 typography_tone_formAccent__co4djb1s"
+                         aria-hidden="true"
+                       >
+                         <path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z">
+                         </path>
+                       </svg>
+                     </div>
+                   </div>
+                 </span>
+               </div>
+               <div class="reset_base__yw2qws0 sprinkles_paddingLeft_xsmall_mobile__1hjdb9vb8 sprinkles_flexGrow_1_mobile__1hjdb9vi8">
+                 <div class="reset_base__yw2qws0 sprinkles_display_flex_mobile__1hjdb9v5c InlineField_sizeVars_standard__1b4ltjx2 InlineField_labelOffset__1b4ltjx6">
+                   <label
+                     class="reset_base__yw2qws0 sprinkles_userSelect_none__1hjdb9v4 sprinkles_display_block_mobile__1hjdb9v50 sprinkles_cursor_pointer__1hjdb9vi virtualTouchable_virtualTouchable__9705do0"
+                     for="id_1"
+                   >
+                     <span class="reset_base__yw2qws0 sprinkles_display_block_mobile__1hjdb9v50 typography_fontFamily__co4djb0 typography_fontWeight_regular__co4djb1 typography_tone_neutral__co4djb1t typography_textSize_standard__co4djb8 capsize_capsizeStyle__1lwixuj4">
+                       This is a checkbox
+                     </span>
+                   </label>
+                 </div>
+               </div>
+             </div>
+           </div>
          </div>
          <div class="reset_base__yw2qws0 App_vanillaBox__inn18b0">
            🧁 Vanilla content
@@ -26189,4 +26064,43 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"site":"seekAnz"}
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/2.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/main.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;

--- a/tests/browser/__snapshots__/custom-src-paths.test.ts.snap
+++ b/tests/browser/__snapshots__/custom-src-paths.test.ts.snap
@@ -1,6 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`custom-src-paths > bundler vite > build > should create valid app 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -31,7 +34,6 @@ exports[`custom-src-paths > bundler vite > build > should create valid app 1`] =
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;
 
 exports[`custom-src-paths > bundler vite > build > should generate the expected files 1`] = `
@@ -76,57 +78,31 @@ SOURCE HTML: <!DOCTYPE html>
 `;
 
 exports[`custom-src-paths > bundler vite > start > should start a development server 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <script type="module">
-      import { injectIntoGlobalHook } from "/@react-refresh";
-injectIntoGlobalHook(window);
-window.$RefreshReg$ = () => {};
-window.$RefreshSig$ = () => (type) => type;
-    </script>
-    <script
-      type="module"
-      src="/@vite/client"
-    >
-    </script>
-    <meta charset="UTF-8">
-    <title>
-      hello-world
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <script
-      type="module"
-      src="/@id/__x00__/index.html?html-proxy&index=0.js"
-    >
-    </script>
-    <script
-      type="module"
-      src="/@id/__x00__/index.html?html-proxy&index=1.js"
-    >
-    </script>
-  </head>
-  <body>
-    <div id="app">
-      <div>
-        Hello custom src paths
-      </div>
-    </div>
-    <script
-      type="module"
-      src="{cwd}/packages/sku/dist/services/vite/entries/vite-client.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -22,12 +22,12 @@
+@@ -1,46 +1,46 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <script type="module">
+       import { injectIntoGlobalHook } from "/@react-refresh";
+ injectIntoGlobalHook(window);
+ window.$RefreshReg$ = () => {};
+ window.$RefreshSig$ = () => (type) => type;
+     </script>
+     <script
+       type="module"
+       src="/@vite/client"
+     >
+     </script>
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
      >
      <script
        type="module"
@@ -141,9 +117,26 @@ POST HYDRATE DIFFS:
      >
      </script>
    </head>
+   <body>
+     <div id="app">
+       <div>
+         Hello custom src paths
+       </div>
+     </div>
+     <script
+       type="module"
+       src="{cwd}/packages/sku/dist/services/vite/entries/vite-client.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`custom-src-paths > bundler webpack > build > should create valid app 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -212,7 +205,6 @@ exports[`custom-src-paths > bundler webpack > build > should create valid app 1`
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;
 
 exports[`custom-src-paths > bundler webpack > build > should generate the expected files 1`] = `
@@ -301,6 +293,9 @@ SOURCE HTML: <!DOCTYPE html>
 `;
 
 exports[`custom-src-paths > bundler webpack > start > should start a development server 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -369,5 +364,4 @@ exports[`custom-src-paths > bundler webpack > start > should start a development
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;

--- a/tests/browser/__snapshots__/library-build.test.ts.snap
+++ b/tests/browser/__snapshots__/library-build.test.ts.snap
@@ -19,36 +19,30 @@ exports[`library-build > build > should generate the expected files 1`] = `
 `;
 
 exports[`library-build > start > should start a development server 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="/MyLibrary.css"
-    >
-  </head>
-  <body>
-    <script src="/MyLibrary.js">
-    </script>
-    <script>
-      window.MyLibrary();
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -21,5 +21,8 @@
+@@ -1,25 +1,28 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       rel="stylesheet"
+       type="text/css"
+       href="/MyLibrary.css"
+     >
+   </head>
+   <body>
+     <script src="/MyLibrary.js">
+     </script>
      <script>
        window.MyLibrary();
      </script>

--- a/tests/browser/__snapshots__/library-file.test.ts.snap
+++ b/tests/browser/__snapshots__/library-file.test.ts.snap
@@ -19,36 +19,30 @@ exports[`library-file > build > should generate the expected files 1`] = `
 `;
 
 exports[`library-file > start > should start a development server 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="/my-library.css"
-    >
-  </head>
-  <body>
-    <script src="/my-library.js">
-    </script>
-    <script>
-      window.MyLibrary();
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -21,5 +21,8 @@
+@@ -1,25 +1,28 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       rel="stylesheet"
+       type="text/css"
+       href="/my-library.css"
+     >
+   </head>
+   <body>
+     <script src="/my-library.js">
+     </script>
      <script>
        window.MyLibrary();
      </script>

--- a/tests/browser/__snapshots__/multiple-routes.test.ts.snap
+++ b/tests/browser/__snapshots__/multiple-routes.test.ts.snap
@@ -342,89 +342,56 @@ SOURCE HTML: <!DOCTYPE html>
 `;
 
 exports[`multiple-routes > bundler: vite > build and serve > should render details page correctly 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="script-src 'self' https://error-tracking.com https://fb-tracking.com https://code.jquery.com 'sha256-rGv16tw6EM5EMe4gsxdgzpqzrzd14bhfa2neQclOXDU=';"
-    >
-    <meta charset="UTF-8">
-    <title>
-      hello-world
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <script src="https://code.jquery.com/jquery-3.5.0.slim.min.js">
-    </script>
-    <script>
-      console.log('Hi');
-    </script>
-    <style type="text/css">
-      body {
-        background: pink;
-      }
-    </style>
-    <link
-      rel="stylesheet"
-      href="/static/place/Details-DGJnH813.css"
-      crossorigin
-    >
-    <link
-      rel="modulepreload"
-      href="/static/place/vite-client-jm3K3cXX.js"
-      crossorigin
-    >
-    <link
-      rel="modulepreload"
-      href="/static/place/Details-B6pbTWh5.js"
-      crossorigin
-    >
-    <link
-      rel="modulepreload"
-      href="/static/place/AsyncComponent-mB82i4mm.js"
-      crossorigin
-    >
-  </head>
-  <body>
-    <div id="app">
-      <h1 class="_1hpn1da0">
-        Welcome to the Details page - au
-        <span>
-          Some special async content
-        </span>
-      </h1>
-    </div>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"site":"au"}
-    </script>
-    <script
-      type="module"
-      src="/static/place/AsyncComponent-mB82i4mm.js"
-    >
-    </script>
-    <script
-      type="module"
-      src="/static/place/Details-B6pbTWh5.js"
-    >
-    </script>
-    <script
-      type="module"
-      src="/static/place/vite-client-jm3K3cXX.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -47,7 +47,7 @@
+@@ -1,78 +1,78 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta
+       http-equiv="Content-Security-Policy"
+       content="script-src 'self' https://error-tracking.com https://fb-tracking.com https://code.jquery.com 'sha256-rGv16tw6EM5EMe4gsxdgzpqzrzd14bhfa2neQclOXDU=';"
+     >
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <script src="https://code.jquery.com/jquery-3.5.0.slim.min.js">
+     </script>
+     <script>
+       console.log('Hi');
+     </script>
+     <style type="text/css">
+       body {
+         background: pink;
+       }
+     </style>
+     <link
+       rel="stylesheet"
+       href="/static/place/Details-DGJnH813.css"
+       crossorigin
+     >
+     <link
+       rel="modulepreload"
+       href="/static/place/vite-client-jm3K3cXX.js"
+       crossorigin
+     >
+     <link
+       rel="modulepreload"
+       href="/static/place/Details-B6pbTWh5.js"
+       crossorigin
+     >
+     <link
+       rel="modulepreload"
+       href="/static/place/AsyncComponent-mB82i4mm.js"
+       crossorigin
+     >
+   </head>
    <body>
      <div id="app">
        <h1 class="_1hpn1da0">
@@ -433,9 +400,38 @@ POST HYDRATE DIFFS:
          <span>
            Some special async content
          </span>
+       </h1>
+     </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"site":"au"}
+     </script>
+     <script
+       type="module"
+       src="/static/place/AsyncComponent-mB82i4mm.js"
+     >
+     </script>
+     <script
+       type="module"
+       src="/static/place/Details-B6pbTWh5.js"
+     >
+     </script>
+     <script
+       type="module"
+       src="/static/place/vite-client-jm3K3cXX.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`multiple-routes > bundler: vite > build and serve > should render home page correctly 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -501,95 +497,59 @@ exports[`multiple-routes > bundler: vite > build and serve > should render home 
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;
 
 exports[`multiple-routes > bundler: vite > start > should render details page correctly 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="script-src 'self' https://error-tracking.com https://fb-tracking.com https://code.jquery.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' 'sha256-rGv16tw6EM5EMe4gsxdgzpqzrzd14bhfa2neQclOXDU=';"
-    >
-    <style
-      type="text/css"
-      data-vanilla-extract-inline-dev-css
-    >
-      .Home_root__ms22la0 {
-  color: red;
-}
-.Details_root__1hpn1da0 {
-  color: blue;
-}
-    </style>
-    <script type="module">
-      import { injectIntoGlobalHook } from "/@react-refresh";
-injectIntoGlobalHook(window);
-window.$RefreshReg$ = () => {};
-window.$RefreshSig$ = () => (type) => type;
-    </script>
-    <script
-      type="module"
-      src="/@vite/client"
-    >
-    </script>
-    <meta charset="UTF-8">
-    <title>
-      hello-world
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <script src="https://code.jquery.com/jquery-3.5.0.slim.min.js">
-    </script>
-    <script>
-      console.log('Hi');
-    </script>
-    <style type="text/css">
-      body {
-        background: pink;
-      }
-    </style>
-    <script
-      type="module"
-      src="/@id/__x00__/index.html?html-proxy&index=0.js"
-    >
-    </script>
-    <script
-      type="module"
-      src="/@id/__x00__/index.html?html-proxy&index=1.js"
-    >
-    </script>
-  </head>
-  <body>
-    <div id="app">
-      <h1 class="Details_root__1hpn1da0">
-        Welcome to the Details page - au
-        <span>
-          Some special async content
-        </span>
-      </h1>
-    </div>
-    <script
-      type="module"
-      src="{cwd}/packages/sku/dist/services/vite/entries/vite-client.js"
-    >
-    </script>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"site":"au"}
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -47,19 +47,27 @@
+@@ -1,80 +1,88 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta
+       http-equiv="Content-Security-Policy"
+       content="script-src 'self' https://error-tracking.com https://fb-tracking.com https://code.jquery.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' 'sha256-rGv16tw6EM5EMe4gsxdgzpqzrzd14bhfa2neQclOXDU=';"
+     >
+     <style
+       type="text/css"
+       data-vanilla-extract-inline-dev-css
+     >
+       .Home_root__ms22la0 {
+   color: red;
+ }
+ .Details_root__1hpn1da0 {
+   color: blue;
+ }
+     </style>
+     <script type="module">
+       import { injectIntoGlobalHook } from "/@react-refresh";
+ injectIntoGlobalHook(window);
+ window.$RefreshReg$ = () => {};
+ window.$RefreshSig$ = () => (type) => type;
+     </script>
+     <script
+       type="module"
+       src="/@vite/client"
+     >
+     </script>
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <script src="https://code.jquery.com/jquery-3.5.0.slim.min.js">
+     </script>
+     <script>
+       console.log('Hi');
+     </script>
+     <style type="text/css">
+       body {
+         background: pink;
+       }
      </style>
      <script
        type="module"
@@ -620,88 +580,72 @@ POST HYDRATE DIFFS:
          <span>
            Some special async content
          </span>
+       </h1>
+     </div>
+     <script
+       type="module"
+       src="{cwd}/packages/sku/dist/services/vite/entries/vite-client.js"
+     >
+     </script>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"site":"au"}
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`multiple-routes > bundler: vite > start > should render home page correctly 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="script-src 'self' https://error-tracking.com https://fb-tracking.com https://code.jquery.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' 'sha256-rGv16tw6EM5EMe4gsxdgzpqzrzd14bhfa2neQclOXDU=';"
-    >
-    <style
-      type="text/css"
-      data-vanilla-extract-inline-dev-css
-    >
-      .Home_root__ms22la0 {
-  color: red;
-}
-    </style>
-    <script type="module">
-      import { injectIntoGlobalHook } from "/@react-refresh";
-injectIntoGlobalHook(window);
-window.$RefreshReg$ = () => {};
-window.$RefreshSig$ = () => (type) => type;
-    </script>
-    <script
-      type="module"
-      src="/@vite/client"
-    >
-    </script>
-    <meta charset="UTF-8">
-    <title>
-      hello-world
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <script src="https://code.jquery.com/jquery-3.5.0.slim.min.js">
-    </script>
-    <script>
-      console.log('Hi');
-    </script>
-    <style type="text/css">
-      body {
-        background: pink;
-      }
-    </style>
-    <script
-      type="module"
-      src="/@id/__x00__/index.html?html-proxy&index=0.js"
-    >
-    </script>
-    <script
-      type="module"
-      src="/@id/__x00__/index.html?html-proxy&index=1.js"
-    >
-    </script>
-  </head>
-  <body>
-    <div id="app">
-      <h1 class="Home_root__ms22la0">
-        Welcome to the Home page - au
-      </h1>
-    </div>
-    <script
-      type="module"
-      src="{cwd}/packages/sku/dist/services/vite/entries/vite-client.js"
-    >
-    </script>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"site":"au"}
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -44,14 +44,22 @@
+@@ -1,74 +1,82 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta
+       http-equiv="Content-Security-Policy"
+       content="script-src 'self' https://error-tracking.com https://fb-tracking.com https://code.jquery.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' 'sha256-rGv16tw6EM5EMe4gsxdgzpqzrzd14bhfa2neQclOXDU=';"
+     >
+     <style
+       type="text/css"
+       data-vanilla-extract-inline-dev-css
+     >
+       .Home_root__ms22la0 {
+   color: red;
+ }
+     </style>
+     <script type="module">
+       import { injectIntoGlobalHook } from "/@react-refresh";
+ injectIntoGlobalHook(window);
+ window.$RefreshReg$ = () => {};
+ window.$RefreshSig$ = () => (type) => type;
+     </script>
+     <script
+       type="module"
+       src="/@vite/client"
+     >
+     </script>
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <script src="https://code.jquery.com/jquery-3.5.0.slim.min.js">
+     </script>
+     <script>
+       console.log('Hi');
+     </script>
+     <style type="text/css">
+       body {
+         background: pink;
+       }
      </style>
      <script
        type="module"
@@ -726,6 +670,24 @@ POST HYDRATE DIFFS:
    </head>
    <body>
      <div id="app">
+       <h1 class="Home_root__ms22la0">
+         Welcome to the Home page - au
+       </h1>
+     </div>
+     <script
+       type="module"
+       src="{cwd}/packages/sku/dist/services/vite/entries/vite-client.js"
+     >
+     </script>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"site":"au"}
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`multiple-routes > bundler: webpack > build and serve > should generate the expected files 1`] = `
@@ -1252,131 +1214,71 @@ SOURCE HTML: <!DOCTYPE html>
 `;
 
 exports[`multiple-routes > bundler: webpack > build and serve > should render details page correctly 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="script-src 'self' https://error-tracking.com https://fb-tracking.com https://code.jquery.com 'sha256-rGv16tw6EM5EMe4gsxdgzpqzrzd14bhfa2neQclOXDU=';"
-    >
-    <meta charset="UTF-8">
-    <title>
-      hello-world
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <script src="https://code.jquery.com/jquery-3.5.0.slim.min.js">
-    </script>
-    <script>
-      console.log('Hi');
-    </script>
-    <style type="text/css">
-      body {
-        background: pink;
-      }
-    </style>
-    <link
-      data-chunk="handlers-Details"
-      rel="stylesheet"
-      href="/static/place/handlers-Details-791506971640531b9f92.css"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/static/place/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/static/place/5.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/static/place/main.js"
-    >
-    <link
-      data-chunk="handlers-Details"
-      rel="preload"
-      as="script"
-      href="/static/place/handlers-Details.chunk.js"
-    >
-    <link
-      data-chunk="AsyncComponent"
-      rel="preload"
-      as="script"
-      href="/static/place/AsyncComponent.chunk.js"
-    >
-  </head>
-  <body>
-    <div id="app">
-      <h1 class="_1hpn1da0">
-        Welcome to the Details page - au
-        <span>
-          Some special async content
-        </span>
-      </h1>
-    </div>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"site":"au"}
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      [1,0]
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":["handlers-Details","AsyncComponent"]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/static/place/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/static/place/5.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/static/place/main.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="handlers-Details"
-      src="/static/place/handlers-Details.chunk.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="AsyncComponent"
-      src="/static/place/AsyncComponent.chunk.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -62,7 +62,7 @@
+@@ -1,120 +1,120 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta
+       http-equiv="Content-Security-Policy"
+       content="script-src 'self' https://error-tracking.com https://fb-tracking.com https://code.jquery.com 'sha256-rGv16tw6EM5EMe4gsxdgzpqzrzd14bhfa2neQclOXDU=';"
+     >
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <script src="https://code.jquery.com/jquery-3.5.0.slim.min.js">
+     </script>
+     <script>
+       console.log('Hi');
+     </script>
+     <style type="text/css">
+       body {
+         background: pink;
+       }
+     </style>
+     <link
+       data-chunk="handlers-Details"
+       rel="stylesheet"
+       href="/static/place/handlers-Details-791506971640531b9f92.css"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/static/place/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/static/place/5.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/static/place/main.js"
+     >
+     <link
+       data-chunk="handlers-Details"
+       rel="preload"
+       as="script"
+       href="/static/place/handlers-Details.chunk.js"
+     >
+     <link
+       data-chunk="AsyncComponent"
+       rel="preload"
+       as="script"
+       href="/static/place/AsyncComponent.chunk.js"
+     >
+   </head>
    <body>
      <div id="app">
        <h1 class="_1hpn1da0">
@@ -1385,9 +1287,65 @@ POST HYDRATE DIFFS:
          <span>
            Some special async content
          </span>
+       </h1>
+     </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"site":"au"}
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       [1,0]
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":["handlers-Details","AsyncComponent"]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/static/place/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/static/place/5.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/static/place/main.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="handlers-Details"
+       src="/static/place/handlers-Details.chunk.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="AsyncComponent"
+       src="/static/place/AsyncComponent.chunk.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`multiple-routes > bundler: webpack > build and serve > should render home page correctly 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -1493,135 +1451,74 @@ exports[`multiple-routes > bundler: webpack > build and serve > should render ho
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;
 
 exports[`multiple-routes > bundler: webpack > start > should render details page correctly 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="script-src 'self' https://error-tracking.com https://fb-tracking.com https://code.jquery.com 'sha256-rGv16tw6EM5EMe4gsxdgzpqzrzd14bhfa2neQclOXDU=' 'unsafe-eval';"
-    >
-    <meta charset="UTF-8">
-    <title>
-      hello-world
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <script src="https://code.jquery.com/jquery-3.5.0.slim.min.js">
-    </script>
-    <script>
-      console.log('Hi');
-    </script>
-    <style type="text/css">
-      body {
-        background: pink;
-      }
-    </style>
-    <link
-      data-chunk="handlers-Details"
-      rel="stylesheet"
-      href="/handlers-Details.css"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/5.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/main.js"
-    >
-    <link
-      data-chunk="handlers-Details"
-      rel="preload"
-      as="script"
-      href="/handlers-Details.js"
-    >
-    <link
-      data-chunk="AsyncComponent"
-      rel="preload"
-      as="script"
-      href="/AsyncComponent.js"
-    >
-  </head>
-  <body>
-    <div id="app">
-      <h1 class="Details_root__1hpn1da0">
-        Welcome to the Details page - au
-        <span>
-          Some special async content
-        </span>
-      </h1>
-    </div>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"site":"au"}
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      [1,0]
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":["handlers-Details","AsyncComponent"]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/5.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/main.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="handlers-Details"
-      src="/handlers-Details.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="AsyncComponent"
-      src="/AsyncComponent.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -62,7 +62,7 @@
+@@ -1,120 +1,120 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta
+       http-equiv="Content-Security-Policy"
+       content="script-src 'self' https://error-tracking.com https://fb-tracking.com https://code.jquery.com 'sha256-rGv16tw6EM5EMe4gsxdgzpqzrzd14bhfa2neQclOXDU=' 'unsafe-eval';"
+     >
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <script src="https://code.jquery.com/jquery-3.5.0.slim.min.js">
+     </script>
+     <script>
+       console.log('Hi');
+     </script>
+     <style type="text/css">
+       body {
+         background: pink;
+       }
+     </style>
+     <link
+       data-chunk="handlers-Details"
+       rel="stylesheet"
+       href="/handlers-Details.css"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/5.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/main.js"
+     >
+     <link
+       data-chunk="handlers-Details"
+       rel="preload"
+       as="script"
+       href="/handlers-Details.js"
+     >
+     <link
+       data-chunk="AsyncComponent"
+       rel="preload"
+       as="script"
+       href="/AsyncComponent.js"
+     >
+   </head>
    <body>
      <div id="app">
        <h1 class="Details_root__1hpn1da0">
@@ -1630,9 +1527,65 @@ POST HYDRATE DIFFS:
          <span>
            Some special async content
          </span>
+       </h1>
+     </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"site":"au"}
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       [1,0]
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":["handlers-Details","AsyncComponent"]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/5.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/main.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="handlers-Details"
+       src="/handlers-Details.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="AsyncComponent"
+       src="/AsyncComponent.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`multiple-routes > bundler: webpack > start > should render home page correctly 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -1738,5 +1691,4 @@ exports[`multiple-routes > bundler: webpack > start > should render home page co
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;

--- a/tests/browser/__snapshots__/polyfills.test.ts.snap
+++ b/tests/browser/__snapshots__/polyfills.test.ts.snap
@@ -1,41 +1,35 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`polyfills > bundler vite > build > should create valid app 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      polyfill
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      rel="modulepreload"
-      href="/static/polyfills/vite-client-C-0jP4HP.js"
-      crossorigin
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div>
-        App with a polyfill
-      </div>
-    </div>
-    <script
-      type="module"
-      src="/static/polyfills/vite-client-C-0jP4HP.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -26,5 +26,11 @@
+@@ -1,30 +1,36 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       polyfill
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       rel="modulepreload"
+       href="/static/polyfills/vite-client-C-0jP4HP.js"
+       crossorigin
+     >
+   </head>
+   <body>
+     <div id="app">
+       <div>
+         App with a polyfill
+       </div>
+     </div>
+     <script
+       type="module"
        src="/static/polyfills/vite-client-C-0jP4HP.js"
      >
      </script>
@@ -51,79 +45,73 @@ POST HYDRATE DIFFS:
 `;
 
 exports[`polyfills > bundler vite > start > should start a development server 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      polyfill
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/2.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/main.js"
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div>
-        App with a polyfill
-      </div>
-    </div>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      []
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":[]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/2.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/main.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -64,5 +64,11 @@
+@@ -1,68 +1,74 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       polyfill
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/2.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/main.js"
+     >
+   </head>
+   <body>
+     <div id="app">
+       <div>
+         App with a polyfill
+       </div>
+     </div>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/2.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
        src="/main.js"
      >
      </script>
@@ -139,79 +127,73 @@ POST HYDRATE DIFFS:
 `;
 
 exports[`polyfills > bundler webpack > build > should create valid app 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      polyfill
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/static/polyfills/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/static/polyfills/2.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/static/polyfills/main.js"
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div>
-        App with a polyfill
-      </div>
-    </div>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      []
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":[]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/static/polyfills/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/static/polyfills/2.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/static/polyfills/main.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -64,5 +64,11 @@
+@@ -1,68 +1,74 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       polyfill
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/static/polyfills/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/static/polyfills/2.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/static/polyfills/main.js"
+     >
+   </head>
+   <body>
+     <div id="app">
+       <div>
+         App with a polyfill
+       </div>
+     </div>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/static/polyfills/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/static/polyfills/2.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
        src="/static/polyfills/main.js"
      >
      </script>
@@ -227,79 +209,73 @@ POST HYDRATE DIFFS:
 `;
 
 exports[`polyfills > bundler webpack > start > should start a development server 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      polyfill
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/2.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/main.js"
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div>
-        App with a polyfill
-      </div>
-    </div>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      []
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":[]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/2.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/main.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -64,5 +64,11 @@
+@@ -1,68 +1,74 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       polyfill
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/2.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/main.js"
+     >
+   </head>
+   <body>
+     <div id="app">
+       <div>
+         App with a polyfill
+       </div>
+     </div>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/2.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
        src="/main.js"
      >
      </script>

--- a/tests/browser/__snapshots__/public-path.test.ts.snap
+++ b/tests/browser/__snapshots__/public-path.test.ts.snap
@@ -1,6 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`public path > bundler: vite > build and serve > should build, serve, and create valid app with no unresolved resources 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -95,7 +98,6 @@ exports[`public path > bundler: vite > build and serve > should build, serve, an
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;
 
 exports[`public path > bundler: vite > build and serve > should build, serve, and create valid app with no unresolved resources 2`] = `
@@ -249,6 +251,9 @@ SOURCE HTML: <!DOCTYPE html>
 `;
 
 exports[`public path > bundler: webpack > build and serve > should build, serve, and create valid app with no unresolved resources 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -339,7 +344,6 @@ exports[`public path > bundler: webpack > build and serve > should build, serve,
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;
 
 exports[`public path > bundler: webpack > build and serve > should build, serve, and create valid app with no unresolved resources 2`] = `

--- a/tests/browser/__snapshots__/react-18.test.ts.snap
+++ b/tests/browser/__snapshots__/react-18.test.ts.snap
@@ -1,6 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`react-18 > bundler vite > build > should create valid app 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -31,10 +34,12 @@ exports[`react-18 > bundler vite > build > should create valid app 1`] = `
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;
 
 exports[`react-18 > bundler vite > start > should start a development server 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -103,10 +108,12 @@ exports[`react-18 > bundler vite > start > should start a development server 1`]
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;
 
 exports[`react-18 > bundler webpack > build > should create valid app 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -175,10 +182,12 @@ exports[`react-18 > bundler webpack > build > should create valid app 1`] = `
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;
 
 exports[`react-18 > bundler webpack > start > should start a development server 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -247,5 +256,4 @@ exports[`react-18 > bundler webpack > start > should start a development server 
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;

--- a/tests/browser/__snapshots__/sku-webpack-plugin.test.ts.snap
+++ b/tests/browser/__snapshots__/sku-webpack-plugin.test.ts.snap
@@ -1,41 +1,30 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`sku-webpack-plugin > build > should create valid app 1`] = `
-<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>
-      Webpack App
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width,initial-scale=1"
-    >
-    <script
-      defer="defer"
-      src="main.js"
-    >
-    </script>
-    <link
-      href="main.css"
-      rel="stylesheet"
-    >
-  </head>
-  <body>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -1,4 +1,4 @@
+@@ -1,24 +1,37 @@
 -<!doctype html>
 +<!DOCTYPE html>
  <html>
    <head>
      <meta charset="utf-8">
-@@ -20,5 +20,18 @@
+     <title>
+       Webpack App
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width,initial-scale=1"
+     >
+     <script
+       defer="defer"
+       src="main.js"
+     >
+     </script>
+     <link
+       href="main.css"
+       rel="stylesheet"
      >
    </head>
    <body>
@@ -2672,35 +2661,29 @@ html._9se0yi11 .s52s2ff {
 `;
 
 exports[`sku-webpack-plugin > start > should start a development server 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>
-      Webpack App
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <script
-      defer
-      src="main.js"
-    >
-    </script>
-    <link
-      href="main.css"
-      rel="stylesheet"
-    >
-  </head>
-  <body>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -20,5 +20,18 @@
+@@ -1,24 +1,37 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="utf-8">
+     <title>
+       Webpack App
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <script
+       defer
+       src="main.js"
+     >
+     </script>
+     <link
+       href="main.css"
+       rel="stylesheet"
      >
    </head>
    <body>

--- a/tests/browser/__snapshots__/sku-with-https.test.ts.snap
+++ b/tests/browser/__snapshots__/sku-with-https.test.ts.snap
@@ -1,80 +1,46 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`sku-with-https > bundler: vite > start > should start a development server > homepage 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="script-src 'self' https://some-cdn.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=';"
-    >
-    <style
-      type="text/css"
-      data-vanilla-extract-inline-dev-css
-    >
-      .styles_root__2vdre50 {
-  display: flex;
-}
-.styles_root__2vdre50 .styles_nested__2vdre51 {
-  font-size: 32px;
-}
-    </style>
-    <script type="module">
-      import { injectIntoGlobalHook } from "/@react-refresh";
-injectIntoGlobalHook(window);
-window.$RefreshReg$ = () => {};
-window.$RefreshSig$ = () => (type) => type;
-    </script>
-    <script
-      type="module"
-      src="/@vite/client"
-    >
-    </script>
-    <meta charset="UTF-8">
-    <title>
-      hello-world
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <script
-      type="module"
-      src="/@id/__x00__/index.html?html-proxy&index=0.js"
-    >
-    </script>
-    <script
-      type="module"
-      src="/@id/__x00__/index.html?html-proxy&index=1.js"
-    >
-    </script>
-  </head>
-  <body>
-    <div id="app">
-      <link
-        rel="preload"
-        as="image"
-        href="/src/logo.png"
-      >
-      <div class="styles_root__2vdre50">
-        <div class="styles_nested__2vdre51">
-          Initial
-        </div>
-        <img src="/src/logo.png">
-      </div>
-    </div>
-    <script
-      type="module"
-      src="{cwd}/packages/sku/dist/services/vite/entries/vite-client.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -37,14 +37,25 @@
+@@ -1,69 +1,80 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta
+       http-equiv="Content-Security-Policy"
+       content="script-src 'self' https://some-cdn.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=';"
+     >
+     <style
+       type="text/css"
+       data-vanilla-extract-inline-dev-css
+     >
+       .styles_root__2vdre50 {
+   display: flex;
+ }
+ .styles_root__2vdre50 .styles_nested__2vdre51 {
+   font-size: 32px;
+ }
+     </style>
+     <script type="module">
+       import { injectIntoGlobalHook } from "/@react-refresh";
+ injectIntoGlobalHook(window);
+ window.$RefreshReg$ = () => {};
+ window.$RefreshSig$ = () => (type) => type;
+     </script>
+     <script
+       type="module"
+       src="/@vite/client"
+     >
+     </script>
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
      >
      <script
        type="module"
@@ -102,7 +68,10 @@ POST HYDRATE DIFFS:
    </head>
    <body>
      <div id="app">
-@@ -55,7 +66,7 @@
+       <link
+         rel="preload"
+         as="image"
+         href="/src/logo.png"
        >
        <div class="styles_root__2vdre50">
          <div class="styles_nested__2vdre51">
@@ -111,17 +80,22 @@ POST HYDRATE DIFFS:
          </div>
          <img src="/src/logo.png">
        </div>
+     </div>
+     <script
+       type="module"
+       src="{cwd}/packages/sku/dist/services/vite/entries/vite-client.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`sku-with-https > bundler: vite > start > should start a development server > middleware 1`] = `
-OK
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
 @@ -1,1 +1,13 @@
--OK
-\\ No newline at end of file
 +<html>
 +  <head>
 +    <meta
@@ -131,7 +105,7 @@ POST HYDRATE DIFFS:
 +  </head>
 +  <body>
 +    <pre style="word-wrap: break-word; white-space: pre-wrap;">
-+      OK
+       OK
 +    </pre>
 +  </body>
 +</html>
@@ -139,96 +113,55 @@ POST HYDRATE DIFFS:
 `;
 
 exports[`sku-with-https > bundler: webpack > start > should start a development server > homepage 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="script-src 'self' https://some-cdn.com 'unsafe-eval';"
-    >
-    <meta charset="UTF-8">
-    <title>
-      hello-world
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="stylesheet"
-      href="/main.css"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/2.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/main.js"
-    >
-  </head>
-  <body>
-    <div id="app">
-      <link
-        rel="preload"
-        as="image"
-        href="/a85d2645cc4d80a20b5b.png"
-      >
-      <div class="styles_root__2vdre50">
-        <div class="styles_nested__2vdre51">
-          Initial
-        </div>
-        <img src="/a85d2645cc4d80a20b5b.png">
-      </div>
-    </div>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      []
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":[]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/2.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/main.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -46,7 +46,7 @@
+@@ -1,85 +1,85 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta
+       http-equiv="Content-Security-Policy"
+       content="script-src 'self' https://some-cdn.com 'unsafe-eval';"
+     >
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="stylesheet"
+       href="/main.css"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/2.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/main.js"
+     >
+   </head>
+   <body>
+     <div id="app">
+       <link
+         rel="preload"
+         as="image"
+         href="/a85d2645cc4d80a20b5b.png"
        >
        <div class="styles_root__2vdre50">
          <div class="styles_nested__2vdre51">
@@ -237,118 +170,107 @@ POST HYDRATE DIFFS:
          </div>
          <img src="/a85d2645cc4d80a20b5b.png">
        </div>
+     </div>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/2.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/main.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`sku-with-https > bundler: webpack > start > should start a development server > middleware 1`] = `
-OK
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
 @@ -1,1 +1,7 @@
--OK
-\\ No newline at end of file
 +<html>
 +  <head>
 +  </head>
 +  <body>
-+    OK
+     OK
 +  </body>
 +</html>
 \\ No newline at end of file
 `;
 
 exports[`sku-with-https > serve > should start a development server 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="script-src 'self' https://some-cdn.com;"
-    >
-    <meta charset="UTF-8">
-    <title>
-      hello-world
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="stylesheet"
-      href="/main-20b517520995ff660440.css"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/2.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/main.js"
-    >
-  </head>
-  <body>
-    <div id="app">
-      <link
-        rel="preload"
-        as="image"
-        href="/a85d2645cc4d80a20b5b.png"
-      >
-      <div class="_2vdre50">
-        <div class="_2vdre51">
-          Initial
-        </div>
-        <img src="/a85d2645cc4d80a20b5b.png">
-      </div>
-    </div>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      []
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":[]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/2.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/main.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -46,7 +46,7 @@
+@@ -1,85 +1,85 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta
+       http-equiv="Content-Security-Policy"
+       content="script-src 'self' https://some-cdn.com;"
+     >
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="stylesheet"
+       href="/main-20b517520995ff660440.css"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/2.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/main.js"
+     >
+   </head>
+   <body>
+     <div id="app">
+       <link
+         rel="preload"
+         as="image"
+         href="/a85d2645cc4d80a20b5b.png"
        >
        <div class="_2vdre50">
          <div class="_2vdre51">
@@ -357,41 +279,67 @@ POST HYDRATE DIFFS:
          </div>
          <img src="/a85d2645cc4d80a20b5b.png">
        </div>
+     </div>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/2.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/main.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`sku-with-https > serve > should support the supplied middleware 1`] = `
-OK
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
 @@ -1,1 +1,7 @@
--OK
-\\ No newline at end of file
 +<html>
 +  <head>
 +  </head>
 +  <body>
-+    OK
+     OK
 +  </body>
 +</html>
 \\ No newline at end of file
 `;
 
 exports[`sku-with-https > start-ssr > should support the supplied middleware 1`] = `
-OK
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
 @@ -1,1 +1,7 @@
--OK
-\\ No newline at end of file
 +<html>
 +  <head>
 +  </head>
 +  <body>
-+    OK
+     OK
 +  </body>
 +</html>
 \\ No newline at end of file

--- a/tests/browser/__snapshots__/ssr-hello-world.test.ts.snap
+++ b/tests/browser/__snapshots__/ssr-hello-world.test.ts.snap
@@ -1,6 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ssr-hello-world > build > default port > should generate a production server based on config 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -14,33 +17,30 @@ exports[`ssr-hello-world > build > default port > should generate a production s
     >
     <meta
       http-equiv="Content-Security-Policy"
-      content="script-src 'self' http://localhost:4000 https://some-cdn.com https://code.jquery.com 'sha256-WHrb12igXgDsoQpp4ijb4PgZBl4AXNijY5y96KkF2hY=';"
+      content="script-src 'self' https://some-cdn.com https://code.jquery.com 'sha256-WHrb12igXgDsoQpp4ijb4PgZBl4AXNijY5y96KkF2hY=';"
     >
     <link
       data-chunk="main"
       rel="stylesheet"
-      href="http://localhost:4000/main-1f5c2cf64419575cffa6.css"
+      href="/main-1f5c2cf64419575cffa6.css"
     >
     <link
       data-chunk="main"
       rel="preload"
       as="script"
-      href="http://localhost:4000/runtime.js"
-      crossorigin="anonymous"
+      href="/runtime.js"
     >
     <link
       data-chunk="main"
       rel="preload"
       as="script"
-      href="http://localhost:4000/2.js"
-      crossorigin="anonymous"
+      href="/2.js"
     >
     <link
       data-chunk="main"
       rel="preload"
       as="script"
-      href="http://localhost:4000/main.js"
-      crossorigin="anonymous"
+      href="/main.js"
     >
   </head>
   <body>
@@ -48,13 +48,13 @@ exports[`ssr-hello-world > build > default port > should generate a production s
       <link
         rel="preload"
         as="image"
-        href="http://localhost:4000/a85d2645cc4d80a20b5b.png"
+        href="/a85d2645cc4d80a20b5b.png"
       >
       <div class="qixxyt0">
         <div class="qixxyt1">
           Hello World
         </div>
-        <img src="http://localhost:4000/a85d2645cc4d80a20b5b.png">
+        <img src="/a85d2645cc4d80a20b5b.png">
       </div>
     </div>
     <script src="https://code.jquery.com/jquery-3.5.0.slim.min.js">
@@ -65,44 +65,41 @@ exports[`ssr-hello-world > build > default port > should generate a production s
     <script
       id="__LOADABLE_REQUIRED_CHUNKS__"
       type="application/json"
-      crossorigin="anonymous"
     >
       []
     </script>
     <script
       id="__LOADABLE_REQUIRED_CHUNKS___ext"
       type="application/json"
-      crossorigin="anonymous"
     >
       {"namedChunks":[]}
     </script>
     <script
       async
       data-chunk="main"
-      src="http://localhost:4000/runtime.js"
-      crossorigin="anonymous"
+      src="/runtime.js"
     >
     </script>
     <script
       async
       data-chunk="main"
-      src="http://localhost:4000/2.js"
-      crossorigin="anonymous"
+      src="/2.js"
     >
     </script>
     <script
       async
       data-chunk="main"
-      src="http://localhost:4000/main.js"
-      crossorigin="anonymous"
+      src="/main.js"
     >
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;
 
 exports[`ssr-hello-world > build > should run on a custom port 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -116,33 +113,30 @@ exports[`ssr-hello-world > build > should run on a custom port 1`] = `
     >
     <meta
       http-equiv="Content-Security-Policy"
-      content="script-src 'self' http://localhost:4000 https://some-cdn.com https://code.jquery.com 'sha256-WHrb12igXgDsoQpp4ijb4PgZBl4AXNijY5y96KkF2hY=';"
+      content="script-src 'self' https://some-cdn.com https://code.jquery.com 'sha256-WHrb12igXgDsoQpp4ijb4PgZBl4AXNijY5y96KkF2hY=';"
     >
     <link
       data-chunk="main"
       rel="stylesheet"
-      href="http://localhost:4000/main-1f5c2cf64419575cffa6.css"
+      href="/main-1f5c2cf64419575cffa6.css"
     >
     <link
       data-chunk="main"
       rel="preload"
       as="script"
-      href="http://localhost:4000/runtime.js"
-      crossorigin="anonymous"
+      href="/runtime.js"
     >
     <link
       data-chunk="main"
       rel="preload"
       as="script"
-      href="http://localhost:4000/2.js"
-      crossorigin="anonymous"
+      href="/2.js"
     >
     <link
       data-chunk="main"
       rel="preload"
       as="script"
-      href="http://localhost:4000/main.js"
-      crossorigin="anonymous"
+      href="/main.js"
     >
   </head>
   <body>
@@ -150,13 +144,13 @@ exports[`ssr-hello-world > build > should run on a custom port 1`] = `
       <link
         rel="preload"
         as="image"
-        href="http://localhost:4000/a85d2645cc4d80a20b5b.png"
+        href="/a85d2645cc4d80a20b5b.png"
       >
       <div class="qixxyt0">
         <div class="qixxyt1">
           Hello World
         </div>
-        <img src="http://localhost:4000/a85d2645cc4d80a20b5b.png">
+        <img src="/a85d2645cc4d80a20b5b.png">
       </div>
     </div>
     <script src="https://code.jquery.com/jquery-3.5.0.slim.min.js">
@@ -167,44 +161,41 @@ exports[`ssr-hello-world > build > should run on a custom port 1`] = `
     <script
       id="__LOADABLE_REQUIRED_CHUNKS__"
       type="application/json"
-      crossorigin="anonymous"
     >
       []
     </script>
     <script
       id="__LOADABLE_REQUIRED_CHUNKS___ext"
       type="application/json"
-      crossorigin="anonymous"
     >
       {"namedChunks":[]}
     </script>
     <script
       async
       data-chunk="main"
-      src="http://localhost:4000/runtime.js"
-      crossorigin="anonymous"
+      src="/runtime.js"
     >
     </script>
     <script
       async
       data-chunk="main"
-      src="http://localhost:4000/2.js"
-      crossorigin="anonymous"
+      src="/2.js"
     >
     </script>
     <script
       async
       data-chunk="main"
-      src="http://localhost:4000/main.js"
-      crossorigin="anonymous"
+      src="/main.js"
     >
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;
 
 exports[`ssr-hello-world > start > should start a development server 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -303,5 +294,4 @@ exports[`ssr-hello-world > start > should start a development server 1`] = `
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;

--- a/tests/browser/__snapshots__/styling.test.ts.snap
+++ b/tests/browser/__snapshots__/styling.test.ts.snap
@@ -1,100 +1,47 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`styling > build > should create valid app 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="stylesheet"
-      href="/styling/main-f11c7eb5d7d4b8c58e2e.css"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/styling/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/styling/2.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/styling/main.js"
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div>
-        <div>
-          Render type:
-          Initial
-        </div>
-        <div>
-          <span
-            class="external"
-            data-automation-external="true"
-          >
-            This should be invisible
-          </span>
-          <div
-            class="qiwkl41 qiwkl40"
-            data-automation-vanilla="true"
-          >
-          </div>
-        </div>
-      </div>
-    </div>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      []
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":[]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/styling/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/styling/2.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/styling/main.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -38,7 +38,7 @@
+@@ -1,89 +1,89 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="stylesheet"
+       href="/styling/main-f11c7eb5d7d4b8c58e2e.css"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/styling/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/styling/2.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/styling/main.js"
+     >
+   </head>
+   <body>
+     <div id="app">
        <div>
          <div>
            Render type:
@@ -103,6 +50,52 @@ POST HYDRATE DIFFS:
          </div>
          <div>
            <span
+             class="external"
+             data-automation-external="true"
+           >
+             This should be invisible
+           </span>
+           <div
+             class="qiwkl41 qiwkl40"
+             data-automation-vanilla="true"
+           >
+           </div>
+         </div>
+       </div>
+     </div>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/styling/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/styling/2.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/styling/main.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`styling > build > should generate the expected files 1`] = `
@@ -231,100 +224,47 @@ SOURCE HTML: <!DOCTYPE html>
 `;
 
 exports[`styling > start > should start a development server 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="stylesheet"
-      href="/main.css"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/2.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/main.js"
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div>
-        <div>
-          Render type:
-          Initial
-        </div>
-        <div>
-          <span
-            class="external"
-            data-automation-external="true"
-          >
-            This should be invisible
-          </span>
-          <div
-            class="BlueBlock_root__qiwkl41 BlueBlock_border__qiwkl40"
-            data-automation-vanilla="true"
-          >
-          </div>
-        </div>
-      </div>
-    </div>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      []
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":[]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/2.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/main.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -38,7 +38,7 @@
+@@ -1,89 +1,89 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="stylesheet"
+       href="/main.css"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/2.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/main.js"
+     >
+   </head>
+   <body>
+     <div id="app">
        <div>
          <div>
            Render type:
@@ -333,4 +273,50 @@ POST HYDRATE DIFFS:
          </div>
          <div>
            <span
+             class="external"
+             data-automation-external="true"
+           >
+             This should be invisible
+           </span>
+           <div
+             class="BlueBlock_root__qiwkl41 BlueBlock_border__qiwkl40"
+             data-automation-vanilla="true"
+           >
+           </div>
+         </div>
+       </div>
+     </div>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/2.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/main.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;

--- a/tests/browser/__snapshots__/suspense.test.ts.snap
+++ b/tests/browser/__snapshots__/suspense.test.ts.snap
@@ -56,6 +56,9 @@ SOURCE HTML: <!DOCTYPE html>
 `;
 
 exports[`suspense > bundler vite > build and serve > should return home page 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -100,7 +103,6 @@ exports[`suspense > bundler vite > build and serve > should return home page 1`]
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;
 
 exports[`suspense > bundler webpack > build and serve > should generate the expected files 1`] = `
@@ -203,6 +205,9 @@ SOURCE HTML: <!DOCTYPE html>
 `;
 
 exports[`suspense > bundler webpack > build and serve > should return home page 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -285,5 +290,4 @@ exports[`suspense > bundler webpack > build and serve > should return home page 
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;

--- a/tests/browser/__snapshots__/translations-ssr.test.ts.snap
+++ b/tests/browser/__snapshots__/translations-ssr.test.ts.snap
@@ -1,6 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ssr translations > should render en 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -92,10 +95,12 @@ exports[`ssr translations > should render en 1`] = `
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;
 
 exports[`ssr translations > should render en-PSEUDO 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -187,10 +192,12 @@ exports[`ssr translations > should render en-PSEUDO 1`] = `
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;
 
 exports[`ssr translations > should render fr 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -282,5 +289,4 @@ exports[`ssr translations > should render fr 1`] = `
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;

--- a/tests/browser/__snapshots__/translations.test.ts.snap
+++ b/tests/browser/__snapshots__/translations.test.ts.snap
@@ -1,58 +1,32 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`translations > bundler vite > should render en 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      rel="modulepreload"
-      href="/vite-client-79htCCWk.js"
-      crossorigin
-    >
-    <link
-      rel="modulepreload"
-      href="/en-translations-Dc5XqNPs.js"
-      crossorigin
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div>
-        Hello sku
-        Company name
-      </div>
-    </div>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"language":"en"}
-    </script>
-    <script
-      type="module"
-      src="/en-translations-Dc5XqNPs.js"
-    >
-    </script>
-    <script
-      type="module"
-      src="/vite-client-79htCCWk.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -23,8 +23,7 @@
+@@ -1,47 +1,46 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       rel="modulepreload"
+       href="/vite-client-79htCCWk.js"
+       crossorigin
+     >
+     <link
+       rel="modulepreload"
+       href="/en-translations-Dc5XqNPs.js"
+       crossorigin
+     >
+   </head>
    <body>
      <div id="app">
        <div>
@@ -62,61 +36,53 @@ POST HYDRATE DIFFS:
        </div>
      </div>
      <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"language":"en"}
+     </script>
+     <script
+       type="module"
+       src="/en-translations-Dc5XqNPs.js"
+     >
+     </script>
+     <script
+       type="module"
+       src="/vite-client-79htCCWk.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`translations > bundler vite > should render en-PSEUDO post-hydration 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      rel="modulepreload"
-      href="/vite-client-79htCCWk.js"
-      crossorigin
-    >
-    <link
-      rel="modulepreload"
-      href="/en-translations-Dc5XqNPs.js"
-      crossorigin
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div>
-        Hello sku
-        Company name
-      </div>
-    </div>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"language":"en"}
-    </script>
-    <script
-      type="module"
-      src="/en-translations-Dc5XqNPs.js"
-    >
-    </script>
-    <script
-      type="module"
-      src="/vite-client-79htCCWk.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -23,8 +23,7 @@
+@@ -1,47 +1,46 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       rel="modulepreload"
+       href="/vite-client-79htCCWk.js"
+       crossorigin
+     >
+     <link
+       rel="modulepreload"
+       href="/en-translations-Dc5XqNPs.js"
+       crossorigin
+     >
+   </head>
    <body>
      <div id="app">
        <div>
@@ -126,61 +92,53 @@ POST HYDRATE DIFFS:
        </div>
      </div>
      <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"language":"en"}
+     </script>
+     <script
+       type="module"
+       src="/en-translations-Dc5XqNPs.js"
+     >
+     </script>
+     <script
+       type="module"
+       src="/vite-client-79htCCWk.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`translations > bundler vite > should render fr 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      rel="modulepreload"
-      href="/vite-client-79htCCWk.js"
-      crossorigin
-    >
-    <link
-      rel="modulepreload"
-      href="/fr-translations-BhmHAfV8.js"
-      crossorigin
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div>
-        Bonjour sku
-        บริษัท
-      </div>
-    </div>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"language":"fr"}
-    </script>
-    <script
-      type="module"
-      src="/fr-translations-BhmHAfV8.js"
-    >
-    </script>
-    <script
-      type="module"
-      src="/vite-client-79htCCWk.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -23,8 +23,7 @@
+@@ -1,47 +1,46 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       rel="modulepreload"
+       href="/vite-client-79htCCWk.js"
+       crossorigin
+     >
+     <link
+       rel="modulepreload"
+       href="/fr-translations-BhmHAfV8.js"
+       crossorigin
+     >
+   </head>
    <body>
      <div id="app">
        <div>
@@ -190,61 +148,53 @@ POST HYDRATE DIFFS:
        </div>
      </div>
      <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"language":"fr"}
+     </script>
+     <script
+       type="module"
+       src="/fr-translations-BhmHAfV8.js"
+     >
+     </script>
+     <script
+       type="module"
+       src="/vite-client-79htCCWk.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`translations > bundler vite > should support query parameters 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      rel="modulepreload"
-      href="/vite-client-79htCCWk.js"
-      crossorigin
-    >
-    <link
-      rel="modulepreload"
-      href="/en-translations-Dc5XqNPs.js"
-      crossorigin
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div>
-        Hello sku
-        Company name
-      </div>
-    </div>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"language":"en"}
-    </script>
-    <script
-      type="module"
-      src="/en-translations-Dc5XqNPs.js"
-    >
-    </script>
-    <script
-      type="module"
-      src="/vite-client-79htCCWk.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -23,8 +23,7 @@
+@@ -1,47 +1,46 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       rel="modulepreload"
+       href="/vite-client-79htCCWk.js"
+       crossorigin
+     >
+     <link
+       rel="modulepreload"
+       href="/en-translations-Dc5XqNPs.js"
+       crossorigin
+     >
+   </head>
    <body>
      <div id="app">
        <div>
@@ -254,192 +204,160 @@ POST HYDRATE DIFFS:
        </div>
      </div>
      <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"language":"en"}
+     </script>
+     <script
+       type="module"
+       src="/en-translations-Dc5XqNPs.js"
+     >
+     </script>
+     <script
+       type="module"
+       src="/vite-client-79htCCWk.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`translations > bundler webpack > should render en 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/5.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/main.js"
-    >
-    <link
-      data-chunk="en-translations"
-      rel="preload"
-      as="script"
-      href="/en-translations.chunk.js"
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div>
-        Hello sku
-        Company name
-      </div>
-    </div>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"language":"en"}
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      [1]
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":["en-translations"]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/5.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/main.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="en-translations"
-      src="/en-translations.chunk.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: NO DIFF
-`;
-
-exports[`translations > bundler webpack > should render en-PSEUDO post-hydration 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/5.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/main.js"
-    >
-    <link
-      data-chunk="en-translations"
-      rel="preload"
-      as="script"
-      href="/en-translations.chunk.js"
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div>
-        Hello sku
-        Company name
-      </div>
-    </div>
-    <script
-      id="__SKU_CLIENT_CONTEXT__"
-      type="application/json"
-    >
-      {"language":"en"}
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      [1]
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":["en-translations"]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/5.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/main.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="en-translations"
-      src="/en-translations.chunk.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -37,8 +37,7 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>
+      My Awesome Project
+    </title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1"
+    >
+    <link
+      data-chunk="main"
+      rel="preload"
+      as="script"
+      href="/runtime.js"
+    >
+    <link
+      data-chunk="main"
+      rel="preload"
+      as="script"
+      href="/5.js"
+    >
+    <link
+      data-chunk="main"
+      rel="preload"
+      as="script"
+      href="/main.js"
+    >
+    <link
+      data-chunk="en-translations"
+      rel="preload"
+      as="script"
+      href="/en-translations.chunk.js"
+    >
+  </head>
+  <body>
+    <div id="app">
+      <div>
+        Hello sku
+        Company name
+      </div>
+    </div>
+    <script
+      id="__SKU_CLIENT_CONTEXT__"
+      type="application/json"
+    >
+      {"language":"en"}
+    </script>
+    <script
+      id="__LOADABLE_REQUIRED_CHUNKS__"
+      type="application/json"
+    >
+      [1]
+    </script>
+    <script
+      id="__LOADABLE_REQUIRED_CHUNKS___ext"
+      type="application/json"
+    >
+      {"namedChunks":["en-translations"]}
+    </script>
+    <script
+      async
+      data-chunk="main"
+      src="/runtime.js"
+    >
+    </script>
+    <script
+      async
+      data-chunk="main"
+      src="/5.js"
+    >
+    </script>
+    <script
+      async
+      data-chunk="main"
+      src="/main.js"
+    >
+    </script>
+    <script
+      async
+      data-chunk="en-translations"
+      src="/en-translations.chunk.js"
+    >
+    </script>
+  </body>
+</html>
+`;
+
+exports[`translations > bundler webpack > should render en-PSEUDO post-hydration 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -1,87 +1,86 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/5.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/main.js"
+     >
+     <link
+       data-chunk="en-translations"
+       rel="preload"
+       as="script"
+       href="/en-translations.chunk.js"
+     >
+   </head>
    <body>
      <div id="app">
        <div>
@@ -449,9 +367,56 @@ POST HYDRATE DIFFS:
        </div>
      </div>
      <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"language":"en"}
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       [1]
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":["en-translations"]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/5.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/main.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="en-translations"
+       src="/en-translations.chunk.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`translations > bundler webpack > should render fr 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -539,10 +504,12 @@ exports[`translations > bundler webpack > should render fr 1`] = `
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;
 
 exports[`translations > bundler webpack > should support query parameters 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
 <!DOCTYPE html>
 <html>
   <head>
@@ -630,5 +597,4 @@ exports[`translations > bundler webpack > should support query parameters 1`] = 
     </script>
   </body>
 </html>
-POST HYDRATE DIFFS: NO DIFF
 `;

--- a/tests/browser/__snapshots__/typescript-css-modules.test.ts.snap
+++ b/tests/browser/__snapshots__/typescript-css-modules.test.ts.snap
@@ -1,93 +1,53 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`typescript-css-modules > build > should create valid app 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="stylesheet"
-      href="/static/typescript/main-4bad37555f2de4beeb21.css"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/static/typescript/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/static/typescript/2.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/static/typescript/main.js"
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div class="_19hsk3y0">
-        <div
-          class="_19hsk3y1"
-          data-automation-text="true"
-        >
-          Hello World
-        </div>
-        <div>
-          Render type:
-          Initial
-        </div>
-      </div>
-    </div>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      []
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":[]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/static/typescript/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/static/typescript/2.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/static/typescript/main.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -44,7 +44,7 @@
+@@ -1,82 +1,82 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="stylesheet"
+       href="/static/typescript/main-4bad37555f2de4beeb21.css"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/static/typescript/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/static/typescript/2.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/static/typescript/main.js"
+     >
+   </head>
+   <body>
+     <div id="app">
+       <div class="_19hsk3y0">
+         <div
+           class="_19hsk3y1"
+           data-automation-text="true"
+         >
+           Hello World
          </div>
          <div>
            Render type:
@@ -96,6 +56,39 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/static/typescript/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/static/typescript/2.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/static/typescript/main.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`typescript-css-modules > build > should generate the expected files 1`] = `
@@ -210,101 +203,56 @@ SOURCE HTML: <!DOCTYPE html>
 `;
 
 exports[`typescript-css-modules > build-ssr > should create valid app 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="stylesheet"
-      href="http://localhost:4003/main-4bad37555f2de4beeb21.css"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="http://localhost:4003/runtime.js"
-      crossorigin="anonymous"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="http://localhost:4003/2.js"
-      crossorigin="anonymous"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="http://localhost:4003/main.js"
-      crossorigin="anonymous"
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div class="_19hsk3y0">
-        <div
-          class="_19hsk3y1"
-          data-automation-text="true"
-        >
-          Hello World
-        </div>
-        <div>
-          Render type:
-          Initial
-        </div>
-      </div>
-    </div>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-      crossorigin="anonymous"
-    >
-      []
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-      crossorigin="anonymous"
-    >
-      {"namedChunks":[]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="http://localhost:4003/runtime.js"
-      crossorigin="anonymous"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="http://localhost:4003/2.js"
-      crossorigin="anonymous"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="http://localhost:4003/main.js"
-      crossorigin="anonymous"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -47,7 +47,7 @@
+@@ -1,90 +1,90 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="stylesheet"
+       href="http://localhost:4003/main-4bad37555f2de4beeb21.css"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="http://localhost:4003/runtime.js"
+       crossorigin="anonymous"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="http://localhost:4003/2.js"
+       crossorigin="anonymous"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="http://localhost:4003/main.js"
+       crossorigin="anonymous"
+     >
+   </head>
+   <body>
+     <div id="app">
+       <div class="_19hsk3y0">
+         <div
+           class="_19hsk3y1"
+           data-automation-text="true"
+         >
+           Hello World
          </div>
          <div>
            Render type:
@@ -313,6 +261,44 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+       crossorigin="anonymous"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+       crossorigin="anonymous"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="http://localhost:4003/runtime.js"
+       crossorigin="anonymous"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="http://localhost:4003/2.js"
+       crossorigin="anonymous"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="http://localhost:4003/main.js"
+       crossorigin="anonymous"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`typescript-css-modules > build-ssr > should generate the expected files 1`] = `
@@ -334,93 +320,53 @@ exports[`typescript-css-modules > build-ssr > should generate the expected files
 `;
 
 exports[`typescript-css-modules > start > should start a development server 1`] = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      My Awesome Project
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <link
-      data-chunk="main"
-      rel="stylesheet"
-      href="/main.css"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/2.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/main.js"
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div class="styles_root__19hsk3y0">
-        <div
-          class="styles_nested__19hsk3y1"
-          data-automation-text="true"
-        >
-          Hello World
-        </div>
-        <div>
-          Render type:
-          Initial
-        </div>
-      </div>
-    </div>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      []
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":[]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/2.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/main.js"
-    >
-    </script>
-  </body>
-</html>
-POST HYDRATE DIFFS: 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -44,7 +44,7 @@
+@@ -1,82 +1,82 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       My Awesome Project
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="stylesheet"
+       href="/main.css"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/2.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/main.js"
+     >
+   </head>
+   <body>
+     <div id="app">
+       <div class="styles_root__19hsk3y0">
+         <div
+           class="styles_nested__19hsk3y1"
+           data-automation-text="true"
+         >
+           Hello World
          </div>
          <div>
            Render type:
@@ -429,4 +375,37 @@ POST HYDRATE DIFFS:
          </div>
        </div>
      </div>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/2.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/main.js"
+     >
+     </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;

--- a/tests/browser/braid-design-system.test.ts
+++ b/tests/browser/braid-design-system.test.ts
@@ -4,6 +4,7 @@ import {
   it,
   expect as globalExpect,
   afterAll,
+  beforeEach,
   vi,
 } from 'vitest';
 import { dirContentsToObject, getPort } from '@sku-private/test-utils';
@@ -31,9 +32,20 @@ function getLocalUrl(site: string, port: number) {
   return `http://${host}:${port}`;
 }
 
-const { sku, fixturePath } = scopeToFixture('braid-design-system');
+const { sku, exec, fixturePath } = scopeToFixture('braid-design-system');
+
+const removeCache = async () => {
+  // remove the cache directory before building to ensure consistent results
+  await exec('rm -rf node_modules/.cache');
+  await exec('rm -rf node_modules/.vite');
+  await exec('rm -rf dist');
+};
 
 describe('braid-design-system', () => {
+  beforeEach(async () => {
+    await vitestPuppeteer.resetBrowser();
+  });
+
   describe.sequential.for(bundlers)('bundler %s', (bundler) => {
     describe('start', async () => {
       const port = await getPort();
@@ -50,6 +62,8 @@ describe('braid-design-system', () => {
       };
 
       beforeAll(async () => {
+        await removeCache();
+
         const start = await sku('start', args[bundler]);
         globalExpect(
           await start.findByText(
@@ -95,6 +109,8 @@ describe('braid-design-system', () => {
       };
 
       beforeAll(async () => {
+        await removeCache();
+
         const build = await sku('build', args[bundler]);
         globalExpect(
           await build.findByText('Sku build complete', {}, { timeout }),

--- a/vitest-puppeteer.config.js
+++ b/vitest-puppeteer.config.js
@@ -3,4 +3,5 @@ export default {
     headless: true,
     acceptInsecureCerts: true,
   },
+  browserContext: 'incognito',
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,13 +31,29 @@ export default defineConfig({
           ],
         },
       },
+      // Isolate braid to reduce flakiness.
+      {
+        extends: true,
+        test: {
+          name: 'braid-design-system',
+          environment: 'puppeteer',
+          globalSetup: 'vitest-environment-puppeteer/global-init',
+          include: [`tests/browser/braid-design-system.test.ts`],
+          sequence: {
+            groupOrder: -1,
+          },
+        },
+      },
       {
         extends: true,
         test: {
           name: 'browser',
           environment: 'puppeteer',
           globalSetup: 'vitest-environment-puppeteer/global-init',
-          include: [`tests/browser/${defaultInclude}`],
+          include: [
+            `tests/browser/${defaultInclude}`,
+            '!tests/browser/braid-design-system.test.ts',
+          ],
         },
       },
     ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     },
   },
   test: {
+    cache: false,
     setupFiles: ['./vitest-setup.ts'],
     // Increasing the number so functions using TEST_TIMEOUT can timeout before the test does.
     hookTimeout: TEST_TIMEOUT + 1000,
@@ -28,9 +29,6 @@ export default defineConfig({
             `private/${defaultInclude}`,
             `tests/node/${defaultInclude}`,
           ],
-          sequence: {
-            groupOrder: 0,
-          },
         },
       },
       {
@@ -40,9 +38,6 @@ export default defineConfig({
           environment: 'puppeteer',
           globalSetup: 'vitest-environment-puppeteer/global-init',
           include: [`tests/browser/${defaultInclude}`],
-          sequence: {
-            groupOrder: 0,
-          },
         },
       },
     ],


### PR DESCRIPTION
Making some changes to try to reduce flakiness on the snapshots.

* I've changed how diffs work a little. Rather than outputting a seperate "POST HYDRATE DIFFS" section, the diffs will display inline. This makes it a lot easier to tell where the diffs are actually present in the dom and makes reviewing changes easier to read. This makes most of the snapshots a little smaller as well. 
* Disabled caching in puppeteer. This was causing some flakiness and also making a false positive appear in the ssr-hello-world test. The explicit publicPath makes the urls fail on the custom-port test, but puppeteer wasn't raising warning because of the cache it seems.
* I've isolated the braid tests. I removed this at one point, but I'm adding it back since they are too inconstant when run with everything else. I'm also resetting the browser object and deleting the cache just in case (now I don't trust anything 🙈)
* Turned on incognito mode for puppeteer. I don't know if this will help, but turning it on just in case some caching is playing with the snapshots.