### PR TITLE
Move"rootResolution" to the webpack config types

### DIFF
--- a/.changeset/lucky-times-appear.md
+++ b/.changeset/lucky-times-appear.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`types`: Sku config has better type safety for webpack and (experimental) vite options

--- a/.changeset/tidy-papers-read.md
+++ b/.changeset/tidy-papers-read.md
@@ -2,6 +2,6 @@
 'sku': patch
 ---
 
-`sku init`: Specify an exact version of `sku` when isntalling dependencies
+`sku init`: Specify an exact version of `sku` when installing dependencies
 
 This fixes an issue where running `sku init` with a snapshot version of `sku` would install the latest version of `sku` instead of the specified version.

--- a/.changeset/wide-insects-retire.md
+++ b/.changeset/wide-insects-retire.md
@@ -2,4 +2,4 @@
 'sku': patch
 ---
 
-`vite start`: Inline Vanilla Extract CSS to fix FOUC
+`vite start`: Inline Vanilla Extract CSS to fix flash of unstyled text

--- a/packages/sku/src/types/types.ts
+++ b/packages/sku/src/types/types.ts
@@ -357,19 +357,6 @@ export interface SkuConfigBase {
   renderEntry?: string;
 
   /**
-   * Enables root resolution.
-   *
-   * By default, sku allows importing from the root of the project e.g. `import something from 'src/modules/something'`.
-   *
-   * Unfortunately, these kinds of imports only work for apps.
-   * In packages, the imports will work locally, but fail when consumed from `node_modules`.
-   *
-   * @default true
-   * @link https://seek-oss.github.io/sku/#/./docs/configuration?id=rootresolution
-   */
-  rootResolution?: boolean;
-
-  /**
    * **Only for static apps**
    *
    * An array of routes for the app. Each route must specify a name and a route corresponding to the path it is hosted under. Each route may also have a custom client entry, which can help with bundle splitting. See static-rendering for more info.
@@ -505,6 +492,19 @@ export interface WebpackSkuConfig {
    * @link https://seek-oss.github.io/sku/#/./docs/configuration?id=dangerouslysetwebpackconfig
    */
   dangerouslySetWebpackConfig?: (skuWebpackConfig: any) => any;
+
+  /**
+   * Enables root resolution.
+   *
+   * By default, sku allows importing from the root of the project e.g. `import something from 'src/modules/something'`.
+   *
+   * Unfortunately, these kinds of imports only work for apps.
+   * In packages, the imports will work locally, but fail when consumed from `node_modules`.
+   *
+   * @default true
+   * @link https://seek-oss.github.io/sku/#/./docs/configuration?id=rootresolution
+   */
+  rootResolution?: boolean;
 }
 
 export interface ViteSkuConfig {


### PR DESCRIPTION
The new `pathAliases` field deprecated `rootResolution` in the vite config, so it is now only a webpack option. Moving it to the webpack types to show this.

I've also added a changeset for the type changes that happened in #1339. There is a changeset for the new field in that PR, but I thought it would be nice to have one for the config separation since it's a QOL improvement for the user.

Fixed a typo too.