### PR TITLE
`vite`: Strip `server.watch` config to fix `build` hang

### DIFF
--- a/.changeset/spicy-readers-stay.md
+++ b/.changeset/spicy-readers-stay.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`vite`: Fixed a bug causing `build` to hang when a custom `server.watch` config was set

--- a/fixtures/vite-plugins/sku.config.ts
+++ b/fixtures/vite-plugins/sku.config.ts
@@ -18,4 +18,13 @@ export default {
       },
     },
   ],
+  // Tests that `server.watch` overrides don't break the Vanilla Extract compiler's Vite server
+  // during a build
+  dangerouslySetViteConfig: () => ({
+    server: {
+      watch: {
+        ignored: /src\/foo\//,
+      },
+    },
+  }),
 } satisfies SkuConfig;

--- a/packages/sku/src/services/vite/helpers/config/createConfig.ts
+++ b/packages/sku/src/services/vite/helpers/config/createConfig.ts
@@ -92,10 +92,9 @@ export const createConfig = (
           vanillaExtractCompilerPluginAllowlist.includes(name),
       }),
       /**
-       * The sku plugin (only sku specific changes). We strip server config for
-       * Vanilla Extract to prevent the build from hanging in certain cases.
+       * The sku plugin (only sku specific changes)
        */
-      skuPlugin({ skuContext, environment, stripServerConfig: true }),
+      skuPlugin({ skuContext, environment }),
     ],
   };
 };

--- a/packages/sku/src/services/vite/helpers/config/createConfig.ts
+++ b/packages/sku/src/services/vite/helpers/config/createConfig.ts
@@ -17,6 +17,7 @@ const TSCONFIG_PLUGIN_NAME = 'sku-tsconfig-paths';
 const vanillaExtractCompilerPluginAllowlist = [
   // Without this plugin, user-configured overrides won't be passed through to the VE compiler
   'sku:dangerously-set-vite-config',
+  'sku:strip-server-config',
   // vite-tsconfig-paths is whitelisted by default, but since we are renaming it to avoid the vite warning we need to explicitly allow it
   TSCONFIG_PLUGIN_NAME,
 ];
@@ -91,9 +92,10 @@ export const createConfig = (
           vanillaExtractCompilerPluginAllowlist.includes(name),
       }),
       /**
-       * the sku plugin (only sku specific changes)
+       * The sku plugin (only sku specific changes). We strip server config for
+       * Vanilla Extract to prevent the build from hanging in certain cases.
        */
-      skuPlugin({ skuContext, environment }),
+      skuPlugin({ skuContext, environment, stripServerConfig: true }),
     ],
   };
 };

--- a/packages/sku/src/services/vite/plugins/stripServerConfig.ts
+++ b/packages/sku/src/services/vite/plugins/stripServerConfig.ts
@@ -1,0 +1,30 @@
+import type { Plugin } from 'vite';
+import { makePluginName } from '../helpers/makePluginName.js';
+
+/**
+ * Conditionally strips `server.watch` config during builds. This prevents the Vanilla Extract
+ * compiler's internal Vite dev server from instantiating a persistent chokidar watcher that
+ * keeps the Node event loop alive after the build completes.
+ *
+ * We must explicitly return `{ server: { watch: null } }` rather than just setting an empty
+ * `config.server`. Setting an empty `server` config alone is not enough because:
+ *   1. Plugin `config` hooks run in order and their return value is merged in with
+ *      "overrides win" semantics. Even if we override `config.server`, the merge of our
+ *      return value (`{}`) over the previous state cannot unset fields.
+ *   2. If `config.server` ends up undefined, Vite falls back to defaults and still creates
+ *      a chokidar watcher.
+ * Returning `watch: null` is the explicit signal that disables the watcher.
+ */
+export function stripServerConfigPlugin({ apply }: { apply: boolean }): Plugin {
+  return {
+    name: makePluginName('strip-server-config'),
+    enforce: 'post',
+    apply: () => apply,
+    config: (cfg) => {
+      cfg.server ??= {};
+      cfg.server.watch = null;
+
+      return cfg;
+    },
+  };
+}

--- a/packages/sku/src/services/vite/skuPlugin.ts
+++ b/packages/sku/src/services/vite/skuPlugin.ts
@@ -20,15 +20,19 @@ import { stripServerConfigPlugin } from './plugins/stripServerConfig.js';
 export const skuPlugin = ({
   skuContext,
   environment,
-  stripServerConfig = false,
 }: {
   skuContext: SkuContext;
   environment?: string;
-  stripServerConfig?: boolean;
 }): PluginOption[] => [
   configPlugin({ skuContext }),
   dangerouslySetViteConfigPlugin(skuContext),
-  stripServerConfigPlugin({ apply: stripServerConfig }),
+  stripServerConfigPlugin({
+    // We can't trust vite to apply this only to its definition of `build` because the VE compiler
+    // is stuck in `serve` mode due to a constraint imposed by the `createServer` API. So instead we
+    // apply it based on the sku command being run.
+    // See https://github.com/vitejs/vite/blob/9a0dd481ac2160078b8173879e0fa86e5e6af05d/packages/vite/src/node/server/index.ts#L501-L505.
+    apply: Boolean(skuContext.commandName?.startsWith('build')),
+  }),
   setNoExternalPlugin(skuContext),
   buildPlugin({ skuContext }),
   devServerPlugin({ skuContext }),

--- a/packages/sku/src/services/vite/skuPlugin.ts
+++ b/packages/sku/src/services/vite/skuPlugin.ts
@@ -12,6 +12,7 @@ import { configPlugin } from './plugins/config.js';
 import { buildPlugin } from './plugins/build.js';
 import { devServerPlugin } from './plugins/devServer.js';
 import { bundleAnalyzerPlugin } from './plugins/bundleAnalyzer.js';
+import { stripServerConfigPlugin } from './plugins/stripServerConfig.js';
 
 /**
  * All sku related functionality and customization as a vite plugin.
@@ -19,12 +20,15 @@ import { bundleAnalyzerPlugin } from './plugins/bundleAnalyzer.js';
 export const skuPlugin = ({
   skuContext,
   environment,
+  stripServerConfig = false,
 }: {
   skuContext: SkuContext;
   environment?: string;
+  stripServerConfig?: boolean;
 }): PluginOption[] => [
   configPlugin({ skuContext }),
   dangerouslySetViteConfigPlugin(skuContext),
+  stripServerConfigPlugin({ apply: stripServerConfig }),
   setNoExternalPlugin(skuContext),
   buildPlugin({ skuContext }),
   devServerPlugin({ skuContext }),


### PR DESCRIPTION
Fixes a build hang caused by user-provided `server.watch` config. Ordinarily the [watcher would be disabled during a build](https://github.com/vanilla-extract-css/vanilla-extract/blob/a4b120f43eeaf8a3545d8d69d3c70073435e0bf9/packages/vite-plugin/src/index.ts#L202-L208), but since moving the dangerouslySet plugin in #1588, this gets overridden. We're now overriding that to ensure it never gets set during a build.

We may look into further restricting what gets set in the VE compiler, but for now this fix does the job.