### PR TITLE
Fix `postinstall` during `sku init`

### DIFF
--- a/.changeset/twenty-bottles-post.md
+++ b/.changeset/twenty-bottles-post.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fixes a bug where `sku`'s `postinstall` script would fail during `sku init`

--- a/packages/sku/scripts/postinstall.js
+++ b/packages/sku/scripts/postinstall.js
@@ -19,7 +19,7 @@ try {
     packageJsonContents = await readFile(packageJson, 'utf-8');
   } catch {
     console.log(
-      `package.json file does not exist at ${packageJson}. Skipping sku postinstall`,
+      `package.json file does not exist at ${packageJson}. Skipping sku postinstall.`,
     );
     process.exit(0);
   }

--- a/packages/sku/scripts/postinstall.js
+++ b/packages/sku/scripts/postinstall.js
@@ -17,10 +17,11 @@ try {
 
   try {
     packageJsonContents = await readFile(packageJson, 'utf-8');
-  } catch (error) {
-    console.error(`Failed to read package.json file at ${packageJson}`);
-    console.error(error);
-    process.exit(1);
+  } catch {
+    console.log(
+      `package.json file does not exist at ${packageJson}. Skipping sku postinstall`,
+    );
+    process.exit(0);
   }
 
   const {


### PR DESCRIPTION
I broke this in https://github.com/seek-oss/sku/pull/1362. The previous behaviour was to eat the "`package.json` not found" error and exit (with exit code 0), but it became a proper exit (with exit code 1) in that PR. We still need to eat this error and successfully exit because otherwise the `postinstall` script fails during `sku init`.

I _think_ this wasn't caught in tests because maybe the postinstall script isn't running? At least that's my hunch.