### PR TITLE
`v16`: Drop support for `vitest` versions below `4.1.0`

### DIFF
--- a/.changeset/solid-maps-know.md
+++ b/.changeset/solid-maps-know.md
@@ -1,0 +1,9 @@
+---
+'sku': major
+---
+
+Drop support for `vitest` versions below `4.1.0`
+
+**BREAKING CHANGE**:
+
+`sku` no longer supports `vitest` versions below `4.1.0`. Consumers that use `vitest` must upgrade their `vitest` dependency to `4.1.0` or later.

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -58,7 +58,7 @@
     "@types/react": "^18.0.0 || ^19.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "vitest": "^3.0.0 || ^4.0.0"
+    "vitest": "^4.1.0"
   },
   "peerDependenciesMeta": {
     "@storybook/react-webpack5": {


### PR DESCRIPTION
Duplicate of https://github.com/seek-oss/sku/pull/1612. 

Keeping this one since the other one has conflicts with https://github.com/seek-oss/sku/pull/1602