### PR TITLE
Isolate `storybook-config` tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,11 @@ import { TEST_TIMEOUT } from '@sku-private/test-utils/constants';
 
 const defaultInclude = '**/*.{test,spec}.?(c|m)[jt]s?(x)';
 
+const flakeyTestGlobs = [
+  'tests/browser/braid-design-system.test.ts',
+  'tests/browser/storybook-config.test.ts',
+];
+
 export default defineConfig({
   plugins: [tsconfigPaths()],
   server: {
@@ -37,10 +42,7 @@ export default defineConfig({
           name: 'flakey',
           environment: 'puppeteer',
           globalSetup: 'vitest-environment-puppeteer/global-init',
-          include: [
-            'tests/browser/braid-design-system.test.ts',
-            'tests/browser/storybook-config.test.ts',
-          ],
+          include: flakeyTestGlobs,
           sequence: {
             groupOrder: -1,
           },
@@ -54,8 +56,7 @@ export default defineConfig({
           globalSetup: 'vitest-environment-puppeteer/global-init',
           include: [
             `tests/browser/${defaultInclude}`,
-            '!tests/browser/braid-design-system.test.ts',
-            '!tests/browser/storybook-config.test.ts',
+            ...flakeyTestGlobs.map((g) => `!${g}`),
           ],
         },
       },


### PR DESCRIPTION
`storybook-config` tests are flakey all of a sudden. Locally they're fine, but when running alongside other tests in CI they hit the test timeout.

Grouping them with the `braid-design-system` tests seems work alright. 