### PR TITLE
Add `jest-to-vitest` codemod and other codemod tweaks

### DIFF
--- a/.changeset/fair-ears-lick.md
+++ b/.changeset/fair-ears-lick.md
@@ -1,0 +1,7 @@
+---
+'@sku-lib/codemod': minor
+---
+
+Only accept paths to directories instead of any glob expression
+
+Globs are no longer accepted as input to the CLI. Only paths to directories are accepted.

--- a/.changeset/long-seals-rule.md
+++ b/.changeset/long-seals-rule.md
@@ -1,0 +1,5 @@
+---
+'@sku-lib/codemod': patch
+---
+
+Correctly calculate changed files

--- a/.changeset/tender-parrots-refuse.md
+++ b/.changeset/tender-parrots-refuse.md
@@ -1,0 +1,5 @@
+---
+'@sku-lib/codemod': minor
+---
+
+WIP: Add `jest-to-vitest` codemod

--- a/.changeset/thin-results-watch.md
+++ b/.changeset/thin-results-watch.md
@@ -1,0 +1,5 @@
+---
+'@sku-lib/codemod': patch
+---
+
+Restrict files to only those with JavaScript and TypeScript extensions

--- a/.changeset/wise-llamas-lead.md
+++ b/.changeset/wise-llamas-lead.md
@@ -1,0 +1,11 @@
+---
+'@sku-lib/codemod': minor
+---
+
+Add `jest-to-vitest` codemod
+
+**EXAMPLE USAGE**:
+
+```sh
+pnpm dlx @sku-lib/codemod jest-to-vitest .
+```

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -10,13 +10,15 @@ pnpm dlx @sku-lib/codemod <codemod> [files] [options]
 
 If you don't specify the `codemod` the CLI will prompt you with a list of available codemods.
 
-If you don't specify any `files` the CLI will prompt you to select files to run the codemod on. It defaults to `'.'`.
+If you don't specify any `files` the CLI will prompt you to select files to run the codemod on.
+It defaults to `'.'`.
 
 ## Available codemods
 
 | Codemod                   | Description                                                                     |
 | ------------------------- | ------------------------------------------------------------------------------- |
 | `transform-vite-loadable` | Converts `sku/@loadable/component` imports to `@sku-lib/vite/loadable` imports. |
+| `jest-to-vitest`          | Converts usage of Jest APIs to Vitest APIs.                                     |
 
 ## Options
 

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -5,13 +5,13 @@
 ## Usage
 
 ```sh
-pnpm dlx @sku-lib/codemod <codemod> [files] [options]
+pnpm dlx @sku-lib/codemod <codemod> [path] [options]
 ```
 
 If you don't specify the `codemod` the CLI will prompt you with a list of available codemods.
 
-If you don't specify any `files` the CLI will prompt you to select files to run the codemod on.
-It defaults to `'.'`.
+If you don't specify a `path` the CLI will prompt you to enter a path to a directory to run the codemod on.
+The default path is `'.'`.
 
 ## Available codemods
 

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -8,7 +8,7 @@
     "build": "tsc --project tsconfig.build.json"
   },
   "dependencies": {
-    "@ast-grep/napi": "^0.37.0",
+    "@ast-grep/napi": "^0.39.4",
     "commander": "^12.1.0",
     "diff": "^7.0.0",
     "picocolors": "^1.1.1",

--- a/packages/codemod/src/codemods/jest-to-vitest.ts
+++ b/packages/codemod/src/codemods/jest-to-vitest.ts
@@ -1,0 +1,142 @@
+import { parse, Lang, type Edit } from '@ast-grep/napi';
+
+const jestGlobals = [
+  'expect',
+  'beforeAll',
+  'beforeEach',
+  'afterAll',
+  'afterEach',
+  'describe',
+  'it',
+  'test',
+];
+
+export const transform = (source: string) => {
+  const ast = parse(Lang.Tsx, source);
+  const root = ast.root();
+
+  const edits: Edit[] = [];
+  const vitestImports = new Set<string>();
+
+  // Replace `jest.<method>` with `vi.<method>`
+
+  const jestMethods = root.findAll({
+    // Matches `jest.<method>` except `jest.requireActual` as that is handled separately
+    rule: {
+      pattern: 'jest.$METHOD',
+      kind: 'member_expression',
+      not: {
+        pattern: 'jest.requireActual',
+      },
+    },
+  });
+
+  for (const node of jestMethods) {
+    const methodArg = node.getMatch('METHOD')?.text();
+
+    if (methodArg) {
+      edits.push(node.replace(`vi.${methodArg}`));
+    }
+  }
+
+  if (jestMethods.length > 0) {
+    vitestImports.add('vi');
+  }
+
+  // Replace `jest.mock()` with `vi.mock()`, replace `jest.requireActual()` with
+  // `await vi.importActual()` within the factory, and make the factory async if it isn't already
+
+  const jestMockNodes = root.findAll({
+    rule: {
+      pattern: 'jest.mock',
+      kind: 'member_expression',
+    },
+  });
+
+  const seenJestRequireActualNodes = new Set<number>();
+  for (const node of jestMockNodes) {
+    const parent = node.parent();
+    if (!parent?.is('call_expression')) {
+      // No parent somehow, or parent isn't a call expression
+      continue;
+    }
+
+    const jestMockFactory = parent.field('arguments')?.child(3);
+    if (!jestMockFactory) {
+      // No factory function, nothing to replace
+      continue;
+    }
+
+    const requireActualNodes = jestMockFactory.findAll({
+      rule: {
+        pattern: 'jest.requireActual',
+        kind: 'member_expression',
+      },
+    });
+
+    const jestMockFactoryEdits = requireActualNodes.map((n) => {
+      seenJestRequireActualNodes.add(n.id());
+      return n.replace('await vi.importActual');
+    });
+
+    // Commit edits to the factory function because further targeted edits seem to be overwritten by
+    // broader edits
+
+    if (jestMockFactoryEdits.length > 0) {
+      const newJestMockFactory =
+        jestMockFactory.commitEdits(jestMockFactoryEdits);
+      const factoryIsAsync = newJestMockFactory.startsWith('async');
+      const replacementText = factoryIsAsync
+        ? newJestMockFactory
+        : `async ${newJestMockFactory}`;
+      const edit = jestMockFactory.replace(replacementText);
+      edits.push(edit);
+    }
+  }
+
+  // Replace `jest.requireActual()` calls outside of `jest.mock()` factories
+
+  const requireActualNodes = root.findAll({
+    rule: {
+      pattern: 'jest.requireActual',
+      kind: 'member_expression',
+    },
+  });
+
+  for (const node of requireActualNodes) {
+    const nodeId = node.id();
+    if (!seenJestRequireActualNodes.has(nodeId)) {
+      const edit = node.replace('await vi.importActual');
+      edits.push(edit);
+    }
+  }
+
+  // Track usage of Jest globals and import them from `vitest`
+
+  const foundJestGlobals = root.findAll({
+    // Matches globals like `beforeAll()`, describe()`, `it()`, etc.
+    rule: {
+      any: jestGlobals.map((global) => ({
+        pattern: global,
+        kind: 'call_expression > identifier',
+      })),
+    },
+  });
+
+  for (const node of foundJestGlobals) {
+    const t = node.text();
+    vitestImports.add(t);
+  }
+
+  const result = root.commitEdits(edits);
+
+  // Unsure why, but committing an edit for the vitest import causes a runtime panic, so we
+  // manually add the import instead
+  if (vitestImports.size > 0) {
+    const serializedImports = Array.from(vitestImports).sort().join(', ');
+
+    return `import { ${serializedImports} } from 'vitest';\n${result}`;
+  }
+
+  return result;
+};

--- a/packages/codemod/src/codemods/transform-vite-loadable.ts
+++ b/packages/codemod/src/codemods/transform-vite-loadable.ts
@@ -2,7 +2,7 @@ import { parse, Lang } from '@ast-grep/napi';
 import type { Transform } from '../utils/types.js';
 
 export const transform: Transform = (source) => {
-  const ast = parse(Lang.TypeScript, source);
+  const ast = parse(Lang.Tsx, source);
   const root = ast.root();
 
   const importStatement = root.find({

--- a/packages/codemod/src/program/index.ts
+++ b/packages/codemod/src/program/index.ts
@@ -10,11 +10,8 @@ program
   .description(description)
   .version(version)
   .argument('[codemod]', 'Codemod slug to run.')
-  .argument(
-    '[source]',
-    'Path to source files or directory to transform including glob patterns.',
-  )
-  .usage('[codemod] [source] [options]')
+  .argument('[path]', 'Path to a directory to transform.')
+  .usage('[codemod] [path] [options]')
   .helpOption('-h, --help', 'Display this help message.')
   .option('-d, --dry', 'Dry run (no changes are made to files)')
   .option(

--- a/packages/codemod/src/transform/runner.ts
+++ b/packages/codemod/src/transform/runner.ts
@@ -58,7 +58,7 @@ export const getPathFromPrompt = async (): Promise<string> => {
 
 export const runTransform = async (
   transform: string,
-  path: string,
+  _path: string,
   options: Options,
 ): Promise<void> => {
   if (options.dry) {
@@ -70,7 +70,7 @@ export const runTransform = async (
   }
 
   const transformer = transform || (await getTransformerFromPrompt());
-  const directory = path || (await getPathFromPrompt());
+  const path = _path || (await getPathFromPrompt());
 
   if (transform && !CODEMODS.find((codemod) => codemod.value === transform)) {
     console.error('Invalid transform choice, pick one of:');
@@ -78,10 +78,10 @@ export const runTransform = async (
     process.exit(1);
   }
 
-  const filesExpanded = await getAllFiles([directory]);
+  const filesExpanded = await getAllFiles(path);
 
   if (!filesExpanded.length) {
-    console.log(`No files found matching "${directory}"`);
+    console.log(`No files found matching "${path}"`);
     return;
   }
 
@@ -141,8 +141,10 @@ export const runTransform = async (
   process.exit(0);
 };
 
-const getAllFiles = (paths: string[]) =>
-  glob([...paths, '!**/node_modules', '!**/dist'], {
+const getAllFiles = (directory: string) =>
+  glob(join(directory, '**/*.?(c|m){js,ts}?(x)'), {
+    ignore: ['**/node_modules', '**/dist', ''],
+    expandDirectories: false,
     absolute: true,
   });
 

--- a/packages/codemod/src/transform/worker.ts
+++ b/packages/codemod/src/transform/worker.ts
@@ -19,10 +19,9 @@ await Promise.all(
     const output = transform(source);
 
     if (!output) {
+      console.log('no output for file: ', filePath);
       return;
     }
-
-    filesChanged++;
 
     if (options.print) {
       const diff = createTwoFilesPatch(
@@ -41,6 +40,9 @@ await Promise.all(
 
     if (!options.dry) {
       await writeFile(filePath, output);
+      if (source !== output) {
+        filesChanged++;
+      }
     }
   }),
 );

--- a/packages/codemod/src/utils/constants.ts
+++ b/packages/codemod/src/utils/constants.ts
@@ -1,13 +1,19 @@
-export type Codemod = {
+type Codemod = {
   description: string;
   value: string;
 };
 
-export const CODEMODS: Codemod[] = [
+export const CODEMODS = [
   {
     description:
       'Transform all webpack loadable imports to Vite loadable imports',
     value: 'transform-vite-loadable',
   },
+  {
+    description: 'Convert Jest tests to Vitest',
+    value: 'jest-to-vitest',
+  },
   /* [add-sku-codemod-generator: codemod] */
-];
+] as const satisfies Codemod[];
+
+export type CodemodName = (typeof CODEMODS)[number]['value'];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -824,8 +824,8 @@ importers:
   packages/codemod:
     dependencies:
       '@ast-grep/napi':
-        specifier: ^0.37.0
-        version: 0.37.0
+        specifier: ^0.39.4
+        version: 0.39.4
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -1537,62 +1537,62 @@ packages:
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
-  '@ast-grep/napi-darwin-arm64@0.37.0':
-    resolution: {integrity: sha512-QAiIiaAbLvMEg/yBbyKn+p1gX2/FuaC0SMf7D7capm/oG4xGMzdeaQIcSosF4TCxxV+hIH4Bz9e4/u7w6Bnk3Q==}
+  '@ast-grep/napi-darwin-arm64@0.39.4':
+    resolution: {integrity: sha512-qK8qs8SxpHUM8BLaGiISxuqugJyP8Rl9EQF6xMconqSvyfgMGuuaphbsqXXcAFjORI3PPYk6klN2zALTmNMFWA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@ast-grep/napi-darwin-x64@0.37.0':
-    resolution: {integrity: sha512-zvcvdgekd4ySV3zUbUp8HF5nk5zqwiMXTuVzTUdl/w08O7JjM6XPOIVT+d2o/MqwM9rsXdzdergY5oY2RdhSPA==}
+  '@ast-grep/napi-darwin-x64@0.39.4':
+    resolution: {integrity: sha512-S2vGHuLA1yzyqvcrP5Dg6c+vb4RxCcXrFwZP0WNonIgUrXTu0wVv0ab0Yo3WgCgYfOSOqG2MXOnJ39u8fJ/Xdg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@ast-grep/napi-linux-arm64-gnu@0.37.0':
-    resolution: {integrity: sha512-L7Sj0lXy8X+BqSMgr1LB8cCoWk0rericdeu+dC8/c8zpsav5Oo2IQKY1PmiZ7H8IHoFBbURLf8iklY9wsD+cyA==}
+  '@ast-grep/napi-linux-arm64-gnu@0.39.4':
+    resolution: {integrity: sha512-IsadlMH5MRDH4tB31InBZuWe8BPkppGSLJPJu6WJbA1JlC6Gr8pF9kshQ+8Vh9n3usWYA4AU8ZBbYPnd3Kb5Cw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@ast-grep/napi-linux-arm64-musl@0.37.0':
-    resolution: {integrity: sha512-LF9sAvYy6es/OdyJDO3RwkX3I82Vkfsng1sqUBcoWC1jVb1wX5YVzHtpQox9JrEhGl+bNp7FYxB4Qba9OdA5GA==}
+  '@ast-grep/napi-linux-arm64-musl@0.39.4':
+    resolution: {integrity: sha512-8+BNJ29UslwIwEfSFDviTxfk/dZCNzAiNlpnvEOQeAGrhrCBf8ubVGNAGx3G2SxaOvbguBghoxyjZ1NqZma5JQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@ast-grep/napi-linux-x64-gnu@0.37.0':
-    resolution: {integrity: sha512-TViz5/klqre6aSmJzswEIjApnGjJzstG/SE8VDWsrftMBMYt2PTu3MeluZVwzSqDao8doT/P+6U11dU05UOgxw==}
+  '@ast-grep/napi-linux-x64-gnu@0.39.4':
+    resolution: {integrity: sha512-Gka51hqZBvof9eO6QYfQWjBWXGaWM5126bw5i1oQu8bKunZXubCelz7AnwC0pnxIHH9tM31ACihnS7UDbfcDUQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@ast-grep/napi-linux-x64-musl@0.37.0':
-    resolution: {integrity: sha512-/BcCH33S9E3ovOAEoxYngUNXgb+JLg991sdyiNP2bSoYd30a9RHrG7CYwW6fMgua3ijQ474eV6cq9yZO1bCpXg==}
+  '@ast-grep/napi-linux-x64-musl@0.39.4':
+    resolution: {integrity: sha512-9/+/EHx0M0RXXt4eBrWF0SEF8W8rioGZHRzZiR/u71eOnjriM2Cgzz2wrMRDQBd3xFzelQILqIpmY9s/5zxz/w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@ast-grep/napi-win32-arm64-msvc@0.37.0':
-    resolution: {integrity: sha512-TjQA4cFoIEW2bgjLkaL9yqT4XWuuLa5MCNd0VCDhGRDMNQ9+rhwi9eLOWRaap3xzT7g+nlbcEHL3AkVCD2+b3A==}
+  '@ast-grep/napi-win32-arm64-msvc@0.39.4':
+    resolution: {integrity: sha512-4jmOGBxOyQHd27j4w1Fm9/RAZeocTgKlSZh3KX5vWYiaIKVGEyenxL6DAchFukUkHu0mmPSG2UJJf5v+QbBsQQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@ast-grep/napi-win32-ia32-msvc@0.37.0':
-    resolution: {integrity: sha512-uNmVka8fJCdYsyOlF9aZqQMLTatEYBynjChVTzUfFMDfmZ0bihs/YTqJVbkSm8TZM7CUX82apvn50z/dX5iWRA==}
+  '@ast-grep/napi-win32-ia32-msvc@0.39.4':
+    resolution: {integrity: sha512-hoOxsE3NCsgPBDp9DX349IwIt5zwB2kNafNzktYSkQcTqFAHSv7NfJKi8QIcamQDPHQ3VN+ch6uEXrSiWnnzuQ==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@ast-grep/napi-win32-x64-msvc@0.37.0':
-    resolution: {integrity: sha512-vCiFOT3hSCQuHHfZ933GAwnPzmL0G04JxQEsBRfqONywyT8bSdDc/ECpAfr3S9VcS4JZ9/F6tkePKW/Om2Dq2g==}
+  '@ast-grep/napi-win32-x64-msvc@0.39.4':
+    resolution: {integrity: sha512-3mlIese51roq6AdIM15YZRagD23jiDpQfFjLmIH5RXVJ1+qRCaMMfq6+Gp/5g1mp9EQlK2RMx4Kakx/J0ou/jg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@ast-grep/napi@0.37.0':
-    resolution: {integrity: sha512-Hb4o6h1Pf6yRUAX07DR4JVY7dmQw+RVQMW5/m55GoiAT/VRoKCWBtIUPPOnqDVhbx1Cjfil9b6EDrgJsUAujEQ==}
+  '@ast-grep/napi@0.39.4':
+    resolution: {integrity: sha512-mm5FlOa3DW6PkKRZw0Gn12vQyFB86Es4yid/Ds7f7kvazQOwvpZ31U3Gp9C4Z3trm4rBYnY861UlvmGw5P7rSg==}
     engines: {node: '>= 10'}
 
   '@babel/code-frame@7.27.1':
@@ -9421,44 +9421,44 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@ast-grep/napi-darwin-arm64@0.37.0':
+  '@ast-grep/napi-darwin-arm64@0.39.4':
     optional: true
 
-  '@ast-grep/napi-darwin-x64@0.37.0':
+  '@ast-grep/napi-darwin-x64@0.39.4':
     optional: true
 
-  '@ast-grep/napi-linux-arm64-gnu@0.37.0':
+  '@ast-grep/napi-linux-arm64-gnu@0.39.4':
     optional: true
 
-  '@ast-grep/napi-linux-arm64-musl@0.37.0':
+  '@ast-grep/napi-linux-arm64-musl@0.39.4':
     optional: true
 
-  '@ast-grep/napi-linux-x64-gnu@0.37.0':
+  '@ast-grep/napi-linux-x64-gnu@0.39.4':
     optional: true
 
-  '@ast-grep/napi-linux-x64-musl@0.37.0':
+  '@ast-grep/napi-linux-x64-musl@0.39.4':
     optional: true
 
-  '@ast-grep/napi-win32-arm64-msvc@0.37.0':
+  '@ast-grep/napi-win32-arm64-msvc@0.39.4':
     optional: true
 
-  '@ast-grep/napi-win32-ia32-msvc@0.37.0':
+  '@ast-grep/napi-win32-ia32-msvc@0.39.4':
     optional: true
 
-  '@ast-grep/napi-win32-x64-msvc@0.37.0':
+  '@ast-grep/napi-win32-x64-msvc@0.39.4':
     optional: true
 
-  '@ast-grep/napi@0.37.0':
+  '@ast-grep/napi@0.39.4':
     optionalDependencies:
-      '@ast-grep/napi-darwin-arm64': 0.37.0
-      '@ast-grep/napi-darwin-x64': 0.37.0
-      '@ast-grep/napi-linux-arm64-gnu': 0.37.0
-      '@ast-grep/napi-linux-arm64-musl': 0.37.0
-      '@ast-grep/napi-linux-x64-gnu': 0.37.0
-      '@ast-grep/napi-linux-x64-musl': 0.37.0
-      '@ast-grep/napi-win32-arm64-msvc': 0.37.0
-      '@ast-grep/napi-win32-ia32-msvc': 0.37.0
-      '@ast-grep/napi-win32-x64-msvc': 0.37.0
+      '@ast-grep/napi-darwin-arm64': 0.39.4
+      '@ast-grep/napi-darwin-x64': 0.39.4
+      '@ast-grep/napi-linux-arm64-gnu': 0.39.4
+      '@ast-grep/napi-linux-arm64-musl': 0.39.4
+      '@ast-grep/napi-linux-x64-gnu': 0.39.4
+      '@ast-grep/napi-linux-x64-musl': 0.39.4
+      '@ast-grep/napi-win32-arm64-msvc': 0.39.4
+      '@ast-grep/napi-win32-ia32-msvc': 0.39.4
+      '@ast-grep/napi-win32-x64-msvc': 0.39.4
 
   '@babel/code-frame@7.27.1':
     dependencies:

--- a/private/testing-library/render-codemod.ts
+++ b/private/testing-library/render-codemod.ts
@@ -1,20 +1,19 @@
 import { render, type RenderOptions } from 'cli-testing-library';
 import { createRequire } from 'node:module';
+import type { CodemodName } from '../../packages/codemod/src/utils/constants.js';
 
 const require = createRequire(import.meta.url);
 const codemodBin = require.resolve('../../packages/codemod/bin.js');
 
-type Command = 'transform-vite-loadable';
-
 const renderCodemod = async (
-  command: Command,
+  command: CodemodName,
   args: string[] = [],
   options: Partial<RenderOptions> = {},
 ) => render(codemodBin, [command, ...args], options);
 
 export const scopeToFixture = (dir: string) => ({
   codemod: (
-    command: Command,
+    command: CodemodName,
     args: string[] = [],
     options: Partial<RenderOptions> = {},
   ) =>

--- a/tests/node/sku-codemods.test.ts
+++ b/tests/node/sku-codemods.test.ts
@@ -1,89 +1,216 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs/promises';
-import dedent from 'dedent';
+import ts from 'dedent';
 import { createFixture } from 'fs-fixture';
 import { scopeToFixture } from '@sku-private/testing-library/codemod';
+import type { CodemodName } from '../../packages/codemod/src/utils/constants.js';
 
-const filesToTest = [
+type TestCase = {
+  filename: string;
+  codemodName: CodemodName;
+  input: string;
+  output: string;
+};
+
+const testCases: TestCase[] = [
   {
     filename: 'customNameFixture.tsx',
-    input: dedent /* typescript */ `import customLoadable from "sku/@loadable/component";
+    codemodName: 'transform-vite-loadable',
+    input: ts /* ts */ `
+      import customLoadable from "sku/@loadable/component";
 
-        const LoadableComponent = customLoadable(() => import('./MyComponent'));`,
-    output: dedent /* typescript */ `import { loadable as customLoadable } from '@sku-lib/vite/loadable';
+      const LoadableComponent = customLoadable(() => import('./MyComponent'));`,
+    output: ts /* ts */ `
+      import { loadable as customLoadable } from '@sku-lib/vite/loadable';
 
-        const LoadableComponent = customLoadable(() => import('./MyComponent'));`,
+      const LoadableComponent = customLoadable(() => import('./MyComponent'));`,
   },
   {
     filename: 'loadableNameFixture.tsx',
-    input: dedent /* typescript */ `import loadable from 'sku/@loadable/component';
+    codemodName: 'transform-vite-loadable',
+    input: ts /* ts */ `
+      import loadable from 'sku/@loadable/component';
 
-        const LoadableComponent = loadable(() => import('./MyComponent'));`,
-    output: dedent /* typescript */ `import { loadable } from '@sku-lib/vite/loadable';
+      const LoadableComponent = loadable(() => import('./MyComponent'));`,
+    output: ts /* ts */ `
+      import { loadable } from '@sku-lib/vite/loadable';
 
-        const LoadableComponent = loadable(() => import('./MyComponent'));`,
+      const LoadableComponent = loadable(() => import('./MyComponent'));`,
   },
   {
     filename: 'onlyNamedImportFixture.tsx',
-    input: dedent /* typescript */ `import { loadableReady } from 'sku/@loadable/component';
+    codemodName: 'transform-vite-loadable',
+    input: ts /* ts */ `
+      import { loadableReady } from 'sku/@loadable/component';
 
-        loadableReady();`,
-    output: dedent /* typescript */ `import { loadableReady } from 'sku/@loadable/component';
+      loadableReady();`,
+    output: ts /* ts */ `
+      import { loadableReady } from 'sku/@loadable/component';
 
-        loadableReady();`,
+      loadableReady();`,
   },
   {
     filename: 'mixedImportFixture.tsx',
-    input: dedent /* typescript */ `import { loadableReady } from 'sku/@loadable/component';
-        import loadable from 'sku/@loadable/component';
+    codemodName: 'transform-vite-loadable',
+    input: ts /* ts */ `
+      import { loadableReady } from 'sku/@loadable/component';
+      import loadable from 'sku/@loadable/component';
 
-        loadable();
+      loadable();
 
-        loadableReady();`,
-    output: dedent /* typescript */ `import { loadableReady } from 'sku/@loadable/component';
-        import { loadable } from '@sku-lib/vite/loadable';
+      loadableReady();`,
+    output: ts /* ts */ `
+      import { loadableReady } from 'sku/@loadable/component';
+      import { loadable } from '@sku-lib/vite/loadable';
 
-        loadable();
+      loadable();
 
-        loadableReady();`,
+      loadableReady();`,
+  },
+  {
+    filename: 'example.test.tsx',
+    codemodName: 'jest-to-vitest',
+    input: ts /* ts */ `
+      const foo = jest.fn();
+      const bar = jest.fn((bar) => bar);
+
+      beforeAll(() => {});
+      afterAll(() => {});
+      beforeEach(() => {});
+      afterEach(() => {});
+
+      jest.mock('./foo', () => {
+        const originalModule = jest.requireActual('./foo');
+
+        return {
+          ...originalModule,
+          foo: 'foo',
+        };
+      })
+
+      jest.mock('./foo', function () {
+        const originalModule = jest.requireActual('./foo');
+
+        return {
+          ...originalModule,
+          foo: 'foo',
+        };
+      })
+
+      jest.mock('./foo2', () => ({
+          ...jest.requireActual('./foo2'),
+          ...jest.requireActual('./foo3'),
+          foo: 'foo',
+        })
+      );
+
+      jest.mock('./foo4', async () => ({
+          ...jest.requireActual('./foo4'),
+          foo: 'foo',
+        })
+      );
+
+      const standalone = jest.requireActual('standalone');
+
+      describe("foo", () => {
+        it("should foo", () => {
+          expect("foo").toBe("foo");
+        });
+        test("should foo", () => {
+          expect("foo").toBe("foo");
+        })
+      })`,
+    output: ts /* ts */ `
+      import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test, vi } from 'vitest';
+      const foo = vi.fn();
+      const bar = vi.fn((bar) => bar);
+
+      beforeAll(() => {});
+      afterAll(() => {});
+      beforeEach(() => {});
+      afterEach(() => {});
+
+      vi.mock('./foo', async () => {
+        const originalModule = await vi.importActual('./foo');
+
+        return {
+          ...originalModule,
+          foo: 'foo',
+        };
+      })
+
+      vi.mock('./foo', async function () {
+        const originalModule = await vi.importActual('./foo');
+
+        return {
+          ...originalModule,
+          foo: 'foo',
+        };
+      })
+
+      vi.mock('./foo2', async () => ({
+          ...await vi.importActual('./foo2'),
+          ...await vi.importActual('./foo3'),
+          foo: 'foo',
+        })
+      );
+
+      vi.mock('./foo4', async () => ({
+          ...await vi.importActual('./foo4'),
+          foo: 'foo',
+        })
+      );
+
+      const standalone = await vi.importActual('standalone');
+
+      describe("foo", () => {
+        it("should foo", () => {
+          expect("foo").toBe("foo");
+        });
+        test("should foo", () => {
+          expect("foo").toBe("foo");
+        })
+      })`,
   },
 ];
 
 describe('sku codemods', () => {
-  describe('"transform-vite-loadable" codemod', async () => {
-    describe.for(filesToTest)(
-      'File $filename',
-      async ({ filename, input, output }) => {
-        const fixture = await createFixture({
-          [filename]: input,
-        });
+  describe.for(testCases)(
+    'Codemod $codemodName - File $filename',
+    async ({ filename, codemodName, input, output }) => {
+      const fixture = await createFixture({
+        [filename]: input,
+      });
 
-        const { codemod } = scopeToFixture(fixture.path);
+      const { codemod } = scopeToFixture(fixture.path);
 
-        it('"--dry" should not change any files', async () => {
-          const cli = await codemod('transform-vite-loadable', ['.', '--dry']);
-          expect(
-            await cli.findByText('files found that would be changed.'),
-          ).toBeInTheConsole();
+      it('"--dry" should not change any files', async () => {
+        const cli = await codemod(codemodName, ['.', '--dry']);
 
-          const fileContent = await fs.readFile(
-            fixture.getPath(filename),
-            'utf-8',
-          );
-          expect(fileContent).toEqual(input);
-        });
+        expect(
+          await cli.findByText('files found that would be changed.'),
+        ).toBeInTheConsole();
 
-        it('Should transform files and match expected output', async () => {
-          const cli = await codemod('transform-vite-loadable', ['.']);
-          expect(await cli.findByText('Changed files')).toBeInTheConsole();
+        const fileContent = await fs.readFile(
+          fixture.getPath(filename),
+          'utf-8',
+        );
 
-          const fileContent = await fs.readFile(
-            fixture.getPath(filename),
-            'utf-8',
-          );
-          expect(fileContent).toEqual(output);
-        });
-      },
-    );
-  });
+        expect(fileContent).toEqual(input);
+      });
+
+      it('Should transform files and match expected output', async () => {
+        const cli = await codemod(codemodName, ['.']);
+
+        expect(await cli.findByText('Changed files')).toBeInTheConsole();
+
+        const fileContent = await fs.readFile(
+          fixture.getPath(filename),
+          'utf-8',
+        );
+
+        expect(fileContent).toEqual(output);
+      });
+    },
+  );
 });


### PR DESCRIPTION
Added a `jest-to-vitest` codemod that handles more cases than the previously recommended [`jest/vitest` codemod](https://app.codemod.com/registry/jest/vitest). Specifically it handles:
- Renaming `jest` to `vi`
- Importing globals such as `expect, it, describe, beforeAll`
- Updating `jest.requireActual` to `await vi.importActual`
- Wrapping functions with `async` that call `await vi.importActual`

And it's much faster, taking ~2s to parse and transform ~2k files, compared to ~20s for the other codemod (though that on does default to using only 4 threads).

I've also tweaked the codemod CLI to no longer accept a glob pattern. It now only accepts a single path to a directory. This was done so we can better control which files are parsed, as the previous implementation would pick up _all_ files, potentially resulting in the codemod parser treating non-JS/TS files as JS.

I also fixed a bug that was resulting in an incorrect changed files count to be reported. Finally, the `sku-codemod` tests have been refactored to enable testing of multiple different codemods.