### PR TITLE
Add warnings for unnecessary polyfills in `start`/`start-ssr` commands

### DIFF
--- a/.changeset/deep-ends-vanish.md
+++ b/.changeset/deep-ends-vanish.md
@@ -2,4 +2,6 @@
 'sku': minor
 ---
 
-Add warnings for unnecessary polyfills during development. `sku start` and `sku start-ssr`, along with `sku build` and `sku build-ssr` now warn about polyfills that are no longer needed for modern browsers to help reduce bundle sizes.
+Emit warnings when unnecessary polyfills are detected
+
+To help reduce bundle size, start and build commands now warn about polyfills that are no longer necessary in modern browsers.

--- a/.changeset/deep-ends-vanish.md
+++ b/.changeset/deep-ends-vanish.md
@@ -2,4 +2,4 @@
 'sku': minor
 ---
 
-Add warnings for unnecessary polyfills during development. `sku start` and `sku start-ssr` now warn about polyfills that are no longer needed for modern browsers to help reduce bundle sizes.
+Add warnings for unnecessary polyfills during development. `sku start` and `sku start-ssr`, along with `sku build` and `sku build-ssr` now warn about polyfills that are no longer needed for modern browsers to help reduce bundle sizes.

--- a/.changeset/deep-ends-vanish.md
+++ b/.changeset/deep-ends-vanish.md
@@ -1,0 +1,5 @@
+---
+'sku': minor
+---
+
+Add warnings for unnecessary polyfills during development. `sku start` and `sku start-ssr` now warn about polyfills that are no longer needed for modern browsers to help reduce bundle sizes.

--- a/fixtures/polyfills/package.json
+++ b/fixtures/polyfills/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "start": "sku start",
     "start:vite": "sku start --experimental-bundler --config sku.config.vite.ts",
+    "start:bad": "sku start --config sku.config.bad.ts",
     "build": "sku build",
     "build:vite": "sku build --experimental-bundler --config sku.config.vite.ts"
   },

--- a/fixtures/polyfills/package.json
+++ b/fixtures/polyfills/package.json
@@ -12,7 +12,8 @@
     "start:vite": "sku start --experimental-bundler --config sku.config.vite.ts",
     "start:bad": "sku start --config sku.config.bad.ts",
     "build": "sku build",
-    "build:vite": "sku build --experimental-bundler --config sku.config.vite.ts"
+    "build:vite": "sku build --experimental-bundler --config sku.config.vite.ts",
+    "build:bad": "sku build --config sku.config.bad.ts"
   },
   "devDependencies": {
     "@sku-private/test-utils": "workspace:*",

--- a/fixtures/polyfills/sku.config.bad.ts
+++ b/fixtures/polyfills/sku.config.bad.ts
@@ -1,0 +1,19 @@
+import { makeStableHashes } from '@sku-private/test-utils';
+import type { SkuConfig } from 'sku';
+
+export default {
+  clientEntry: 'src/client.tsx',
+  renderEntry: 'src/render.tsx',
+  publicPath: '/static/polyfills',
+  port: 4200,
+  dangerouslySetWebpackConfig: (config) => makeStableHashes(config),
+  polyfills: [
+    './src/polyfills.ts',
+    '@sku-private/3rd-party-polyfill',
+    'core-js',
+    'core-js/stable',
+    'core-js/es6',
+    'core-js/features/promise',
+    'isomorphic-fetch',
+  ],
+} satisfies SkuConfig;

--- a/packages/sku/src/program/commands/build-ssr/build-ssr.action.ts
+++ b/packages/sku/src/program/commands/build-ssr/build-ssr.action.ts
@@ -16,7 +16,7 @@ import {
   configureProject,
   validatePeerDeps,
 } from '../../../utils/configure.js';
-import { displayPolyfillWarnings } from '../../../utils/polyfillWarnings.js';
+import { validatePolyfills } from '../../../utils/polyfillWarnings.js';
 import type { StatsChoices } from '../../options/stats/stats.option.js';
 import type { SkuContext } from '../../../context/createSkuContext.js';
 
@@ -37,9 +37,8 @@ export const buildSsrAction = async ({
   const { port, cspEnabled } = skuContext;
   await configureProject(skuContext);
   validatePeerDeps(skuContext);
+  validatePolyfills(skuContext.polyfills);
 
-  // Check for unnecessary polyfills and display warnings
-  displayPolyfillWarnings(skuContext.polyfills);
   try {
     await runVocabCompile(skuContext);
     const [clientConfig, serverConfig] = makeWebpackConfig({

--- a/packages/sku/src/program/commands/build-ssr/build-ssr.action.ts
+++ b/packages/sku/src/program/commands/build-ssr/build-ssr.action.ts
@@ -16,6 +16,7 @@ import {
   configureProject,
   validatePeerDeps,
 } from '../../../utils/configure.js';
+import { displayPolyfillWarnings } from '../../../utils/polyfillWarnings.js';
 import type { StatsChoices } from '../../options/stats/stats.option.js';
 import type { SkuContext } from '../../../context/createSkuContext.js';
 
@@ -36,6 +37,9 @@ export const buildSsrAction = async ({
   const { port, cspEnabled } = skuContext;
   await configureProject(skuContext);
   validatePeerDeps(skuContext);
+
+  // Check for unnecessary polyfills and display warnings
+  displayPolyfillWarnings(skuContext.polyfills);
   try {
     await runVocabCompile(skuContext);
     const [clientConfig, serverConfig] = makeWebpackConfig({

--- a/packages/sku/src/program/commands/build/build.action.ts
+++ b/packages/sku/src/program/commands/build/build.action.ts
@@ -1,6 +1,6 @@
 import type { StatsChoices } from '../../options/stats/stats.option.js';
 import type { SkuContext } from '../../../context/createSkuContext.js';
-import { displayPolyfillWarnings } from '../../../utils/polyfillWarnings.js';
+import { validatePolyfills } from '../../../utils/polyfillWarnings.js';
 
 export const buildAction = async ({
   stats,
@@ -9,8 +9,7 @@ export const buildAction = async ({
   stats: StatsChoices;
   skuContext: SkuContext;
 }) => {
-  // Check for unnecessary polyfills and display warnings
-  displayPolyfillWarnings(skuContext.polyfills);
+  validatePolyfills(skuContext.polyfills);
 
   if (skuContext.bundler === 'vite') {
     const { viteBuildHandler } = await import('./vite-build-handler.js');

--- a/packages/sku/src/program/commands/build/build.action.ts
+++ b/packages/sku/src/program/commands/build/build.action.ts
@@ -1,5 +1,6 @@
 import type { StatsChoices } from '../../options/stats/stats.option.js';
 import type { SkuContext } from '../../../context/createSkuContext.js';
+import { displayPolyfillWarnings } from '../../../utils/polyfillWarnings.js';
 
 export const buildAction = async ({
   stats,
@@ -8,6 +9,9 @@ export const buildAction = async ({
   stats: StatsChoices;
   skuContext: SkuContext;
 }) => {
+  // Check for unnecessary polyfills and display warnings
+  displayPolyfillWarnings(skuContext.polyfills);
+
   if (skuContext.bundler === 'vite') {
     const { viteBuildHandler } = await import('./vite-build-handler.js');
     await viteBuildHandler({ skuContext });

--- a/packages/sku/src/program/commands/start-ssr/start-ssr.action.ts
+++ b/packages/sku/src/program/commands/start-ssr/start-ssr.action.ts
@@ -1,6 +1,6 @@
 import type { StatsChoices } from '../../options/stats/stats.option.js';
 import type { SkuContext } from '../../../context/createSkuContext.js';
-import { displayPolyfillWarnings } from '../../../utils/polyfillWarnings.js';
+import { validatePolyfills } from '../../../utils/polyfillWarnings.js';
 
 export const startSsrAction = async ({
   stats,
@@ -15,8 +15,7 @@ export const startSsrAction = async ({
     );
   }
 
-  // Check for unnecessary polyfills and display warnings
-  displayPolyfillWarnings(skuContext.polyfills);
+  validatePolyfills(skuContext.polyfills);
 
   const { webpackStartSsrHandler } = await import(
     './webpack-start-ssr-handler.js'

--- a/packages/sku/src/program/commands/start-ssr/start-ssr.action.ts
+++ b/packages/sku/src/program/commands/start-ssr/start-ssr.action.ts
@@ -1,6 +1,5 @@
 import type { StatsChoices } from '../../options/stats/stats.option.js';
 import type { SkuContext } from '../../../context/createSkuContext.js';
-import { detectUnnecessaryPolyfills } from '../../../utils/polyfillDetector.js';
 import { displayPolyfillWarnings } from '../../../utils/polyfillWarnings.js';
 
 export const startSsrAction = async ({
@@ -17,8 +16,7 @@ export const startSsrAction = async ({
   }
 
   // Check for unnecessary polyfills and display warnings
-  const detectedPolyfills = detectUnnecessaryPolyfills(skuContext.polyfills);
-  displayPolyfillWarnings(detectedPolyfills);
+  displayPolyfillWarnings(skuContext.polyfills);
 
   const { webpackStartSsrHandler } = await import(
     './webpack-start-ssr-handler.js'

--- a/packages/sku/src/program/commands/start-ssr/start-ssr.action.ts
+++ b/packages/sku/src/program/commands/start-ssr/start-ssr.action.ts
@@ -1,5 +1,7 @@
 import type { StatsChoices } from '../../options/stats/stats.option.js';
 import type { SkuContext } from '../../../context/createSkuContext.js';
+import { detectUnnecessaryPolyfills } from '../../../utils/polyfillDetector.js';
+import { displayPolyfillWarnings } from '../../../utils/polyfillWarnings.js';
 
 export const startSsrAction = async ({
   stats,
@@ -13,6 +15,10 @@ export const startSsrAction = async ({
       'The command does not supported the Vite bundler at this time. SSR is only supported with Webpack.',
     );
   }
+
+  // Check for unnecessary polyfills and display warnings
+  const detectedPolyfills = detectUnnecessaryPolyfills(skuContext.polyfills);
+  displayPolyfillWarnings(detectedPolyfills);
 
   const { webpackStartSsrHandler } = await import(
     './webpack-start-ssr-handler.js'

--- a/packages/sku/src/program/commands/start/start.action.ts
+++ b/packages/sku/src/program/commands/start/start.action.ts
@@ -7,6 +7,8 @@ import {
 } from '../../../utils/configure.js';
 import { watchVocabCompile } from '../../../services/vocab/runVocab.js';
 import { checkHosts, withHostile } from '../../../context/hosts.js';
+import { detectUnnecessaryPolyfills } from '../../../utils/polyfillDetector.js';
+import { displayPolyfillWarnings } from '../../../utils/polyfillWarnings.js';
 import chalk from 'chalk';
 
 export const startAction = async (
@@ -30,6 +32,10 @@ export const startAction = async (
 
   withHostile(checkHosts)(skuContext);
   validatePeerDeps(skuContext);
+
+  // Check for unnecessary polyfills and display warnings
+  const detectedPolyfills = detectUnnecessaryPolyfills(skuContext.polyfills);
+  displayPolyfillWarnings(detectedPolyfills);
 
   if (skuContext.bundler === 'vite') {
     const { viteStartHandler } = await import('./vite-start-handler.js');

--- a/packages/sku/src/program/commands/start/start.action.ts
+++ b/packages/sku/src/program/commands/start/start.action.ts
@@ -7,7 +7,6 @@ import {
 } from '../../../utils/configure.js';
 import { watchVocabCompile } from '../../../services/vocab/runVocab.js';
 import { checkHosts, withHostile } from '../../../context/hosts.js';
-import { detectUnnecessaryPolyfills } from '../../../utils/polyfillDetector.js';
 import { displayPolyfillWarnings } from '../../../utils/polyfillWarnings.js';
 import chalk from 'chalk';
 
@@ -34,8 +33,7 @@ export const startAction = async (
   validatePeerDeps(skuContext);
 
   // Check for unnecessary polyfills and display warnings
-  const detectedPolyfills = detectUnnecessaryPolyfills(skuContext.polyfills);
-  displayPolyfillWarnings(detectedPolyfills);
+  displayPolyfillWarnings(skuContext.polyfills);
 
   if (skuContext.bundler === 'vite') {
     const { viteStartHandler } = await import('./vite-start-handler.js');

--- a/packages/sku/src/program/commands/start/start.action.ts
+++ b/packages/sku/src/program/commands/start/start.action.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../utils/configure.js';
 import { watchVocabCompile } from '../../../services/vocab/runVocab.js';
 import { checkHosts, withHostile } from '../../../context/hosts.js';
-import { displayPolyfillWarnings } from '../../../utils/polyfillWarnings.js';
+import { validatePolyfills } from '../../../utils/polyfillWarnings.js';
 import chalk from 'chalk';
 
 export const startAction = async (
@@ -31,9 +31,7 @@ export const startAction = async (
 
   withHostile(checkHosts)(skuContext);
   validatePeerDeps(skuContext);
-
-  // Check for unnecessary polyfills and display warnings
-  displayPolyfillWarnings(skuContext.polyfills);
+  validatePolyfills(skuContext.polyfills);
 
   if (skuContext.bundler === 'vite') {
     const { viteStartHandler } = await import('./vite-start-handler.js');

--- a/packages/sku/src/utils/polyfillDetector.test.ts
+++ b/packages/sku/src/utils/polyfillDetector.test.ts
@@ -21,12 +21,12 @@ describe('polyfillDetector', () => {
           {
             "docsUrl": "https://github.com/zloirock/core-js#usage",
             "polyfillName": "core-js",
-            "reason": "Most ES2015-ES2017 features are natively supported in modern browsers",
+            "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs",
           },
           {
             "docsUrl": "https://babeljs.io/docs/en/babel-polyfill",
             "polyfillName": "@babel/polyfill",
-            "reason": "Deprecated package, replaced by core-js",
+            "reason": "Deprecated package",
           },
           {
             "polyfillName": "whatwg-fetch",
@@ -69,17 +69,17 @@ describe('polyfillDetector', () => {
           {
             "docsUrl": "https://github.com/zloirock/core-js#usage",
             "polyfillName": "core-js/stable",
-            "reason": "Most ES2015-ES2017 features are natively supported in modern browsers",
+            "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs",
           },
           {
             "docsUrl": "https://github.com/zloirock/core-js#usage",
             "polyfillName": "core-js/es6",
-            "reason": "Most ES2015-ES2017 features are natively supported in modern browsers",
+            "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs",
           },
           {
             "docsUrl": "https://github.com/zloirock/core-js#usage",
             "polyfillName": "core-js/features/promise",
-            "reason": "Most ES2015-ES2017 features are natively supported in modern browsers",
+            "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs",
           },
         ]
       `);

--- a/packages/sku/src/utils/polyfillDetector.test.ts
+++ b/packages/sku/src/utils/polyfillDetector.test.ts
@@ -21,7 +21,7 @@ describe('polyfillDetector', () => {
           {
             "docsUrl": "https://github.com/zloirock/core-js#usage",
             "polyfillName": "core-js",
-            "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs",
+            "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs.",
           },
           {
             "docsUrl": "https://babeljs.io/docs/en/babel-polyfill",
@@ -30,7 +30,7 @@ describe('polyfillDetector', () => {
           },
           {
             "polyfillName": "whatwg-fetch",
-            "reason": "Fetch API is natively supported in modern browsers",
+            "reason": "Fetch API is well established and works across many devices and browser versions. It has been available across browsers since March 2017.",
           },
         ]
       `);
@@ -69,17 +69,17 @@ describe('polyfillDetector', () => {
           {
             "docsUrl": "https://github.com/zloirock/core-js#usage",
             "polyfillName": "core-js/stable",
-            "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs",
+            "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs.",
           },
           {
             "docsUrl": "https://github.com/zloirock/core-js#usage",
             "polyfillName": "core-js/es6",
-            "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs",
+            "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs.",
           },
           {
             "docsUrl": "https://github.com/zloirock/core-js#usage",
             "polyfillName": "core-js/features/promise",
-            "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs",
+            "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs.",
           },
         ]
       `);

--- a/packages/sku/src/utils/polyfillDetector.test.ts
+++ b/packages/sku/src/utils/polyfillDetector.test.ts
@@ -53,5 +53,36 @@ describe('polyfillDetector', () => {
 
       expect(result).toHaveLength(0);
     });
+
+    it('should detect core-js prefix variants', ({ expect }) => {
+      const polyfills = [
+        'core-js/stable',
+        'core-js/es6',
+        'core-js/features/promise',
+      ];
+
+      const result = detectUnnecessaryPolyfills(polyfills);
+
+      expect(result).toHaveLength(3);
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "docsUrl": "https://github.com/zloirock/core-js#usage",
+            "polyfillName": "core-js/stable",
+            "reason": "Most ES2015-ES2017 features are natively supported in modern browsers",
+          },
+          {
+            "docsUrl": "https://github.com/zloirock/core-js#usage",
+            "polyfillName": "core-js/es6",
+            "reason": "Most ES2015-ES2017 features are natively supported in modern browsers",
+          },
+          {
+            "docsUrl": "https://github.com/zloirock/core-js#usage",
+            "polyfillName": "core-js/features/promise",
+            "reason": "Most ES2015-ES2017 features are natively supported in modern browsers",
+          },
+        ]
+      `);
+    });
   });
 });

--- a/packages/sku/src/utils/polyfillDetector.test.ts
+++ b/packages/sku/src/utils/polyfillDetector.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from 'vitest';
+import { detectUnnecessaryPolyfills } from './polyfillDetector.js';
+
+describe('polyfillDetector', () => {
+  describe('detectUnnecessaryPolyfills', () => {
+    it('should detect unnecessary polyfills from the registry', ({
+      expect,
+    }) => {
+      const polyfills = [
+        'core-js',
+        '@babel/polyfill',
+        'whatwg-fetch',
+        'some-unknown-polyfill',
+      ];
+
+      const result = detectUnnecessaryPolyfills(polyfills);
+
+      expect(result).toHaveLength(3);
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "docsUrl": "https://github.com/zloirock/core-js#usage",
+            "polyfillName": "core-js",
+            "reason": "Most ES2015-ES2017 features are natively supported in modern browsers",
+          },
+          {
+            "docsUrl": "https://babeljs.io/docs/en/babel-polyfill",
+            "polyfillName": "@babel/polyfill",
+            "reason": "Deprecated package, replaced by core-js",
+          },
+          {
+            "polyfillName": "whatwg-fetch",
+            "reason": "Fetch API is natively supported in modern browsers",
+          },
+        ]
+      `);
+    });
+
+    it('should return empty array when no unnecessary polyfills are found', ({
+      expect,
+    }) => {
+      const polyfills = ['some-unknown-polyfill', 'another-unknown-polyfill'];
+
+      const result = detectUnnecessaryPolyfills(polyfills);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should handle empty polyfills array', ({ expect }) => {
+      const polyfills: string[] = [];
+
+      const result = detectUnnecessaryPolyfills(polyfills);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/packages/sku/src/utils/polyfillDetector.ts
+++ b/packages/sku/src/utils/polyfillDetector.ts
@@ -15,8 +15,11 @@ export const detectUnnecessaryPolyfills = (
   polyfills: string[],
 ): DetectedPolyfill[] =>
   polyfills
-    .filter((polyfillName) => polyfillName in POLYFILL_REGISTRY)
+    .filter(
+      (polyfillName) =>
+        polyfillName in POLYFILL_REGISTRY || polyfillName.startsWith('core-js'),
+    )
     .map((polyfillName) => ({
       polyfillName,
-      ...POLYFILL_REGISTRY[polyfillName]!,
+      ...(POLYFILL_REGISTRY[polyfillName] || POLYFILL_REGISTRY['core-js']!),
     }));

--- a/packages/sku/src/utils/polyfillDetector.ts
+++ b/packages/sku/src/utils/polyfillDetector.ts
@@ -1,0 +1,30 @@
+import {
+  POLYFILL_REGISTRY,
+  type PolyfillRegistryEntry,
+} from './polyfillRegistry.js';
+
+export interface DetectedPolyfill extends PolyfillRegistryEntry {
+  polyfillName: string;
+}
+
+/**
+ * Detects unnecessary polyfills from the configured polyfills array
+ * by matching package names against the registry.
+ */
+export const detectUnnecessaryPolyfills = (
+  polyfills: string[],
+): DetectedPolyfill[] =>
+  polyfills.flatMap((polyfillName) => {
+    const registryEntry = POLYFILL_REGISTRY[polyfillName];
+
+    if (!registryEntry) {
+      return [];
+    }
+
+    return [
+      {
+        polyfillName,
+        ...registryEntry,
+      },
+    ];
+  });

--- a/packages/sku/src/utils/polyfillDetector.ts
+++ b/packages/sku/src/utils/polyfillDetector.ts
@@ -14,17 +14,9 @@ export interface DetectedPolyfill extends PolyfillRegistryEntry {
 export const detectUnnecessaryPolyfills = (
   polyfills: string[],
 ): DetectedPolyfill[] =>
-  polyfills.flatMap((polyfillName) => {
-    const registryEntry = POLYFILL_REGISTRY[polyfillName];
-
-    if (!registryEntry) {
-      return [];
-    }
-
-    return [
-      {
-        polyfillName,
-        ...registryEntry,
-      },
-    ];
-  });
+  polyfills
+    .filter((polyfillName) => polyfillName in POLYFILL_REGISTRY)
+    .map((polyfillName) => ({
+      polyfillName,
+      ...POLYFILL_REGISTRY[polyfillName]!,
+    }));

--- a/packages/sku/src/utils/polyfillRegistry.ts
+++ b/packages/sku/src/utils/polyfillRegistry.ts
@@ -11,7 +11,7 @@ export type PolyfillRegistry = Record<string, PolyfillRegistryEntry>;
 export const POLYFILL_REGISTRY: PolyfillRegistry = {
   'core-js': {
     reason:
-      'Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs',
+      'Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs.',
     docsUrl: 'https://github.com/zloirock/core-js#usage',
   },
   '@babel/polyfill': {
@@ -24,24 +24,30 @@ export const POLYFILL_REGISTRY: PolyfillRegistry = {
   },
   'regenerator-runtime': {
     reason:
-      'async/await is well established and works across many devices and browser versions',
+      'async/await is well established and works across many devices and browser versions. It has been available across browsers since April 2017.',
   },
   'es6-promise': {
-    reason: 'Promises are natively supported in modern browsers',
+    reason:
+      'Promises is well established and works across many devices and browser versions. It has been available across browsers since July 2015.',
   },
   'es6-promise/auto': {
-    reason: 'Promises are natively supported in modern browsers',
+    reason:
+      'Promises is well established and works across many devices and browser versions. It has been available across browsers since July 2015.',
   },
   'promise-polyfill': {
-    reason: 'Promises are natively supported in modern browsers',
+    reason:
+      'Promises is well established and works across many devices and browser versions. It has been available across browsers since July 2015.',
   },
   'whatwg-fetch': {
-    reason: 'Fetch API is natively supported in modern browsers',
+    reason:
+      'Fetch API is well established and works across many devices and browser versions. It has been available across browsers since March 2017.',
   },
   'isomorphic-fetch': {
-    reason: 'Fetch API is natively supported in modern browsers',
+    reason:
+      'Fetch API is well established and works across many devices and browser versions. It has been available across browsers since March 2017, and Node.js since April 2022.',
   },
   'intersection-observer': {
-    reason: 'IntersectionObserver is natively supported in modern browsers',
+    reason:
+      'IntersectionObserver is well established and works across many devices and browser versions. It has been available across browsers since March 2019.',
   },
 } as const;

--- a/packages/sku/src/utils/polyfillRegistry.ts
+++ b/packages/sku/src/utils/polyfillRegistry.ts
@@ -11,15 +11,16 @@ export type PolyfillRegistry = Record<string, PolyfillRegistryEntry>;
 export const POLYFILL_REGISTRY: PolyfillRegistry = {
   'core-js': {
     reason:
-      'Most ES2015-ES2017 features are natively supported in modern browsers',
+      'Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs',
     docsUrl: 'https://github.com/zloirock/core-js#usage',
   },
   '@babel/polyfill': {
-    reason: 'Deprecated package, replaced by core-js',
+    reason: 'Deprecated package',
     docsUrl: 'https://babeljs.io/docs/en/babel-polyfill',
   },
   'regenerator-runtime': {
-    reason: 'async/await is natively supported in modern browsers',
+    reason:
+      'async/await is well established and works across many devices and browser versions',
   },
   'es6-promise': {
     reason: 'Promises are natively supported in modern browsers',

--- a/packages/sku/src/utils/polyfillRegistry.ts
+++ b/packages/sku/src/utils/polyfillRegistry.ts
@@ -1,0 +1,42 @@
+export interface PolyfillRegistryEntry {
+  reason: string;
+  docsUrl?: string;
+}
+
+export type PolyfillRegistry = Record<string, PolyfillRegistryEntry>;
+
+/**
+ * Registry of polyfills that are unnecessary for sku's supported browsers
+ */
+export const POLYFILL_REGISTRY: PolyfillRegistry = {
+  'core-js': {
+    reason:
+      'Most ES2015-ES2017 features are natively supported in modern browsers',
+    docsUrl: 'https://github.com/zloirock/core-js#usage',
+  },
+  '@babel/polyfill': {
+    reason: 'Deprecated package, replaced by core-js',
+    docsUrl: 'https://babeljs.io/docs/en/babel-polyfill',
+  },
+  'regenerator-runtime': {
+    reason: 'async/await is natively supported in modern browsers',
+  },
+  'es6-promise': {
+    reason: 'Promises are natively supported in modern browsers',
+  },
+  'es6-promise/auto': {
+    reason: 'Promises are natively supported in modern browsers',
+  },
+  'promise-polyfill': {
+    reason: 'Promises are natively supported in modern browsers',
+  },
+  'whatwg-fetch': {
+    reason: 'Fetch API is natively supported in modern browsers',
+  },
+  'isomorphic-fetch': {
+    reason: 'Fetch API is natively supported in modern browsers',
+  },
+  'intersection-observer': {
+    reason: 'IntersectionObserver is natively supported in modern browsers',
+  },
+} as const;

--- a/packages/sku/src/utils/polyfillRegistry.ts
+++ b/packages/sku/src/utils/polyfillRegistry.ts
@@ -18,6 +18,10 @@ export const POLYFILL_REGISTRY: PolyfillRegistry = {
     reason: 'Deprecated package',
     docsUrl: 'https://babeljs.io/docs/en/babel-polyfill',
   },
+  'babel/polyfill': {
+    reason: 'Deprecated package',
+    docsUrl: 'https://babeljs.io/docs/en/babel-polyfill',
+  },
   'regenerator-runtime': {
     reason:
       'async/await is well established and works across many devices and browser versions',

--- a/packages/sku/src/utils/polyfillWarnings.ts
+++ b/packages/sku/src/utils/polyfillWarnings.ts
@@ -1,12 +1,15 @@
 import { styleText } from 'node:util';
-import type { DetectedPolyfill } from './polyfillDetector.js';
+import {
+  detectUnnecessaryPolyfills,
+  type DetectedPolyfill,
+} from './polyfillDetector.js';
 
 /**
  * Displays warnings for unnecessary polyfills in a clean, formatted way
  */
-export const displayPolyfillWarnings = (
-  detectedPolyfills: DetectedPolyfill[],
-): void => {
+export const displayPolyfillWarnings = (polyfills: string[]): void => {
+  const detectedPolyfills = detectUnnecessaryPolyfills(polyfills);
+
   if (detectedPolyfills.length === 0) {
     return;
   }

--- a/packages/sku/src/utils/polyfillWarnings.ts
+++ b/packages/sku/src/utils/polyfillWarnings.ts
@@ -1,0 +1,45 @@
+import { styleText } from 'node:util';
+import type { DetectedPolyfill } from './polyfillDetector.js';
+
+/**
+ * Displays warnings for unnecessary polyfills in a clean, formatted way
+ */
+export const displayPolyfillWarnings = (
+  detectedPolyfills: DetectedPolyfill[],
+): void => {
+  if (detectedPolyfills.length === 0) {
+    return;
+  }
+
+  console.log();
+  console.log(styleText('yellow', '⚠️  Unnecessary polyfills detected'));
+  console.log();
+
+  console.log(
+    styleText('dim', 'The following polyfills may no longer be necessary:'),
+  );
+  console.log();
+
+  detectedPolyfills.forEach((polyfill) => displayPolyfillWarning(polyfill));
+
+  console.log(
+    styleText(
+      'dim',
+      '💡 Consider removing these polyfills to reduce your bundle size.',
+    ),
+  );
+  console.log();
+};
+
+const displayPolyfillWarning = (polyfill: DetectedPolyfill): void => {
+  console.log(
+    styleText('red', `  ❌ ${styleText('bold', polyfill.polyfillName)}`),
+  );
+  console.log(styleText('dim', `     ${polyfill.reason}`));
+
+  if (polyfill.docsUrl) {
+    console.log(styleText('dim', `     Docs: ${polyfill.docsUrl}`));
+  }
+
+  console.log();
+};

--- a/packages/sku/src/utils/polyfillWarnings.ts
+++ b/packages/sku/src/utils/polyfillWarnings.ts
@@ -5,9 +5,9 @@ import {
 } from './polyfillDetector.js';
 
 /**
- * Displays warnings for unnecessary polyfills in a clean, formatted way
+ * Validates and displays warnings for unnecessary polyfills in a clean, formatted way
  */
-export const displayPolyfillWarnings = (polyfills: string[]): void => {
+export const validatePolyfills = (polyfills: string[]): void => {
   const detectedPolyfills = detectUnnecessaryPolyfills(polyfills);
 
   if (detectedPolyfills.length === 0) {


### PR DESCRIPTION
# 🏴‍☠️ 🦜 POLY(fill) WANT A CRACKER? 🦜 🏴‍☠️ 
Our browser support policy has been evolving, but the polyfills teams use don't always keep up, resulting in larger bundle sizes than what is necessary. 
We've added warnings during `sku start` and `sku start-ssr` to help teams identify unnecessary polyfills that are no longer needed for modern browsers.

Example output:
<img width="796" height="177" alt="Screenshot 2025-09-16 at 3 09 02 pm" src="https://github.com/user-attachments/assets/ab67adb8-1226-433d-8595-812a83b2e232" />
