### PR TITLE
`sku configure`: Don't emit `.npmrc` warning on CI

### DIFF
--- a/.changeset/olive-knives-judge.md
+++ b/.changeset/olive-knives-judge.md
@@ -1,0 +1,7 @@
+---
+'sku': patch
+---
+
+Don't emit `.npmrc` validation warning on CI
+
+`.npmrc` files may be generated on CI, causing a false positive

--- a/packages/sku/src/services/packageManager/__snapshots__/pnpmConfig.test.ts.snap
+++ b/packages/sku/src/services/packageManager/__snapshots__/pnpmConfig.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: false > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -19,7 +19,7 @@ exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExis
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: false > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
 [
   [
     "
@@ -38,7 +38,7 @@ exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExis
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: false > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -55,9 +55,9 @@ exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExis
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
+exports[`validatePnpmConfig > When isCI: false > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
 
-exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: false > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -89,7 +89,7 @@ exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExis
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: false > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
 [
   [
     "
@@ -121,7 +121,7 @@ exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExis
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: false > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -151,7 +151,7 @@ exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExis
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: false > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
 [
   [
     "
@@ -169,7 +169,7 @@ exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExis
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: true > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -188,7 +188,7 @@ exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExist
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: true > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
 [
   [
     "
@@ -207,7 +207,7 @@ exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExist
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: true > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -224,28 +224,9 @@ exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExist
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
+exports[`validatePnpmConfig > When isCI: true > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
 
-exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
-[
-  [
-    "
---------------------------------------------------------------------------------
-
-    pnpm-plugin-sku is not configured correctly
-
-    Please ensure you are on PNPM v10.13.0 or later.
-
-    Please delete your top-level node_modules and run "pnpm add --config
-    pnpm-plugin-sku && pnpm install".
-
---------------------------------------------------------------------------------
-  ",
-  ],
-]
-`;
-
-exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: true > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -264,7 +245,26 @@ exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExist
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: true > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+[
+  [
+    "
+--------------------------------------------------------------------------------
+
+    pnpm-plugin-sku is not configured correctly
+
+    Please ensure you are on PNPM v10.13.0 or later.
+
+    Please delete your top-level node_modules and run "pnpm add --config
+    pnpm-plugin-sku && pnpm install".
+
+--------------------------------------------------------------------------------
+  ",
+  ],
+]
+`;
+
+exports[`validatePnpmConfig > When isCI: true > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -281,4 +281,4 @@ exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExist
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
+exports[`validatePnpmConfig > When isCI: true > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;

--- a/packages/sku/src/services/packageManager/__snapshots__/pnpmConfig.test.ts.snap
+++ b/packages/sku/src/services/packageManager/__snapshots__/pnpmConfig.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`validatePnpmConfig > when in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -19,7 +19,7 @@ exports[`validatePnpmConfig > when in CI > when npmrcExists: false, hasRecommend
 ]
 `;
 
-exports[`validatePnpmConfig > when in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
 [
   [
     "
@@ -38,7 +38,7 @@ exports[`validatePnpmConfig > when in CI > when npmrcExists: false, hasRecommend
 ]
 `;
 
-exports[`validatePnpmConfig > when in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -55,123 +55,9 @@ exports[`validatePnpmConfig > when in CI > when npmrcExists: false, hasRecommend
 ]
 `;
 
-exports[`validatePnpmConfig > when in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
+exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
 
-exports[`validatePnpmConfig > when in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
-[
-  [
-    "
---------------------------------------------------------------------------------
-
-    pnpm-plugin-sku is not configured correctly
-
-    Please ensure you are on PNPM v10.13.0 or later.
-
-    Please delete your top-level node_modules and run "pnpm add --config
-    pnpm-plugin-sku && pnpm install".
-
---------------------------------------------------------------------------------
-  ",
-  ],
-]
-`;
-
-exports[`validatePnpmConfig > when in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
-[
-  [
-    "
---------------------------------------------------------------------------------
-
-    pnpm-plugin-sku is not configured correctly
-
-    Please ensure you are on PNPM v10.13.0 or later.
-
-    Please delete your top-level node_modules and run "pnpm add --config
-    pnpm-plugin-sku && pnpm install".
-
---------------------------------------------------------------------------------
-  ",
-  ],
-]
-`;
-
-exports[`validatePnpmConfig > when in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
-[
-  [
-    "
---------------------------------------------------------------------------------
-
-    pnpm-plugin-sku is not configured correctly
-
-    Please delete your top-level node_modules and run "pnpm add --config
-    pnpm-plugin-sku && pnpm install".
-
---------------------------------------------------------------------------------
-  ",
-  ],
-]
-`;
-
-exports[`validatePnpmConfig > when in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
-
-exports[`validatePnpmConfig > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
-[
-  [
-    "
---------------------------------------------------------------------------------
-
-    pnpm-plugin-sku is not configured correctly
-
-    Please ensure you are on PNPM v10.13.0 or later.
-
-    Please delete your top-level node_modules and run "pnpm add --config
-    pnpm-plugin-sku && pnpm install".
-
---------------------------------------------------------------------------------
-  ",
-  ],
-]
-`;
-
-exports[`validatePnpmConfig > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
-[
-  [
-    "
---------------------------------------------------------------------------------
-
-    pnpm-plugin-sku is not configured correctly
-
-    Please ensure you are on PNPM v10.13.0 or later.
-
-    Please delete your top-level node_modules and run "pnpm add --config
-    pnpm-plugin-sku && pnpm install".
-
---------------------------------------------------------------------------------
-  ",
-  ],
-]
-`;
-
-exports[`validatePnpmConfig > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
-[
-  [
-    "
---------------------------------------------------------------------------------
-
-    pnpm-plugin-sku is not configured correctly
-
-    Please delete your top-level node_modules and run "pnpm add --config
-    pnpm-plugin-sku && pnpm install".
-
---------------------------------------------------------------------------------
-  ",
-  ],
-]
-`;
-
-exports[`validatePnpmConfig > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
-
-exports[`validatePnpmConfig > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -203,7 +89,7 @@ exports[`validatePnpmConfig > when not in CI > when npmrcExists: true, hasRecomm
 ]
 `;
 
-exports[`validatePnpmConfig > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
 [
   [
     "
@@ -235,7 +121,7 @@ exports[`validatePnpmConfig > when not in CI > when npmrcExists: true, hasRecomm
 ]
 `;
 
-exports[`validatePnpmConfig > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -265,7 +151,7 @@ exports[`validatePnpmConfig > when not in CI > when npmrcExists: true, hasRecomm
 ]
 `;
 
-exports[`validatePnpmConfig > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > When isCI: false > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
 [
   [
     "
@@ -282,3 +168,117 @@ exports[`validatePnpmConfig > when not in CI > when npmrcExists: true, hasRecomm
   ],
 ]
 `;
+
+exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+[
+  [
+    "
+--------------------------------------------------------------------------------
+
+    pnpm-plugin-sku is not configured correctly
+
+    Please ensure you are on PNPM v10.13.0 or later.
+
+    Please delete your top-level node_modules and run "pnpm add --config
+    pnpm-plugin-sku && pnpm install".
+
+--------------------------------------------------------------------------------
+  ",
+  ],
+]
+`;
+
+exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+[
+  [
+    "
+--------------------------------------------------------------------------------
+
+    pnpm-plugin-sku is not configured correctly
+
+    Please ensure you are on PNPM v10.13.0 or later.
+
+    Please delete your top-level node_modules and run "pnpm add --config
+    pnpm-plugin-sku && pnpm install".
+
+--------------------------------------------------------------------------------
+  ",
+  ],
+]
+`;
+
+exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+[
+  [
+    "
+--------------------------------------------------------------------------------
+
+    pnpm-plugin-sku is not configured correctly
+
+    Please delete your top-level node_modules and run "pnpm add --config
+    pnpm-plugin-sku && pnpm install".
+
+--------------------------------------------------------------------------------
+  ",
+  ],
+]
+`;
+
+exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
+
+exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+[
+  [
+    "
+--------------------------------------------------------------------------------
+
+    pnpm-plugin-sku is not configured correctly
+
+    Please ensure you are on PNPM v10.13.0 or later.
+
+    Please delete your top-level node_modules and run "pnpm add --config
+    pnpm-plugin-sku && pnpm install".
+
+--------------------------------------------------------------------------------
+  ",
+  ],
+]
+`;
+
+exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+[
+  [
+    "
+--------------------------------------------------------------------------------
+
+    pnpm-plugin-sku is not configured correctly
+
+    Please ensure you are on PNPM v10.13.0 or later.
+
+    Please delete your top-level node_modules and run "pnpm add --config
+    pnpm-plugin-sku && pnpm install".
+
+--------------------------------------------------------------------------------
+  ",
+  ],
+]
+`;
+
+exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+[
+  [
+    "
+--------------------------------------------------------------------------------
+
+    pnpm-plugin-sku is not configured correctly
+
+    Please delete your top-level node_modules and run "pnpm add --config
+    pnpm-plugin-sku && pnpm install".
+
+--------------------------------------------------------------------------------
+  ",
+  ],
+]
+`;
+
+exports[`validatePnpmConfig > When isCI: true > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;

--- a/packages/sku/src/services/packageManager/__snapshots__/pnpmConfig.test.ts.snap
+++ b/packages/sku/src/services/packageManager/__snapshots__/pnpmConfig.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`validatePnpmConfig > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > when in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -19,7 +19,7 @@ exports[`validatePnpmConfig > when npmrcExists: false, hasRecommendedPnpmVersion
 ]
 `;
 
-exports[`validatePnpmConfig > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > when in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
 [
   [
     "
@@ -38,7 +38,7 @@ exports[`validatePnpmConfig > when npmrcExists: false, hasRecommendedPnpmVersion
 ]
 `;
 
-exports[`validatePnpmConfig > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > when in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -55,9 +55,123 @@ exports[`validatePnpmConfig > when npmrcExists: false, hasRecommendedPnpmVersion
 ]
 `;
 
-exports[`validatePnpmConfig > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
+exports[`validatePnpmConfig > when in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
 
-exports[`validatePnpmConfig > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > when in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+[
+  [
+    "
+--------------------------------------------------------------------------------
+
+    pnpm-plugin-sku is not configured correctly
+
+    Please ensure you are on PNPM v10.13.0 or later.
+
+    Please delete your top-level node_modules and run "pnpm add --config
+    pnpm-plugin-sku && pnpm install".
+
+--------------------------------------------------------------------------------
+  ",
+  ],
+]
+`;
+
+exports[`validatePnpmConfig > when in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+[
+  [
+    "
+--------------------------------------------------------------------------------
+
+    pnpm-plugin-sku is not configured correctly
+
+    Please ensure you are on PNPM v10.13.0 or later.
+
+    Please delete your top-level node_modules and run "pnpm add --config
+    pnpm-plugin-sku && pnpm install".
+
+--------------------------------------------------------------------------------
+  ",
+  ],
+]
+`;
+
+exports[`validatePnpmConfig > when in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+[
+  [
+    "
+--------------------------------------------------------------------------------
+
+    pnpm-plugin-sku is not configured correctly
+
+    Please delete your top-level node_modules and run "pnpm add --config
+    pnpm-plugin-sku && pnpm install".
+
+--------------------------------------------------------------------------------
+  ",
+  ],
+]
+`;
+
+exports[`validatePnpmConfig > when in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
+
+exports[`validatePnpmConfig > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+[
+  [
+    "
+--------------------------------------------------------------------------------
+
+    pnpm-plugin-sku is not configured correctly
+
+    Please ensure you are on PNPM v10.13.0 or later.
+
+    Please delete your top-level node_modules and run "pnpm add --config
+    pnpm-plugin-sku && pnpm install".
+
+--------------------------------------------------------------------------------
+  ",
+  ],
+]
+`;
+
+exports[`validatePnpmConfig > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+[
+  [
+    "
+--------------------------------------------------------------------------------
+
+    pnpm-plugin-sku is not configured correctly
+
+    Please ensure you are on PNPM v10.13.0 or later.
+
+    Please delete your top-level node_modules and run "pnpm add --config
+    pnpm-plugin-sku && pnpm install".
+
+--------------------------------------------------------------------------------
+  ",
+  ],
+]
+`;
+
+exports[`validatePnpmConfig > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+[
+  [
+    "
+--------------------------------------------------------------------------------
+
+    pnpm-plugin-sku is not configured correctly
+
+    Please delete your top-level node_modules and run "pnpm add --config
+    pnpm-plugin-sku && pnpm install".
+
+--------------------------------------------------------------------------------
+  ",
+  ],
+]
+`;
+
+exports[`validatePnpmConfig > when not in CI > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
+
+exports[`validatePnpmConfig > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -89,7 +203,7 @@ exports[`validatePnpmConfig > when npmrcExists: true, hasRecommendedPnpmVersionI
 ]
 `;
 
-exports[`validatePnpmConfig > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
 [
   [
     "
@@ -121,7 +235,7 @@ exports[`validatePnpmConfig > when npmrcExists: true, hasRecommendedPnpmVersionI
 ]
 `;
 
-exports[`validatePnpmConfig > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -151,7 +265,7 @@ exports[`validatePnpmConfig > when npmrcExists: true, hasRecommendedPnpmVersionI
 ]
 `;
 
-exports[`validatePnpmConfig > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > when not in CI > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
 [
   [
     "

--- a/packages/sku/src/services/packageManager/pnpmConfig.test.ts
+++ b/packages/sku/src/services/packageManager/pnpmConfig.test.ts
@@ -6,12 +6,11 @@ import { validatePnpmConfig } from './pnpmConfig.js';
 
 describe('validatePnpmConfig', () => {
   describe.for([true, false])('When isCI: $0', (mockedIsCI) => {
-    describe('when not in CI', () => {
-      beforeEach(() => {
-        vi.spyOn(ci, 'default', 'get').mockReturnValue(mockedIsCI);
-      });
+    beforeEach(() => {
+      vi.spyOn(ci, 'default', 'get').mockReturnValue(mockedIsCI);
+    });
 
-      describe.for`
+    describe.for`
     npmrcExists | hasRecommendedPnpmVersionInstalled | pnpmPluginSkuInstalled
     ${false}    | ${false}                           | ${false}
     ${false}    | ${false}                           | ${true}
@@ -22,32 +21,31 @@ describe('validatePnpmConfig', () => {
     ${true}     | ${true}                            | ${false}
     ${true}     | ${true}                            | ${true}
   `(
-        'when npmrcExists: $npmrcExists, hasRecommendedPnpmVersionInstalled: $hasRecommendedPnpmVersionInstalled, pnpmPluginSkuInstalled: $pnpmPluginSkuInstalled',
-        ({
-          npmrcExists,
-          hasRecommendedPnpmVersionInstalled,
-          pnpmPluginSkuInstalled,
-        }) => {
-          it('should log appropriate messages', async ({ expect }) => {
-            const logSpy = vi
-              .spyOn(global.console, 'log')
-              .mockImplementation(() => {});
+      'when npmrcExists: $npmrcExists, hasRecommendedPnpmVersionInstalled: $hasRecommendedPnpmVersionInstalled, pnpmPluginSkuInstalled: $pnpmPluginSkuInstalled',
+      ({
+        npmrcExists,
+        hasRecommendedPnpmVersionInstalled,
+        pnpmPluginSkuInstalled,
+      }) => {
+        it('should log appropriate messages', async ({ expect }) => {
+          const logSpy = vi
+            .spyOn(global.console, 'log')
+            .mockImplementation(() => {});
 
-            const fileTree: FileTree = npmrcExists ? { '.npmrc': '' } : {};
-            await using fixture = await createFixture(fileTree);
+          const fileTree: FileTree = npmrcExists ? { '.npmrc': '' } : {};
+          await using fixture = await createFixture(fileTree);
 
-            const rootDir = fixture.path;
+          const rootDir = fixture.path;
 
-            await validatePnpmConfig({
-              rootDir,
-              hasRecommendedPnpmVersionInstalled,
-              pnpmPluginSkuInstalled,
-            });
-
-            expect(logSpy.mock.calls).toMatchSnapshot();
+          await validatePnpmConfig({
+            rootDir,
+            hasRecommendedPnpmVersionInstalled,
+            pnpmPluginSkuInstalled,
           });
-        },
-      );
-    });
+
+          expect(logSpy.mock.calls).toMatchSnapshot();
+        });
+      },
+    );
   });
 });

--- a/packages/sku/src/services/packageManager/pnpmConfig.test.ts
+++ b/packages/sku/src/services/packageManager/pnpmConfig.test.ts
@@ -1,10 +1,16 @@
-import { describe, it, vi } from 'vitest';
+import { describe, it, vi, beforeEach } from 'vitest';
 import { createFixture, type FileTree } from 'fs-fixture';
+import * as ci from '../../utils/isCI.js';
 
 import { validatePnpmConfig } from './pnpmConfig.js';
 
 describe('validatePnpmConfig', () => {
-  describe.for`
+  describe('when not in CI', () => {
+    beforeEach(() => {
+      vi.spyOn(ci, 'default', 'get').mockReturnValue(false);
+    });
+
+    describe.for`
     npmrcExists | hasRecommendedPnpmVersionInstalled | pnpmPluginSkuInstalled
     ${false}    | ${false}                           | ${false}
     ${false}    | ${false}                           | ${true}
@@ -15,30 +21,75 @@ describe('validatePnpmConfig', () => {
     ${true}     | ${true}                            | ${false}
     ${true}     | ${true}                            | ${true}
   `(
-    'when npmrcExists: $npmrcExists, hasRecommendedPnpmVersionInstalled: $hasRecommendedPnpmVersionInstalled, pnpmPluginSkuInstalled: $pnpmPluginSkuInstalled',
-    ({
-      npmrcExists,
-      hasRecommendedPnpmVersionInstalled,
-      pnpmPluginSkuInstalled,
-    }) => {
-      it('should log appropriate messages', async ({ expect }) => {
-        const logSpy = vi
-          .spyOn(global.console, 'log')
-          .mockImplementation(() => {});
+      'when npmrcExists: $npmrcExists, hasRecommendedPnpmVersionInstalled: $hasRecommendedPnpmVersionInstalled, pnpmPluginSkuInstalled: $pnpmPluginSkuInstalled',
+      ({
+        npmrcExists,
+        hasRecommendedPnpmVersionInstalled,
+        pnpmPluginSkuInstalled,
+      }) => {
+        it('should log appropriate messages', async ({ expect }) => {
+          const logSpy = vi
+            .spyOn(global.console, 'log')
+            .mockImplementation(() => {});
 
-        const fileTree: FileTree = npmrcExists ? { '.npmrc': '' } : {};
-        await using fixture = await createFixture(fileTree);
+          const fileTree: FileTree = npmrcExists ? { '.npmrc': '' } : {};
+          await using fixture = await createFixture(fileTree);
 
-        const rootDir = fixture.path;
+          const rootDir = fixture.path;
 
-        await validatePnpmConfig({
-          rootDir,
-          hasRecommendedPnpmVersionInstalled,
-          pnpmPluginSkuInstalled,
+          await validatePnpmConfig({
+            rootDir,
+            hasRecommendedPnpmVersionInstalled,
+            pnpmPluginSkuInstalled,
+          });
+
+          expect(logSpy.mock.calls).toMatchSnapshot();
         });
+      },
+    );
+  });
 
-        expect(logSpy.mock.calls).toMatchSnapshot();
-      });
-    },
-  );
+  describe('when in CI', () => {
+    beforeEach(() => {
+      vi.spyOn(ci, 'default', 'get').mockReturnValue(true);
+    });
+
+    describe.for`
+    npmrcExists | hasRecommendedPnpmVersionInstalled | pnpmPluginSkuInstalled
+    ${false}    | ${false}                           | ${false}
+    ${false}    | ${false}                           | ${true}
+    ${false}    | ${true}                            | ${false}
+    ${false}    | ${true}                            | ${true}
+    ${true}     | ${false}                           | ${false}
+    ${true}     | ${false}                           | ${true}
+    ${true}     | ${true}                            | ${false}
+    ${true}     | ${true}                            | ${true}
+  `(
+      'when npmrcExists: $npmrcExists, hasRecommendedPnpmVersionInstalled: $hasRecommendedPnpmVersionInstalled, pnpmPluginSkuInstalled: $pnpmPluginSkuInstalled',
+      ({
+        npmrcExists,
+        hasRecommendedPnpmVersionInstalled,
+        pnpmPluginSkuInstalled,
+      }) => {
+        it('should log appropriate messages', async ({ expect }) => {
+          const logSpy = vi
+            .spyOn(global.console, 'log')
+            .mockImplementation(() => {});
+
+          const fileTree: FileTree = npmrcExists ? { '.npmrc': '' } : {};
+          await using fixture = await createFixture(fileTree);
+
+          const rootDir = fixture.path;
+
+          await validatePnpmConfig({
+            rootDir,
+            hasRecommendedPnpmVersionInstalled,
+            pnpmPluginSkuInstalled,
+          });
+
+          expect(logSpy.mock.calls).toMatchSnapshot();
+        });
+      },
+    );
+  });
 });

--- a/packages/sku/src/services/packageManager/pnpmConfig.ts
+++ b/packages/sku/src/services/packageManager/pnpmConfig.ts
@@ -2,6 +2,7 @@ import banner from '../../utils/banners/banner.js';
 import exists from '../../utils/exists.js';
 import chalk from 'chalk';
 import path from 'node:path';
+import isCI from '../../utils/isCI.js';
 
 const accent = chalk.blue.bold;
 const info = chalk.bold;
@@ -17,7 +18,7 @@ export const validatePnpmConfig = async ({
 }) => {
   const npmrcExists = await exists(path.join(rootDir, '.npmrc'));
 
-  if (npmrcExists) {
+  if (!isCI && npmrcExists) {
     banner('warning', 'Detected .npmrc file', [
       `Please migrate all ${accent('.npmrc')} configuration to ${accent('pnpm-workspace.yaml')} and add ${accent('.npmrc')} to your ${accent('.gitignore')}. See ${info('https://pnpm.io/settings')} for more information.`,
     ]);


### PR DESCRIPTION
`.npmrc` files may be generated on CI, causing this warning to be displayed when really it's not valid. The rest of the PNPM config warnings are fine to emit on CI.