### PR TITLE
`v16`: Load sku config asynchronously

### DIFF
--- a/.changeset/pink-keys-strive.md
+++ b/.changeset/pink-keys-strive.md
@@ -1,0 +1,9 @@
+---
+'sku': major
+---
+
+Use async `jiti` API to load sku config
+
+**BREAKING CHANGE**:
+
+`sku` config files are now loaded asynchronously using `sku`'s existing `jiti` dependency. There are no changes expected for consumers, but out of an abundance of caution this change is being released in a major version.

--- a/packages/sku/src/config/eslint/config.ts
+++ b/packages/sku/src/config/eslint/config.ts
@@ -11,7 +11,7 @@ export const createEslintConfig = async ({
 }: {
   configPath?: string;
 } = {}): Promise<Linter.Config[]> => {
-  const skuContext = getSkuContext({ configPath });
+  const skuContext = await getSkuContext({ configPath });
   const { eslintDecorator, eslintIgnore, languages, paths, testRunner } =
     skuContext;
   const { relativeTarget } = paths;

--- a/packages/sku/src/config/jest/jsBabelTransform.ts
+++ b/packages/sku/src/config/jest/jsBabelTransform.ts
@@ -5,7 +5,7 @@ import targets from '../targets.json' with { type: 'json' };
 
 import { getSkuContext } from '../../context/createSkuContext.js';
 
-const { rootResolution } = getSkuContext();
+const { rootResolution } = await getSkuContext();
 
 const transformer: ReturnType<typeof createTransformer> = createTransformer(
   babelConfig({

--- a/packages/sku/src/config/jest/preset.ts
+++ b/packages/sku/src/config/jest/preset.ts
@@ -4,7 +4,7 @@ import { cwd } from '@sku-private/utils';
 import { getSkuContext } from '../../context/createSkuContext.js';
 import type { Config } from 'jest';
 
-const { paths, rootResolution, jestDecorator } = getSkuContext();
+const { paths, rootResolution, jestDecorator } = await getSkuContext();
 
 const slash = '[/\\\\]'; // Cross-platform path delimiter regex
 const compilePackagesRegex = (await paths.compilePackages())

--- a/packages/sku/src/config/jest/tsBabelTransform.ts
+++ b/packages/sku/src/config/jest/tsBabelTransform.ts
@@ -4,7 +4,7 @@ import babelConfig from '../babel.js';
 import targets from '../targets.json' with { type: 'json' };
 import { getSkuContext } from '../../context/createSkuContext.js';
 
-const { rootResolution } = getSkuContext();
+const { rootResolution } = await getSkuContext();
 
 const transformer: ReturnType<typeof createTransformer> = createTransformer(
   babelConfig({

--- a/packages/sku/src/config/storybook/webpackConfig.ts
+++ b/packages/sku/src/config/storybook/webpackConfig.ts
@@ -13,7 +13,7 @@ export default async (
   config: Configuration,
   { isDevServer }: { isDevServer: boolean },
 ) => {
-  const skuContext = getSkuContext();
+  const skuContext = await getSkuContext();
   const { paths } = skuContext;
   const clientWebpackConfig = (
     await makeWebpackConfig({

--- a/packages/sku/src/context/createSkuContext.ts
+++ b/packages/sku/src/context/createSkuContext.ts
@@ -14,16 +14,11 @@ import defaultClientEntry from './defaultClientEntry.js';
 import _debug from 'debug';
 import { resolveAppSkuConfigPath } from './configPath.js';
 
-import { createRequire } from 'node:module';
-import { fileURLToPath } from 'node:url';
 import { getCjsInteropDeps } from './cjsInteropDeps.js';
 import type { PackageJson } from 'type-fest';
+import { createJiti } from 'jiti';
 
-const require = createRequire(import.meta.url);
-const __filename = fileURLToPath(import.meta.url);
-
-const createJiti = require('jiti');
-const jiti = createJiti(__filename);
+const jiti = createJiti(import.meta.url);
 
 const debug = _debug('sku:config');
 
@@ -54,23 +49,25 @@ interface SkuContextOptions {
 }
 let storedSkuContext: SkuContext;
 
-export const getSkuContext = (skuContextOptions: SkuContextOptions = {}) => {
+export const getSkuContext = async (
+  skuContextOptions: SkuContextOptions = {},
+) => {
   if (storedSkuContext) {
     return storedSkuContext;
   }
-  storedSkuContext = createSkuContext(skuContextOptions);
+  storedSkuContext = await createSkuContext(skuContextOptions);
   return storedSkuContext;
 };
 
-const getSkuConfig = ({
+const getSkuConfig = async ({
   configPath,
 }: {
   configPath?: string;
-}): {
+}): Promise<{
   appSkuConfig: SkuConfig;
   appSkuConfigPath?: string;
   configPath?: string;
-} => {
+}> => {
   const appSkuConfigPath = resolveAppSkuConfigPath({ configPath });
 
   if (!appSkuConfigPath) {
@@ -81,10 +78,9 @@ const getSkuConfig = ({
     };
   }
 
-  const mod = jiti(appSkuConfigPath) as { default: SkuConfig } & SkuConfig;
-
-  // Jiti require doesn't support the `default` config so we have to check for `default` ourselves
-  const appSkuConfig = mod?.default ?? mod;
+  const appSkuConfig = await jiti.import<SkuConfig>(appSkuConfigPath, {
+    default: true,
+  });
 
   return {
     appSkuConfig,
@@ -95,7 +91,7 @@ const getSkuConfig = ({
 
 export type NormalizedRoute = SkuRouteObject & { siteIndex?: number };
 
-export const createSkuContext = ({
+export const createSkuContext = async ({
   configPath,
   port: portArg,
   strictPort,
@@ -104,7 +100,7 @@ export const createSkuContext = ({
     appSkuConfig,
     appSkuConfigPath,
     configPath: appConfigPath,
-  } = getSkuConfig({ configPath });
+  } = await getSkuConfig({ configPath });
 
   const skuConfig = {
     ...defaultSkuConfig,
@@ -346,5 +342,5 @@ type ExtraSkuContextOptions = {
   listUrls?: boolean;
 };
 
-export type SkuContext = ReturnType<typeof createSkuContext> &
+export type SkuContext = Awaited<ReturnType<typeof createSkuContext>> &
   ExtraSkuContextOptions;

--- a/packages/sku/src/context/hosts.test.ts
+++ b/packages/sku/src/context/hosts.test.ts
@@ -14,7 +14,7 @@ describe('setupHosts', () => {
   });
 
   it('should set site-specific hosts', async () => {
-    const context = createSkuContext({});
+    const context = await createSkuContext({});
     const mockSetHosts = vi.fn(async () => {});
 
     await setupHosts({
@@ -34,7 +34,7 @@ describe('setupHosts', () => {
   });
 
   it('should set app-wide hosts', async () => {
-    const context = createSkuContext({});
+    const context = await createSkuContext({});
     const mockSetHosts = vi.fn(async () => {});
 
     await setupHosts({
@@ -51,7 +51,7 @@ describe('setupHosts', () => {
   });
 
   it('should combine app-wide and site-specific hosts', async () => {
-    const context = createSkuContext({});
+    const context = await createSkuContext({});
     const mockSetHosts = vi.fn(async () => {});
 
     await setupHosts({
@@ -68,7 +68,7 @@ describe('setupHosts', () => {
   });
 
   it('should set ipv4 and ipv6 hosts', async () => {
-    const context = createSkuContext({});
+    const context = await createSkuContext({});
     const mockSetHosts = vi.fn(async () => {});
 
     await setupHosts({
@@ -85,7 +85,7 @@ describe('setupHosts', () => {
   });
 
   it('should not set hosts if none are defined', async () => {
-    const context = createSkuContext({});
+    const context = await createSkuContext({});
     const mockSetHosts = vi.fn(async () => {});
 
     await setupHosts({
@@ -101,7 +101,7 @@ describe('setupHosts', () => {
   });
 
   it('should throw an error if setting hosts fails', async () => {
-    const context = createSkuContext({});
+    const context = await createSkuContext({});
     const mockSetHosts = vi
       .fn(async () => {})
       .mockRejectedValue(new Error('Failed to set hosts'));
@@ -131,7 +131,7 @@ describe('checkHosts', () => {
 
   // All this function does is output info to the console so rather than testing the output we can just that it doesn't throw.
   it('should not throw errors', async () => {
-    const context = createSkuContext({});
+    const context = await createSkuContext({});
     const mockGetHosts = vi.fn(async () => []);
 
     await expect(

--- a/packages/sku/src/postinstall.ts
+++ b/packages/sku/src/postinstall.ts
@@ -32,7 +32,7 @@ export const postinstall = async ({
 
   try {
     log('postinstall', 'running configure');
-    const skuContext = createSkuContext({});
+    const skuContext = await createSkuContext({});
     configureApp(skuContext);
   } catch (error) {
     console.error(

--- a/packages/sku/src/program/hooks/preAction/preAction.hook.ts
+++ b/packages/sku/src/program/hooks/preAction/preAction.hook.ts
@@ -3,9 +3,12 @@ import type { Command } from 'commander';
 import { getSkuContext } from '../../../context/createSkuContext.js';
 import { setGlobalTags } from '../../../services/telemetry/index.js';
 
-export const preActionHook = (rootCommand: Command, actionCommand: Command) => {
+export const preActionHook = async (
+  rootCommand: Command,
+  actionCommand: Command,
+) => {
   const { port, strictPort } = actionCommand.opts();
-  const skuContext = getSkuContext({
+  const skuContext = await getSkuContext({
     configPath: rootCommand.opts()?.config,
     port,
     strictPort,


### PR DESCRIPTION
This moves us off the deprecated CJS `jiti` entrypoint, which also enables ESM-only things like top-level-await inside sku config. This isn't _that_ useful, but may be a blocker for some consumers migrating to Vite - Braid's docs site is one such example.