### PR TITLE
Replace `resolve-from` dependency with native `require.resolve`

### DIFF
--- a/.changeset/happy-moles-vanish.md
+++ b/.changeset/happy-moles-vanish.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Replace `resolve-from` dependency with native `require.resolve`

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -168,7 +168,6 @@
     "pretty-ms": "^9.2.0",
     "prompts": "^2.4.2",
     "react-refresh": "^0.17.0",
-    "resolve-from": "^5.0.0",
     "rollup-plugin-visualizer": "^6.0.3",
     "selfsigned": "^3.0.1",
     "semver": "^7.3.4",

--- a/packages/sku/src/services/vite/helpers/config/dependencyGraph.ts
+++ b/packages/sku/src/services/vite/helpers/config/dependencyGraph.ts
@@ -1,15 +1,14 @@
 import assert from 'node:assert';
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import resolveSync from 'resolve-from';
 
 import type { PackageJson } from 'type-fest';
 import debug from 'debug';
+import { createRequire } from 'node:module';
 
 const log = debug('sku:dependency-graph');
 
-export const resolveFrom = async (fromDirectory: string, moduleId: string) =>
-  resolveSync(fromDirectory, moduleId);
+const require = createRequire(import.meta.url);
 
 const ROOT = 'ROOT';
 
@@ -38,7 +37,9 @@ const analyseDependency = async (
   rootDir: string,
   depGraph: DepGraph,
 ) => {
-  const packageJsonPath = await resolveFrom(rootDir, `${dep}/package.json`);
+  const packageJsonPath = require.resolve(`${dep}/package.json`, {
+    paths: [rootDir],
+  });
   const packageJson = await loadPackage(packageJsonPath);
 
   const dependencies = Object.keys(packageJson.dependencies ?? {});

--- a/packages/sku/src/services/vite/plugins/esbuild/fixViteVanillaExtractDepScanPlugin.ts
+++ b/packages/sku/src/services/vite/plugins/esbuild/fixViteVanillaExtractDepScanPlugin.ts
@@ -1,13 +1,15 @@
 import type { Plugin } from 'esbuild';
 import { cssFileFilter } from '@vanilla-extract/integration';
-import resolveFrom from 'resolve-from';
 import { dirname } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
 
 export const fixViteVanillaExtractDepScanPlugin = (): Plugin => ({
   name: 'fix-vite-vanilla-extract-dep-scan',
   setup(build) {
-    build.onResolve({ filter: cssFileFilter }, async ({ importer, path }) => ({
-      path: resolveFrom(dirname(importer), path),
+    build.onResolve({ filter: cssFileFilter }, ({ importer, path }) => ({
+      path: require.resolve(path, { paths: [dirname(importer)] }),
       external: true,
     }));
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1198,9 +1198,6 @@ importers:
       react-refresh:
         specifier: ^0.17.0
         version: 0.17.0
-      resolve-from:
-        specifier: ^5.0.0
-        version: 5.0.0
       rollup-plugin-visualizer:
         specifier: ^6.0.3
         version: 6.0.3(rollup@4.44.2)
@@ -17866,7 +17863,6 @@ snapshots:
       prompts: 2.4.2
       react: 18.3.1
       react-refresh: 0.17.0
-      resolve-from: 5.0.0
       rollup-plugin-visualizer: 6.0.3(rollup@4.44.2)
       selfsigned: 3.0.1
       semver: 7.7.2
@@ -18018,7 +18014,6 @@ snapshots:
       prompts: 2.4.2
       react: 19.1.1
       react-refresh: 0.17.0
-      resolve-from: 5.0.0
       rollup-plugin-visualizer: 6.0.3(rollup@4.44.2)
       selfsigned: 3.0.1
       semver: 7.7.2


### PR DESCRIPTION
I don't think `resolve-from` has been necessary since about Node v8 😅.