### PR TITLE
`vitest`: Fix watch mode

### DIFF
--- a/.changeset/large-pots-smile.md
+++ b/.changeset/large-pots-smile.md
@@ -1,0 +1,5 @@
+---
+'@sku-lib/vitest': patch
+---
+
+Fix `watch` mode

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -20,7 +20,7 @@ export const runVitest = async ({
   const results = parseCLI(['vitest', ...args]);
   const { cjsInteropDependencies, compilePackages } = skuContext;
 
-  const vitest = await startVitest(
+  const ctx = await startVitest(
     'test',
     results.filter,
     { config: false, ...results.options },
@@ -43,5 +43,7 @@ export const runVitest = async ({
     {},
   );
 
-  await vitest.close();
+  if (!ctx.shouldKeepServer()) {
+    await ctx.exit();
+  }
 };


### PR DESCRIPTION
This implementation is based off [what the official CLI does](https://github.com/vitest-dev/vitest/blob/a54ff97659c215b047145f0eab53094948cb17a3/packages/vitest/src/node/cli/cac.ts#L299-L301), which is what we should've referenced from the beginning.