### PR TITLE
`vitest`: Correctly forward compile packages

### DIFF
--- a/.changeset/gold-rivers-hide.md
+++ b/.changeset/gold-rivers-hide.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`vitest`: Correctly forward compile packages

--- a/packages/sku/src/program/commands/test/vitest-test-handler.ts
+++ b/packages/sku/src/program/commands/test/vitest-test-handler.ts
@@ -53,7 +53,7 @@ export const vitestHandler = async ({
     args,
     skuContext: {
       cjsInteropDependencies: skuContext.cjsInteropDependencies,
-      compilePackages: skuContext.skuConfig.compilePackages,
+      compilePackages: skuContext.paths.compilePackages,
     },
   });
 };


### PR DESCRIPTION
`skuContext.skuConfig.compilePackages` doesn't contain sku-detected compile packages, whereas `skuContext.paths.compilePackages` does. These are then passed to `ssr.noExternal`, which results in these packages being processed by Vite ([inlined](https://vitest.dev/config/#server-deps-inline)), and I _think_ eventually run through [Vitest's own CJS interop handler](https://vitest.dev/config/#deps-interopdefault). This leads me to believe that the CJS interop plugin isn't actually doing anything in the Vitest config, but that can be addressed separately.