### PR TITLE
Fix typo in PNPM plugin config property, add types

### DIFF
--- a/.changeset/few-snakes-carry.md
+++ b/.changeset/few-snakes-carry.md
@@ -1,0 +1,5 @@
+---
+'pnpm-plugin-sku': patch
+---
+
+Fix typo in config property

--- a/packages/pnpm-plugin/package.json
+++ b/packages/pnpm-plugin/package.json
@@ -17,5 +17,8 @@
   "bugs": {
     "url": "https://github.com/seek-oss/sku/issues"
   },
-  "homepage": "https://github.com/seek-oss/sku#readme"
+  "homepage": "https://github.com/seek-oss/sku#readme",
+  "devDependencies": {
+    "@pnpm/types": "^1000.7.0"
+  }
 }

--- a/packages/pnpm-plugin/pnpmfile.cjs
+++ b/packages/pnpm-plugin/pnpmfile.cjs
@@ -1,7 +1,11 @@
+// @ts-check
 module.exports = {
   hooks: {
+    /** @param {import("@pnpm/types").PnpmSettings} config */
     updateConfig(config) {
+      // @ts-expect-error Property isn't in PnpmSettings for some reason
       config.publicHoistPattern ??= [];
+      // @ts-expect-error Property isn't in PnpmSettings for some reason
       config.publicHoistPattern.push('eslint', 'prettier');
 
       config.onlyBuiltDependencies ??= [];
@@ -12,8 +16,8 @@ module.exports = {
         'unrs-resolver',
       );
 
-      config.ignoreBuiltDependencies ??= [];
-      config.ignoreBuiltDependencies.push('core-js', 'core-js-pure');
+      config.ignoredBuiltDependencies ??= [];
+      config.ignoredBuiltDependencies.push('core-js', 'core-js-pure');
 
       return config;
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -871,7 +871,11 @@ importers:
         specifier: ^5.6.2
         version: 5.8.3
 
-  packages/pnpm-plugin: {}
+  packages/pnpm-plugin:
+    devDependencies:
+      '@pnpm/types':
+        specifier: ^1000.7.0
+        version: 1000.7.0
 
   packages/sku:
     dependencies:
@@ -2897,6 +2901,10 @@ packages:
         optional: true
       webpack-plugin-serve:
         optional: true
+
+  '@pnpm/types@1000.7.0':
+    resolution: {integrity: sha512-1s7FvDqmOEIeFGLUj/VO8sF5lGFxeE/1WALrBpfZhDnMXY/x8FbmuygTTE5joWifebcZ8Ww8Kw2CgBoStsIevQ==}
+    engines: {node: '>=18.12'}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -11020,6 +11028,8 @@ snapshots:
       type-fest: 4.41.0
       webpack-dev-server: 5.2.0(debug@4.4.1)(webpack-cli@5.1.4)(webpack@5.100.0)
       webpack-hot-middleware: 2.26.1
+
+  '@pnpm/types@1000.7.0': {}
 
   '@polka/url@1.0.0-next.29': {}
 


### PR DESCRIPTION
I was wondering why `core-js` and `core-js-pure` weren't being ignored in a consuming package. Turns out I typoed the property name, so I added the `@pnpm/types` package so we can reference [PNPM config types](https://github.com/pnpm/pnpm/blob/d0216696cdd4dde040d711f1321ab4334852c7f3/packages/types/src/package.ts#L158). `publicHoistPattern` isn't present in the type for some reason, maybe because they resolve it in a different way internally, but it's better than nothing.