### PR TITLE
`v16`: Remove telemetry `gauge` interop

### DIFF
--- a/.changeset/four-owls-guess.md
+++ b/.changeset/four-owls-guess.md
@@ -1,0 +1,9 @@
+---
+'sku': major
+---
+
+Remove interop for very old versions of `@seek/sku-telemetry`
+
+**BREAKING CHANGE**:
+
+`sku` is no longer compatible with `@seek/sku-telemetry` versions below v1.3.0. v1.3.0 was released almost 6 years ago so most consumers are unlikely to be affected.

--- a/packages/sku/src/services/telemetry/provider.ts
+++ b/packages/sku/src/services/telemetry/provider.ts
@@ -86,11 +86,6 @@ const resolveProvider = () => {
     const mod = _mod?.default ?? _mod;
     const realProvider = mod({}) as TelemetryProvider;
 
-    // For backwards compat with older versions of @seek/sku-telemetry
-    if (typeof realProvider.gauge !== 'function') {
-      realProvider.gauge = noopDebug('gauge');
-    }
-
     activeProvider = realProvider;
     usingRealProvider = true;
   } catch {


### PR DESCRIPTION
The `gauge` function was added to sku telemetry a long time ago, so this interop was necessary in case an older version the telemetry dep was used with a newer version of sku. Sku doesn't actually use `gauge` anywhere, but regardless this interop is old and no longer necessary.