### PR TITLE
`v16`: Convert loadable entrypoint to JavaScript

### DIFF
--- a/.changeset/chatty-bananas-glow.md
+++ b/.changeset/chatty-bananas-glow.md
@@ -1,0 +1,9 @@
+---
+'sku': major
+---
+
+Convert `sku/@loadable/component` entrypoint to JavaScript
+
+**BREAKING CHANGE**:
+
+This entrypoint has historically been provided as a TypeScript file, but there is now no longer a reason to do so. This change should not affect any users, but out of an abundance of caution it is being treated as a breaking change.

--- a/fixtures/display-names-prod/sku.config.ts
+++ b/fixtures/display-names-prod/sku.config.ts
@@ -1,3 +1,4 @@
+import { makeStableHashes } from '@sku-private/test-utils';
 import type { SkuConfig } from 'sku';
 
 export default {
@@ -5,4 +6,5 @@ export default {
   renderEntry: 'src/render.tsx',
   displayNamesProd: true,
   port: 8200,
+  dangerouslySetWebpackConfig: (config) => makeStableHashes(config),
 } satisfies SkuConfig;

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -10,7 +10,7 @@
   "module": "./dist/index.mjs",
   "exports": {
     ".": "./dist/index.mjs",
-    "./@loadable/component": "./dist/@loadable/component/index.ts",
+    "./@loadable/component": "./dist/@loadable/component.mjs",
     "./config/prettier": "./dist/config/prettier.mjs",
     "./config/eslint": "./dist/config/eslint.mjs",
     "./config/storybook": "./dist/config/storybook.cjs",

--- a/packages/sku/tsdown.config.ts
+++ b/packages/sku/tsdown.config.ts
@@ -10,16 +10,13 @@ export default defineConfig([
         from: 'src/services/vite/client.d.ts',
         to: 'dist/vite/',
       },
-      {
-        from: 'src/@loadable/component/index.ts',
-        to: 'dist/@loadable/component/',
-      },
     ],
     // Need to use unbundled mode because `webpack/entry/server/index.ts` calls webpackHot.accept which needs a known path to the server app at runtime.
     // If we use bundled mode, the server app will be bundled into the main bundle, and the webpackHot.accept will not be able to find the server app.
     unbundle: true,
     entry: {
       index: 'src/index.ts',
+      '@loadable/component': 'src/@loadable/component/index.ts',
       'bin/sku': 'src/bin/sku.ts',
       'config/eslint': 'src/config/eslint/config.ts',
       'config/prettier': 'src/config/prettier.ts',
@@ -29,7 +26,6 @@ export default defineConfig([
       'jest/js-transform': 'src/config/jest/jsBabelTransform.ts',
       'jest/ts-transform': 'src/config/jest/tsBabelTransform.ts',
       postinstall: './src/postinstall.ts',
-      'vite/client': 'src/services/vite/index.ts',
       'vite/prerender-worker':
         'src/services/vite/helpers/prerender/prerenderWorker.ts',
       'webpack-plugin':

--- a/tests/browser/__snapshots__/display-names-prod.test.ts.snap
+++ b/tests/browser/__snapshots__/display-names-prod.test.ts.snap
@@ -91,7 +91,7 @@ exports[`display-names-prod > bundler: webpack > build > should create build out
   "index.html": SCRIPTS: [
     "/runtime-4e4ddd3925944f2652a9.js",
     "/955-34cf590039548cb8d552.js",
-    "/main-a11b15d161b49c7f467b.js",
+    "/main-3c2044de0d8b9410e281.js",
   ]
 CSS: []
 SOURCE HTML: <!DOCTYPE html>
@@ -205,8 +205,8 @@ SOURCE HTML: <!DOCTYPE html>
     </script>
   </body>
 </html>,
-  "main-a11b15d161b49c7f467b.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "main-a11b15d161b49c7f467b.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "main-3c2044de0d8b9410e281.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "main-3c2044de0d8b9410e281.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-4e4ddd3925944f2652a9.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "runtime-4e4ddd3925944f2652a9.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }

--- a/tests/browser/__snapshots__/display-names-prod.test.ts.snap
+++ b/tests/browser/__snapshots__/display-names-prod.test.ts.snap
@@ -86,12 +86,12 @@ SOURCE HTML: <!DOCTYPE html>
 
 exports[`display-names-prod > bundler: webpack > build > should create build output 1`] = `
 {
-  "955-34cf590039548cb8d552.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "955-34cf590039548cb8d552.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "2.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "2.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "index.html": SCRIPTS: [
-    "/runtime-4e4ddd3925944f2652a9.js",
-    "/955-34cf590039548cb8d552.js",
-    "/main-3c2044de0d8b9410e281.js",
+    "/runtime.js",
+    "/2.js",
+    "/main.js",
   ]
 CSS: []
 SOURCE HTML: <!DOCTYPE html>
@@ -205,9 +205,9 @@ SOURCE HTML: <!DOCTYPE html>
     </script>
   </body>
 </html>,
-  "main-3c2044de0d8b9410e281.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "main-3c2044de0d8b9410e281.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "runtime-4e4ddd3925944f2652a9.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
-  "runtime-4e4ddd3925944f2652a9.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "main.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "main.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "runtime.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "runtime.js.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;


### PR DESCRIPTION
I think this was just a leftover thing we did from the days before we started bundling `sku`. I can't think of a good reason to keep doing it, so the entrypoint is now MJS.

I also removed the `vite/client` entrypoint from `tsdown`, as that's configured manually in `package.json` because it points to a `.d.ts` file.