### PR TITLE
`v16`: Convert jest file mock to MJS

### DIFF
--- a/.changeset/fluffy-goats-care.md
+++ b/.changeset/fluffy-goats-care.md
@@ -1,0 +1,9 @@
+---
+'sku': major
+---
+
+`jest`: Convert internal file mock to ESM
+
+**BREAKING CHANGE**:
+
+The internal file mock used by sku to mock asset imports in Jest tests has been converted to ESM. No impact is expected for consumers, but out of an abundance of caution this is being released as a breaking change.

--- a/fixtures/jest-test/src/imageConsumer.ts
+++ b/fixtures/jest-test/src/imageConsumer.ts
@@ -1,0 +1,3 @@
+import image from './image.gif';
+
+export { image };

--- a/fixtures/jest-test/src/index.test.ts
+++ b/fixtures/jest-test/src/index.test.ts
@@ -1,11 +1,11 @@
+import { image } from './imageConsumer.ts';
+
 describe('good tests (Jest)', () => {
   it('should be true', () => {
     expect(true).toBe(true);
   });
 
-  it('should return a file mock', async () => {
-    const { default: fileMock } = await import('./image.gif');
-
-    expect(fileMock).toMatchInlineSnapshot('"MOCK_FILE"');
+  it('should mock asset imports', () => {
+    expect(image).toMatchInlineSnapshot('"MOCK_FILE"');
   });
 });

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -22,7 +22,7 @@
   },
   "imports": {
     "#entries/*": "./dist/entries/*.mjs",
-    "#jest/file-mock": "./dist/jest/file-mock.cjs",
+    "#jest/file-mock": "./dist/jest/file-mock.mjs",
     "#jest/*": "./dist/jest/*.mjs",
     "#vite/*": "./dist/vite/*.mjs",
     "#webpack/*": "./dist/webpack/*.mjs"

--- a/packages/sku/tsdown.config.ts
+++ b/packages/sku/tsdown.config.ts
@@ -25,6 +25,7 @@ export default defineConfig([
       'config/prettier': 'src/config/prettier.ts',
       'entries/vite-client': 'src/services/vite/entries/vite-client.tsx',
       'entries/vite-render': 'src/services/vite/entries/vite-render.tsx',
+      'jest/file-mock': 'src/config/jest/fileMock.ts',
       'jest-preset': 'src/config/jest/preset.ts',
       'jest/js-transform': 'src/config/jest/jsBabelTransform.ts',
       'jest/ts-transform': 'src/config/jest/tsBabelTransform.ts',
@@ -57,7 +58,6 @@ export default defineConfig([
     format: ['cjs'],
     entry: {
       'config/storybook': './src/config/storybook/config.ts',
-      'jest/file-mock': 'src/config/jest/fileMock.ts',
     },
   },
 ]);


### PR DESCRIPTION
Taking a look at Jest v30's source code, I didn't see a reason why this shouldn't work, and based on the results of the `jest-test` fixture it seems to work fine.