### PR TITLE
`codemod`: Update existing `vitest` import if detected

### DIFF
--- a/.changeset/ten-bats-yawn.md
+++ b/.changeset/ten-bats-yawn.md
@@ -1,0 +1,5 @@
+---
+'@sku-lib/codemod': patch
+---
+
+Update existing `vitest` import if detected

--- a/tests/node/sku-codemods.test.ts
+++ b/tests/node/sku-codemods.test.ts
@@ -234,6 +234,24 @@ const testCases: TestCase[] = [
       it.only.fails("foo")
     `,
   },
+  {
+    filename: 'existingVitestImport.test.ts',
+    codemodName: 'jest-to-vitest',
+    input: ts /* ts */ `
+      import { test, vi } from 'vitest';
+      test("foo")
+      it("foo")
+      describe("foo")
+      vi.mock('foo')
+    `,
+    output: ts /* ts */ `
+      import { describe, it, test, vi } from 'vitest';
+      test("foo")
+      it("foo")
+      describe("foo")
+      vi.mock('foo')
+    `,
+  },
 ];
 
 describe('sku codemods', () => {


### PR DESCRIPTION
This should handle situations where the codemod is run multiple times, or if a partial migration is attempted by the user before using the codemod.