### PR TITLE
Add descriptions to `create` templates

### DIFF
--- a/packages/create/src/cli.ts
+++ b/packages/create/src/cli.ts
@@ -50,8 +50,18 @@ program
         name: 'template',
         message: 'Which template would you like to use?',
         choices: [
-          { title: 'webpack', value: 'webpack' },
-          { title: 'vite (experimental)', value: 'vite' },
+          {
+            title: 'Webpack',
+            value: 'webpack',
+            description:
+              "Equivalent to the existing 'sku init' template. Uses Webpack for serving and bundling your application, and Jest for running tests. Select this template for a stable, battle-tested development environment.",
+          },
+          {
+            title: 'Vite (experimental)',
+            value: 'vite',
+            description:
+              'NOT PRODUCTION-READY. An experimental template that uses Vite for serving and bundling your application, and Vitest for running tests. Select this template for fast builds and lightning-fast local development.',
+          },
         ],
         initial: 0,
       });

--- a/packages/create/src/cli.ts
+++ b/packages/create/src/cli.ts
@@ -54,13 +54,13 @@ program
             title: 'Webpack',
             value: 'webpack',
             description:
-              "Equivalent to the existing 'sku init' template. Uses Webpack for serving and bundling your application, and Jest for running tests. Select this template for a stable, battle-tested development environment.",
+              "Equivalent to the existing 'sku init' template. Uses Webpack for serving and bundling your application, and Jest for running tests. Select this template for a familiar, production-ready development environment.",
           },
           {
             title: 'Vite (experimental)',
             value: 'vite',
             description:
-              'NOT PRODUCTION-READY. An experimental template that uses Vite for serving and bundling your application, and Vitest for running tests. Select this template for fast builds and lightning-fast local development.',
+              'NOT PRODUCTION-READY. An experimental template that uses Vite for serving and bundling your application, and Vitest for running tests. Select this template to experiment with upcoming features.',
           },
         ],
         initial: 0,
@@ -74,7 +74,7 @@ program
         type: 'confirm',
         name: 'confirmVite',
         message:
-          '⚠️  Vite support in sku is currently experimental and not yet suitable for production use. Continue?',
+          '⚠️ Vite support in sku is currently experimental and not yet suitable for production use. Continue?',
         initial: false,
       });
 


### PR DESCRIPTION
To make it easier to at-a-glance decide which template to use. While the `(experimental)` label should do well on its own, adding a little bit more information to both templates should help consumers make an informed decision. Happy to iterate on the wording.

No changeset as the change will be released in the initial release of the create package.