### PR TITLE
Extend unnecessary polyfill detection to include dependencies

### DIFF
--- a/packages/sku/src/utils/detectUnnecessaryPolyfillsFromConfig.ts
+++ b/packages/sku/src/utils/detectUnnecessaryPolyfillsFromConfig.ts
@@ -1,5 +1,7 @@
-import { POLYFILL_REGISTRY } from './polyfillRegistry.js';
-import type { DetectedPolyfillWithSource } from './polyfillDetector.js';
+import {
+  type DetectedPolyfillWithSource,
+  getDeprecatedPolyfill,
+} from './polyfillDetector.js';
 
 /**
  * Detects unnecessary polyfills from the configured polyfills array
@@ -9,12 +11,9 @@ export const detectUnnecessaryPolyfillsFromConfig = (
   polyfills: string[],
 ): DetectedPolyfillWithSource[] =>
   polyfills
-    .filter(
-      (polyfillName) =>
-        polyfillName in POLYFILL_REGISTRY || polyfillName.startsWith('core-js'),
-    )
+    .filter((polyfillName) => getDeprecatedPolyfill(polyfillName))
     .map((polyfillName) => ({
       polyfillName,
       detectionSource: 'config' as const,
-      ...(POLYFILL_REGISTRY[polyfillName] || POLYFILL_REGISTRY['core-js']!),
+      ...getDeprecatedPolyfill(polyfillName)!,
     }));

--- a/packages/sku/src/utils/detectUnnecessaryPolyfillsFromConfig.ts
+++ b/packages/sku/src/utils/detectUnnecessaryPolyfillsFromConfig.ts
@@ -1,0 +1,20 @@
+import { POLYFILL_REGISTRY } from './polyfillRegistry.js';
+import type { DetectedPolyfillWithSource } from './polyfillDetector.js';
+
+/**
+ * Detects unnecessary polyfills from the configured polyfills array
+ * by matching package names against the registry.
+ */
+export const detectUnnecessaryPolyfillsFromConfig = (
+  polyfills: string[],
+): DetectedPolyfillWithSource[] =>
+  polyfills
+    .filter(
+      (polyfillName) =>
+        polyfillName in POLYFILL_REGISTRY || polyfillName.startsWith('core-js'),
+    )
+    .map((polyfillName) => ({
+      polyfillName,
+      detectionSource: 'config' as const,
+      ...(POLYFILL_REGISTRY[polyfillName] || POLYFILL_REGISTRY['core-js']!),
+    }));

--- a/packages/sku/src/utils/detectUnnecessaryPolyfillsFromDependencies.ts
+++ b/packages/sku/src/utils/detectUnnecessaryPolyfillsFromDependencies.ts
@@ -1,0 +1,56 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { getPathFromCwd } from '@sku-lib/utils';
+import { POLYFILL_REGISTRY } from './polyfillRegistry.js';
+import type { DetectedPolyfillWithSource } from './polyfillDetector.js';
+
+/**
+ * Detects unnecessary polyfills from package.json dependencies
+ * by matching package names against the registry.
+ */
+export const detectUnnecessaryPolyfillsFromDependencies =
+  (): DetectedPolyfillWithSource[] => {
+    const packageJsonPath = getPathFromCwd('package.json');
+
+    if (!existsSync(packageJsonPath)) {
+      return [];
+    }
+
+    try {
+      const packageJsonContent = readFileSync(packageJsonPath, 'utf-8');
+      const packageJson = JSON.parse(packageJsonContent);
+
+      const dependencies = packageJson.dependencies || {};
+      const devDependencies = packageJson.devDependencies || {};
+
+      const detectedPolyfills: DetectedPolyfillWithSource[] = [];
+
+      // Check dependencies
+      for (const depName of Object.keys(dependencies)) {
+        if (depName in POLYFILL_REGISTRY || depName.startsWith('core-js')) {
+          detectedPolyfills.push({
+            polyfillName: depName,
+            detectionSource: 'dependency',
+            dependencyType: 'dependencies',
+            ...(POLYFILL_REGISTRY[depName] || POLYFILL_REGISTRY['core-js']!),
+          });
+        }
+      }
+
+      // Check devDependencies
+      for (const depName of Object.keys(devDependencies)) {
+        if (depName in POLYFILL_REGISTRY || depName.startsWith('core-js')) {
+          detectedPolyfills.push({
+            polyfillName: depName,
+            detectionSource: 'dependency',
+            dependencyType: 'devDependencies',
+            ...(POLYFILL_REGISTRY[depName] || POLYFILL_REGISTRY['core-js']!),
+          });
+        }
+      }
+
+      return detectedPolyfills;
+    } catch {
+      // If we can't read or parse package.json, return empty array
+      return [];
+    }
+  };

--- a/packages/sku/src/utils/detectUnnecessaryPolyfillsFromDependencies.ts
+++ b/packages/sku/src/utils/detectUnnecessaryPolyfillsFromDependencies.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { getPathFromCwd } from '@sku-lib/utils';
 import {
   type DetectedPolyfillWithSource,
@@ -12,12 +12,6 @@ import {
 export const detectUnnecessaryPolyfillsFromDependencies =
   (): DetectedPolyfillWithSource[] => {
     const packageJsonPath = getPathFromCwd('package.json');
-
-    if (!existsSync(packageJsonPath)) {
-      throw new Error(
-        `package.json not found at ${packageJsonPath} - this is required for polyfill detection`,
-      );
-    }
 
     try {
       const packageJsonContent = readFileSync(packageJsonPath, 'utf-8');

--- a/packages/sku/src/utils/polyfillDetector.test.ts
+++ b/packages/sku/src/utils/polyfillDetector.test.ts
@@ -19,16 +19,19 @@ describe('polyfillDetector', () => {
       expect(result).toMatchInlineSnapshot(`
         [
           {
+            "detectionSource": "config",
             "docsUrl": "https://github.com/zloirock/core-js#usage",
             "polyfillName": "core-js",
             "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs.",
           },
           {
+            "detectionSource": "config",
             "docsUrl": "https://babeljs.io/docs/en/babel-polyfill",
             "polyfillName": "@babel/polyfill",
             "reason": "Deprecated package",
           },
           {
+            "detectionSource": "config",
             "polyfillName": "whatwg-fetch",
             "reason": "Fetch API is well established and works across many devices and browser versions. It has been available across browsers since March 2017.",
           },
@@ -67,16 +70,19 @@ describe('polyfillDetector', () => {
       expect(result).toMatchInlineSnapshot(`
         [
           {
+            "detectionSource": "config",
             "docsUrl": "https://github.com/zloirock/core-js#usage",
             "polyfillName": "core-js/stable",
             "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs.",
           },
           {
+            "detectionSource": "config",
             "docsUrl": "https://github.com/zloirock/core-js#usage",
             "polyfillName": "core-js/es6",
             "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs.",
           },
           {
+            "detectionSource": "config",
             "docsUrl": "https://github.com/zloirock/core-js#usage",
             "polyfillName": "core-js/features/promise",
             "reason": "Polyfills many features that may be unnecessary. Consider removing or using targeted polyfills for specific APIs.",

--- a/packages/sku/src/utils/polyfillDetector.ts
+++ b/packages/sku/src/utils/polyfillDetector.ts
@@ -1,4 +1,7 @@
-import type { PolyfillRegistryEntry } from './polyfillRegistry.js';
+import {
+  type PolyfillRegistryEntry,
+  POLYFILL_REGISTRY,
+} from './polyfillRegistry.js';
 import { detectUnnecessaryPolyfillsFromDependencies } from './detectUnnecessaryPolyfillsFromDependencies.js';
 import { detectUnnecessaryPolyfillsFromConfig } from './detectUnnecessaryPolyfillsFromConfig.js';
 
@@ -7,6 +10,23 @@ export interface DetectedPolyfillWithSource extends PolyfillRegistryEntry {
   detectionSource: 'config' | 'dependency';
   dependencyType?: 'dependencies' | 'devDependencies';
 }
+
+/**
+ * Gets the polyfill registry entry for a given polyfill name, or null if not deprecated
+ */
+export const getDeprecatedPolyfill = (
+  polyfillName: string,
+): PolyfillRegistryEntry | null => {
+  if (polyfillName in POLYFILL_REGISTRY) {
+    return POLYFILL_REGISTRY[polyfillName];
+  }
+
+  if (polyfillName.startsWith('core-js')) {
+    return POLYFILL_REGISTRY['core-js']!;
+  }
+
+  return null;
+};
 
 /**
  * Detects unnecessary polyfills from both config and dependencies

--- a/packages/sku/src/utils/polyfillDetector.ts
+++ b/packages/sku/src/utils/polyfillDetector.ts
@@ -1,25 +1,34 @@
-import {
-  POLYFILL_REGISTRY,
-  type PolyfillRegistryEntry,
-} from './polyfillRegistry.js';
+import type { PolyfillRegistryEntry } from './polyfillRegistry.js';
+import { detectUnnecessaryPolyfillsFromDependencies } from './detectUnnecessaryPolyfillsFromDependencies.js';
+import { detectUnnecessaryPolyfillsFromConfig } from './detectUnnecessaryPolyfillsFromConfig.js';
 
-export interface DetectedPolyfill extends PolyfillRegistryEntry {
+export interface DetectedPolyfillWithSource extends PolyfillRegistryEntry {
   polyfillName: string;
+  detectionSource: 'config' | 'dependency';
+  dependencyType?: 'dependencies' | 'devDependencies';
 }
 
 /**
- * Detects unnecessary polyfills from the configured polyfills array
+ * Detects unnecessary polyfills from both config and dependencies
  * by matching package names against the registry.
  */
 export const detectUnnecessaryPolyfills = (
   polyfills: string[],
-): DetectedPolyfill[] =>
-  polyfills
-    .filter(
-      (polyfillName) =>
-        polyfillName in POLYFILL_REGISTRY || polyfillName.startsWith('core-js'),
-    )
-    .map((polyfillName) => ({
-      polyfillName,
-      ...(POLYFILL_REGISTRY[polyfillName] || POLYFILL_REGISTRY['core-js']!),
-    }));
+): DetectedPolyfillWithSource[] => {
+  const configPolyfills = detectUnnecessaryPolyfillsFromConfig(polyfills);
+  const dependencyPolyfills = detectUnnecessaryPolyfillsFromDependencies();
+
+  const polyfillMap = new Map<string, DetectedPolyfillWithSource>();
+
+  // Add dependency polyfills
+  dependencyPolyfills.forEach((polyfill) =>
+    polyfillMap.set(polyfill.polyfillName, polyfill),
+  );
+
+  // Add config polyfills
+  configPolyfills.forEach((polyfill) =>
+    polyfillMap.set(polyfill.polyfillName, polyfill),
+  );
+
+  return Array.from(polyfillMap.values());
+};

--- a/packages/sku/src/utils/polyfillWarnings.ts
+++ b/packages/sku/src/utils/polyfillWarnings.ts
@@ -1,7 +1,7 @@
 import { styleText } from 'node:util';
 import {
   detectUnnecessaryPolyfills,
-  type DetectedPolyfill,
+  type DetectedPolyfillWithSource,
 } from './polyfillDetector.js';
 import provider from '../services/telemetry/provider.js';
 
@@ -37,14 +37,39 @@ export const validatePolyfills = (polyfills: string[]): void => {
   console.log();
 };
 
-const displayPolyfillWarning = (polyfill: DetectedPolyfill): void => {
+const displayPolyfillWarning = (polyfill: DetectedPolyfillWithSource): void => {
+  const sourceText =
+    polyfill.detectionSource === 'config'
+      ? 'found in config'
+      : `found in ${polyfill.dependencyType}`;
+
   console.log(
-    styleText('red', `  ❌ ${styleText('bold', polyfill.polyfillName)}`),
+    styleText(
+      'red',
+      `  ❌ ${styleText('bold', polyfill.polyfillName)} ${styleText('dim', `(${sourceText})`)}`,
+    ),
   );
   console.log(styleText('dim', `     ${polyfill.reason}`));
 
   if (polyfill.docsUrl) {
     console.log(styleText('dim', `     Docs: ${polyfill.docsUrl}`));
+  }
+
+  // Provide actionable guidance based on detection source
+  if (polyfill.detectionSource === 'config') {
+    console.log(
+      styleText(
+        'dim',
+        `     Action: Remove from polyfills array in sku.config.ts`,
+      ),
+    );
+  } else {
+    console.log(
+      styleText(
+        'dim',
+        `     Action: Remove from ${polyfill.dependencyType} in package.json`,
+      ),
+    );
   }
 
   console.log();


### PR DESCRIPTION
# 🦜 POLY(fill) WANT A CRACKER? 2: ELECTRIC BOOGALOO 🦜
 Builds on the unnecessary polyfill detection introduced in #1405 by expanding detection beyond `sku.config.ts` to also scan `package.json` dependencies and devDependencies. 

Warnings will include the source of the polyfill (config or deps), and action guidance
E.g.
Before
```
  ❌ raf
     requestAnimationFrame is well established and works across many devices and browser versions. It has been available across browsers since July 2015.
```

  After
```
  ❌ raf (found in dependencies)
     requestAnimationFrame is well established and works across many devices and browser versions. It has been available across browsers since July 2015.
     Action: Remove from dependencies in package.json
```