### PR TITLE
Add `fixture` script for running fixture scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,11 +78,17 @@ pnpm run test:update
 > [!TIP]
 > The test suite needs to pass for your changes to be accepted, so it's worth running this locally during development and right before committing.
 
-You can also run any `sku` CLI command against any of the app fixtures.
+You can also run commands directly against any of the app fixtures.
 This can be a faster way to iterate on a feature than rather than running the test suite every time you make a change.
 
-1. `cd` into the fixture you want to test. E.g. `cd fixtures/styling`.
-1. Run your sku command. E.g. `pnpm run sku build`.
+There are 2 ways to run commands against a fixture:
+
+1. Run `pnpm fixture`, select the fixture you want and the `package.json` script to run
+2. `cd` into the fixture and run a command directly. E.g. `cd fixtures/styling && pnpm sku start`.
+
+> [!TIP]
+> `pnpm fixture` lists scripts in a fixture's `package.json` file.
+> If there's a script that's commonly run in a specific fixture, feel free to add it to the `package.json` file.
 
 Once you've made the desired changes and you're ready to commit, stage your local changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,10 +81,11 @@ pnpm run test:update
 You can also run commands directly against any of the app fixtures.
 This can be a faster way to iterate on a feature than rather than running the test suite every time you make a change.
 
-There are 2 ways to run commands against a fixture:
+There are 3 ways to run commands against a fixture:
 
 1. Run `pnpm fixture`, select the fixture you want and the `package.json` script to run
-2. `cd` into the fixture and run a command directly. E.g. `cd fixtures/styling && pnpm sku start`.
+1. Use `pnpm`'s `--filter` flag to target a specific fixture: `pnpm --filter="@sku-fixtures/styling" exec sku start`
+1. `cd` into the fixture and run a command directly: `cd fixtures/styling && pnpm sku start`.
 
 > [!TIP]
 > `pnpm fixture` lists scripts in a fixture's `package.json` file.

--- a/fixtures/assertion-removal/package.json
+++ b/fixtures/assertion-removal/package.json
@@ -6,6 +6,9 @@
     "react": "catalog:",
     "react-dom": "catalog:"
   },
+  "exports": {
+    "./package.json": "./package.json"
+  },
   "devDependencies": {
     "@types/node": "catalog:",
     "@types/react": "catalog:",

--- a/fixtures/styling/package.json
+++ b/fixtures/styling/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "start": "storybook dev --ci --exact-port --port 8090"
   },
+  "exports": {
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@sku-fixtures/package-with-styles": "./fake/node_modules/package-with-styles",
     "react": "catalog:",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:tsc:sku": "pnpm --filter 'sku' lint:tsc",
     "build": "pnpm --filter './packages/**' build",
     "check": "pnpm install --frozen-lockfile && echo 'Ignore paths from lint-staged'",
+    "fixture": "pnpm --filter '@sku-private/scripts' fixture",
     "test": "SKU_TELEMETRY=false SKU_DISABLE_CACHE=true OPEN_TAB=false vitest run",
     "test:update": "SKU_TELEMETRY=false SKU_DISABLE_CACHE=true OPEN_TAB=false vitest run -u",
     "setup-test-hosts": "tsx private/test-utils/setupTestHosts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1359,6 +1359,21 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
 
+  private/scripts:
+    devDependencies:
+      '@clack/prompts':
+        specifier: 1.0.0-alpha.4
+        version: 1.0.0-alpha.4
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
+      tsx:
+        specifier: ^4.19.4
+        version: 4.20.3
+
   private/test-utils:
     devDependencies:
       '@types/hostile':
@@ -2238,6 +2253,12 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@clack/core@1.0.0-alpha.4':
+    resolution: {integrity: sha512-VCtU+vjyKPMSakVrB9q1bOnXN7QW/w4+YQDQCOF59GrzydW+169i0fVx/qzRRXJgt8KGj/pZZ/JxXroFZIDByg==}
+
+  '@clack/prompts@1.0.0-alpha.4':
+    resolution: {integrity: sha512-KnmtDF2xQGoI5AlBme9akHtvCRV0RKAARUXHBQO2tMwnY8B08/4zPWigT7uLK25UPrMCEqnyQPkKRjNdhPbf8g==}
 
   '@csstools/color-helpers@5.0.2':
     resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
@@ -10320,6 +10341,17 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.1
       prettier: 2.8.8
+
+  '@clack/core@1.0.0-alpha.4':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.0.0-alpha.4':
+    dependencies:
+      '@clack/core': 1.0.0-alpha.4
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@csstools/color-helpers@5.0.2': {}
 

--- a/private/scripts/package.json
+++ b/private/scripts/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@sku-private/scripts",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "fixture": "tsx ./src/fixture.ts"
+  },
+  "devDependencies": {
+    "@clack/prompts": "1.0.0-alpha.4",
+    "@types/cross-spawn": "^6.0.6",
+    "cross-spawn": "^7.0.6",
+    "tsx": "^4.19.4"
+  }
+}

--- a/private/scripts/src/fixture.ts
+++ b/private/scripts/src/fixture.ts
@@ -1,0 +1,71 @@
+import { resolve, join } from 'node:path';
+import { readdir } from 'node:fs/promises';
+import { autocomplete, group, cancel, log } from '@clack/prompts';
+
+import { spawn } from 'cross-spawn';
+import { styleText } from 'node:util';
+
+const fixturesDir = resolve('../../fixtures');
+const fixturesDirContents = await readdir(fixturesDir, {
+  withFileTypes: true,
+});
+
+const allFixtures = fixturesDirContents
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name);
+
+const groupResult = await group(
+  {
+    fixture: () =>
+      autocomplete({
+        message: 'Select a fixture',
+        options: allFixtures.map((fixture) => ({
+          value: fixture,
+        })),
+      }),
+    script: async ({ results }) => {
+      if (!results.fixture) {
+        throw new Error('No fixture selected somehow');
+      }
+
+      const fixturePackageJson = await import(
+        join(fixturesDir, results.fixture, 'package.json')
+      );
+      const fixtureScripts = fixturePackageJson?.scripts;
+
+      if (!fixtureScripts || Object.keys(fixtureScripts).length === 0) {
+        throw new Error(
+          `No scripts found in '${groupResult.fixture}' fixture `,
+        );
+      }
+
+      return autocomplete({
+        message: 'Select a script',
+        options: Object.entries(fixtureScripts as Record<string, string>).map(
+          ([scriptName, script]) => ({
+            label: scriptName,
+            value: script,
+          }),
+        ),
+      });
+    },
+  },
+  {
+    onCancel: () => {
+      cancel('Operation cancelled.');
+      process.exit(0);
+    },
+  },
+);
+
+const workingDirectory = join(fixturesDir, groupResult.fixture);
+
+log.info(
+  `Running ${styleText(['bold', 'blue'], groupResult.script as string)} in ${styleText(['bold', 'blue'], groupResult.fixture)} fixture`,
+);
+
+spawn('pnpm', (groupResult.script as string).split(' '), {
+  cwd: workingDirectory,
+  env: { ...process.env, SKU_TELEMETRY: 'false' },
+  stdio: 'inherit',
+});


### PR DESCRIPTION
Cobbled together a little script that lists all fixtures, and then lists all scripts for the selected fixture, and then runs that script. Saves having to `cd` directly into directories and memorize script names or needing to use `pnpm --filter`.

https://github.com/user-attachments/assets/33624111-d217-4b6b-8a34-2c5652e6b496


`@clack/prompts` is neat. Will followup replacing our `prompts` dev dep with it.