### PR TITLE
`storybook`: Pass through `sku` sourcemap config to the Storybook webpack config

### DIFF
--- a/.changeset/kind-otters-hope.md
+++ b/.changeset/kind-otters-hope.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`storybook`: Pass through `sku` sourcemap config to the Storybook webpack config

--- a/packages/sku/src/config/storybook/webpackConfig.js
+++ b/packages/sku/src/config/storybook/webpackConfig.js
@@ -67,6 +67,7 @@ export default (config, { isDevServer }) => {
     module: clientWebpackConfig.module,
     resolve: clientWebpackConfig.resolve,
     plugins: clientWebpackConfig.plugins,
+    devtool: clientWebpackConfig.devtool,
     stats: 'errors-only',
   });
 };


### PR DESCRIPTION
Some stack traces are very hard to trace in Storybook, particularly during local dev. This PR passes through the same sourcemap config value (the awfully named [`devtool`](https://webpack.js.org/configuration/devtool/)) sku uses into the Storybook webpack config.