### PR TITLE
Replace accidental `debug` usage with `obug`

### DIFF
--- a/packages/sku/src/utils/warnOnLegacyReact.ts
+++ b/packages/sku/src/utils/warnOnLegacyReact.ts
@@ -1,11 +1,11 @@
 import { requireFromCwd } from '@sku-private/utils';
 import { banner, link, strong } from '@sku-private/utils/console';
 import semver from 'semver';
-import _debug from 'debug';
+import { createDebug } from 'obug';
 
 const MIN_REACT_VERSION = '19.0.0';
 
-const debug = _debug('sku:warnOnLegacyReact');
+const debug = createDebug('sku:warnOnLegacyReact');
 
 export const warnOnLegacyReact = () => {
   try {


### PR DESCRIPTION
I think this snuck in via #1603 because it wasn't up to date with the upstream branch.