### PR TITLE
`init`: fixing non-pinned deps

### DIFF
--- a/.changeset/lemon-bags-unite.md
+++ b/.changeset/lemon-bags-unite.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`init`: dependencies will now correctly be pinned in workspaces

--- a/packages/sku/src/program/commands/init/init.action.ts
+++ b/packages/sku/src/program/commands/init/init.action.ts
@@ -205,7 +205,13 @@ export const initAction = async (
     }),
   );
 
-  const deps = ['braid-design-system', 'react', 'react-dom'];
+  // By default, deps will installed with an exact version. However, this doesn't seem to work without specifying a version.
+  // Adding @latest pins the version.
+  const deps = [
+    'braid-design-system@latest',
+    'react@latest',
+    'react-dom@latest',
+  ];
 
   const devDeps = [
     '@vanilla-extract/css',


### PR DESCRIPTION
When running `sku init` inside a workspace, dependancies are not pinned unless a version is specified. sku has an [install](https://github.com/seek-oss/sku/blob/1ade4818388a82c9182249d9be045a9cb97792d3/packages/sku/src/services/packageManager/install.ts#L9) command that has `exact` set to **true** by default. That _should_ pin dependancies ([here](https://github.com/seek-oss/sku/blob/master/packages/sku/src/services/packageManager/packageManager.ts#L167-L170)), but it doesn't seem to work without a version specified (`@latest` in this case)

This can be seen when running the sku-init test without doing cleanup and checking out the package.json generated.