### PR TITLE
`docs`: Add section about vitest testing library matchers

### DIFF
--- a/docs/docs/vite.md
+++ b/docs/docs/vite.md
@@ -183,6 +183,16 @@ To run test without watch mode you can use `sku test --run`:
 }
 ```
 
+**Testing Library Matchers**
+
+If your test setup file includes an import for `@testing-library/jest-dom`, you may need to change this to `@testing-library/jest-dom/vitest`:
+
+```diff
+// test-setup.ts
+- import '@testing-library/jest-dom';
++ import '@testing-library/jest-dom/vitest';
+```
+
 **Globals disabled**
 
 Jest enables global APIs such as `it`, `describe`, `beforeAll`, etc., by default.
@@ -198,7 +208,7 @@ Be aware that since globals are disabled, some common libraries like `testing-li
 If using these libraries, you will need to add cleanup to your configured `setupTests` file.
 
 ```diff
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 
 + import { cleanup } from '@testing-library/react';
 + import { afterEach } from 'vitest';

--- a/fixtures/sku-test/package.json
+++ b/fixtures/sku-test/package.json
@@ -5,11 +5,15 @@
   "devDependencies": {
     "sku": "workspace:*",
     "@types/jest": "^30.0.0",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
+    "@types/react": "catalog:"
   },
   "dependencies": {
     "@sku-private/3rd-party-cjs-interop-dep": "workspace:*",
-    "@apollo/client": "^3.14.0"
+    "@apollo/client": "^3.14.0",
+    "react": "catalog:"
   },
   "skuSkipValidatePeerDeps": true
 }

--- a/fixtures/sku-test/setup-test.ts
+++ b/fixtures/sku-test/setup-test.ts
@@ -1,1 +1,3 @@
+import '@testing-library/jest-dom';
+
 console.log('running setup test');

--- a/fixtures/sku-test/setup-test.vitest.ts
+++ b/fixtures/sku-test/setup-test.vitest.ts
@@ -1,0 +1,3 @@
+import '@testing-library/jest-dom/vitest';
+
+console.log('running setup test');

--- a/fixtures/sku-test/sku.config.vitest.ts
+++ b/fixtures/sku-test/sku.config.vitest.ts
@@ -2,6 +2,6 @@ import { makeStableViteHashes } from '@sku-private/test-utils';
 
 export default {
   __UNSAFE_EXPERIMENTAL__testRunner: 'vitest',
-  setupTests: ['./setup-test.ts'],
+  setupTests: ['./setup-test.vitest.ts'],
   __UNSAFE_EXPERIMENTAL__dangerouslySetViteConfig: makeStableViteHashes,
 };

--- a/fixtures/sku-test/src/jest.test.ts
+++ b/fixtures/sku-test/src/jest.test.ts
@@ -1,5 +1,16 @@
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
+
 describe('good tests', () => {
   it('should be true', () => {
     expect(true).toBe(true);
+  });
+});
+
+describe('testing-library', () => {
+  it('should render a div', () => {
+    const { getByText } = render(createElement('div', null, 'Hello World'));
+
+    expect(getByText('Hello World')).toBeInTheDocument();
   });
 });

--- a/fixtures/sku-test/src/vitest.test.ts
+++ b/fixtures/sku-test/src/vitest.test.ts
@@ -1,7 +1,17 @@
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
 import { describe, it, expect } from 'vitest';
 
 describe('good tests', () => {
   it('should be true', () => {
     expect(true).toBe(true);
+  });
+});
+
+describe('testing-library', () => {
+  it('should render a div', () => {
+    const { getByText } = render(createElement('div', null, 'Hello World'));
+
+    expect(getByText('Hello World')).toBeInTheDocument();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,10 +532,22 @@ importers:
       '@sku-private/3rd-party-cjs-interop-dep':
         specifier: workspace:*
         version: link:../../private/3rd-party-cjs-interop-dep
+      react:
+        specifier: 'catalog:'
+        version: 19.1.1
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.8.0
+        version: 6.8.0
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.1.9
       sku:
         specifier: workspace:*
         version: link:../../packages/sku
@@ -3357,8 +3369,8 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
-  '@testing-library/jest-dom@6.6.3':
-    resolution: {integrity: sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==}
+  '@testing-library/jest-dom@6.8.0':
+    resolution: {integrity: sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
   '@testing-library/react@16.3.0':
@@ -11771,14 +11783,13 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.6.3':
+  '@testing-library/jest-dom@6.8.0':
     dependencies:
       '@adobe/css-tools': 4.4.3
       aria-query: 5.3.2
-      chalk: 3.0.0
       css.escape: 1.5.1
       dom-accessibility-api: 0.6.3
-      lodash: 4.17.21
+      picocolors: 1.1.1
       redent: 3.0.0
 
   '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
@@ -18201,7 +18212,7 @@ snapshots:
   storybook@9.1.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.2(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)):
     dependencies:
       '@storybook/global': 5.0.0
-      '@testing-library/jest-dom': 6.6.3
+      '@testing-library/jest-dom': 6.8.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
       '@vitest/mocker': 3.2.4(vite@7.1.2(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))


### PR DESCRIPTION
Not sure how necessary this is, but it can't hurt to suggest it. `@testing-library/jest-dom/vitest` is a really confusing entrypoint unfortunately.

I've also added some testing library tests to the `sku-test` fixture. We already have a testing library test in the `braid-design-system`, but I don't think some separate, non-braid-related tests will hurt.