### PR TITLE
`v16`: Remove deprecated default export from `sku/webpack-plugin` entrypoint

### DIFF
--- a/.changeset/hot-spoons-flow.md
+++ b/.changeset/hot-spoons-flow.md
@@ -1,0 +1,14 @@
+---
+'sku': major
+---
+
+Remove deprecated default export from `sku/webpack-plugin` entrypoint
+
+The named export `SkuWebpackPlugin` is now the only export provided by the `sku/webpack-plugin` entrypoint.
+
+**MIGRATION GUIDE**:
+
+```diff
+-import SkuWebpackPlugin from 'sku/webpack-plugin';
++import { SkuWebpackPlugin } from 'sku/webpack-plugin';
+```

--- a/packages/sku/src/services/webpack/config/plugins/skuWebpackPlugin.ts
+++ b/packages/sku/src/services/webpack/config/plugins/skuWebpackPlugin.ts
@@ -231,6 +231,3 @@ export class SkuWebpackPlugin implements WebpackPluginInstance {
     }
   }
 }
-
-/** @deprecated Please use the named `SkuWebpackPlugin` export */
-export default SkuWebpackPlugin;


### PR DESCRIPTION
No point in having both a named and default export.