### PR TITLE
`start`: Fix 404 messaging

### DIFF
--- a/.changeset/bitter-nails-carry.md
+++ b/.changeset/bitter-nails-carry.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`start`: Shows 404 messaging instead of an error when routes are empty

--- a/.changeset/bitter-nails-carry.md
+++ b/.changeset/bitter-nails-carry.md
@@ -2,4 +2,4 @@
 'sku': patch
 ---
 
-`start`: Shows 404 messaging instead of an error when routes are empty
+`start`: Shows Not Found (404) messaging instead of an error when routes are empty

--- a/packages/sku/src/program/commands/start/webpack-start-handler.ts
+++ b/packages/sku/src/program/commands/start/webpack-start-handler.ts
@@ -131,7 +131,7 @@ export const webpackStartHandler = async ({
           hostname: req.hostname,
           path: req.path,
           sites,
-        }) || { route: '' };
+        });
 
         if (!matchingRoute) {
           return next();


### PR DESCRIPTION
When going to a non-existent route, sku would show a 404 messaging `Cannot GET {route_path}`. When adding Vite support, this message broke and instead sku would throw a `getLanguageFromRoute` error when encountering a 404. This PR fixes restores the 404 messaging.