### PR TITLE
`vite`: Fix loadable css ordering bug

### DIFF
--- a/.changeset/six-books-stare.md
+++ b/.changeset/six-books-stare.md
@@ -1,0 +1,5 @@
+---
+'@sku-lib/vite': patch
+---
+
+`vite`: Fixed a bug that caused apps using loadable components to sometimes emit incorrectly ordered CSS chunks resulting in broken styles

--- a/fixtures/vite-loadable-css-order/.gitignore
+++ b/fixtures/vite-loadable-css-order/.gitignore
@@ -1,0 +1,9 @@
+# managed by sku
+.eslintcache
+.prettierrc
+coverage/
+dist/
+eslint.config.mjs
+report/
+tsconfig.json
+# end managed by sku

--- a/fixtures/vite-loadable-css-order/.prettierignore
+++ b/fixtures/vite-loadable-css-order/.prettierignore
@@ -1,0 +1,10 @@
+# managed by sku
+.eslintcache
+.prettierrc
+coverage/
+dist/
+eslint.config.mjs
+pnpm-lock.yaml
+report/
+tsconfig.json
+# end managed by sku

--- a/fixtures/vite-loadable-css-order/package.json
+++ b/fixtures/vite-loadable-css-order/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@sku-fixtures/vite-loadable-css-order",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "sku start",
+    "build": "sku build"
+  },
+  "dependencies": {
+    "braid-design-system": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-router": "^7.9.6",
+    "@sku-private/react-lib-with-loadable": "workspace:*"
+  },
+  "devDependencies": {
+    "@sku-lib/vite": "workspace:^",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "sku": "workspace:*"
+  },
+  "skuSkipValidatePeerDeps": true
+}

--- a/fixtures/vite-loadable-css-order/sku.config.ts
+++ b/fixtures/vite-loadable-css-order/sku.config.ts
@@ -1,0 +1,12 @@
+import type { SkuConfig } from 'sku';
+
+export default {
+  bundler: 'vite',
+  routes: [
+    {
+      name: 'home',
+      route: '/',
+    },
+    { name: 'details', route: '/details/:id' },
+  ],
+} satisfies SkuConfig;

--- a/fixtures/vite-loadable-css-order/src/App.tsx
+++ b/fixtures/vite-loadable-css-order/src/App.tsx
@@ -1,0 +1,35 @@
+import 'braid-design-system/reset';
+import { loadable } from '@sku-lib/vite/loadable';
+import { MyComponent } from '@sku-private/react-lib-with-loadable';
+import { Actions, BraidProvider, Button, Stack } from 'braid-design-system';
+import seekJobs from 'braid-design-system/themes/seekJobs';
+import { StrictMode } from 'react';
+import { Routes, Route } from 'react-router';
+
+import { Nav } from './Nav.tsx';
+import { routes } from './routes';
+
+const Home = loadable(() => import('./Home.tsx'), {
+  resolveComponent: (module) => module.Home,
+});
+const Details = loadable(() => import('./Details.tsx'), {
+  resolveComponent: (module) => module.Details,
+});
+
+export default () => (
+  <StrictMode>
+    <BraidProvider theme={seekJobs}>
+      <Stack space="medium">
+        <MyComponent />
+        <Routes>
+          <Route path={routes.home.path} element={<Home />} />
+          <Route path={routes.details.path} element={<Details />} />
+        </Routes>
+        <Nav />
+        <Actions>
+          <Button>Click me</Button>
+        </Actions>
+      </Stack>
+    </BraidProvider>
+  </StrictMode>
+);

--- a/fixtures/vite-loadable-css-order/src/App.tsx
+++ b/fixtures/vite-loadable-css-order/src/App.tsx
@@ -16,7 +16,7 @@ const Details = loadable(() => import('./Details.tsx'), {
   resolveComponent: (module) => module.Details,
 });
 
-export default () => (
+export const App = () => (
   <StrictMode>
     <BraidProvider theme={seekJobs}>
       <Stack space="medium">

--- a/fixtures/vite-loadable-css-order/src/Details.tsx
+++ b/fixtures/vite-loadable-css-order/src/Details.tsx
@@ -1,0 +1,3 @@
+import { Text } from 'braid-design-system';
+
+export const Details = () => <Text>Details</Text>;

--- a/fixtures/vite-loadable-css-order/src/Home.tsx
+++ b/fixtures/vite-loadable-css-order/src/Home.tsx
@@ -1,0 +1,3 @@
+import { Text } from 'braid-design-system';
+
+export const Home = () => <Text>Home</Text>;

--- a/fixtures/vite-loadable-css-order/src/Nav.tsx
+++ b/fixtures/vite-loadable-css-order/src/Nav.tsx
@@ -2,14 +2,12 @@ import { Inline, Text } from 'braid-design-system';
 import { Link } from 'react-router';
 
 export const Nav = () => (
-  <>
-    <Inline space="medium">
-      <Text>
-        <Link to="/">home</Link>
-      </Text>
-      <Text>
-        <Link to="/details/1">details 1</Link>
-      </Text>
-    </Inline>
-  </>
+  <Inline space="medium">
+    <Text>
+      <Link to="/">home</Link>
+    </Text>
+    <Text>
+      <Link to="/details/1">details 1</Link>
+    </Text>
+  </Inline>
 );

--- a/fixtures/vite-loadable-css-order/src/Nav.tsx
+++ b/fixtures/vite-loadable-css-order/src/Nav.tsx
@@ -1,0 +1,15 @@
+import { Inline, Text } from 'braid-design-system';
+import { Link } from 'react-router';
+
+export const Nav = () => (
+  <>
+    <Inline space="medium">
+      <Text>
+        <Link to="/">home</Link>
+      </Text>
+      <Text>
+        <Link to="/details/1">details 1</Link>
+      </Text>
+    </Inline>
+  </>
+);

--- a/fixtures/vite-loadable-css-order/src/client.tsx
+++ b/fixtures/vite-loadable-css-order/src/client.tsx
@@ -1,0 +1,14 @@
+import { hydrateRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router';
+
+import App from './App';
+import type { RouteName } from './routes';
+
+export default ({ route }: { route: RouteName }) => {
+  hydrateRoot(
+    document.getElementById('app')!,
+    <BrowserRouter>
+      <App route={route} />
+    </BrowserRouter>,
+  );
+};

--- a/fixtures/vite-loadable-css-order/src/client.tsx
+++ b/fixtures/vite-loadable-css-order/src/client.tsx
@@ -1,14 +1,13 @@
 import { hydrateRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router';
 
-import App from './App';
-import type { RouteName } from './routes';
+import { App } from './App';
 
-export default ({ route }: { route: RouteName }) => {
+export default () => {
   hydrateRoot(
     document.getElementById('app')!,
     <BrowserRouter>
-      <App route={route} />
+      <App />
     </BrowserRouter>,
   );
 };

--- a/fixtures/vite-loadable-css-order/src/render.tsx
+++ b/fixtures/vite-loadable-css-order/src/render.tsx
@@ -1,0 +1,31 @@
+import { StaticRouter } from 'react-router';
+import type { Render } from 'sku';
+
+import App from './App';
+
+export default {
+  renderApp: async ({ SkuProvider, route, renderToStringAsync }) =>
+    await renderToStringAsync(
+      <SkuProvider>
+        <StaticRouter location={route}>
+          <App />
+        </StaticRouter>
+      </SkuProvider>,
+    ),
+
+  renderDocument: ({ app, bodyTags, headTags }) => `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="UTF-8" />
+        <title>vite-loadable-css-order</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        ${headTags}
+      </head>
+      <body>
+        <div id="app">${app}</div>
+        ${bodyTags}
+      </body>
+    </html>
+  `,
+} satisfies Render;

--- a/fixtures/vite-loadable-css-order/src/render.tsx
+++ b/fixtures/vite-loadable-css-order/src/render.tsx
@@ -1,7 +1,7 @@
 import { StaticRouter } from 'react-router';
 import type { Render } from 'sku';
 
-import App from './App';
+import { App } from './App';
 
 export default {
   renderApp: async ({ SkuProvider, route, renderToStringAsync }) =>

--- a/fixtures/vite-loadable-css-order/src/routes.ts
+++ b/fixtures/vite-loadable-css-order/src/routes.ts
@@ -2,5 +2,3 @@ export const routes = {
   home: { path: '/' },
   details: { path: '/details/:id' },
 };
-
-export type RouteName = keyof typeof routes;

--- a/fixtures/vite-loadable-css-order/src/routes.ts
+++ b/fixtures/vite-loadable-css-order/src/routes.ts
@@ -1,0 +1,6 @@
+export const routes = {
+  home: { path: '/' },
+  details: { path: '/details/:id' },
+};
+
+export type RouteName = keyof typeof routes;

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -179,6 +179,9 @@
     "fixtures/vite-cjs-interop-apollo-client-v4": {
       "entry": ["src/client.tsx", "src/render.tsx", "sku.config.*"],
     },
+    "fixtures/vite-loadable-css-order": {
+      "entry": ["src/client.tsx", "src/render.tsx", "sku.config.*"],
+    },
     "fixtures/vite-plugins": {
       "entry": ["src/client.tsx", "src/render.tsx", "sku.config.*"],
     },

--- a/packages/vite/src/loadable/collector.ts
+++ b/packages/vite/src/loadable/collector.ts
@@ -96,6 +96,7 @@ const parseManifestForEntry = ({
   preloads,
   scripts,
   base,
+  seenChunks = new Set<string>(),
 }: {
   manifest: Manifest;
   entry: string;
@@ -103,6 +104,7 @@ const parseManifestForEntry = ({
   preloads: Map<string, Preload>;
   scripts: Map<string, InjectableScript>;
   base?: string;
+  seenChunks?: Set<string>;
 }) => {
   const foundChunk =
     manifest[entry] ??
@@ -111,7 +113,35 @@ const parseManifestForEntry = ({
   if (!foundChunk) {
     return;
   }
+
+  // Guard against revisiting a chunk (and against cycles in the import graph).
+  // We key on the output file name, mirroring Vite's `getCssFilesForChunk`
+  // `seenChunks` set, since `entry` can be either a manifest key or a chunk
+  // name resolving to the same chunk.
+  if (seenChunks.has(foundChunk.file)) {
+    return;
+  }
+  seenChunks.add(foundChunk.file);
+
   const entryChunk = parseEntryChunk(foundChunk, { base });
+
+  // Recurse into imports BEFORE registering this chunk's own CSS/assets so that
+  // dependency CSS is emitted first. This matches the post-order DFS Vite uses
+  // in `getCssFilesForChunk`, ensuring the cascade order is correct (e.g. a
+  // reset stylesheet in a dependency loads before the importing chunk's atoms).
+  if (entryChunk.imports) {
+    for (const chunk of entryChunk.imports) {
+      parseManifestForEntry({
+        manifest,
+        entry: chunk,
+        nonce,
+        preloads,
+        scripts,
+        base,
+        seenChunks,
+      });
+    }
+  }
 
   if (entryChunk.css) {
     for (const chunk of entryChunk.css) {
@@ -131,21 +161,6 @@ const parseManifestForEntry = ({
     isEntry: Boolean(entryChunk.isEntry),
     nonce,
   });
-
-  if (entryChunk.imports) {
-    for (const chunk of entryChunk.imports) {
-      if (!preloads.has(chunk)) {
-        parseManifestForEntry({
-          manifest,
-          entry: chunk,
-          nonce,
-          preloads,
-          scripts,
-          base,
-        });
-      }
-    }
-  }
 };
 
 const parseEntryChunk = (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ catalogs:
       specifier: ^19.1.7
       version: 19.2.3
     '@vanilla-extract/css':
-      specifier: ^1.20.0
+      specifier: ^1.20.1
       version: 1.20.1
     '@vanilla-extract/integration':
       specifier: ^8.0.9
@@ -945,6 +945,37 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sku
 
+  fixtures/vite-loadable-css-order:
+    dependencies:
+      '@sku-private/react-lib-with-loadable':
+        specifier: workspace:*
+        version: link:../../private/react-lib-with-loadable
+      braid-design-system:
+        specifier: 'catalog:'
+        version: 34.1.0(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
+      react-router:
+        specifier: ^7.9.6
+        version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    devDependencies:
+      '@sku-lib/vite':
+        specifier: workspace:^
+        version: link:../../packages/vite
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      sku:
+        specifier: workspace:*
+        version: link:../../packages/sku
+
   fixtures/vite-plugins:
     dependencies:
       react:
@@ -1562,6 +1593,21 @@ importers:
       plop:
         specifier: ^4.0.1
         version: 4.0.5(@types/node@25.6.0)
+
+  private/react-lib-with-loadable:
+    dependencies:
+      '@sku-lib/vite':
+        specifier: workspace:*
+        version: link:../../packages/vite
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      braid-design-system:
+        specifier: 'catalog:'
+        version: 34.1.0(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
 
   private/scripts:
     devDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,17 +6,19 @@ packages:
   - private/*
 
 catalog:
+  '@types/debug': '^4.1.12'
   '@types/node': ^22.18.8
   '@types/react': ^19.1.9
   '@types/react-dom': ^19.1.7
-  '@vanilla-extract/vite-plugin': ^5.2.1
+  '@vanilla-extract/css': '^1.20.1'
   '@vanilla-extract/integration': '^8.0.9'
   '@vanilla-extract/jest-transform': '^1.1.21'
+  '@vanilla-extract/vite-plugin': ^5.2.1
   '@vanilla-extract/webpack-plugin': '^2.3.26'
-  '@vanilla-extract/css': '^1.20.0'
   '@vocab/vite': ^1.0.3
   braid-design-system: ^34.0.0
   commander: ^14.0.1
+  debug: ^4.4.3
   # 05/08/25: there is currently a bug in later versions of jiti that break eslint ts support. Pinning to 2.4.2 fixes the issue. (last checked with v2.6.1)
   # 12/11/25: Unpinning for now and using JS eslint config because jiti peer deps from other packages are causing issues. We can re-evaluate later.
   jiti: ^2.4.2
@@ -24,13 +26,9 @@ catalog:
   react-dom: ^19.1.0
   vite: ^8.0.1
   vitest: ^4.1.0
-  debug: ^4.4.3
-  '@types/debug': '^4.1.12'
 
-overrides:
-  # Multiple versions of esbuild tend to crop up in the lockfile. Pin to a specific minor version
-  # purely to reduce installation size.
-  esbuild: ~0.28.0
+configDependencies:
+  pnpm-plugin-sku: 0.0.3+sha512-XPcqT+jnn4oGgkUCMLSmlj3R367WTD6O8TlIufxAej7TfE28h4IOVWaJdqVWIq2QRqGoJxjCCXUhlT5Y0vIHaQ==
 
 ignoredBuiltDependencies:
   - core-js-pure
@@ -44,10 +42,12 @@ onlyBuiltDependencies:
   - unrs-resolver
   - sku
 
+overrides:
+  # Multiple versions of esbuild tend to crop up in the lockfile. Pin to a specific minor version
+  # purely to reduce installation size.
+  esbuild: ~0.28.0
+
 preferWorkspacePackages: true
 
 publicHoistPattern:
   - '@babel/*'
-
-configDependencies:
-  pnpm-plugin-sku: 0.0.3+sha512-XPcqT+jnn4oGgkUCMLSmlj3R367WTD6O8TlIufxAej7TfE28h4IOVWaJdqVWIq2QRqGoJxjCCXUhlT5Y0vIHaQ==

--- a/private/react-lib-with-loadable/package.json
+++ b/private/react-lib-with-loadable/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@sku-private/react-lib-with-loadable",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@sku-lib/vite": "workspace:*",
+    "@types/react": "catalog:",
+    "braid-design-system": "catalog:",
+    "react": "catalog:"
+  }
+}

--- a/private/react-lib-with-loadable/src/MyAsyncComponent.tsx
+++ b/private/react-lib-with-loadable/src/MyAsyncComponent.tsx
@@ -1,0 +1,8 @@
+import { Text, Inline } from 'braid-design-system';
+
+export default () => (
+  <Inline space="small">
+    <Text>Async component</Text>
+    <Text>From app</Text>
+  </Inline>
+);

--- a/private/react-lib-with-loadable/src/MyComponent.tsx
+++ b/private/react-lib-with-loadable/src/MyComponent.tsx
@@ -1,0 +1,11 @@
+import { loadable } from '@sku-lib/vite/loadable';
+import { Text } from 'braid-design-system';
+
+const MyAsyncComponent = loadable(() => import('./MyAsyncComponent.tsx'));
+
+export const MyComponent = () => (
+  <div>
+    <Text>Async component from dep</Text>
+    <MyAsyncComponent />
+  </div>
+);

--- a/private/react-lib-with-loadable/src/index.ts
+++ b/private/react-lib-with-loadable/src/index.ts
@@ -1,0 +1,1 @@
+export { MyComponent } from './MyComponent.tsx';

--- a/private/react-lib-with-loadable/tsconfig.json
+++ b/private/react-lib-with-loadable/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@tsconfig/node22/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "target": "ESNext",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "jsx": "react-jsx"
+  },
+  "include": ["./src/**/*"]
+}

--- a/private/test-utils/package.json
+++ b/private/test-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@sku-private/test-utils",
   "private": true,
+  "version": "0.0.0",
   "type": "module",
   "main": "index.ts",
   "exports": {

--- a/tests/browser/__snapshots__/multiple-routes.test.ts.snap
+++ b/tests/browser/__snapshots__/multiple-routes.test.ts.snap
@@ -20,8 +20,8 @@ exports[`multiple-routes > bundler: vite > build and serve > should generate the
   "jsx-runtime.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "production/au/details/$id/index.html": SCRIPTS: [
     "https://code.jquery.com/jquery-3.5.0.slim.min.js",
-    "/static/place/vite-client.js",
     "/static/place/jsx-runtime.js",
+    "/static/place/vite-client.js",
     "/static/place/Details.js",
     "/static/place/AsyncComponent.js",
   ]
@@ -106,20 +106,20 @@ SOURCE HTML: <!DOCTYPE html>
     </script>
     <script
       type="module"
-      src="SCRIPTS[2]"
+      src="SCRIPTS[1]"
     >
     </script>
     <script
       type="module"
-      src="SCRIPTS[1]"
+      src="SCRIPTS[2]"
     >
     </script>
   </body>
 </html>,
   "production/au/index.html": SCRIPTS: [
     "https://code.jquery.com/jquery-3.5.0.slim.min.js",
-    "/static/place/vite-client.js",
     "/static/place/jsx-runtime.js",
+    "/static/place/vite-client.js",
     "/static/place/Home.js",
   ]
 CSS: [
@@ -190,20 +190,20 @@ SOURCE HTML: <!DOCTYPE html>
     </script>
     <script
       type="module"
-      src="SCRIPTS[2]"
+      src="SCRIPTS[1]"
     >
     </script>
     <script
       type="module"
-      src="SCRIPTS[1]"
+      src="SCRIPTS[2]"
     >
     </script>
   </body>
 </html>,
   "production/nz/nz/details/:id/index.html": SCRIPTS: [
     "https://code.jquery.com/jquery-3.5.0.slim.min.js",
-    "/static/place/vite-client.js",
     "/static/place/jsx-runtime.js",
+    "/static/place/vite-client.js",
     "/static/place/Details.js",
     "/static/place/AsyncComponent.js",
   ]
@@ -288,20 +288,20 @@ SOURCE HTML: <!DOCTYPE html>
     </script>
     <script
       type="module"
-      src="SCRIPTS[2]"
+      src="SCRIPTS[1]"
     >
     </script>
     <script
       type="module"
-      src="SCRIPTS[1]"
+      src="SCRIPTS[2]"
     >
     </script>
   </body>
 </html>,
   "production/nz/nz/index.html": SCRIPTS: [
     "https://code.jquery.com/jquery-3.5.0.slim.min.js",
-    "/static/place/vite-client.js",
     "/static/place/jsx-runtime.js",
+    "/static/place/vite-client.js",
     "/static/place/Home.js",
   ]
 CSS: [
@@ -372,12 +372,12 @@ SOURCE HTML: <!DOCTYPE html>
     </script>
     <script
       type="module"
-      src="SCRIPTS[2]"
+      src="SCRIPTS[1]"
     >
     </script>
     <script
       type="module"
-      src="SCRIPTS[1]"
+      src="SCRIPTS[2]"
     >
     </script>
   </body>
@@ -424,12 +424,12 @@ exports[`multiple-routes > bundler: vite > build and serve > should render detai
      >
      <link
        rel="modulepreload"
-       href="/static/place/vite-client.js"
+       href="/static/place/jsx-runtime.js"
        crossorigin
      >
      <link
        rel="modulepreload"
-       href="/static/place/jsx-runtime.js"
+       href="/static/place/vite-client.js"
        crossorigin
      >
      <link
@@ -520,12 +520,12 @@ exports[`multiple-routes > bundler: vite > build and serve > should render home 
     >
     <link
       rel="modulepreload"
-      href="/static/place/vite-client.js"
+      href="/static/place/jsx-runtime.js"
       crossorigin
     >
     <link
       rel="modulepreload"
-      href="/static/place/jsx-runtime.js"
+      href="/static/place/vite-client.js"
       crossorigin
     >
     <link

--- a/tests/browser/__snapshots__/translations.test.ts.snap
+++ b/tests/browser/__snapshots__/translations.test.ts.snap
@@ -18,12 +18,12 @@ exports[`translations > bundler vite > should render en 1`] = `
      >
      <link
        rel="modulepreload"
-       href="/vite-client.js"
+       href="/rolldown-runtime.js"
        crossorigin
      >
      <link
        rel="modulepreload"
-       href="/rolldown-runtime.js"
+       href="/vite-client.js"
        crossorigin
      >
      <link
@@ -84,12 +84,12 @@ exports[`translations > bundler vite > should render en-PSEUDO post-hydration 1`
      >
      <link
        rel="modulepreload"
-       href="/vite-client.js"
+       href="/rolldown-runtime.js"
        crossorigin
      >
      <link
        rel="modulepreload"
-       href="/rolldown-runtime.js"
+       href="/vite-client.js"
        crossorigin
      >
      <link
@@ -150,12 +150,12 @@ exports[`translations > bundler vite > should render fr 1`] = `
      >
      <link
        rel="modulepreload"
-       href="/vite-client.js"
+       href="/rolldown-runtime.js"
        crossorigin
      >
      <link
        rel="modulepreload"
-       href="/rolldown-runtime.js"
+       href="/vite-client.js"
        crossorigin
      >
      <link
@@ -216,12 +216,12 @@ exports[`translations > bundler vite > should support query parameters 1`] = `
      >
      <link
        rel="modulepreload"
-       href="/vite-client.js"
+       href="/rolldown-runtime.js"
        crossorigin
      >
      <link
        rel="modulepreload"
-       href="/rolldown-runtime.js"
+       href="/vite-client.js"
        crossorigin
      >
      <link

--- a/tests/node/vite-loadable-css-order.test.ts
+++ b/tests/node/vite-loadable-css-order.test.ts
@@ -1,0 +1,56 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+import { parse } from 'node-html-parser';
+
+import { scopeToFixture, waitFor } from '@sku-private/testing-library';
+
+const { sku, fixturePath } = scopeToFixture('vite-loadable-css-order');
+
+const getStylesheetHrefs = (html: string) =>
+  parse(html)
+    .querySelectorAll('link[rel="stylesheet"]')
+    .map((link) => link.getAttribute('href'))
+    .filter((href): href is string => Boolean(href));
+
+describe('vite loadable CSS ordering', () => {
+  it("should emit CSS for a chunk's dependencies (reset) before the emitting its own CSS (rest)", async () => {
+    const build = await sku('build');
+
+    await waitFor(() => {
+      expect(build.hasExit()).toMatchObject({ exitCode: 0 });
+    });
+    expect(await build.findByText('Sku build complete')).toBeInTheConsole();
+
+    const html = await readFile(fixturePath('./dist/index.html'), 'utf-8');
+    const hrefs = getStylesheetHrefs(html);
+
+    // Identify which emitted stylesheet contains the reset by reading each file
+    // and looking for `box-sizing:border-box`, which the Braid reset provides.
+    // See https://github.com/seek-oss/braid-design-system/blob/9fc0b9a705e1ab7b5c33561ac88c3dc41335e08c/packages/braid-design-system/src/lib/css/reset/reset.css.ts#L9
+    const cssContents = await Promise.all(
+      hrefs.map(async (href) => {
+        const fileName = path.basename(href);
+        const contents = await readFile(
+          fixturePath(`./dist/${fileName}`),
+          'utf-8',
+        );
+        return { href, contents };
+      }),
+    );
+
+    const resetIndex = cssContents.findIndex(({ contents }) =>
+      contents.includes('box-sizing:border-box'),
+    );
+    const restIndex = cssContents.findIndex(({ href }) =>
+      href.includes('vite-client'),
+    );
+
+    expect(resetIndex).toBeGreaterThanOrEqual(0);
+    expect(restIndex).toBeGreaterThanOrEqual(0);
+
+    // The reset must load before other styles
+    expect(resetIndex).toBeLessThan(restIndex);
+  });
+});

--- a/tests/node/vite-loadable-css-order.test.ts
+++ b/tests/node/vite-loadable-css-order.test.ts
@@ -1,10 +1,10 @@
-import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { describe, it, expect } from 'vitest';
 import { parse } from 'node-html-parser';
 
 import { scopeToFixture, waitFor } from '@sku-private/testing-library';
+import { dirContentsToObject } from '@sku-private/test-utils';
 
 const { sku, fixturePath } = scopeToFixture('vite-loadable-css-order');
 
@@ -23,23 +23,21 @@ describe('vite loadable CSS ordering', () => {
     });
     expect(await build.findByText('Sku build complete')).toBeInTheConsole();
 
-    const html = await readFile(fixturePath('./dist/index.html'), 'utf-8');
-    const hrefs = getStylesheetHrefs(html);
+    const distFiles = await dirContentsToObject(fixturePath('dist'), [
+      'css',
+      'html',
+    ]);
+    const hrefs = getStylesheetHrefs(distFiles['index.html']);
+
+    const cssContents = hrefs.map((href) => {
+      const fileName = path.basename(href);
+      const contents = distFiles[fileName];
+      return { href, contents };
+    });
 
     // Identify which emitted stylesheet contains the reset by reading each file
     // and looking for `box-sizing:border-box`, which the Braid reset provides.
     // See https://github.com/seek-oss/braid-design-system/blob/9fc0b9a705e1ab7b5c33561ac88c3dc41335e08c/packages/braid-design-system/src/lib/css/reset/reset.css.ts#L9
-    const cssContents = await Promise.all(
-      hrefs.map(async (href) => {
-        const fileName = path.basename(href);
-        const contents = await readFile(
-          fixturePath(`./dist/${fileName}`),
-          'utf-8',
-        );
-        return { href, contents };
-      }),
-    );
-
     const resetIndex = cssContents.findIndex(({ contents }) =>
       contents.includes('box-sizing:border-box'),
     );


### PR DESCRIPTION
This PR fixes a bug that could cause stylesheets to be ordered incorrectly in static HTML. In some cases this resulted in styling issues caused by improper positioning of the Braid reset styles (i.e. not first).

The culprit was our vite loadable implementation - we were registering chunk assets _before_ traversing into them, resulting in a backwards dependency order. The fix was relatively simple - recurse into the chunk's imports first so we emit dependencies in the correct order. Also added a list of seen chunks to prevent duplicate work and potential infinite recursion.

The added fixture was initially a reproduction of the bug - it seems to only manifest when an app has both a loadable component in its source code and in a dependency. There may be some more nuance to this (i.e. shared styles between them via braid), but that's the general situation.

I've validated the fix in an internal repo where the bug originally occurred and it fixed the chunk order.