### PR TITLE
Simplify public asset copying logic

### DIFF
--- a/.changeset/fiery-breads-grab.md
+++ b/.changeset/fiery-breads-grab.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Simplify public asset copying logic

--- a/packages/sku/src/utils/buildFileUtils.ts
+++ b/packages/sku/src/utils/buildFileUtils.ts
@@ -3,7 +3,7 @@ import { rm, mkdir } from 'node:fs/promises';
 import { fdir as Fdir } from 'fdir';
 
 import exists from './exists.js';
-import copyDirContents from './copyDirContents.js';
+import { copyDirContents } from './copyDirContents.js';
 import type { SkuContext } from '../context/createSkuContext.js';
 
 export const cleanTargetDirectory = async (

--- a/packages/sku/src/utils/copyDirContents.test.ts
+++ b/packages/sku/src/utils/copyDirContents.test.ts
@@ -1,0 +1,101 @@
+import { describe, it } from 'vitest';
+import { createFixture } from 'fs-fixture';
+import { stat } from 'node:fs/promises';
+
+import { copyDirContents } from './copyDirContents.js';
+
+describe('copyDirContents', () => {
+  it('copies files and nested directories when dest does not exist', async ({
+    expect,
+  }) => {
+    await using fixture = await createFixture({
+      'public/favicon.ico': 'favicon',
+      'public/assets/logo.png': 'logo',
+      'public/nested/deep/file.txt': 'deep file',
+    });
+
+    const srcPath = fixture.getPath('public');
+    const destPath = fixture.getPath('target');
+
+    await copyDirContents(srcPath, destPath);
+
+    expect(await fixture.readFile('target/favicon.ico', 'utf8')).toBe(
+      'favicon',
+    );
+    expect(await fixture.readFile('target/assets/logo.png', 'utf8')).toBe(
+      'logo',
+    );
+    expect(await fixture.readFile('target/nested/deep/file.txt', 'utf8')).toBe(
+      'deep file',
+    );
+
+    const destStat = await stat(destPath);
+    expect(destStat.isDirectory()).toBe(true);
+  });
+
+  it('merges contents when dest exists as a directory', async ({ expect }) => {
+    await using fixture = await createFixture({
+      'public/favicon.ico': 'new favicon',
+      'public/new-file.txt': 'new file',
+      'target/existing.txt': 'existing file',
+    });
+
+    const srcPath = fixture.getPath('public');
+    const destPath = fixture.getPath('target');
+
+    await copyDirContents(srcPath, destPath);
+
+    expect(await fixture.readFile('target/favicon.ico', 'utf8')).toBe(
+      'new favicon',
+    );
+    expect(await fixture.readFile('target/new-file.txt', 'utf8')).toBe(
+      'new file',
+    );
+    expect(await fixture.readFile('target/existing.txt', 'utf8')).toBe(
+      'existing file',
+    );
+  });
+
+  it('overwrites existing files in dest', async ({ expect }) => {
+    await using fixture = await createFixture({
+      'public/favicon.ico': 'updated favicon',
+      'target/favicon.ico': 'old favicon',
+    });
+
+    const srcPath = fixture.getPath('public');
+    const destPath = fixture.getPath('target');
+
+    await copyDirContents(srcPath, destPath);
+
+    expect(await fixture.readFile('target/favicon.ico', 'utf8')).toBe(
+      'updated favicon',
+    );
+  });
+
+  it('throws when source is not a directory', async ({ expect }) => {
+    await using fixture = await createFixture({
+      'not-a-dir.txt': 'file contents',
+    });
+
+    const srcPath = fixture.getPath('not-a-dir.txt');
+    const destPath = fixture.getPath('target');
+
+    await expect(copyDirContents(srcPath, destPath)).rejects.toThrow(
+      `Source ${srcPath} is not a directory`,
+    );
+  });
+
+  it('throws when dest exists as a file', async ({ expect }) => {
+    await using fixture = await createFixture({
+      'public/favicon.ico': 'favicon',
+      target: 'not a directory',
+    });
+
+    const srcPath = fixture.getPath('public');
+    const destPath = fixture.getPath('target');
+
+    await expect(copyDirContents(srcPath, destPath)).rejects.toThrow(
+      `Destination ${destPath} is not a directory`,
+    );
+  });
+});

--- a/packages/sku/src/utils/copyDirContents.ts
+++ b/packages/sku/src/utils/copyDirContents.ts
@@ -1,38 +1,22 @@
-import { resolve } from 'node:path';
-import { stat, mkdir, readdir, copyFile } from 'node:fs/promises';
-import exists from './exists.js';
+import { cp, stat } from 'node:fs/promises';
+import { hasErrorCode } from './error-guards.js';
 
-const copyDirContents = async (srcPath: string, destPath: string) => {
+export const copyDirContents = async (srcPath: string, destPath: string) => {
   const srcStat = await stat(srcPath);
   if (!srcStat.isDirectory()) {
     throw new Error(`Source ${srcPath} is not a directory`);
   }
 
-  if (await exists(destPath)) {
+  try {
     const destStat = await stat(destPath);
     if (!destStat.isDirectory()) {
       throw new Error(`Destination ${destPath} is not a directory`);
     }
-  } else {
-    await mkdir(destPath);
-  }
-
-  const srcItems = await readdir(srcPath);
-
-  for (const srcItem of srcItems) {
-    const srcItemPath = resolve(srcPath, srcItem);
-    const srcItemStat = await stat(srcItemPath);
-
-    const destItemPath = resolve(destPath, srcItem);
-
-    if (srcItemStat.isFile()) {
-      // destItemPath will also be a file path, not a folder
-      await copyFile(srcItemPath, destItemPath);
-    } else if (srcItemStat.isDirectory()) {
-      // recursively copy src item directory contents
-      await copyDirContents(srcItemPath, destItemPath);
+  } catch (error) {
+    if (!hasErrorCode(error) || error.code !== 'ENOENT') {
+      throw error;
     }
   }
-};
 
-export default copyDirContents;
+  await cp(srcPath, destPath, { recursive: true });
+};


### PR DESCRIPTION
An agent rightly pointed out that the `copyDirContents` logic was needlessly complicated. Recursive `cp` merges the target with the destination, _and_ creates the target directory if it doesn't already exist, so doing the recursion ourselves with `readdir` and `mkdir` was unnecessary.

The test suite that was added was passing before the refactor.