### PR TITLE
`codemod`: Add support for detecting chained test methods

### DIFF
--- a/.changeset/polite-onions-hang.md
+++ b/.changeset/polite-onions-hang.md
@@ -1,0 +1,5 @@
+---
+'@sku-lib/codemod': minor
+---
+
+Add support for detecting chained test methods such as `it.each` and `test.skip.each`

--- a/tests/node/sku-codemods.test.ts
+++ b/tests/node/sku-codemods.test.ts
@@ -186,6 +186,21 @@ const testCases: TestCase[] = [
         })
       })`,
   },
+  {
+    filename: 'chainedTestMethods.test.ts',
+    codemodName: 'jest-to-vitest',
+    input: ts /* ts */ `
+      test.only("foo")
+      describe.skip.each("foo")
+      it.skip.each("foo")
+    `,
+    output: ts /* ts */ `
+      import { describe, it, test } from 'vitest';
+      test.only("foo")
+      describe.skip.each("foo")
+      it.skip.each("foo")
+    `,
+  },
 ];
 
 describe('sku codemods', () => {


### PR DESCRIPTION
Add support for detecting chained test methods such as `it.each` and `test.skip.each`.