### PR TITLE
`v16`: Drop support for Storybook v7, v8 and v9

### DIFF
--- a/.changeset/curvy-buttons-float.md
+++ b/.changeset/curvy-buttons-float.md
@@ -1,0 +1,9 @@
+---
+'sku': major
+---
+
+Publish Storybook config as ESM-only
+
+**BREAKING CHANGE**:
+
+The Storybook config available via the `sku/config/storybook` entrypoint is now published as ESM-only and requires a version of Storybook that supports ESM config. This change is coupled with dropping support for older Storybook versions, so a compatible (ESM-supporting) version is guaranteed as part of the required Storybook upgrade.

--- a/.changeset/violet-friends-grab.md
+++ b/.changeset/violet-friends-grab.md
@@ -1,0 +1,14 @@
+---
+'sku': major
+---
+
+Drop support for Storybook v7, v8 and v9
+
+**BREAKING CHANGE**:
+
+`sku`'s `@storybook/react-webpack5` peer dependency range no longer includes `^7.0.0 || ^8.0.0 || ^9.0.0`. `^10.0.0` is now the only supported version range. Consumers must upgrade `@storybook/react-wepback5` and any other Storybook-related dependencies to at least v10.
+
+Please refer to the [Storybook v10 migration guide] for breaking changes as well as guidance on automatically upgrading your Storybook to v10.
+
+[Storybook v10 migration guide]: https://storybook.js.org/docs/10/releases/migration-guide
+

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -13,7 +13,7 @@
     "./@loadable/component": "./dist/@loadable/component.mjs",
     "./config/prettier": "./dist/config/prettier.mjs",
     "./config/eslint": "./dist/config/eslint.mjs",
-    "./config/storybook": "./dist/config/storybook.cjs",
+    "./config/storybook": "./dist/config/storybook.mjs",
     "./bin/sku": "./dist/bin/sku.mjs",
     "./jest-preset": "./dist/jest-preset.mjs",
     "./vite/client": "./dist/vite/client.d.ts",

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -54,7 +54,7 @@
   },
   "homepage": "https://github.com/seek-oss/sku#readme",
   "peerDependencies": {
-    "@storybook/react-webpack5": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+    "@storybook/react-webpack5": "^10.0.0",
     "@types/react": "^18.0.0 || ^19.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",

--- a/packages/sku/tsdown.config.ts
+++ b/packages/sku/tsdown.config.ts
@@ -20,6 +20,7 @@ export default defineConfig([
       'bin/sku': 'src/bin/sku.ts',
       'config/eslint': 'src/config/eslint/config.ts',
       'config/prettier': 'src/config/prettier.ts',
+      'config/storybook': './src/config/storybook/config.ts',
       'entries/vite-client': 'src/services/vite/entries/vite-client.tsx',
       'entries/vite-render': 'src/services/vite/entries/vite-render.tsx',
       'jest/file-mock': 'src/config/jest/fileMock.ts',
@@ -46,16 +47,6 @@ export default defineConfig([
         'virtual:sku/polyfills',
         '@vanilla-extract/css/adapter',
       ],
-    },
-  },
-  // Storybook config needs to be cjs for webpack storybook to work.
-  // @see https://github.com/storybookjs/storybook/issues/23972#issuecomment-1948534058
-  {
-    ...defaultConfig,
-    exports: false,
-    format: ['cjs'],
-    entry: {
-      'config/storybook': './src/config/storybook/config.ts',
     },
   },
 ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1211,7 +1211,7 @@ importers:
         specifier: workspace:^
         version: link:../vite
       '@storybook/react-webpack5':
-        specifier: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+        specifier: ^10.0.0
         version: 10.4.6(@swc/core@1.15.41)(@types/react-dom@19.2.3)(@types/react@19.2.17)(cssnano@7.1.9)(esbuild@0.28.1)(postcss@8.5.15)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@5.9.3)
       '@swc/core':
         specifier: ^1.6.13


### PR DESCRIPTION
ESM config support got a bit better somewhere around storybook v8, but we never shipped an ESM storybook config - until now. With v10 being ESM-only, it felt like the right time to drop support for all older versions and ship an ESM-only storybook config too.