### PR TITLE
`utils`: Remove `private: true` from utils package.json

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,7 +2,6 @@
   "name": "@sku-lib/utils",
   "version": "0.0.0",
   "description": "Shared utilities for sku packages",
-  "private": true,
   "type": "module",
   "exports": {
     ".": "./dist/index.js",


### PR DESCRIPTION
We need to publish the new utils package, but it is currently still set to private, causing changesets to error (which is correct behaviour). Removing `private: true` so we can publish it and unblock CI.