### PR TITLE
Recommending compile packages instead of cjsInterop

### DIFF
--- a/docs/docs/vite.md
+++ b/docs/docs/vite.md
@@ -359,21 +359,22 @@ There are a few options to resolve this issue:
 - Upgrade the dependency to a version that supports ESM
 - Replace the dependency with an alternative that supports ESM
 
-Failing those solutions, `sku` provides a [`__UNSAFE_EXPERIMENTAL__cjsInteropDependencies`][cjs interop] configuration option can be used as a last resort:
+Failing those solutions, `sku` provides a [`compilePackages`][compilePackages] option that will compile the given modules as if they were part of your source code, increasing bundle size, but allowing vite to interop the CJS code.
+_Use this option as a last resort_:
 
 ```typescript
 // sku.config.ts
 import type { SkuConfig } from 'sku';
 
 export default {
-  __UNSAFE_EXPERIMENTAL__cjsInteropDependencies: [
+  compilePackages: [
     'someDependency'
   ],
   ...
 } satisfies SkuConfig;
 ```
 
-[cjs interop]: ./docs/configuration.md#__unsafe_experimental__cjsinteropdependencies
+[compilePackages]: ./docs/configuration.md#compilePackages
 
 ### Vite client types
 


### PR DESCRIPTION
Changing the recommendation of using  `cjsInteropDependencies` to `compilePackages` instead. A few reasons for this: 
* Using `__UNSAFE_EXPERIMENTAL__cjsInteropDependencies` won't necessarily fix the issue, and debugging might be more confusing for the consumer. Placing deps in `compilePackages` should fix their  cjs issues more consistantly.
* The downside is bundles might be bigger if used, but we want people to move to esm alternatives anyway, so it's a trade off they should consider as a last-resort.
* The webpack bundler uses compilePackages already so it's a feature users may already be familiar with.
* Any common use cases for cjsInterop we can hard-code in to sku (like we do with apollo) so this should only be used for internal packages for the most part where we can fix things a bit more heavy handedly.