### PR TITLE
`codemod`: Simplify async mock factory logic

### DIFF
--- a/.changeset/lazy-dolls-taste.md
+++ b/.changeset/lazy-dolls-taste.md
@@ -1,0 +1,5 @@
+---
+'@sku-lib/codemod': patch
+---
+
+Simplify logic for making mock factories async within `jest.mock` calls

--- a/tests/node/sku-codemods.test.ts
+++ b/tests/node/sku-codemods.test.ts
@@ -85,6 +85,7 @@ const testCases: TestCase[] = [
         return {
           ...originalModule,
           foo: 'foo',
+          bar: jest.fn(),
         };
       })
 
@@ -94,6 +95,7 @@ const testCases: TestCase[] = [
         return {
           ...originalModule,
           foo: 'foo',
+          bar: jest.fn(),
         };
       })
 
@@ -101,12 +103,14 @@ const testCases: TestCase[] = [
           ...jest.requireActual('./foo2'),
           ...jest.requireActual('./foo3'),
           foo: 'foo',
+          bar: jest.fn(),
         })
       );
 
       jest.mock('./foo4', async () => ({
           ...jest.requireActual('./foo4'),
           foo: 'foo',
+          bar: jest.fn(),
         })
       );
 
@@ -143,6 +147,7 @@ const testCases: TestCase[] = [
         return {
           ...originalModule,
           foo: 'foo',
+          bar: vi.fn(),
         };
       })
 
@@ -152,6 +157,7 @@ const testCases: TestCase[] = [
         return {
           ...originalModule,
           foo: 'foo',
+          bar: vi.fn(),
         };
       })
 
@@ -159,12 +165,14 @@ const testCases: TestCase[] = [
           ...await vi.importActual('./foo2'),
           ...await vi.importActual('./foo3'),
           foo: 'foo',
+          bar: vi.fn(),
         })
       );
 
       vi.mock('./foo4', async () => ({
           ...await vi.importActual('./foo4'),
           foo: 'foo',
+          bar: vi.fn(),
         })
       );
 


### PR DESCRIPTION
Closes #1404.

By using a more targeted rule that only finds non-async mock factories, we can simplify some logic within the codemod while also handling the same edge case that would've been fixed in #1404.