### PR TITLE
Share package manager version normalization util

### DIFF
--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@sku-private/tsdown": "workspace:*",
     "@sku-private/utils": "workspace:*",
+    "@sku-private/test-utils": "workspace:*",
     "@types/prompts": "^2.4.9",
     "fs-fixture": "^2.6.0",
     "typescript": "^5.6.2"

--- a/packages/create/src/generators/packageJson.test.ts
+++ b/packages/create/src/generators/packageJson.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'vitest';
 import { createFixture } from 'fs-fixture';
 import { generatePackageJson } from './packageJson.js';
+import { normalizePackageManagerVersion } from '@sku-private/test-utils';
 
 describe('generatePackageJson', () => {
   it('should generate package.json for webpack template', async ({
@@ -105,23 +106,28 @@ describe('generatePackageJson', () => {
       packageManager: 'pnpm',
     });
 
-    const packageJsonContent = await fixture.readFile('package.json', 'utf8');
+    const packageJsonContent = JSON.parse(
+      await fixture.readFile('package.json', 'utf8'),
+    );
+
+    packageJsonContent.packageManager = normalizePackageManagerVersion(
+      packageJsonContent.packageManager,
+    );
 
     expect(packageJsonContent).toMatchInlineSnapshot(`
-      "{
+      {
         "name": "my-app",
-        "version": "1.0.0",
+        "packageManager": "pnpm@10.VERSION_IGNORED",
         "private": true,
         "scripts": {
-          "start": "sku start",
           "build": "sku build",
-          "test": "sku test",
           "format": "sku format",
-          "lint": "sku lint"
+          "lint": "sku lint",
+          "start": "sku start",
+          "test": "sku test",
         },
-        "packageManager": "pnpm@10.33.4"
+        "version": "1.0.0",
       }
-      "
     `);
 
     await fixture.rm();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1072,6 +1072,9 @@ importers:
         specifier: ^2.8.3
         version: 2.9.0
     devDependencies:
+      '@sku-private/test-utils':
+        specifier: workspace:*
+        version: link:../../private/test-utils
       '@sku-private/tsdown':
         specifier: workspace:*
         version: link:../../private/tsdown
@@ -1583,6 +1586,9 @@ importers:
       '@types/klaw':
         specifier: ^3.0.6
         version: 3.0.7
+      '@types/semver':
+        specifier: ^7.5.8
+        version: 7.7.1
       '@types/webpack-stats-plugin':
         specifier: ^0.3.5
         version: 0.3.5
@@ -1595,6 +1601,9 @@ importers:
       klaw:
         specifier: ^4.1.0
         version: 4.1.0
+      semver:
+        specifier: ^7.6.3
+        version: 7.7.4
       webpack-stats-plugin:
         specifier: ^1.0.3
         version: 1.1.3
@@ -1646,9 +1655,6 @@ importers:
       '@sku-private/testing-library':
         specifier: workspace:*
         version: link:../private/testing-library
-      '@types/semver':
-        specifier: ^7.5.8
-        version: 7.7.1
       dedent:
         specifier: ^1.5.1
         version: 1.7.2(babel-plugin-macros@3.1.0)
@@ -1658,9 +1664,6 @@ importers:
       node-html-parser:
         specifier: ^7.0.1
         version: 7.1.0
-      semver:
-        specifier: ^7.6.3
-        version: 7.7.4
       webpack:
         specifier: ^5.52.0
         version: 5.106.2(esbuild@0.28.0)(webpack-cli@6.0.1)

--- a/private/test-utils/index.ts
+++ b/private/test-utils/index.ts
@@ -2,3 +2,4 @@ export { ListExternalsWebpackPlugin } from './ListExternalsWebpackPlugin.ts';
 export { dirContentsToObject } from './dirContentsToObject.ts';
 export { makeStableHashes, makeStableViteHashes } from './skuConfig.ts';
 export { getPort } from './getPort.ts';
+export { normalizePackageManagerVersion } from './normalize.ts';

--- a/private/test-utils/normalize.ts
+++ b/private/test-utils/normalize.ts
@@ -1,0 +1,12 @@
+import { major } from 'semver';
+
+/**
+ * We only really care about the major version of the package manager version field.
+ * This functino replaces the minor and patch version of the package manager version
+ * with `VERSION_IGNORED`.
+ */
+export const normalizePackageManagerVersion = (packageManager: string) => {
+  const [name, version] = packageManager.split('@');
+  const packageManagerMajorVersion = major(version);
+  return `${name}@${packageManagerMajorVersion}.VERSION_IGNORED`;
+};

--- a/private/test-utils/package.json
+++ b/private/test-utils/package.json
@@ -10,10 +10,12 @@
   "devDependencies": {
     "@types/hostile": "^1.3.5",
     "@types/klaw": "^3.0.6",
+    "@types/semver": "^7.5.8",
     "@types/webpack-stats-plugin": "^0.3.5",
     "get-port": "^7.1.0",
     "hostile": "^1.3.3",
     "klaw": "^4.1.0",
+    "semver": "^7.6.3",
     "webpack-stats-plugin": "^1.0.3"
   }
 }

--- a/tests/node/sku-create.test.ts
+++ b/tests/node/sku-create.test.ts
@@ -5,7 +5,7 @@ import fs from 'node:fs/promises';
 import { configure } from '@sku-private/testing-library';
 import { scopeToFixture } from '@sku-private/testing-library/create';
 import path from 'node:path';
-import { major } from 'semver';
+import { normalizePackageManagerVersion } from '@sku-private/test-utils';
 
 const { create, fixturePath } = scopeToFixture('sku-create');
 
@@ -188,11 +188,9 @@ function replaceDependencyVersions(packageJson: Record<string, any>) {
   }
 
   if ('packageManager' in newPackageJson) {
-    // Only keep the major version number because we have direct control over it and it will reduce
-    // snapshot noise
-    const [name, version] = newPackageJson.packageManager.split('@');
-    const packageManagerMajorVersion = major(version);
-    newPackageJson.packageManager = `${name}@${packageManagerMajorVersion}.VERSION_IGNORED`;
+    newPackageJson.packageManager = normalizePackageManagerVersion(
+      newPackageJson.packageManager,
+    );
   }
 
   return newPackageJson;

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,11 +8,9 @@
   "devDependencies": {
     "@sku-private/test-utils": "workspace:*",
     "@sku-private/testing-library": "workspace:*",
-    "@types/semver": "^7.5.8",
     "dedent": "^1.5.1",
     "jsonc-parser": "^3.0.0",
     "node-html-parser": "^7.0.1",
-    "semver": "^7.6.3",
     "webpack": "^5.52.0",
     "webpack-cli": "^6.0.0",
     "webpack-dev-server": "<=5.2.0",


### PR DESCRIPTION
Probably should've done this in #1574. I'm surprised pnpm v10 is still getting releases - seems like they're backporting some stuff from v11 for the time being.