### PR TITLE
`vite`: Pass through options set via `dangerouslySetViteConfig` to the Vanilla Extract plugin

### DIFF
--- a/.changeset/proud-beans-flow.md
+++ b/.changeset/proud-beans-flow.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`vite`: Pass through options set via `dangerouslySetViteConfig` to the Vanilla Extract plugin

--- a/packages/sku/src/services/vite/helpers/config/createConfig.ts
+++ b/packages/sku/src/services/vite/helpers/config/createConfig.ts
@@ -12,6 +12,15 @@ import { skuPlugin } from '../../skuPlugin.js';
 
 const require = createRequire(import.meta.url);
 
+const TSCONFIG_PLUGIN_NAME = 'sku-tsconfig-paths';
+
+const vanillaExtractCompilerPluginAllowlist = [
+  // Without this plugin, user-configured overrides won't be passed through to the VE compiler
+  'sku:dangerously-set-vite-config',
+  // vite-tsconfig-paths is whitelisted by default, but since we are renaming it to avoid the vite warning we need to explicitly allow it
+  TSCONFIG_PLUGIN_NAME,
+];
+
 export const createConfig = (
   skuContext: SkuContext,
   environment?: string,
@@ -37,8 +46,6 @@ export const createConfig = (
       require.resolve('@sku-lib/babel-plugin-display-name'),
     );
   }
-
-  const TSCONFIG_PLUGIN_NAME = 'sku-tsconfig-paths';
 
   return {
     resolve: {
@@ -80,8 +87,8 @@ export const createConfig = (
         ],
       }),
       vanillaExtractPlugin({
-        // vite-tsconfig-paths is whitelisted by default, but since we are renaming it to avoid the vite warning we need to filter it manually.
-        unstable_pluginFilter: ({ name }) => name === TSCONFIG_PLUGIN_NAME,
+        unstable_pluginFilter: ({ name }) =>
+          vanillaExtractCompilerPluginAllowlist.includes(name),
       }),
       /**
        * the sku plugin (only sku specific changes)


### PR DESCRIPTION
A small fix that ensures user-configured vite config overrides get passed through to the VE plugin. There's only a small subset of Vite config that can meaningfully affect VE modules, but that subset should still work instead of not work.

This fix plays a part in a broader issue we need to think about that's caused by the majority of our sku config being split up in to plugins. By not explicitly allowing those plugins into the VE plugin there may be bugs that crop up in the future. That being said I'm not sure if we want to pass through _all_ sku plugins, but for now passing through this one makes sense.

This is necessary for getting Braid onto sku + vite due to [its usage of aliases/defines](https://github.com/seek-oss/braid-design-system/blob/9fc0b9a705e1ab7b5c33561ac88c3dc41335e08c/site/sku.config.ts#L40-L59).