### PR TITLE
Flatten webpack plugins folder structure

### DIFF
--- a/.changeset/bitter-dolls-know.md
+++ b/.changeset/bitter-dolls-know.md
@@ -3,3 +3,9 @@
 ---
 
 Expose named `SkuWebpackPlugin` export from `sku/webpack-plugin`, deprecate default export
+
+**MIGRATION GUIDE**
+```diff
+-import SkuWebpackPlugin from 'sku/webpack-plugin';
++import { SkuWebpackPlugin } from 'sku/webpack-plugin';
+```

--- a/.changeset/bitter-dolls-know.md
+++ b/.changeset/bitter-dolls-know.md
@@ -1,0 +1,5 @@
+---
+'sku': minor
+---
+
+Expose named `SkuWebpackPlugin` export from `sku/webpack-plugin`, deprecate default export

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -80,7 +80,7 @@ See the [custom builds documentation] for more information.
 Example:
 
 ```ts
-import SkuWebpackPlugin from 'sku/webpack-plugin';
+import { SkuWebpackPlugin } from 'sku/webpack-plugin';
 ```
 
 [custom builds documentation]: ./docs/custom-builds.md

--- a/docs/docs/custom-builds.md
+++ b/docs/docs/custom-builds.md
@@ -3,7 +3,7 @@
 If your project has a custom [webpack](https://webpack.js.org) build, you can use the `SkuWebpackPlugin` in your webpack config as part of your plugins array:
 
 ```js
-import SkuWebpackPlugin from 'sku/webpack-plugin';
+import { SkuWebpackPlugin } from 'sku/webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 
 export default {

--- a/fixtures/sku-webpack-plugin/webpack.config.mjs
+++ b/fixtures/sku-webpack-plugin/webpack.config.mjs
@@ -1,6 +1,6 @@
 import HTMLWebackPlugin from 'html-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import SkuWebpackPlugin from 'sku/webpack-plugin';
+import { SkuWebpackPlugin } from 'sku/webpack-plugin';
 
 export default {
   entry: './main.js',

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -30,7 +30,7 @@
       "types": "./dist/services/vite/client.d.ts"
     },
     "./@loadable/component": "./src/@loadable/component/index.ts",
-    "./webpack-plugin": "./dist/services/webpack/config/plugins/sku-webpack-plugin/index.js",
+    "./webpack-plugin": "./dist/services/webpack/config/plugins/skuWebpackPlugin.js",
     "./package.json": "./package.json"
   },
   "engines": {

--- a/packages/sku/src/services/webpack/config/plugins/metricsPlugin.ts
+++ b/packages/sku/src/services/webpack/config/plugins/metricsPlugin.ts
@@ -1,14 +1,14 @@
 import { performance } from 'node:perf_hooks';
 import prettyMilliseconds from 'pretty-ms';
 import debug from 'debug';
-import provider from '../../../../telemetry/index.js';
+import provider from '../../../telemetry/index.js';
 import type { Compiler, WebpackPluginInstance } from 'webpack';
 
 const log = debug('sku:metrics');
 
 const smp = 'sku-metrics-plugin';
 
-class MetricsPlugin implements WebpackPluginInstance {
+export class MetricsPlugin implements WebpackPluginInstance {
   private initial: boolean;
   private readonly target: string;
   private readonly type: string;
@@ -50,5 +50,3 @@ class MetricsPlugin implements WebpackPluginInstance {
     });
   }
 }
-
-export default MetricsPlugin;

--- a/packages/sku/src/services/webpack/config/plugins/skuWebpackPlugin.ts
+++ b/packages/sku/src/services/webpack/config/plugins/skuWebpackPlugin.ts
@@ -19,7 +19,7 @@ import {
 import targets from '../../../../config/targets.json' with { type: 'json' };
 import { rootResolutionFileExtensions } from '../../../../config/fileResolutionExtensions.js';
 
-class SkuWebpackPlugin implements WebpackPluginInstance {
+export class SkuWebpackPlugin implements WebpackPluginInstance {
   options: SkuWebpackPluginOptions;
   compilePackages: string[];
   include: string[];
@@ -202,4 +202,5 @@ class SkuWebpackPlugin implements WebpackPluginInstance {
   }
 }
 
+/** @deprecated Please use the named `SkuWebpackPlugin` export */
 export default SkuWebpackPlugin;

--- a/packages/sku/src/services/webpack/config/plugins/skuWebpackPlugin.ts
+++ b/packages/sku/src/services/webpack/config/plugins/skuWebpackPlugin.ts
@@ -10,13 +10,14 @@ import {
   IMAGE,
   SVG,
   resolvePackage,
-} from '../../utils/index.js';
-import defaultCompilePackages from '../../../../../context/defaultCompilePackages.js';
-import validateOptions, {
+} from '../utils/index.js';
+import defaultCompilePackages from '../../../../context/defaultCompilePackages.js';
+import {
+  validateOptions,
   type SkuWebpackPluginOptions,
 } from './validateOptions.js';
-import targets from '../../../../../config/targets.json' with { type: 'json' };
-import { rootResolutionFileExtensions } from '../../../../../config/fileResolutionExtensions.js';
+import targets from '../../../../config/targets.json' with { type: 'json' };
+import { rootResolutionFileExtensions } from '../../../../config/fileResolutionExtensions.js';
 
 class SkuWebpackPlugin implements WebpackPluginInstance {
   options: SkuWebpackPluginOptions;

--- a/packages/sku/src/services/webpack/config/plugins/validateOptions.ts
+++ b/packages/sku/src/services/webpack/config/plugins/validateOptions.ts
@@ -2,7 +2,7 @@ import Validator from 'fastest-validator';
 import browserslist from 'browserslist';
 import chalk from 'chalk';
 import { closest } from 'fastest-levenshtein';
-import { hasErrorMessage } from '../../../../../utils/error-guards.js';
+import { hasErrorMessage } from '../../../../utils/error-guards.js';
 
 // @ts-expect-error
 const validator = new Validator();
@@ -90,7 +90,7 @@ const validate = validator.compile(schema);
 
 const availableOptions = Object.keys(schema);
 
-const validateOptions = (options: SkuWebpackPluginOptions) => {
+export const validateOptions = (options: SkuWebpackPluginOptions) => {
   const errors = [];
 
   // Validate extra keys
@@ -138,5 +138,3 @@ const validateOptions = (options: SkuWebpackPluginOptions) => {
     exitWithErrors(errors);
   }
 };
-
-export default validateOptions;

--- a/packages/sku/src/services/webpack/config/webpack.config.ssr.ts
+++ b/packages/sku/src/services/webpack/config/webpack.config.ssr.ts
@@ -9,7 +9,7 @@ import LoadablePlugin from '@loadable/webpack-plugin';
 import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 
-import SkuWebpackPlugin from './plugins/skuWebpackPlugin.js';
+import { SkuWebpackPlugin } from './plugins/skuWebpackPlugin.js';
 import { MetricsPlugin } from './plugins/metricsPlugin.js';
 import { VocabWebpackPlugin } from '@vocab/webpack';
 

--- a/packages/sku/src/services/webpack/config/webpack.config.ssr.ts
+++ b/packages/sku/src/services/webpack/config/webpack.config.ssr.ts
@@ -9,8 +9,8 @@ import LoadablePlugin from '@loadable/webpack-plugin';
 import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 
-import SkuWebpackPlugin from './plugins/sku-webpack-plugin/index.js';
-import MetricsPlugin from './plugins/metrics-plugin/index.js';
+import SkuWebpackPlugin from './plugins/skuWebpackPlugin.js';
+import { MetricsPlugin } from './plugins/metricsPlugin.js';
 import { VocabWebpackPlugin } from '@vocab/webpack';
 
 import { bundleAnalyzerPlugin } from './plugins/bundleAnalyzer.js';

--- a/packages/sku/src/services/webpack/config/webpack.config.ts
+++ b/packages/sku/src/services/webpack/config/webpack.config.ts
@@ -8,7 +8,7 @@ import LoadablePlugin from '@loadable/webpack-plugin';
 import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 import { bundleAnalyzerPlugin } from './plugins/bundleAnalyzer.js';
-import SkuWebpackPlugin from './plugins/skuWebpackPlugin.js';
+import { SkuWebpackPlugin } from './plugins/skuWebpackPlugin.js';
 import { MetricsPlugin } from './plugins/metricsPlugin.js';
 import { VocabWebpackPlugin } from '@vocab/webpack';
 

--- a/packages/sku/src/services/webpack/config/webpack.config.ts
+++ b/packages/sku/src/services/webpack/config/webpack.config.ts
@@ -8,8 +8,8 @@ import LoadablePlugin from '@loadable/webpack-plugin';
 import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 import { bundleAnalyzerPlugin } from './plugins/bundleAnalyzer.js';
-import SkuWebpackPlugin from './plugins/sku-webpack-plugin/index.js';
-import MetricsPlugin from './plugins/metrics-plugin/index.js';
+import SkuWebpackPlugin from './plugins/skuWebpackPlugin.js';
+import { MetricsPlugin } from './plugins/metricsPlugin.js';
 import { VocabWebpackPlugin } from '@vocab/webpack';
 
 import { JAVASCRIPT, resolvePackage } from './utils/index.js';


### PR DESCRIPTION
Flattened the folder structure of our webpack plugins and replaced some default exports with named exports. ~I left `SkuWebpackPlugin`'s export alone as it's public API so didn't want to break it just yet~ Exposed a named `SkuWebpackPlugin` and deprecated the default export.