### PR TITLE
`codemod`: Add support for converting jest mocked typecasts to `vi.mocked` function calls

### DIFF
--- a/.changeset/puny-things-grow.md
+++ b/.changeset/puny-things-grow.md
@@ -1,0 +1,5 @@
+---
+'@sku-lib/codemod': minor
+---
+
+Add support for converting `jest.Mock` and `jest.MockedFunction` typecasts into `vi.mocked` function calls

--- a/tests/node/sku-codemods.test.ts
+++ b/tests/node/sku-codemods.test.ts
@@ -112,6 +112,13 @@ const testCases: TestCase[] = [
 
       const standalone = jest.requireActual('standalone');
 
+      const mockedFoo = foo as jest.Mock;
+      const mockedFoo = foo as jest.Mock<any>;
+      const mockedFoo = foo as jest.Mock<any, any, any>;
+      const mockedFoo = foo as jest.MockedFunction;
+      const mockedFoo = foo as jest.MockedFunction<typeof foo>;
+      const mockedFoo = foo as jest.MockedFunction<typeof foo> & { otherProperty: any };
+
       describe("foo", () => {
         it("should foo", () => {
           expect("foo").toBe("foo");
@@ -162,6 +169,13 @@ const testCases: TestCase[] = [
       );
 
       const standalone = await vi.importActual('standalone');
+
+      const mockedFoo = vi.mocked(foo);
+      const mockedFoo = vi.mocked(foo);
+      const mockedFoo = vi.mocked(foo);
+      const mockedFoo = vi.mocked(foo);
+      const mockedFoo = vi.mocked(foo);
+      const mockedFoo = vi.mocked(foo);
 
       describe("foo", () => {
         it("should foo", () => {


### PR DESCRIPTION
Patterns such as `const mockedFoo = foo as jest.Mock;` and `const mockedFoo = foo as jest.MockedFunction<typeof foo>;` seem to be common enough patterns that a codemod would be useful to convert them to use `vi.mocked()`.