### PR TITLE
Remove warning when `.npmrc` file is detected

### DIFF
--- a/.changeset/itchy-days-stop.md
+++ b/.changeset/itchy-days-stop.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Remove warning when `.npmrc` file is detected

--- a/packages/sku/src/services/packageManager/__snapshots__/pnpmConfig.test.ts.snap
+++ b/packages/sku/src/services/packageManager/__snapshots__/pnpmConfig.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`validatePnpmConfig > When isCI: false > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > when hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -19,7 +19,7 @@ exports[`validatePnpmConfig > When isCI: false > when npmrcExists: false, hasRec
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: false > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > when hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 2`] = `
 [
   [
     "
@@ -38,138 +38,7 @@ exports[`validatePnpmConfig > When isCI: false > when npmrcExists: false, hasRec
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: false > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
-[
-  [
-    "
---------------------------------------------------------------------------------
-
-    pnpm-plugin-sku is not configured correctly
-
-    Please delete your top-level node_modules and run "pnpm add --config
-    pnpm-plugin-sku && pnpm install".
-
---------------------------------------------------------------------------------
-  ",
-  ],
-]
-`;
-
-exports[`validatePnpmConfig > When isCI: false > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
-
-exports[`validatePnpmConfig > When isCI: false > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
-[
-  [
-    "
---------------------------------------------------------------------------------
-
-    Detected .npmrc file
-
-    Please migrate all .npmrc configuration to pnpm-workspace.yaml and add
-    .npmrc to your .gitignore. See https://pnpm.io/settings for more
-    information.
-
---------------------------------------------------------------------------------
-  ",
-  ],
-  [
-    "
---------------------------------------------------------------------------------
-
-    pnpm-plugin-sku is not configured correctly
-
-    Please ensure you are on PNPM v10.13.0 or later.
-
-    Please delete your top-level node_modules and run "pnpm add --config
-    pnpm-plugin-sku && pnpm install".
-
---------------------------------------------------------------------------------
-  ",
-  ],
-]
-`;
-
-exports[`validatePnpmConfig > When isCI: false > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
-[
-  [
-    "
---------------------------------------------------------------------------------
-
-    Detected .npmrc file
-
-    Please migrate all .npmrc configuration to pnpm-workspace.yaml and add
-    .npmrc to your .gitignore. See https://pnpm.io/settings for more
-    information.
-
---------------------------------------------------------------------------------
-  ",
-  ],
-  [
-    "
---------------------------------------------------------------------------------
-
-    pnpm-plugin-sku is not configured correctly
-
-    Please ensure you are on PNPM v10.13.0 or later.
-
-    Please delete your top-level node_modules and run "pnpm add --config
-    pnpm-plugin-sku && pnpm install".
-
---------------------------------------------------------------------------------
-  ",
-  ],
-]
-`;
-
-exports[`validatePnpmConfig > When isCI: false > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
-[
-  [
-    "
---------------------------------------------------------------------------------
-
-    Detected .npmrc file
-
-    Please migrate all .npmrc configuration to pnpm-workspace.yaml and add
-    .npmrc to your .gitignore. See https://pnpm.io/settings for more
-    information.
-
---------------------------------------------------------------------------------
-  ",
-  ],
-  [
-    "
---------------------------------------------------------------------------------
-
-    pnpm-plugin-sku is not configured correctly
-
-    Please delete your top-level node_modules and run "pnpm add --config
-    pnpm-plugin-sku && pnpm install".
-
---------------------------------------------------------------------------------
-  ",
-  ],
-]
-`;
-
-exports[`validatePnpmConfig > When isCI: false > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
-[
-  [
-    "
---------------------------------------------------------------------------------
-
-    Detected .npmrc file
-
-    Please migrate all .npmrc configuration to pnpm-workspace.yaml and add
-    .npmrc to your .gitignore. See https://pnpm.io/settings for more
-    information.
-
---------------------------------------------------------------------------------
-  ",
-  ],
-]
-`;
-
-exports[`validatePnpmConfig > When isCI: true > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > when hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
 [
   [
     "
@@ -188,7 +57,7 @@ exports[`validatePnpmConfig > When isCI: true > when npmrcExists: false, hasReco
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: true > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > when hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 2`] = `
 [
   [
     "
@@ -207,7 +76,7 @@ exports[`validatePnpmConfig > When isCI: true > when npmrcExists: false, hasReco
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: true > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > when hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
 [
   [
     "
@@ -224,47 +93,7 @@ exports[`validatePnpmConfig > When isCI: true > when npmrcExists: false, hasReco
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: true > when npmrcExists: false, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
-
-exports[`validatePnpmConfig > When isCI: true > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
-[
-  [
-    "
---------------------------------------------------------------------------------
-
-    pnpm-plugin-sku is not configured correctly
-
-    Please ensure you are on PNPM v10.13.0 or later.
-
-    Please delete your top-level node_modules and run "pnpm add --config
-    pnpm-plugin-sku && pnpm install".
-
---------------------------------------------------------------------------------
-  ",
-  ],
-]
-`;
-
-exports[`validatePnpmConfig > When isCI: true > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: false, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `
-[
-  [
-    "
---------------------------------------------------------------------------------
-
-    pnpm-plugin-sku is not configured correctly
-
-    Please ensure you are on PNPM v10.13.0 or later.
-
-    Please delete your top-level node_modules and run "pnpm add --config
-    pnpm-plugin-sku && pnpm install".
-
---------------------------------------------------------------------------------
-  ",
-  ],
-]
-`;
-
-exports[`validatePnpmConfig > When isCI: true > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 1`] = `
+exports[`validatePnpmConfig > when hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: false > should log appropriate messages 2`] = `
 [
   [
     "
@@ -281,4 +110,6 @@ exports[`validatePnpmConfig > When isCI: true > when npmrcExists: true, hasRecom
 ]
 `;
 
-exports[`validatePnpmConfig > When isCI: true > when npmrcExists: true, hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
+exports[`validatePnpmConfig > when hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 1`] = `[]`;
+
+exports[`validatePnpmConfig > when hasRecommendedPnpmVersionInstalled: true, pnpmPluginSkuInstalled: true > should log appropriate messages 2`] = `[]`;

--- a/packages/sku/src/services/packageManager/packageManager.ts
+++ b/packages/sku/src/services/packageManager/packageManager.ts
@@ -87,9 +87,11 @@ export const isAtLeastPnpmV10 = () =>
 
 const recommendedPnpmVersion = '10.13.0';
 export const isAtLeastRecommendedPnpmVersion = () =>
-  packageManager === 'pnpm' &&
-  packageManagerVersion &&
-  semver.satisfies(packageManagerVersion, `>=${recommendedPnpmVersion}`);
+  Boolean(
+    packageManager === 'pnpm' &&
+      packageManagerVersion &&
+      semver.satisfies(packageManagerVersion, `>=${recommendedPnpmVersion}`),
+  );
 
 export const getCommand = (
   agent: SupportedPackageManager,

--- a/packages/sku/src/services/packageManager/pnpmConfig.test.ts
+++ b/packages/sku/src/services/packageManager/pnpmConfig.test.ts
@@ -1,51 +1,33 @@
-import { describe, it, vi, beforeEach } from 'vitest';
-import { createFixture, type FileTree } from 'fs-fixture';
-import * as ci from '../../utils/isCI.js';
+import { describe, it, vi } from 'vitest';
 
 import { validatePnpmConfig } from './pnpmConfig.js';
 
 describe('validatePnpmConfig', () => {
-  describe.for([true, false])('When isCI: $0', (mockedIsCI) => {
-    beforeEach(() => {
-      vi.spyOn(ci, 'default', 'get').mockReturnValue(mockedIsCI);
-    });
-
-    describe.for`
-    npmrcExists | hasRecommendedPnpmVersionInstalled | pnpmPluginSkuInstalled
-    ${false}    | ${false}                           | ${false}
-    ${false}    | ${false}                           | ${true}
-    ${false}    | ${true}                            | ${false}
-    ${false}    | ${true}                            | ${true}
-    ${true}     | ${false}                           | ${false}
-    ${true}     | ${false}                           | ${true}
-    ${true}     | ${true}                            | ${false}
-    ${true}     | ${true}                            | ${true}
+  describe.for`
+    hasRecommendedPnpmVersionInstalled | pnpmPluginSkuInstalled
+    ${false}                           | ${false}
+    ${false}                           | ${true}
+    ${true}                            | ${false}
+    ${true}                            | ${true}
+    ${false}                           | ${false}
+    ${false}                           | ${true}
+    ${true}                            | ${false}
+    ${true}                            | ${true}
   `(
-      'when npmrcExists: $npmrcExists, hasRecommendedPnpmVersionInstalled: $hasRecommendedPnpmVersionInstalled, pnpmPluginSkuInstalled: $pnpmPluginSkuInstalled',
-      ({
-        npmrcExists,
-        hasRecommendedPnpmVersionInstalled,
-        pnpmPluginSkuInstalled,
-      }) => {
-        it('should log appropriate messages', async ({ expect }) => {
-          const logSpy = vi
-            .spyOn(global.console, 'log')
-            .mockImplementation(() => {});
+    'when hasRecommendedPnpmVersionInstalled: $hasRecommendedPnpmVersionInstalled, pnpmPluginSkuInstalled: $pnpmPluginSkuInstalled',
+    ({ hasRecommendedPnpmVersionInstalled, pnpmPluginSkuInstalled }) => {
+      it('should log appropriate messages', async ({ expect }) => {
+        const logSpy = vi
+          .spyOn(global.console, 'log')
+          .mockImplementation(() => {});
 
-          const fileTree: FileTree = npmrcExists ? { '.npmrc': '' } : {};
-          await using fixture = await createFixture(fileTree);
-
-          const rootDir = fixture.path;
-
-          await validatePnpmConfig({
-            rootDir,
-            hasRecommendedPnpmVersionInstalled,
-            pnpmPluginSkuInstalled,
-          });
-
-          expect(logSpy.mock.calls).toMatchSnapshot();
+        await validatePnpmConfig({
+          hasRecommendedPnpmVersionInstalled,
+          pnpmPluginSkuInstalled,
         });
-      },
-    );
-  });
+
+        expect(logSpy.mock.calls).toMatchSnapshot();
+      });
+    },
+  );
 });

--- a/packages/sku/src/services/packageManager/pnpmConfig.ts
+++ b/packages/sku/src/services/packageManager/pnpmConfig.ts
@@ -1,29 +1,15 @@
 import banner from '../../utils/banners/banner.js';
-import exists from '../../utils/exists.js';
 import chalk from 'chalk';
-import path from 'node:path';
-import isCI from '../../utils/isCI.js';
 
 const accent = chalk.blue.bold;
-const info = chalk.bold;
 
 export const validatePnpmConfig = async ({
-  rootDir,
   hasRecommendedPnpmVersionInstalled,
   pnpmPluginSkuInstalled,
 }: {
-  rootDir: string;
   hasRecommendedPnpmVersionInstalled: boolean;
   pnpmPluginSkuInstalled: boolean;
 }) => {
-  const npmrcExists = await exists(path.join(rootDir, '.npmrc'));
-
-  if (!isCI && npmrcExists) {
-    banner('warning', 'Detected .npmrc file', [
-      `Please migrate all ${accent('.npmrc')} configuration to ${accent('pnpm-workspace.yaml')} and add ${accent('.npmrc')} to your ${accent('.gitignore')}. See ${info('https://pnpm.io/settings')} for more information.`,
-    ]);
-  }
-
   if (!pnpmPluginSkuInstalled || !hasRecommendedPnpmVersionInstalled) {
     const messages: string[] = [];
 

--- a/packages/sku/src/utils/configureApp.ts
+++ b/packages/sku/src/utils/configureApp.ts
@@ -163,6 +163,7 @@ export default async (skuContext: SkuContext) => {
     patterns: gitIgnorePatterns.map(convertToForwardSlashPaths),
   });
 
+  // If there's no rootDir, we're either inside `sku init`, or we can't determine the user's package manager
   if (rootDir && isAtLeastPnpmV10()) {
     const pnpmConfigDependencies = await getPnpmConfigDependencies();
 
@@ -172,10 +173,7 @@ export default async (skuContext: SkuContext) => {
       pnpmConfigDependencies.includes('pnpm-plugin-sku');
 
     await validatePnpmConfig({
-      rootDir,
-      hasRecommendedPnpmVersionInstalled: Boolean(
-        hasRecommendedPnpmVersionInstalled,
-      ),
+      hasRecommendedPnpmVersionInstalled,
       pnpmPluginSkuInstalled,
     });
   }


### PR DESCRIPTION
This warning was perhaps a bit shortsighted as it doesn't account for situations where you want to be explicit about a scope->registry relationship for a repo, in which case you _need_ a local (to the repo) `.npmrc` file.