### PR TITLE
`codemod`: Correctly replace `jest.fn` with `vi.fn` inside mock factories

### DIFF
--- a/.changeset/tough-wings-throw.md
+++ b/.changeset/tough-wings-throw.md
@@ -1,0 +1,5 @@
+---
+'@sku-lib/codemod': patch
+---
+
+Fixed a bug causing `jest.fn` to not be replaced with `vi.fn` inside mock factories

--- a/tests/node/sku-codemods.test.ts
+++ b/tests/node/sku-codemods.test.ts
@@ -85,6 +85,7 @@ const testCases: TestCase[] = [
         return {
           ...originalModule,
           foo: 'foo',
+          bar: jest.fn(),
         };
       })
 
@@ -143,6 +144,7 @@ const testCases: TestCase[] = [
         return {
           ...originalModule,
           foo: 'foo',
+          bar: vi.fn(),
         };
       })
 


### PR DESCRIPTION
An alternative solution would be to commit edits and re-parse the result between some steps of the codemod, but that's less efficient so I opted against it.