### PR TITLE
Fix opening on fallback port

### DIFF
--- a/.changeset/loud-insects-prove.md
+++ b/.changeset/loud-insects-prove.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Fix the browser not opening to the right url when a fallback port it used

--- a/.changeset/loud-insects-prove.md
+++ b/.changeset/loud-insects-prove.md
@@ -2,4 +2,4 @@
 'sku': patch
 ---
 
-Fix the browser not opening to the right url when a fallback port it used
+`vite`: Fix the browser not opening to the right url when a fallback port it used

--- a/packages/sku/src/services/vite/index.ts
+++ b/packages/sku/src/services/vite/index.ts
@@ -31,26 +31,36 @@ export const viteService = {
     skuContext: SkuContext;
     environment: string;
   }) => {
-    const server = await createServer(createConfig(skuContext, environment));
-
     const availablePort = await allocatePort({
       port: skuContext.port.client,
       strictPort: skuContext.port.strictPort,
     });
 
+    const skuContextOverride = {
+      ...skuContext,
+      port: {
+        ...skuContext.port,
+        client: availablePort,
+      },
+    };
+
+    const server = await createServer(
+      createConfig(skuContextOverride, environment),
+    );
+
     await server.listen(availablePort);
 
-    const hosts = getAppHosts(skuContext);
+    const hosts = getAppHosts(skuContextOverride);
 
     console.log('Starting development server...');
     const urls = serverUrls({
       hosts,
       port: availablePort,
-      initialPath: skuContext.initialPath,
+      initialPath: skuContextOverride.initialPath,
       https: skuContext.httpsDevServer,
     });
 
-    if (skuContext.listUrls) {
+    if (skuContextOverride.listUrls) {
       urls.printAll();
     } else {
       urls.print();


### PR DESCRIPTION
Pass the port allocated at start through skuContext into the Vite dev plugins so the opened URL uses the fallback port when the default is taken.