### PR TITLE
Fix broken entrypoints

### DIFF
--- a/.changeset/cuddly-camels-accept.md
+++ b/.changeset/cuddly-camels-accept.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fixes a bug causing incorrect bundling of the `sku/@loadable/component` and `sku/vite/client` entrypoints

--- a/packages/sku/tsdown.config.ts
+++ b/packages/sku/tsdown.config.ts
@@ -8,11 +8,11 @@ export default defineConfig([
     copy: [
       {
         from: 'src/services/vite/client.d.ts',
-        to: 'dist/vite/client.d.ts',
+        to: 'dist/vite/',
       },
       {
         from: 'src/@loadable/component/index.ts',
-        to: 'dist/@loadable/component/index.ts',
+        to: 'dist/@loadable/component/',
       },
     ],
     // Need to use unbundled mode because `webpack/entry/server/index.ts` calls webpackHot.accept which needs a known path to the server app at runtime.


### PR DESCRIPTION
`copy` behaviour changed in [`tsdown@0.17.4`](https://github.com/rolldown/tsdown/releases/tag/v0.17.4), causing incorrect bundling of a few of our entrypoints. This PR fixes those entrypoints so they are bundled correctly - the same way they were in 15.13.0.