### PR TITLE
`vite`: Tidy up prerender route log

### DIFF
--- a/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
+++ b/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
@@ -92,14 +92,18 @@ await Promise.all(
       }
 
       await ensureTargetDirectory(path.dirname(filePath));
+      const relativeOutputPath = path.relative(process.cwd(), filePath);
+
       try {
+        console.log(
+          `Writing HTML for route "${route}" to "${relativeOutputPath}"`,
+        );
         await writeFile(resolve(filePath), html);
       } catch (e) {
-        throw new Error(`Error writing file ${filePath}`, { cause: e });
+        throw new Error(`Error writing file to "${relativeOutputPath}"`, {
+          cause: e,
+        });
       }
-
-      // Make this a nicer log.
-      console.log(`Static Site Generation for route: ${route} to ${filePath}`);
     },
   ),
 );


### PR DESCRIPTION
`// Make this a nicer log` ✅ 

Currently the logged path is absolute, which isn't that useful as I feel like it's safe to assume the user knows that the output path is always relative to the app root.