### PR TITLE
`vite`: Handle error when importing sku render entrypoint

### DIFF
--- a/.changeset/shiny-peas-clean.md
+++ b/.changeset/shiny-peas-clean.md
@@ -4,4 +4,4 @@
 
 `vite`: Improve error messaging during `sku build`
 
-The path of the first route that fails to render will now be logged, along with a stack trace to aid debugging. Errors that occur before rendering will also now be logged with a stack trace.
+Pre-render errors and failures in the first errored route will now be logged with stack traces for easier debugging.

--- a/.changeset/shiny-peas-clean.md
+++ b/.changeset/shiny-peas-clean.md
@@ -4,4 +4,4 @@
 
 `vite`: Improve error messaging during `sku build`
 
-The path of the first route that fails to render will now be logged, along with a stack trace to aid debugging
+The path of the first route that fails to render will now be logged, along with a stack trace to aid debugging. Errors that occur before rendering will also now be logged with a stack trace.

--- a/fixtures/vite-render-error/sku.config.renderError.ts
+++ b/fixtures/vite-render-error/sku.config.renderError.ts
@@ -1,0 +1,9 @@
+import { makeStableViteHashes } from '@sku-private/test-utils';
+import type { SkuConfig } from 'sku';
+
+export default {
+  bundler: 'vite',
+  dangerouslySetViteConfig: makeStableViteHashes,
+  routes: [{ route: '/', name: 'home' }],
+  renderEntry: 'src/renderError.tsx',
+} satisfies SkuConfig;

--- a/fixtures/vite-render-error/src/renderError.tsx
+++ b/fixtures/vite-render-error/src/renderError.tsx
@@ -1,0 +1,34 @@
+import html from 'dedent';
+import { renderToString } from 'react-dom/server';
+import type { Render } from 'sku';
+
+import { App } from './App';
+
+throw new Error('Render entrypoint error');
+
+export default {
+  renderApp: ({ SkuProvider, route }) =>
+    renderToString(
+      <SkuProvider>
+        <App route={route} />
+      </SkuProvider>,
+    ),
+
+  provideClientContext: ({ route }) => ({ route }),
+
+  renderDocument: ({ app, bodyTags, headTags }) => html /* html */ `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="UTF-8" />
+        <title>hello-world</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        ${headTags}
+      </head>
+      <body>
+        <div id="app">${app}</div>
+        ${bodyTags}
+      </body>
+    </html>
+  `,
+} satisfies Render;

--- a/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
+++ b/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
@@ -33,9 +33,11 @@ const [manifest, render] = await Promise.all([
   readFile(resolve(path.join(targetPath, '.vite/manifest.json')), 'utf-8').then(
     JSON.parse,
   ),
-  import(resolve(path.join(outDir.ssg, renderEntryChunkName))).then(
-    (m) => m.default,
-  ),
+  import(resolve(path.join(outDir.ssg, renderEntryChunkName)))
+    .then((m) => m.default)
+    .catch((e) => {
+      throw new Error(`Error importing sku render entrypoint`, { cause: e });
+    }),
 ]);
 
 await Promise.all(

--- a/tests/node/vite-render-error.test.ts
+++ b/tests/node/vite-render-error.test.ts
@@ -4,6 +4,19 @@ import { scopeToFixture, waitFor } from '@sku-private/testing-library';
 
 const { sku } = scopeToFixture('vite-render-error');
 
+const filterNodeInternalStackFrames = (stack: string) =>
+  stack
+    .split('\n')
+    .filter((line) => !line.includes('node:internal'))
+    .join('\n');
+
+const aggregateStdErr = (
+  stderrArr: Array<{ contents: string | Buffer<ArrayBufferLike> }>,
+) =>
+  stderrArr
+    .map((item) => filterNodeInternalStackFrames(item.contents.toString()))
+    .join('\n');
+
 describe('vite render error', () => {
   it('should emit an error with the route name and stack trace when a route fails to render', async () => {
     const build = await sku('build');
@@ -12,7 +25,7 @@ describe('vite render error', () => {
       expect(build.hasExit()).toMatchObject({ exitCode: 1 });
     });
 
-    const stderr = build.stderrArr.map((item) => item.contents).join('\n');
+    const stderr = aggregateStdErr(build.stderrArr);
 
     expect(stderr).toMatchInlineSnapshot(`
       "Error rendering HTML for route "/"
@@ -37,15 +50,12 @@ describe('vite render error', () => {
       expect(build.hasExit()).toMatchObject({ exitCode: 1 });
     });
 
-    const stderr = build.stderrArr.map((item) => item.contents).join('\n');
+    const stderr = aggregateStdErr(build.stderrArr);
 
     expect(stderr).toMatchInlineSnapshot(`
       "Error importing sku render entrypoint
       Error: Render entrypoint error
           at <anonymous> ({cwd}/fixtures/vite-render-error/src/renderError.tsx:7:7)
-          at ModuleJob.run (node:internal/modules/esm/module_job:343:25)
-          at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
-          at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:665:26)
           at async Promise.all (index 1)
           at async file://{cwd}/packages/sku/dist/vite/prerender-worker.mjs:17:28"
     `);

--- a/tests/node/vite-render-error.test.ts
+++ b/tests/node/vite-render-error.test.ts
@@ -5,7 +5,7 @@ import { scopeToFixture, waitFor } from '@sku-private/testing-library';
 const { sku } = scopeToFixture('vite-render-error');
 
 describe('vite render error', () => {
-  it('should emit a render error with the route name and stack trace', async () => {
+  it('should emit an error with the route name and stack trace when a route fails to render', async () => {
     const build = await sku('build');
 
     await waitFor(() => {
@@ -27,6 +27,27 @@ describe('vite render error', () => {
           at retryNode ({cwd}/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.js:5040:16)
           at renderNodeDestructive ({cwd}/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.js:4843:7)
           at renderElement ({cwd}/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.js:4777:11)"
+    `);
+  });
+
+  it('should emit an error with a stack trace when the render entrypoint throws an error', async () => {
+    const build = await sku('build', ['--config', 'sku.config.renderError.ts']);
+
+    await waitFor(() => {
+      expect(build.hasExit()).toMatchObject({ exitCode: 1 });
+    });
+
+    const stderr = build.stderrArr.map((item) => item.contents).join('\n');
+
+    expect(stderr).toMatchInlineSnapshot(`
+      "Error importing sku render entrypoint
+      Error: Render entrypoint error
+          at <anonymous> ({cwd}/fixtures/vite-render-error/src/renderError.tsx:7:7)
+          at ModuleJob.run (node:internal/modules/esm/module_job:343:25)
+          at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
+          at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:665:26)
+          at async Promise.all (index 1)
+          at async file://{cwd}/packages/sku/dist/vite/prerender-worker.mjs:17:28"
     `);
   });
 });


### PR DESCRIPTION
I noticed that there was no stack trace when an error occurs while importing the render entrypoint. This happens _before_ route rendering, so the error handling in #1548 doesn't handle it.

This PR adds error handling for this case.