### PR TITLE
`v16`: Update prettier to `~3.9.0`

### DIFF
--- a/.changeset/loud-donkeys-argue.md
+++ b/.changeset/loud-donkeys-argue.md
@@ -2,7 +2,7 @@
 'sku': minor
 ---
 
-Update prettier dependency from ~3.8.0 to ~3.9.0
+Update `prettier` dependency from `~3.8.0` to `~3.9.0`
 
 This change may result in some code formatting changes. Please review [the Prettier 3.9.0 release notes].
 

--- a/.changeset/loud-donkeys-argue.md
+++ b/.changeset/loud-donkeys-argue.md
@@ -1,0 +1,9 @@
+---
+'sku': minor
+---
+
+Update prettier dependency from ~3.8.0 to ~3.9.0
+
+This change may result in some code formatting changes. Please review [the Prettier 3.9.0 release notes].
+
+[the Prettier 3.9.0 release notes]: https://prettier.io/blog/2026/06/27/3.9.0

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "knip": "^6.14.2",
     "nano-staged": "catalog:",
     "playwright": "^1.60.0",
-    "prettier": "~3.8.0",
+    "prettier": "~3.9.0",
     "renovate-config-seek": "^0.4.0",
     "tsdown": "^0.21.0",
     "tsx": "^4.19.4",

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -145,7 +145,7 @@
     "postcss": "^8.5.8",
     "postcss-lightningcss": "^1.1.0",
     "postcss-loader": "^8.0.0",
-    "prettier": "~3.8.0",
+    "prettier": "~3.9.0",
     "react-refresh": "^0.18.0",
     "rolldown": "^1.0.0-rc.9",
     "rollup-plugin-visualizer": "^7.0.1",

--- a/packages/sku/src/utils/detectUnnecessaryPolyfillsFromDependencies.ts
+++ b/packages/sku/src/utils/detectUnnecessaryPolyfillsFromDependencies.ts
@@ -36,8 +36,7 @@ export const detectUnnecessaryPolyfillsFromDependencies =
             polyfillName: depName,
             detectionSource: 'dependency',
             dependencyType: dependencyType as
-              | 'dependencies'
-              | 'devDependencies',
+              'dependencies' | 'devDependencies',
             ...polyfill,
           });
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,8 +147,8 @@ importers:
         specifier: ^1.60.0
         version: 1.61.0
       prettier:
-        specifier: ~3.8.0
-        version: 3.8.4
+        specifier: ~3.9.0
+        version: 3.9.4
       renovate-config-seek:
         specifier: ^0.4.0
         version: 0.4.0
@@ -783,7 +783,7 @@ importers:
         version: link:../../packages/sku
       storybook:
         specifier: ^10.0.0
-        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.5)(react-dom@19.2.7)(react@19.2.7)
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
 
   fixtures/styling:
     dependencies:
@@ -823,7 +823,7 @@ importers:
         version: link:../../packages/sku
       storybook:
         specifier: ^10.0.0
-        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.5)(react-dom@19.2.7)(react@19.2.7)
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
 
   fixtures/suspense:
     dependencies:
@@ -1382,8 +1382,8 @@ importers:
         specifier: ^8.0.0
         version: 8.2.1(postcss@8.5.15)(typescript@6.0.3)(webpack@5.107.2)
       prettier:
-        specifier: ~3.8.0
-        version: 3.8.4
+        specifier: ~3.9.0
+        version: 3.9.4
       react-refresh:
         specifier: ^0.18.0
         version: 0.18.0
@@ -1558,7 +1558,7 @@ importers:
     devDependencies:
       '@prettier/sync':
         specifier: ^0.6.1
-        version: 0.6.1(prettier@3.8.5)
+        version: 0.6.1(prettier@3.9.4)
       '@types/css':
         specifier: ^0.0.38
         version: 0.0.38
@@ -8674,13 +8674,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.8.4:
-    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
-    engines: {node: '>=14'}
-    hasBin: true
-
-  prettier@3.8.5:
-    resolution: {integrity: sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==}
+  prettier@3.9.4:
+    resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -12875,10 +12870,10 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@prettier/sync@0.6.1(prettier@3.8.5)':
+  '@prettier/sync@0.6.1(prettier@3.9.4)':
     dependencies:
       make-synchronized: 0.8.0
-      prettier: 3.8.5
+      prettier: 3.9.4
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -13069,7 +13064,7 @@ snapshots:
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@18.3.1)(storybook@10.4.6)
       react: 18.3.1
       react-dom: 19.2.7(react@18.3.1)
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
       ts-dedent: 2.3.0
     optionalDependencies:
       '@types/react': 19.2.17
@@ -13099,7 +13094,7 @@ snapshots:
       fork-ts-checker-webpack-plugin: 9.1.0(typescript@6.0.3)(webpack@5.107.2)
       html-webpack-plugin: 5.6.7(webpack@5.107.2)
       magic-string: 0.30.21
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
       style-loader: 4.0.0(webpack@5.107.2)
       terser-webpack-plugin: 5.6.1(@swc/core@1.15.41)(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.107.2)
       ts-dedent: 2.3.0
@@ -13135,7 +13130,7 @@ snapshots:
       fork-ts-checker-webpack-plugin: 9.1.0(typescript@6.0.3)(webpack@5.107.2)
       html-webpack-plugin: 5.6.7(webpack@5.107.2)
       magic-string: 0.30.21
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
       style-loader: 4.0.0(webpack@5.107.2)
       terser-webpack-plugin: 5.6.1(esbuild@0.28.1)(webpack@5.107.2)
       ts-dedent: 2.3.0
@@ -13163,12 +13158,12 @@ snapshots:
 
   '@storybook/core-webpack@10.4.6(storybook@10.4.6)':
     dependencies:
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
       ts-dedent: 2.3.0
 
   '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(storybook@10.4.6)(vite@8.0.16)(webpack@5.107.2)':
     dependencies:
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
@@ -13198,7 +13193,7 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.12
       semver: 7.8.5
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
       tsconfig-paths: 4.2.0
       webpack: 5.107.2(@swc/core@1.15.41)(esbuild@0.28.1)(postcss@8.5.15)
     optionalDependencies:
@@ -13230,7 +13225,7 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.12
       semver: 7.8.5
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
       tsconfig-paths: 4.2.0
       webpack: 5.107.2(esbuild@0.28.1)
     optionalDependencies:
@@ -13269,7 +13264,7 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-dom: 19.2.7(react@18.3.1)
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -13278,7 +13273,7 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -13290,7 +13285,7 @@ snapshots:
       '@storybook/react': 10.4.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -13319,7 +13314,7 @@ snapshots:
       '@storybook/react': 10.4.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -13349,7 +13344,7 @@ snapshots:
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -14160,7 +14155,7 @@ snapshots:
       intl-messageformat: 10.7.18
       picocolors: 1.1.1
       picomatch: 4.0.4
-      prettier: 3.8.4
+      prettier: 3.9.4
       tinyglobby: 0.2.17
     transitivePeerDependencies:
       - supports-color
@@ -18381,9 +18376,7 @@ snapshots:
 
   prettier@2.8.8: {}
 
-  prettier@3.8.4: {}
-
-  prettier@3.8.5: {}
+  prettier@3.9.4: {}
 
   pretty-error@4.0.0:
     dependencies:
@@ -19216,7 +19209,7 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7):
+  storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.7)(react@19.2.7)
@@ -19235,34 +19228,7 @@ snapshots:
       ws: 8.21.0
     optionalDependencies:
       '@types/react': 19.2.17
-      prettier: 3.8.4
-    transitivePeerDependencies:
-      - '@testing-library/dom'
-      - bufferutil
-      - react
-      - react-dom
-      - utf-8-validate
-
-  storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.5)(react-dom@19.2.7)(react@19.2.7):
-    dependencies:
-      '@storybook/global': 5.0.0
-      '@storybook/icons': 2.0.2(react-dom@19.2.7)(react@19.2.7)
-      '@testing-library/jest-dom': 6.9.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/expect': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@webcontainer/env': 1.1.1
-      esbuild: 0.28.1
-      open: 10.2.0
-      oxc-parser: 0.127.0
-      oxc-resolver: 11.21.3
-      recast: 0.23.11
-      semver: 7.8.5
-      use-sync-external-store: 1.6.0(react@19.2.7)
-      ws: 8.21.0
-    optionalDependencies:
-      '@types/react': 19.2.17
-      prettier: 3.8.5
+      prettier: 3.9.4
     transitivePeerDependencies:
       - '@testing-library/dom'
       - bufferutil


### PR DESCRIPTION
[Release notes](https://prettier.io/blog/2026/06/27/3.9.0).