### PR TITLE
`docs`: Update vite migration guide

### DIFF
--- a/docs/docs/vite.md
+++ b/docs/docs/vite.md
@@ -84,7 +84,16 @@ After changing the repo to `type: module`, the [eslint-cjs-to-esm](https://githu
 npx eslint-cjs-to-esm "./src/**/*.{js,ts}" --rule "node/file-extension-in-import: off, file-extension-in-import-ts/file-extension-in-import-ts: off, import/extensions: off"
 ```
 
-The following sections detail changes that may be required.
+Common files that may need to be updated include:
+
+- [Dev server middleware][devServerMiddleware]
+- [Polyfills][polyfills]
+- Configuration for external tooling
+
+The following sections detail changes that may be required to migrate CJS code to ESM.
+
+[devServerMiddleware]: ./docs/configuration.md#devservermiddleware
+[polyfills]: ./docs/configuration.md#polyfills
 
 #### ESM syntax
 
@@ -168,7 +177,7 @@ Note that additional changes may still be required after running this codemod.
 pnpm dlx @sku-lib/codemod jest-to-vitest .
 ```
 
-**Default watch mode**
+**Default Watch Mode**
 
 `vitest` defaults to watch mode when running tests.
 To run tests without watch mode you can use the `--run` flag:
@@ -185,6 +194,15 @@ To run tests without watch mode you can use the `--run` flag:
 
 Watch mode won't trigger in CI environments, so it's safe to omit the flag in your pipeline.
 
+**Code Coverage Dependencies**
+
+Vitest does not install code coverage dependencies by default.
+To collect code coverage, pass the `--coverage` flag to the `sku test` command and install the `@vitest/coverage-v8` package:
+
+```bash
+pnpm add -D @vitest/coverage-v8
+```
+
 **Testing Library Matchers**
 
 If your test setup file includes an import for `@testing-library/jest-dom`, you may need to change this to `@testing-library/jest-dom/vitest`:
@@ -195,7 +213,7 @@ If your test setup file includes an import for `@testing-library/jest-dom`, you 
 + import '@testing-library/jest-dom/vitest';
 ```
 
-**Globals disabled**
+**Globals Disabled**
 
 Jest enables global APIs such as `it`, `describe`, `beforeAll`, etc., by default.
 Vitest does not.

--- a/fixtures/display-names-prod/sku.config.ts
+++ b/fixtures/display-names-prod/sku.config.ts
@@ -4,4 +4,5 @@ export default {
   clientEntry: 'src/client.tsx',
   renderEntry: 'src/render.tsx',
   displayNamesProd: true,
+  port: 8200,
 } satisfies SkuConfig;


### PR DESCRIPTION
Added information about:
- Common files that may need to be converted to ESM
- Vitest code coverage