### PR TITLE
`codemod`: Clean up deps, use async `glob`

### DIFF
--- a/.changeset/slimy-wolves-remain.md
+++ b/.changeset/slimy-wolves-remain.md
@@ -1,0 +1,5 @@
+---
+'@sku-lib/codemod': patch
+---
+
+Move `typescript` to dev dependencies

--- a/.changeset/solid-pigs-judge.md
+++ b/.changeset/solid-pigs-judge.md
@@ -1,0 +1,5 @@
+---
+'@sku-lib/codemod': patch
+---
+
+Use async `glob` to find files

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -13,8 +13,7 @@
     "diff": "^7.0.0",
     "picocolors": "^1.1.1",
     "prompts": "^2.4.2",
-    "tinyglobby": "^0.2.13",
-    "typescript": "~5.8.0"
+    "tinyglobby": "^0.2.13"
   },
   "repository": {
     "type": "git",
@@ -34,7 +33,7 @@
   "homepage": "https://github.com/seek-oss/sku/packages/codemod#readme",
   "devDependencies": {
     "@types/diff": "^7.0.1",
-    "@types/jscodeshift": "^17.3.0",
-    "@types/prompts": "^2.4.9"
+    "@types/prompts": "^2.4.9",
+    "typescript": "~5.8.0"
   }
 }

--- a/packages/codemod/src/transform/runner.ts
+++ b/packages/codemod/src/transform/runner.ts
@@ -1,4 +1,4 @@
-import { globSync } from 'tinyglobby';
+import { glob } from 'tinyglobby';
 import prompts from 'prompts';
 import { dirname, join, resolve } from 'node:path';
 import { CODEMODS } from '../utils/constants.js';
@@ -144,8 +144,8 @@ export const runTransform = async (
   process.exit(0);
 };
 
-const getAllFiles = async (paths: string[]) =>
-  globSync([...paths, '!**/node_modules', '!**/dist'], {
+const getAllFiles = (paths: string[]) =>
+  glob([...paths, '!**/node_modules', '!**/dist'], {
     absolute: true,
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -844,19 +844,16 @@ importers:
       tinyglobby:
         specifier: ^0.2.13
         version: 0.2.14
-      typescript:
-        specifier: ~5.8.0
-        version: 5.8.3
     devDependencies:
       '@types/diff':
         specifier: ^7.0.1
         version: 7.0.2
-      '@types/jscodeshift':
-        specifier: ^17.3.0
-        version: 17.3.0
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
+      typescript:
+        specifier: ~5.8.0
+        version: 5.8.3
 
   packages/pnpm-plugin: {}
 
@@ -3331,9 +3328,6 @@ packages:
 
   '@types/jest@30.0.0':
     resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
-
-  '@types/jscodeshift@17.3.0':
-    resolution: {integrity: sha512-ogvGG8VQQqAQQ096uRh+d6tBHrYuZjsumHirKtvBa5qEyTMN3IQJ7apo+sw9lxaB/iKWIhbbLlF3zmAWk9XQIg==}
 
   '@types/jsdom@21.1.7':
     resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
@@ -11657,11 +11651,6 @@ snapshots:
     dependencies:
       expect: 30.0.4
       pretty-format: 30.0.2
-
-  '@types/jscodeshift@17.3.0':
-    dependencies:
-      ast-types: 0.16.1
-      recast: 0.23.11
 
   '@types/jsdom@21.1.7':
     dependencies:


### PR DESCRIPTION
- Moved `typescript` to a dev dep
- Removed unused `@types/jscodeshift` dev dep
- Convert a `globSync` to an async `glob`