### PR TITLE
Improve `postinstall` script

### DIFF
--- a/.changeset/great-kids-smash.md
+++ b/.changeset/great-kids-smash.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Optimize and improve error handling inside `postinstall` script


### PR DESCRIPTION
Various changes:
- Improve error handling. Previously thrown errors would be caught by the surrounding `try/catch`, so _any_ error would log `package.json does not exist`, which isn't great. Now we simply log errors and exit the script.
- Run multiple promises concurrently
- Replace `chalk` with native `styleText`