### PR TITLE
feat(webpack): add webpackFilesystemCache for production builds

### DIFF
--- a/.changeset/webpack-filesystem-cache-config.md
+++ b/.changeset/webpack-filesystem-cache-config.md
@@ -1,0 +1,7 @@
+---
+'sku': minor
+---
+
+`webpack`: Add `webpackFilesystemCache` so production builds (`sku build` / `sku build-ssr`) and CI can opt in to Webpack filesystem caching.
+
+Accepts either a mode (`'development' | 'always'`) or an options object exposing Webpack's [advanced cache options](https://webpack.js.org/guides/caching/#advanced-options) (`compression`, `maxAge`, extra `buildDependencies`). Sku always invalidates the cache when `sku.config.*` or the installed `sku` version changes. Override the mode with `SKU_WEBPACK_FILESYSTEM_CACHE`. Default remains `'development'` (cache only for the local dev server).

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -492,6 +492,18 @@ Unfortunately, these kinds of imports only work for apps. In packages, the impor
 
 You can set this option in `sku.config.js`, or adding `"skuCompilePackage": true` to your `package.json` will disable this behaviour by default.
 
+## webpackFilesystemCache
+
+Type: `'development' | 'always' | { mode?, compression?, maxAge?, buildDependencies? }`
+
+Default: `'development'`
+
+Bundler: `webpack`
+
+Controls Webpack’s [filesystem cache](https://webpack.js.org/configuration/cache/#cachetype). With `'development'`, the cache is used only for the local dev server. Set to `'always'` to also use it for production builds and in CI (unless `SKU_DISABLE_CACHE` is set). Override the mode with `SKU_WEBPACK_FILESYSTEM_CACHE=development` or `SKU_WEBPACK_FILESYSTEM_CACHE=always`.
+
+Pass an object to tune Webpack's [advanced cache options](https://webpack.js.org/guides/caching/#advanced-options) (`compression`, `maxAge`) and add extra `buildDependencies`. Sku always invalidates the cache on changes to `sku.config.*` and to the installed `sku` version. See [Caching](./extra-features?id=caching) for Docker and CI notes.
+
 ## routes
 
 Type: `Array<string | {route: string, name: string, entry: string, languages: Array<string>}>`

--- a/docs/docs/extra-features.md
+++ b/docs/docs/extra-features.md
@@ -156,12 +156,32 @@ export default {
 ### [Webpack filesystem cache]
 
 This cache stores generated webpack modules and chunks.
-It is only emitted during local development.
-Its purpose is to reduce the time it takes to start the local development server.
+By default (`webpackFilesystemCache: 'development'` in `sku.config.ts`), it is only used for the local development server (`sku start` / `sku start-ssr`).
+
+Set `webpackFilesystemCache: 'always'` to also enable it for `sku build` / `sku build-ssr` (including in CI), unless `SKU_DISABLE_CACHE` is set. You can override the mode with `SKU_WEBPACK_FILESYSTEM_CACHE=development` or `SKU_WEBPACK_FILESYSTEM_CACHE=always`.
+
+For finer control, pass an options object that mirrors Webpack's [advanced cache options]:
+
+```ts
+export default {
+  webpackFilesystemCache: {
+    mode: 'always',
+    compression: 'gzip',
+    maxAge: 1000 * 60 * 60 * 24 * 7,
+    buildDependencies: ['./tsconfig.json'],
+  },
+} satisfies SkuConfig;
+```
+
+Sku always invalidates the cache when your `sku.config.*` or the installed `sku` version changes; any `buildDependencies` you provide are added on top.
+
+In Docker or Buildkite, pair `'always'` with a [BuildKit cache mount] on `node_modules/.cache/webpack` so the cache persists between image builds on the same agents.
 
 > This cache is stored in `node_modules/.cache/webpack` and can be safely deleted at any time.
 
 [webpack filesystem cache]: https://webpack.js.org/configuration/cache/#cachetype
+[advanced cache options]: https://webpack.js.org/guides/caching/#advanced-options
+[BuildKit cache mount]: https://docs.docker.com/build/cache/optimize/#use-cache-mounts
 
 ### [`babel-loader` cache]
 

--- a/packages/sku/src/context/configSchema.ts
+++ b/packages/sku/src/context/configSchema.ts
@@ -197,6 +197,40 @@ export default validator.compile({
   rootResolution: {
     type: 'boolean',
   },
+  webpackFilesystemCache: [
+    {
+      type: 'enum',
+      values: ['development', 'always'],
+      optional: true,
+    },
+    {
+      type: 'object',
+      optional: true,
+      props: {
+        mode: {
+          type: 'enum',
+          values: ['development', 'always'],
+          optional: true,
+        },
+        compression: {
+          type: 'enum',
+          values: [false, 'gzip', 'brotli'],
+          optional: true,
+        },
+        maxAge: {
+          type: 'number',
+          optional: true,
+          integer: true,
+          positive: true,
+        },
+        buildDependencies: {
+          type: 'array',
+          optional: true,
+          items: { type: 'string' },
+        },
+      },
+    },
+  ],
   languages: languagesToCompile,
   skipPackageCompatibilityCompilation: {
     type: 'array',

--- a/packages/sku/src/context/createSkuContext.ts
+++ b/packages/sku/src/context/createSkuContext.ts
@@ -1,4 +1,10 @@
-import type { SkuConfig, SkuRoute, SkuRouteObject } from '../types/types.js';
+import type {
+  SkuConfig,
+  SkuRoute,
+  SkuRouteObject,
+  WebpackFilesystemCacheMode,
+  WebpackFilesystemCacheOptions,
+} from '../types/types.js';
 import { getPathFromCwd, requireFromCwd } from '@sku-private/utils';
 import { existsSync } from 'node:fs';
 import defaultSkuConfig from './defaultSkuConfig.js';
@@ -257,6 +263,22 @@ export const createSkuContext = ({
     skuConfig.skipPackageCompatibilityCompilation;
   const externalizeNodeModules = skuConfig.externalizeNodeModules;
 
+  const envWebpackFilesystemCacheMode = process.env
+    .SKU_WEBPACK_FILESYSTEM_CACHE as WebpackFilesystemCacheMode | undefined;
+  const rawWebpackFilesystemCache = skuConfig.webpackFilesystemCache;
+  const baseWebpackFilesystemCache: WebpackFilesystemCacheOptions =
+    typeof rawWebpackFilesystemCache === 'string'
+      ? { mode: rawWebpackFilesystemCache }
+      : (rawWebpackFilesystemCache ?? { mode: 'development' });
+  const webpackFilesystemCache: WebpackFilesystemCacheOptions = {
+    ...baseWebpackFilesystemCache,
+    mode:
+      envWebpackFilesystemCacheMode === 'always' ||
+      envWebpackFilesystemCacheMode === 'development'
+        ? envWebpackFilesystemCacheMode
+        : (baseWebpackFilesystemCache.mode ?? 'development'),
+  };
+
   const tsPaths =
     skuConfig.bundler === 'vite' || skuConfig.testRunner === 'vitest'
       ? generateTypeScriptPaths(skuConfig.pathAliases)
@@ -314,6 +336,7 @@ export const createSkuContext = ({
     cspExtraScriptSrcHosts,
     httpsDevServer,
     rootResolution,
+    webpackFilesystemCache,
     languages,
     initialPath,
     transformOutputPath: skuConfig.transformOutputPath,

--- a/packages/sku/src/context/defaultSkuConfig.ts
+++ b/packages/sku/src/context/defaultSkuConfig.ts
@@ -44,6 +44,7 @@ export default {
   httpsDevServer: false,
   devServerMiddleware: undefined,
   rootResolution: !isCompilePackage,
+  webpackFilesystemCache: { mode: 'development' },
   languages: undefined,
   skipPackageCompatibilityCompilation: [],
   externalizeNodeModules: false,

--- a/packages/sku/src/index.ts
+++ b/packages/sku/src/index.ts
@@ -3,4 +3,7 @@ export type {
   RenderCallbackParams,
   Server,
   SkuConfig,
+  WebpackFilesystemCacheConfig,
+  WebpackFilesystemCacheMode,
+  WebpackFilesystemCacheOptions,
 } from './types/types.js';

--- a/packages/sku/src/services/webpack/config/cache.ts
+++ b/packages/sku/src/services/webpack/config/cache.ts
@@ -1,25 +1,53 @@
+import { createRequire } from 'node:module';
+
 import isCI from '../../../utils/isCI.js';
 import type { SkuContext } from '../../../context/createSkuContext.js';
+import type { WebpackFilesystemCacheOptions } from '../../../types/types.js';
+
+const require = createRequire(import.meta.url);
 
 const disableCacheOverride = Boolean(process.env.SKU_DISABLE_CACHE);
 
 function getWebpackCacheSettings({
   isDevServer,
   paths,
+  webpackFilesystemCache,
 }: {
   isDevServer: boolean;
   paths: SkuContext['paths'];
+  webpackFilesystemCache: WebpackFilesystemCacheOptions;
 }) {
-  if (isDevServer && !isCI && !disableCacheOverride) {
-    return {
-      type: 'filesystem',
-      buildDependencies: {
-        config: paths.appSkuConfigPath ? [paths.appSkuConfigPath] : [],
-      },
-    };
+  if (disableCacheOverride) {
+    return false;
   }
 
-  return false;
+  const {
+    mode = 'development',
+    compression,
+    maxAge,
+    buildDependencies = [],
+  } = webpackFilesystemCache;
+
+  const cacheEnabled = mode === 'always' || (isDevServer && !isCI);
+  if (!cacheEnabled) {
+    return false;
+  }
+
+  // Always invalidate on the user's sku config and on the installed sku version.
+  const skuPackageJsonPath = require.resolve('sku/package.json');
+  const defaultBuildDependencies = [
+    paths.appSkuConfigPath,
+    skuPackageJsonPath,
+  ].filter((entry): entry is string => Boolean(entry));
+
+  return {
+    type: 'filesystem' as const,
+    ...(compression !== undefined ? { compression } : {}),
+    ...(maxAge !== undefined ? { maxAge } : {}),
+    buildDependencies: {
+      config: [...defaultBuildDependencies, ...buildDependencies],
+    },
+  };
 }
 
 export default getWebpackCacheSettings;

--- a/packages/sku/src/services/webpack/config/webpack.config.ssr.ts
+++ b/packages/sku/src/services/webpack/config/webpack.config.ssr.ts
@@ -51,6 +51,7 @@ const makeWebpackConfig = ({
     skipPackageCompatibilityCompilation,
     externalizeNodeModules,
     sourceMapsProd,
+    webpackFilesystemCache,
   } = skuContext;
   const isProductionBuild = process.env.NODE_ENV === 'production';
   const webpackMode = isProductionBuild ? 'production' : 'development';
@@ -94,7 +95,11 @@ const makeWebpackConfig = ({
         filename: `${fileMask}.js`,
         chunkFilename: `${fileMask}.js`,
       },
-      cache: getCacheSettings({ isDevServer, paths }),
+      cache: getCacheSettings({
+        isDevServer,
+        paths,
+        webpackFilesystemCache,
+      }),
       optimization: {
         nodeEnv: process.env.NODE_ENV,
         minimize: isProductionBuild,
@@ -248,7 +253,11 @@ const makeWebpackConfig = ({
         hotUpdateChunkFilename: `[id].[fullhash].hot-update.${type === 'module' ? 'c' : ''}js`,
         library: { name: 'server', type: 'var' },
       },
-      cache: getCacheSettings({ isDevServer, paths }),
+      cache: getCacheSettings({
+        isDevServer,
+        paths,
+        webpackFilesystemCache,
+      }),
       optimization: {
         nodeEnv: process.env.NODE_ENV,
         emitOnErrors: isProductionBuild,

--- a/packages/sku/src/services/webpack/config/webpack.config.ts
+++ b/packages/sku/src/services/webpack/config/webpack.config.ts
@@ -56,6 +56,7 @@ const makeWebpackConfig = ({
     skipPackageCompatibilityCompilation,
     externalizeNodeModules,
     sourceMapsProd,
+    webpackFilesystemCache,
   } = skuContext;
   const isProductionBuild = process.env.NODE_ENV === 'production';
 
@@ -134,7 +135,11 @@ const makeWebpackConfig = ({
             }
           : {}),
       },
-      cache: getCacheSettings({ isDevServer, paths }),
+      cache: getCacheSettings({
+        isDevServer,
+        paths,
+        webpackFilesystemCache,
+      }),
       optimization: {
         nodeEnv: process.env.NODE_ENV,
         minimize: isProductionBuild,
@@ -292,7 +297,11 @@ const makeWebpackConfig = ({
         filename: 'render.js',
         library: { name: 'static', type: 'umd2', export: 'default' },
       },
-      cache: getCacheSettings({ isDevServer, paths }),
+      cache: getCacheSettings({
+        isDevServer,
+        paths,
+        webpackFilesystemCache,
+      }),
       optimization: {
         nodeEnv: process.env.NODE_ENV,
       },

--- a/packages/sku/src/types/types.ts
+++ b/packages/sku/src/types/types.ts
@@ -443,6 +443,51 @@ export interface SkuConfigBase {
   transformOutputPath?: TransformOutputPathFunction;
 }
 
+export type WebpackFilesystemCacheMode = 'development' | 'always';
+
+/**
+ * Advanced configuration for Webpack's [filesystem cache].
+ * Mirrors the relevant subset of Webpack's `cache` options.
+ *
+ * [filesystem cache]: https://webpack.js.org/configuration/cache/#cachetype
+ */
+export interface WebpackFilesystemCacheOptions {
+  /**
+   * When the cache is enabled.
+   *
+   * - `'development'` (default): only used for the local dev server.
+   * - `'always'`: also used for `sku build` / `sku build-ssr` and in CI.
+   */
+  mode?: WebpackFilesystemCacheMode;
+
+  /**
+   * Compression for cache files. Reduces disk usage at the cost of some CPU.
+   *
+   * @default false
+   * @see https://webpack.js.org/configuration/cache/#cachecompression
+   */
+  compression?: false | 'gzip' | 'brotli';
+
+  /**
+   * Maximum age (ms) of unused cache entries before they're cleaned up.
+   *
+   * @see https://webpack.js.org/configuration/cache/#cachemaxage
+   */
+  maxAge?: number;
+
+  /**
+   * Additional files whose changes should invalidate the cache.
+   * Sku already includes the resolved `sku.config.*` and `sku/package.json`.
+   *
+   * @see https://webpack.js.org/configuration/cache/#cachebuilddependencies
+   */
+  buildDependencies?: string[];
+}
+
+export type WebpackFilesystemCacheConfig =
+  | WebpackFilesystemCacheMode
+  | WebpackFilesystemCacheOptions;
+
 export interface WebpackSkuConfig {
   /**
    * A folder of public assets to be copied into the `target` directory after `sku build` or `sku build-ssr`.
@@ -514,6 +559,21 @@ export interface WebpackSkuConfig {
    * @link https://seek-oss.github.io/sku/#/./docs/configuration?id=rootresolution
    */
   rootResolution?: boolean;
+
+  /**
+   * Controls [Webpack filesystem caching](https://webpack.js.org/configuration/cache/#cachetype).
+   *
+   * Pass either a mode string or an options object:
+   *
+   * - `'development'` (default): cache is used only for the local dev server (`sku start` / `sku start-ssr`), not for production builds or in CI.
+   * - `'always'`: cache is also used for `sku build` / `sku build-ssr` and in CI, unless `SKU_DISABLE_CACHE` is set.
+   * - Object form: `{ mode, compression, maxAge, buildDependencies }` to tune Webpack's [advanced cache options](https://webpack.js.org/guides/caching/#advanced-options).
+   *
+   * The mode can also be overridden with `SKU_WEBPACK_FILESYSTEM_CACHE=development|always`.
+   *
+   * In Docker/Buildkite, pair `'always'` with a BuildKit cache mount on `node_modules/.cache/webpack` (and optionally `node_modules/.cache/babel-loader`) so the cache persists between builds.
+   */
+  webpackFilesystemCache?: WebpackFilesystemCacheConfig;
 }
 
 export interface ViteSkuConfig {


### PR DESCRIPTION
## Summary

- Adds `webpackFilesystemCache` to `sku.config` so consumers can opt in to Webpack 5 filesystem cache for `sku build` / `sku build-ssr` and CI.
- Accepts either a mode (`'development' | 'always'`) **or** an options object exposing Webpack's [advanced cache options](https://webpack.js.org/guides/caching/#advanced-options):

  ```ts
  webpackFilesystemCache: {
    mode: 'always',
    compression: 'gzip',
    maxAge: 1000 * 60 * 60 * 24 * 7,
    buildDependencies: ['./tsconfig.json'],
  }
  ```

- Sku always invalidates the cache on `sku.config.*` and on the installed `sku` version; consumer `buildDependencies` are appended.
- Mode override via `SKU_WEBPACK_FILESYSTEM_CACHE=development|always`; full disable via `SKU_DISABLE_CACHE`.
- Default behaviour is unchanged (`'development'` → cache only for the dev server).

## Changeset

Includes `.changeset/webpack-filesystem-cache-config.md` per [CONTRIBUTING](https://github.com/seek-oss/sku/blob/master/CONTRIBUTING.md).

## Docs

- `docs/docs/configuration.md`
- `docs/docs/extra-features.md` (incl. example, BuildKit cache mount note)

## Test plan

- [x] `pnpm --filter sku lint:tsc`
- [x] `pnpm lint:tsc`
- [x] `pnpm lint:eslint`
- [x] `pnpm lint:prettier`
- [ ] `pnpm test` (CI)