### PR TITLE
Fix vanilla-extract dep scan for aliased `css.ts` imports

### DIFF
--- a/.changeset/violet-lions-greet.md
+++ b/.changeset/violet-lions-greet.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+vite: make vanilla-extract dep scan resolve path aliases for `css.ts` imports

--- a/fixtures/path-aliases/package.json
+++ b/fixtures/path-aliases/package.json
@@ -2,18 +2,19 @@
   "name": "@sku-fixtures/custom-output-target",
   "private": true,
   "type": "module",
+  "scripts": {
+    "build:vite": "sku build --config sku.config.vite.ts",
+    "start:vite": "sku start --config sku.config.vite.ts"
+  },
   "dependencies": {
     "react": "catalog:",
     "react-dom": "catalog:"
-  },
-  "scripts": {
-    "start:vite": "sku start --config sku.config.vite.ts",
-    "build:vite": "sku build --config sku.config.vite.ts"
   },
   "devDependencies": {
     "@sku-private/test-utils": "workspace:*",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@vanilla-extract/css": "catalog:",
     "sku": "workspace:*"
   }
 }

--- a/fixtures/path-aliases/sku.config.vite.ts
+++ b/fixtures/path-aliases/sku.config.vite.ts
@@ -8,6 +8,14 @@ export default {
   pathAliases: {
     '@components/*': './src/components/*',
     '@utils/*': './src/utils/*',
+    '#styles/*': './src/styles/*',
   },
-  dangerouslySetViteConfig: makeStableViteHashes,
+  dangerouslySetViteConfig: () => ({
+    ...makeStableViteHashes(),
+    optimizeDeps: {
+      // css resolution issues only occur during the first optimization.
+      // Forcing a re-optimization to be able to test the error consistently.
+      force: true,
+    },
+  }),
 } satisfies SkuConfig;

--- a/fixtures/path-aliases/src/App.tsx
+++ b/fixtures/path-aliases/src/App.tsx
@@ -1,9 +1,17 @@
 import { Button } from '@components/Button';
 import { add } from 'src/utils/add';
 
+// This does not get picked up by the vanilla-extract css filter since it doesn't have a ts/js extension (e.g., "foo.css.ts")
+import * as stylesCss from '#styles/root.css';
+
+// This _does_ get picked up by the vanilla-extract css filter so we need to make sure that it resolves correctly.
+// The internal resolve (`this.resolve`) is used in that plugin to make sure it resolves aliases.
+import * as stylesCssTs from '#styles/root.css.ts';
+
 export default () => (
   <div>
-    <p>6 + 9 = {add(6, 9)}</p>
+    <p className={stylesCss.paragraph}>6 + 9 = {add(6, 9)}</p>
+    <p className={stylesCssTs.paragraph}>this text is red</p>
     <Button />
   </div>
 );

--- a/fixtures/path-aliases/src/styles/root.css.ts
+++ b/fixtures/path-aliases/src/styles/root.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css';
+
+export const paragraph = style({
+  color: 'red',
+});

--- a/packages/sku/src/services/vite/plugins/esbuild/fixViteVanillaExtractDepScanPlugin.ts
+++ b/packages/sku/src/services/vite/plugins/esbuild/fixViteVanillaExtractDepScanPlugin.ts
@@ -1,10 +1,9 @@
 import type { RolldownPluginOption } from 'rolldown';
 import { cssFileFilter } from '@vanilla-extract/integration';
 import { makePluginName } from '../../helpers/makePluginName.js';
-import { dirname } from 'node:path';
-import { createRequire } from 'node:module';
+import _debug from 'debug';
 
-const require = createRequire(import.meta.url);
+const debug = _debug('sku:fix-vanilla-extract-dep-scan');
 
 export const fixViteVanillaExtractDepScanPlugin = (): RolldownPluginOption => ({
   name: makePluginName('fix-vanilla-extract-dep-scan'),
@@ -13,13 +12,16 @@ export const fixViteVanillaExtractDepScanPlugin = (): RolldownPluginOption => ({
     filter: {
       id: cssFileFilter,
     },
-    handler: (source, importer) => {
-      const id = require.resolve(source, {
-        paths: importer ? [dirname(importer)] : undefined,
-      });
+    async handler(source, importer) {
+      const resolved = await this.resolve(source, importer);
+      // If it can't be resolved, don't do anything.
+      if (!resolved) {
+        debug(`Could not resolve "${source}" from "${importer}"`);
+        return null;
+      }
 
       return {
-        id,
+        id: resolved.id,
         // keep the absolute path of the css file so its externalized correctly.
         external: 'absolute',
       };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,6 +418,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
+      '@vanilla-extract/css':
+        specifier: 'catalog:'
+        version: 1.20.0(babel-plugin-macros@3.1.0)
       sku:
         specifier: workspace:*
         version: link:../../packages/sku

--- a/tests/browser/path-aliases.test.ts
+++ b/tests/browser/path-aliases.test.ts
@@ -31,6 +31,7 @@ describe('pathAliases', () => {
         'src/*': ['./src/*'],
         '@components/*': ['./src/components/*'],
         '@utils/*': ['./src/utils/*'],
+        '#styles/*': ['./src/styles/*'],
       });
     });
 
@@ -82,6 +83,8 @@ describe('pathAliases', () => {
       expect(
         start.queryByError('The plugin "vite-tsconfig-paths" is detected.'),
       ).not.toBeInTheConsole();
+
+      expect(start.queryByError('PLUGIN_ERROR')).not.toBeInTheConsole();
 
       expect(
         start.queryByError(


### PR DESCRIPTION
Importing vanilla-extract css files in ts files can be done by including or excluding the `ts` extension.

```ts
// both of these import src/styles.css.ts without errors
import * as styles from '#src/styles.css';
import * as styles from '#src/styles.css.ts';
```

However, when including the ts extensions, the import gets caught by the vanilla-extract css filter that the fixViteVanillaExtractDepScanPlugin uses. If a path alias is configured, the built-in resolve to this file fails since it doesn't resolve the alias.

To fix this, we can use the rolldown resolve with `this.resolve`. This uses all the configured rolldown plugins, including the ts alias resolution. This PR adds that in.