### PR TITLE
Hiding `dep.onlyBundle` and `deps.neverBundle` warnings and notices

### DIFF
--- a/packages/sku/tsdown.config.ts
+++ b/packages/sku/tsdown.config.ts
@@ -40,14 +40,16 @@ export default defineConfig([
       'webpack/render': 'src/services/webpack/entry/render/index.ts',
       'webpack/server': 'src/services/webpack/entry/server/index.ts',
     },
-    external: [
-      '__sku_alias__renderEntry',
-      '__sku_alias__clientEntry',
-      '__sku_alias__serverEntry',
-      '__sku_alias__webpackStats',
-      'virtual:sku/polyfills',
-      '@vanilla-extract/css/adapter',
-    ],
+    deps: {
+      neverBundle: [
+        '__sku_alias__renderEntry',
+        '__sku_alias__clientEntry',
+        '__sku_alias__serverEntry',
+        '__sku_alias__webpackStats',
+        'virtual:sku/polyfills',
+        '@vanilla-extract/css/adapter',
+      ],
+    },
   },
   // Storybook config needs to be cjs for webpack storybook to work.
   // @see https://github.com/storybookjs/storybook/issues/23972#issuecomment-1948534058

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -4,4 +4,9 @@ export default defineConfig({
   workspace: {
     include: ['packages/*'],
   },
+  deps: {
+    // @sku-private/utils gets bundled into sku, as well as its dependencies (it's a private package).
+    // tsdown raises a notice about this. Rather than listing all the deps we'll just disable the warning.
+    onlyBundle: false,
+  },
 });


### PR DESCRIPTION
We were getting a tsdown deprecation notice for `externals` and a notice to use `dep.onlyBundle`. I've moved to `deps.neverBundle` to fix the deprecation notice and am turning off the `onlyBundle` warnings. We could list the deps but it seems to have some conflics when I tried. Was easier to turn it off, and even if we listed the deps I don't think it would have a huge impact.