### PR TITLE
`webpack`: Improve CSS minification and autoprefixing tests

### DIFF
--- a/fixtures/styling/src/components/BlueBlock.css.ts
+++ b/fixtures/styling/src/components/BlueBlock.css.ts
@@ -7,6 +7,18 @@ export const border = style({
 export const root = style({
   width: '100px',
   height: '100px',
-  background: 'blue',
+  // Optimized to `background: #00f`
+  background: '#0000ff',
   fontSize: '64px',
+});
+
+export const test = style({
+  // Tests that calc functions are not optimized (sku turns this off explicitly).
+  // cssnano and lightningcss both incorrectly optimize this to `width: 100%`.
+  width: 'calc(100vh - calc(100vh - 100%))',
+
+  // Tests that user-agent prefixes are applied where necessary based on browser targets.
+  // `height: -webkit-fill-available` and `height: -moz-available` should be added as
+  // fallbacks.
+  height: 'stretch',
 });

--- a/packages/sku/src/services/webpack/config/utils/loaders.ts
+++ b/packages/sku/src/services/webpack/config/utils/loaders.ts
@@ -56,6 +56,11 @@ export const makeExternalCssLoaders = (
                   cssnano({
                     preset: [
                       'default',
+                      // The calc optimizer can make incorrect assumptions, so we disable it.
+                      // See https://github.com/postcss/postcss-calc/issues/238.
+                      //
+                      // Turning off calc optimizations is currently not possible in lightningcss.
+                      // See https://github.com/parcel-bundler/lightningcss/issues/12.
                       {
                         calc: false,
                       },

--- a/tests/browser/__snapshots__/styling.test.ts.snap
+++ b/tests/browser/__snapshots__/styling.test.ts.snap
@@ -19,7 +19,7 @@ exports[`styling > build > should create valid app 1`] = `
      <link
        data-chunk="main"
        rel="stylesheet"
-       href="/styling/main-f11c7eb5d7d4b8c58e2e.css"
+       href="/styling/main-f373f2b7a80be49b3db1.css"
      >
      <link
        data-chunk="main"
@@ -108,7 +108,7 @@ exports[`styling > build > should generate the expected files 1`] = `
     "/styling/main.js",
   ]
 CSS: [
-    "/styling/main-f11c7eb5d7d4b8c58e2e.css",
+    "/styling/main-f373f2b7a80be49b3db1.css",
   ]
 SOURCE HTML: <!DOCTYPE html>
 <html>
@@ -199,7 +199,7 @@ SOURCE HTML: <!DOCTYPE html>
     </script>
   </body>
 </html>,
-  "main-f11c7eb5d7d4b8c58e2e.css": .external {
+  "main-f373f2b7a80be49b3db1.css": .external {
   display: none;
   font-size: 9px;
 }
@@ -207,15 +207,21 @@ SOURCE HTML: <!DOCTYPE html>
   border: 10px solid red;
 }
 .qiwkl41 {
-  background: blue;
+  background: #00f;
   font-size: 64px;
   height: 100px;
   width: 100px;
 }
+.qiwkl42 {
+  height: -webkit-fill-available;
+  height: -moz-available;
+  height: stretch;
+  width: calc(100vh - calc(100vh - 100%));
+}
 
-/*# sourceMappingURL=main-f11c7eb5d7d4b8c58e2e.css.map*/
+/*# sourceMappingURL=main-f373f2b7a80be49b3db1.css.map*/
 ,
-  "main-f11c7eb5d7d4b8c58e2e.css.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "main-f373f2b7a80be49b3db1.css.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "main.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "main.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime.js": "CONTENTS IGNORED IN SNAPSHOT TEST",


### PR DESCRIPTION
Split these changes out from a separate PR that might not go anywhere.

We don't _really_ test our minification explicitly because our snapshots format the CSS, so any whitespace minification ends up reverted. I've added a bit more CSS to the `styling` fixture so we have coverage on a few CSS bundling features sku enables:
- Minification: `#0000ff` -> `#00f`
- Autoprefixing: `height: stretch`
- Disabled `calc` minification: minifiers don't handle certain cases. This was disabled long ago in https://github.com/seek-oss/sku/pull/589, but now we explicitly test for it and have a bit more context as to _why_ we turn it off.