### PR TITLE
`vite`: Improve error messaging during `sku build`

### DIFF
--- a/.changeset/shiny-peas-clean.md
+++ b/.changeset/shiny-peas-clean.md
@@ -1,0 +1,7 @@
+---
+'sku': minor
+---
+
+`vite`: Improve error messaging during `sku build`
+
+The path of the first route that fails to render will now be logged, along with a stack trace to aid debugging

--- a/fixtures/vite-render-error/.gitignore
+++ b/fixtures/vite-render-error/.gitignore
@@ -1,0 +1,9 @@
+# managed by sku
+.eslintcache
+.prettierrc
+coverage/
+dist/
+eslint.config.mjs
+report/
+tsconfig.json
+# end managed by sku

--- a/fixtures/vite-render-error/.prettierignore
+++ b/fixtures/vite-render-error/.prettierignore
@@ -1,0 +1,10 @@
+# managed by sku
+.eslintcache
+.prettierrc
+coverage/
+dist/
+eslint.config.mjs
+pnpm-lock.yaml
+report/
+tsconfig.json
+# end managed by sku

--- a/fixtures/vite-render-error/package.json
+++ b/fixtures/vite-render-error/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@sku-fixtures/vite-render-error",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "sku build",
+    "start": "sku start"
+  },
+  "dependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "sku": "workspace:*"
+  },
+  "skuSkipValidatePeerDeps": true
+}

--- a/fixtures/vite-render-error/sku.config.ts
+++ b/fixtures/vite-render-error/sku.config.ts
@@ -1,0 +1,8 @@
+import { makeStableViteHashes } from '@sku-private/test-utils';
+import type { SkuConfig } from 'sku';
+
+export default {
+  bundler: 'vite',
+  dangerouslySetViteConfig: makeStableViteHashes,
+  routes: [{ route: '/', name: 'home' }],
+} satisfies SkuConfig;

--- a/fixtures/vite-render-error/src/App.tsx
+++ b/fixtures/vite-render-error/src/App.tsx
@@ -1,0 +1,13 @@
+import { HomePage } from './HomePage.tsx';
+
+type Props = {
+  route: string;
+};
+
+export const App = ({ route }: Props) => {
+  if (route === '/') {
+    return <HomePage />;
+  }
+
+  return <div>Page not found</div>;
+};

--- a/fixtures/vite-render-error/src/HomePage.tsx
+++ b/fixtures/vite-render-error/src/HomePage.tsx
@@ -1,0 +1,4 @@
+export const HomePage = () => {
+  throw new Error('Home page error');
+  return <div>Welcome to the home page</div>;
+};

--- a/fixtures/vite-render-error/src/client.tsx
+++ b/fixtures/vite-render-error/src/client.tsx
@@ -1,0 +1,11 @@
+import { hydrateRoot } from 'react-dom/client';
+
+import { App } from './App';
+
+type ClientContext = {
+  route: string;
+};
+
+export default ({ route }: ClientContext) => {
+  hydrateRoot(document.getElementById('app')!, <App route={route} />);
+};

--- a/fixtures/vite-render-error/src/render.tsx
+++ b/fixtures/vite-render-error/src/render.tsx
@@ -1,0 +1,32 @@
+import html from 'dedent';
+import { renderToString } from 'react-dom/server';
+import type { Render } from 'sku';
+
+import { App } from './App';
+
+export default {
+  renderApp: ({ SkuProvider, route }) =>
+    renderToString(
+      <SkuProvider>
+        <App route={route} />
+      </SkuProvider>,
+    ),
+
+  provideClientContext: ({ route }) => ({ route }),
+
+  renderDocument: ({ app, bodyTags, headTags }) => html /* html */ `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="UTF-8" />
+        <title>hello-world</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        ${headTags}
+      </head>
+      <body>
+        <div id="app">${app}</div>
+        ${bodyTags}
+      </body>
+    </html>
+  `,
+} satisfies Render;

--- a/packages/sku/src/program/commands/build/vite-build-handler.ts
+++ b/packages/sku/src/program/commands/build/vite-build-handler.ts
@@ -6,9 +6,10 @@ import {
 import { runVocabCompile } from '../../../services/vocab/runVocab.js';
 import { performance } from 'node:perf_hooks';
 import provider from '../../../services/telemetry/index.js';
-import chalk from 'chalk';
 import prettyMilliseconds from 'pretty-ms';
 import { viteService } from '../../../services/vite/index.js';
+import { styleText } from 'node:util';
+import { PrerenderWorkerError } from '../../../services/vite/helpers/prerender/prerenderConcurrently.js';
 
 export const viteBuildHandler = async ({
   skuContext,
@@ -35,7 +36,10 @@ export const viteBuildHandler = async ({
     });
 
     console.log(
-      chalk.green(`Sku build complete in ${prettyMilliseconds(timeTaken)}`),
+      styleText(
+        'green',
+        `Sku build complete in ${prettyMilliseconds(timeTaken)}`,
+      ),
     );
   } catch (error) {
     const timeTaken = performance.now();
@@ -45,7 +49,15 @@ export const viteBuildHandler = async ({
       csp: cspEnabled,
     });
 
-    console.error(chalk.red(error));
+    if (error instanceof PrerenderWorkerError) {
+      console.error(styleText('red', error.message));
+      console.error(error.cause);
+    } else if (error instanceof Error) {
+      console.error(styleText('red', error.message));
+      console.error(error.stack);
+    } else {
+      console.error(styleText('red', String(error)));
+    }
 
     process.exitCode = 1;
   } finally {

--- a/packages/sku/src/services/vite/helpers/prerender/prerenderConcurrently.ts
+++ b/packages/sku/src/services/vite/helpers/prerender/prerenderConcurrently.ts
@@ -17,14 +17,24 @@ export type JobWorkerData = {
   targetPath: string;
 };
 
+export class PrerenderWorkerError extends Error {
+  constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'PrerenderWorkerError';
+  }
+}
+
 const runJobs = (jobs: JobWorkerData[]): Promise<void> => {
   const workerPath = new URL(import.meta.resolve('#vite/prerender-worker'));
   const worker = new Worker(workerPath, {
     workerData: jobs,
+    execArgv: ['--enable-source-maps'],
   });
 
   return new Promise((resolve, reject) => {
-    worker.on('error', reject);
+    worker.on('error', (error) => {
+      reject(new PrerenderWorkerError(error.message, { cause: error.cause }));
+    });
 
     worker.on('exit', (code) => {
       if (code === 0) {

--- a/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
+++ b/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
@@ -51,7 +51,6 @@ await Promise.all(
       routeName,
       language,
     }: JobWorkerData) => {
-      // TODO: It would be nice to type this file properly
       const loadableCollector = createCollector({
         manifest,
         base: publicPath,
@@ -66,28 +65,35 @@ await Promise.all(
         });
       }
 
-      let html = await createPreRenderedHtml({
-        environment,
-        language,
-        route,
-        routeName,
-        site,
-        render,
-        loadableCollector,
-        createUnsafeNonce: cspHandler
-          ? cspHandler.createUnsafeNonce
-          : undefined,
-      });
+      let html = '';
+      try {
+        html = await createPreRenderedHtml({
+          environment,
+          language,
+          route,
+          routeName,
+          site,
+          render,
+          loadableCollector,
+          createUnsafeNonce: cspHandler
+            ? cspHandler.createUnsafeNonce
+            : undefined,
+        });
 
-      if (cspHandler) {
-        html = cspHandler.handleHtml(html);
+        if (cspHandler) {
+          html = cspHandler.handleHtml(html);
+        }
+      } catch (e) {
+        throw new Error(`Error rendering HTML for route ${route}`, {
+          cause: e,
+        });
       }
 
-      await ensureTargetDirectory(filePath.split('/').slice(0, -1).join('/'));
+      await ensureTargetDirectory(path.dirname(filePath));
       try {
         await writeFile(resolve(filePath), html);
       } catch (e) {
-        console.error('Error writing file', filePath, e);
+        throw new Error(`Error writing file ${filePath}`, { cause: e });
       }
 
       // Make this a nicer log.

--- a/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
+++ b/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
@@ -84,7 +84,7 @@ await Promise.all(
           html = cspHandler.handleHtml(html);
         }
       } catch (e) {
-        throw new Error(`Error rendering HTML for route ${route}`, {
+        throw new Error(`Error rendering HTML for route "${route}"`, {
           cause: e,
         });
       }

--- a/packages/sku/src/services/vite/plugins/build.ts
+++ b/packages/sku/src/services/vite/plugins/build.ts
@@ -57,6 +57,8 @@ export const buildPlugin = ({
         },
         ssr: {
           build: {
+            // Sourcemaps are necessary to get useful stack traces for errors thrown during prerendering
+            sourcemap: 'inline',
             ssr: true,
             outDir: outDir.ssg,
             rolldownOptions: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -943,6 +943,25 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sku
 
+  fixtures/vite-render-error:
+    dependencies:
+      react:
+        specifier: 'catalog:'
+        version: 19.2.4
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      sku:
+        specifier: workspace:*
+        version: link:../../packages/sku
+
   packages/babel-plugin-display-name:
     dependencies:
       '@babel/core':

--- a/tests/node/vite-render-error.test.ts
+++ b/tests/node/vite-render-error.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+
+import { scopeToFixture, waitFor } from '@sku-private/testing-library';
+
+const { sku } = scopeToFixture('vite-render-error');
+
+describe('vite render error', () => {
+  it('should emit a render error with the route name and stack trace', async () => {
+    const build = await sku('build');
+
+    await waitFor(() => {
+      expect(build.hasExit()).toMatchObject({ exitCode: 1 });
+    });
+
+    const stderr = build.stderrArr.map((item) => item.contents).join('');
+
+    expect(stderr).toMatchInlineSnapshot(`
+      "Error rendering HTML for route /Error: Home page error
+          at HomePage ({cwd}/fixtures/vite-render-error/src/HomePage.tsx:2:9)
+          at renderWithHooks ({cwd}/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.js:4196:18)
+          at renderElement ({cwd}/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.js:4334:14)
+          at retryNode ({cwd}/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.js:5040:16)
+          at renderNodeDestructive ({cwd}/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.js:4843:7)
+          at finishFunctionComponent ({cwd}/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.js:4237:9)
+          at renderElement ({cwd}/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.js:4336:7)
+          at retryNode ({cwd}/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.js:5040:16)
+          at renderNodeDestructive ({cwd}/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.js:4843:7)
+          at renderElement ({cwd}/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.js:4777:11)"
+    `);
+  });
+});

--- a/tests/node/vite-render-error.test.ts
+++ b/tests/node/vite-render-error.test.ts
@@ -12,10 +12,11 @@ describe('vite render error', () => {
       expect(build.hasExit()).toMatchObject({ exitCode: 1 });
     });
 
-    const stderr = build.stderrArr.map((item) => item.contents).join('');
+    const stderr = build.stderrArr.map((item) => item.contents).join('\n');
 
     expect(stderr).toMatchInlineSnapshot(`
-      "Error rendering HTML for route /Error: Home page error
+      "Error rendering HTML for route "/"
+      Error: Home page error
           at HomePage ({cwd}/fixtures/vite-render-error/src/HomePage.tsx:2:9)
           at renderWithHooks ({cwd}/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.js:4196:18)
           at renderElement ({cwd}/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.js:4334:14)


### PR DESCRIPTION
Errors during pre-rendering are very terse and contain no stack trace. This PR addresses this by adding inline sourcemaps to the `render` bundle and enabling sourcemaps on the pre-render workers.

I used a custom error to distinguish pre-render errors from other errors because logging an error with a message and a cause needs to be handled differently than logging a regular error. Without this special handling the worker's stack trace is also logged, which isn't useful information to the user.