### PR TITLE
`vitest`: Correctly forward CJS interop dependencies

### DIFF
--- a/.changeset/lemon-bats-grab.md
+++ b/.changeset/lemon-bats-grab.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`vitest`: Correctly forward CJS interop dependencies

--- a/packages/sku/src/context/createSkuContext.ts
+++ b/packages/sku/src/context/createSkuContext.ts
@@ -40,6 +40,8 @@ const generateTypeScriptPaths = (
   return typeScriptPaths;
 };
 
+const defaultCjsInteropDependencies = ['@apollo/client', 'lodash'];
+
 interface SkuContextOptions {
   configPath?: string;
   port?: number;
@@ -289,6 +291,10 @@ export const createSkuContext = ({
     skipPackageCompatibilityCompilation,
     externalizeNodeModules,
     defaultClientEntry,
+    cjsInteropDependencies: [
+      ...defaultCjsInteropDependencies,
+      ...skuConfig.__UNSAFE_EXPERIMENTAL__cjsInteropDependencies,
+    ],
   };
 };
 

--- a/packages/sku/src/program/commands/test/vitest-test-handler.ts
+++ b/packages/sku/src/program/commands/test/vitest-test-handler.ts
@@ -52,8 +52,7 @@ export const vitestHandler = async ({
     setupFiles: skuContext.paths.setupTests,
     args,
     skuContext: {
-      cjsInteropDependencies:
-        skuContext.skuConfig.__UNSAFE_EXPERIMENTAL__cjsInteropDependencies,
+      cjsInteropDependencies: skuContext.cjsInteropDependencies,
       compilePackages: skuContext.skuConfig.compilePackages,
     },
   });

--- a/packages/sku/src/services/vite/helpers/config/baseConfig.ts
+++ b/packages/sku/src/services/vite/helpers/config/baseConfig.ts
@@ -53,11 +53,7 @@ const getBaseConfig = (skuContext: SkuContext): InlineConfig => {
       vocabConfig && vocabPluginVite.default({ vocabConfig }),
       tsconfigPaths(),
       cjsInterop({
-        dependencies: [
-          '@apollo/client',
-          'lodash',
-          ...skuContext.skuConfig.__UNSAFE_EXPERIMENTAL__cjsInteropDependencies,
-        ],
+        dependencies: skuContext.cjsInteropDependencies,
       }),
       react({
         babel: {


### PR DESCRIPTION
The default CJS interop dependencies were only injected in the base vite config, rather than at the sku context level, allowing them to passed to vitest as well.