### PR TITLE
Flatten utils folder structure

### DIFF
--- a/packages/sku/src/context/getSiteForHost.ts
+++ b/packages/sku/src/context/getSiteForHost.ts
@@ -1,6 +1,6 @@
-import type { SkuContext } from '../../context/createSkuContext.js';
+import type { SkuContext } from './createSkuContext.js';
 
-const getSiteForHost = (
+export const getSiteForHost = (
   hostname: string,
   defaultSite: string | undefined,
   sites: SkuContext['sites'],
@@ -17,5 +17,3 @@ const getSiteForHost = (
 
   return defaultSite ? defaultSite : sites[0].name;
 };
-
-export default getSiteForHost;

--- a/packages/sku/src/context/hosts.test.ts
+++ b/packages/sku/src/context/hosts.test.ts
@@ -1,5 +1,5 @@
 import { describe, beforeEach, afterEach, it, vi } from 'vitest';
-import { createSkuContext } from '../../context/createSkuContext.js';
+import { createSkuContext } from './createSkuContext.js';
 import { checkHosts, setupHosts } from './hosts.js';
 
 describe('setupHosts', () => {

--- a/packages/sku/src/context/hosts.ts
+++ b/packages/sku/src/context/hosts.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
 
-import { suggestScript } from '../suggestScript.js';
-import { hasErrorCode } from '../error-guards.js';
-import type { SkuContext } from '../../context/createSkuContext.js';
+import { suggestScript } from '../utils/suggestScript.js';
+import { hasErrorCode } from '../utils/error-guards.js';
+import type { SkuContext } from './createSkuContext.js';
 import { promisify } from 'node:util';
 import { set, get } from 'hostile';
 

--- a/packages/sku/src/context/resolveEnvironment.ts
+++ b/packages/sku/src/context/resolveEnvironment.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import type { SkuContext } from '../../context/createSkuContext.js';
+import type { SkuContext } from './createSkuContext.js';
 
 export const resolveEnvironment = ({
   environment: environmentOption,

--- a/packages/sku/src/openBrowser.ts
+++ b/packages/sku/src/openBrowser.ts
@@ -3,16 +3,16 @@
 
 import chalk from 'chalk';
 import open from 'open';
-import isCI from '../utils/isCI.js';
+import isCI from './utils/isCI.js';
 import getDefaultBrowser from 'default-browser';
 import { fileURLToPath } from 'node:url';
 import { resolve } from 'node:path';
 import debug from 'debug';
-import { execAsync } from '../utils/execAsync.js';
+import { execAsync } from './utils/execAsync.js';
 
 const log = debug('sku:openBrowser');
 
-export const BIN_DIR = resolve(fileURLToPath(import.meta.url), '../../../bin');
+const BIN_DIR = resolve(fileURLToPath(import.meta.url), '../../bin');
 
 const OSX_CHROME = 'google chrome';
 

--- a/packages/sku/src/program/commands/format/format.action.ts
+++ b/packages/sku/src/program/commands/format/format.action.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { configureProject } from '../../../utils/configure.js';
 import { fix as esLintFix } from '../../../services/eslint/runESLint.js';
-import { write as prettierWrite } from '../../../services/prettier/runPrettier.js';
+import { write as prettierWrite } from '../../../services/prettier.js';
 import type { SkuContext } from '../../../context/createSkuContext.js';
 
 export const formatAction = async (

--- a/packages/sku/src/program/commands/init/init.action.ts
+++ b/packages/sku/src/program/commands/init/init.action.ts
@@ -19,7 +19,7 @@ import {
   rootDir,
   packageManagerVersion,
 } from '../../../services/packageManager/packageManager.js';
-import { write as prettierWrite } from '../../../services/prettier/runPrettier.js';
+import { write as prettierWrite } from '../../../services/prettier.js';
 import { fix as esLintFix } from '../../../services/eslint/runESLint.js';
 import install from '../../../services/packageManager/install.js';
 

--- a/packages/sku/src/program/commands/lint/lint.action.ts
+++ b/packages/sku/src/program/commands/lint/lint.action.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { check as esLintCheck } from '../../../services/eslint/runESLint.js';
-import { check as prettierCheck } from '../../../services/prettier/runPrettier.js';
+import { check as prettierCheck } from '../../../services/prettier.js';
 import runTsc from '../../../services/typescript/runTsc.js';
 
 import { runVocabCompile } from '../../../services/vocab/runVocab.js';

--- a/packages/sku/src/program/commands/serve/serve.action.ts
+++ b/packages/sku/src/program/commands/serve/serve.action.ts
@@ -8,11 +8,11 @@ import {
   checkHosts,
   getAppHosts,
   withHostile,
-} from '../../../utils/contextUtils/hosts.js';
+} from '../../../context/hosts.js';
 import allocatePort from '../../../utils/allocatePort.js';
-import { openBrowser } from '../../../openBrowser/index.js';
-import getSiteForHost from '../../../utils/contextUtils/getSiteForHost.js';
-import { resolveEnvironment } from '../../../utils/contextUtils/resolveEnvironment.js';
+import { openBrowser } from '../../../openBrowser.js';
+import { getSiteForHost } from '../../../context/getSiteForHost.js';
+import { resolveEnvironment } from '../../../context/resolveEnvironment.js';
 import provider from '../../../services/telemetry/index.js';
 import createServer from '../../../utils/createServer.js';
 import {

--- a/packages/sku/src/program/commands/setup-hosts/setup-hosts.action.ts
+++ b/packages/sku/src/program/commands/setup-hosts/setup-hosts.action.ts
@@ -1,4 +1,4 @@
-import { setupHosts, withHostile } from '../../../utils/contextUtils/hosts.js';
+import { setupHosts, withHostile } from '../../../context/hosts.js';
 import provider from '../../../services/telemetry/index.js';
 import type { SkuContext } from '../../../context/createSkuContext.js';
 

--- a/packages/sku/src/program/commands/start-ssr/webpack-start-ssr-handler.ts
+++ b/packages/sku/src/program/commands/start-ssr/webpack-start-ssr-handler.ts
@@ -16,11 +16,11 @@ import {
   checkHosts,
   getAppHosts,
   withHostile,
-} from '../../../utils/contextUtils/hosts.js';
+} from '../../../context/hosts.js';
 import makeWebpackConfig from '../../../services/webpack/config/webpack.config.ssr.js';
 import getStatsConfig from '../../../services/webpack/config/statsConfig.js';
 import allocatePort from '../../../utils/allocatePort.js';
-import { openBrowser } from '../../../openBrowser/index.js';
+import { openBrowser } from '../../../openBrowser.js';
 import createServerManager from '../../../services/serverManager.js';
 
 import { watchVocabCompile } from '../../../services/vocab/runVocab.js';

--- a/packages/sku/src/program/commands/start/start.action.ts
+++ b/packages/sku/src/program/commands/start/start.action.ts
@@ -6,7 +6,7 @@ import {
   validatePeerDeps,
 } from '../../../utils/configure.js';
 import { watchVocabCompile } from '../../../services/vocab/runVocab.js';
-import { checkHosts, withHostile } from '../../../utils/contextUtils/hosts.js';
+import { checkHosts, withHostile } from '../../../context/hosts.js';
 import chalk from 'chalk';
 
 export const startAction = async (
@@ -24,8 +24,8 @@ export const startAction = async (
   console.log(chalk.blue(`sku start`));
 
   await Promise.all([
-    await configureProject(skuContext),
-    await watchVocabCompile(skuContext),
+    configureProject(skuContext),
+    watchVocabCompile(skuContext),
   ]);
 
   withHostile(checkHosts)(skuContext);

--- a/packages/sku/src/program/commands/start/webpack-start-handler.ts
+++ b/packages/sku/src/program/commands/start/webpack-start-handler.ts
@@ -4,17 +4,17 @@ import chalk from 'chalk';
 import exceptionFormatter from 'exception-formatter';
 import type { RequestHandler } from 'express';
 
-import { openBrowser } from '../../../openBrowser/index.js';
+import { openBrowser } from '../../../openBrowser.js';
 import getCertificate from '../../../utils/certificate.js';
 
 import getStatsConfig from '../../../services/webpack/config/statsConfig.js';
 import createHtmlRenderPlugin from '../../../services/webpack/config/plugins/createHtmlRenderPlugin.js';
 import makeWebpackConfig from '../../../services/webpack/config/webpack.config.js';
 
-import { getAppHosts } from '../../../utils/contextUtils/hosts.js';
+import { getAppHosts } from '../../../context/hosts.js';
 import allocatePort from '../../../utils/allocatePort.js';
-import getSiteForHost from '../../../utils/contextUtils/getSiteForHost.js';
-import { resolveEnvironment } from '../../../utils/contextUtils/resolveEnvironment.js';
+import { getSiteForHost } from '../../../context/getSiteForHost.js';
+import { resolveEnvironment } from '../../../context/resolveEnvironment.js';
 import { getMatchingRoute } from '../../../utils/routeMatcher.js';
 import {
   getLanguageFromRoute,

--- a/packages/sku/src/services/prettier.ts
+++ b/packages/sku/src/services/prettier.ts
@@ -1,16 +1,16 @@
-import exists from '../../utils/exists.js';
+import exists from '../utils/exists.js';
 import path, { dirname } from 'node:path';
 import chalk from 'chalk';
-import { runBin } from '../../utils/runBin.js';
-import { getPathFromCwd } from '../../utils/cwd.js';
-import { suggestScript } from '../../utils/suggestScript.js';
+import { runBin } from '../utils/runBin.js';
+import { getPathFromCwd } from '../utils/cwd.js';
+import { suggestScript } from '../utils/suggestScript.js';
 
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const prettierIgnorePath = getPathFromCwd('.prettierignore');
-const prettierConfigPath = path.join(__dirname, '../../config/prettier.js');
+const prettierConfigPath = path.join(__dirname, '../config/prettier.js');
 
 const runPrettier = async ({
   write,

--- a/packages/sku/src/services/vite/helpers/config/createConfig.ts
+++ b/packages/sku/src/services/vite/helpers/config/createConfig.ts
@@ -6,7 +6,7 @@ import { middlewarePlugin } from '../../plugins/middlewarePlugin.js';
 import { startTelemetryPlugin } from '../../plugins/startTelemetry.js';
 import { HMRTelemetryPlugin } from '../../plugins/HMRTelemetry.js';
 import { httpsDevServerPlugin } from '../../plugins/httpsDevServerPlugin.js';
-import { getAppHosts } from '../../../../utils/contextUtils/hosts.js';
+import { getAppHosts } from '../../../../context/hosts.js';
 import isCI from '../../../../utils/isCI.js';
 import { bundleAnalyzerPlugin } from '../../plugins/bundleAnalyzer.js';
 import { vitePluginSsrCss } from '../../plugins/ssrCss/plugin.js';

--- a/packages/sku/src/services/vite/index.ts
+++ b/packages/sku/src/services/vite/index.ts
@@ -8,7 +8,7 @@ import {
 } from './helpers/config/createConfig.js';
 import { cleanTargetDirectory } from '../../utils/buildFileUtils.js';
 import { createOutDir } from './helpers/bundleConfig.js';
-import { getAppHosts } from '../../utils/contextUtils/hosts.js';
+import { getAppHosts } from '../../context/hosts.js';
 import chalk from 'chalk';
 import { prerenderConcurrently } from './helpers/prerender/prerenderConcurrently.js';
 import allocatePort from '../../utils/allocatePort.js';

--- a/packages/sku/src/services/vite/plugins/httpsDevServerPlugin.ts
+++ b/packages/sku/src/services/vite/plugins/httpsDevServerPlugin.ts
@@ -1,5 +1,5 @@
 import type { SkuContext } from '../../../context/createSkuContext.js';
-import { getAppHosts } from '../../../utils/contextUtils/hosts.js';
+import { getAppHosts } from '../../../context/hosts.js';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 import path from 'node:path';
 import type { Plugin } from 'vite';

--- a/packages/sku/src/utils/contextUtils/getServerEntry.ts
+++ b/packages/sku/src/utils/contextUtils/getServerEntry.ts
@@ -1,1 +1,0 @@
-export const getServerEntry = () => {};

--- a/packages/sku/src/utils/routeMatcher.ts
+++ b/packages/sku/src/utils/routeMatcher.ts
@@ -1,6 +1,6 @@
 import type { NormalizedRoute } from '../context/createSkuContext.js';
 import { match } from 'path-to-regexp';
-import getSiteForHost from './contextUtils/getSiteForHost.js';
+import { getSiteForHost } from '../context/getSiteForHost.js';
 import type { SkuSiteObject } from '../types/types.js';
 
 /**


### PR DESCRIPTION
- Moved `src/utils/contextUtils` contents into `src/context` as they both contain "context-related utilities"
- Moved `runPrettier.ts` up a directory and renamed it to `prettier.ts`
- Moved `openBrowser/index.ts` up a directory and renamed it to `openBrowser.ts`
- Deleted `getServerEntry.ts` as it was never used