### PR TITLE
`csp`: Add `cspDelivery` config option

### DIFF
--- a/.changeset/eight-donkeys-carry.md
+++ b/.changeset/eight-donkeys-carry.md
@@ -1,0 +1,12 @@
+---
+'sku': minor
+---
+
+`csp`: Add `cspDelivery` config option.
+
+A new configuration option, `cspDelivery`, allows control of how the Content Security Policy is delivered and can be set to one of two values:
+
+- `tag`: The CSP is embedded directly in the rendered HTML content via a `<meta http-equiv="Content-Security-Policy" …>` tag. This is the default and matches the previous behaviour.
+- `header`: The CSP is written to a JSON metadata file alongside the rendered HTML content. This metadata can be used at deployment and/or request time to include a `Content-Security-Policy` header in the response for the rendered HTML content.
+
+See the [Content Security Policy](https://seek-oss.github.io/sku/docs/csp#delivery) section of the sku docs for more details.

--- a/fixtures/security-controls/sku.config.vite.csp-delivery.ts
+++ b/fixtures/security-controls/sku.config.vite.csp-delivery.ts
@@ -1,0 +1,6 @@
+import viteConfig from './sku.config.vite.ts';
+
+export default {
+  ...viteConfig,
+  cspDelivery: 'header',
+};

--- a/packages/sku/src/context/configSchema.ts
+++ b/packages/sku/src/context/configSchema.ts
@@ -183,6 +183,7 @@ export default validator.compile({
     type: 'boolean',
   },
   cspEnabled: { type: 'boolean' },
+  cspDelivery: { type: 'enum', values: ['tag', 'header'] },
   cspExtraScriptSrcHosts: {
     type: 'array',
     items: { type: 'string' },

--- a/packages/sku/src/context/createSkuContext.ts
+++ b/packages/sku/src/context/createSkuContext.ts
@@ -213,6 +213,7 @@ export const createSkuContext = async ({
   const sourceMapsProd = Boolean(skuConfig.sourceMapsProd);
   const displayNamesProd = Boolean(skuConfig.displayNamesProd);
   const cspEnabled = skuConfig.cspEnabled;
+  const cspDelivery = skuConfig.cspDelivery;
   const cspExtraScriptSrcHosts = skuConfig.cspExtraScriptSrcHosts;
   const httpsDevServer = skuConfig.httpsDevServer;
   const languages = normalizedLanguages;
@@ -271,6 +272,7 @@ export const createSkuContext = async ({
     sourceMapsProd,
     displayNamesProd,
     cspEnabled,
+    cspDelivery,
     cspExtraScriptSrcHosts,
     httpsDevServer,
     languages,

--- a/packages/sku/src/context/defaultSkuConfig.ts
+++ b/packages/sku/src/context/defaultSkuConfig.ts
@@ -39,6 +39,7 @@ export default {
   eslintIgnore: [],
   supportedBrowsers: browserslistConfigSeek,
   cspEnabled: false,
+  cspDelivery: 'tag',
   cspExtraScriptSrcHosts: [],
   httpsDevServer: false,
   devServerMiddleware: undefined,

--- a/packages/sku/src/services/vite/helpers/prerender/prerenderConcurrently.ts
+++ b/packages/sku/src/services/vite/helpers/prerender/prerenderConcurrently.ts
@@ -19,6 +19,7 @@ export type Job = {
 export type SharedWorkerData = {
   publicPath: string;
   cspEnabled: boolean;
+  cspDelivery: 'tag' | 'header';
   cspExtraScriptSrcHosts: string[];
   targetPath: string;
   manifest: Manifest;
@@ -102,6 +103,7 @@ export const prerenderConcurrently = async (skuContext: SkuContext) => {
   const sharedWorkerData = {
     publicPath: skuContext.publicPath,
     cspEnabled: skuContext.cspEnabled,
+    cspDelivery: skuContext.cspDelivery,
     cspExtraScriptSrcHosts: skuContext.cspExtraScriptSrcHosts,
     targetPath,
     manifest: JSON.parse(rawManifest) as Manifest,

--- a/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
+++ b/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
@@ -27,6 +27,7 @@ if (!typedWorkerData || typedWorkerData.jobs.length === 0) {
 const {
   sharedWorkerData: {
     cspEnabled,
+    cspDelivery,
     cspExtraScriptSrcHosts,
     manifest,
     publicPath,
@@ -68,6 +69,7 @@ await Promise.all(
         });
       }
 
+      const metadata: { csp?: string } = {};
       let html = '';
       try {
         html = await createPreRenderedHtml({
@@ -84,7 +86,13 @@ await Promise.all(
         });
 
         if (cspHandler) {
-          html = cspHandler.handleHtml(html);
+          const root = cspHandler.processHtml(html);
+
+          if (cspDelivery === 'tag') {
+            html = cspHandler.updateHtml(root);
+          } else if (cspDelivery === 'header') {
+            metadata.csp = cspHandler.createCSP();
+          }
         }
       } catch (e) {
         throw new Error(`Error rendering HTML for route "${route}"`, {
@@ -104,6 +112,22 @@ await Promise.all(
         throw new Error(`Error writing file to "${relativeOutputPath}"`, {
           cause: e,
         });
+      }
+
+      if (Object.keys(metadata).length !== 0) {
+        const json = JSON.stringify({ metadata }, null, 2);
+
+        try {
+          console.log(
+            `Writing metadata for route "${route}" to "${relativeOutputPath}.json"`,
+          );
+          await writeFile(`${filePath}.json`, json);
+        } catch (e) {
+          throw new Error(
+            `Error writing file to "${relativeOutputPath}.json"`,
+            { cause: e },
+          );
+        }
       }
     },
   ),

--- a/packages/sku/src/services/vite/plugins/middleware.ts
+++ b/packages/sku/src/services/vite/plugins/middleware.ts
@@ -1,5 +1,6 @@
 import type { SkuContext } from '../../../context/createSkuContext.js';
 import type { Plugin } from 'vite';
+import type { OutgoingHttpHeaders } from 'node:http';
 import { createRequire } from 'node:module';
 import type { ViteRenderFunction } from '../../../types/types.js';
 import { getMatchingRoute } from '../../../utils/routeMatcher.js';
@@ -118,6 +119,7 @@ export const middlewarePlugin = ({
         try {
           const { viteRender } = await server.ssrLoadModule(renderEntry);
 
+          const headers: OutgoingHttpHeaders = { 'content-type': 'text/html' };
           let html = await (viteRender as ViteRenderFunction)({
             environment,
             language,
@@ -133,10 +135,16 @@ export const middlewarePlugin = ({
           html = await server.transformIndexHtml(req.url || '/', html);
 
           if (cspHandler) {
-            html = cspHandler.handleHtml(html);
+            const root = cspHandler.processHtml(html);
+
+            if (skuContext.cspDelivery === 'tag') {
+              html = cspHandler.updateHtml(root);
+            } else if (skuContext.cspDelivery === 'header') {
+              headers['content-security-policy'] = cspHandler.createCSP();
+            }
           }
 
-          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.writeHead(200, headers);
           res.end(html);
         } catch (e) {
           // If an error is caught, let vite fix the stracktrace so it maps back to

--- a/packages/sku/src/services/webpack/entry/csp.ts
+++ b/packages/sku/src/services/webpack/entry/csp.ts
@@ -20,6 +20,8 @@ export type CSPHandler = {
   createCSP: () => string;
   createCSPTag: () => string;
   createUnsafeNonce: () => string;
+  processHtml: (html: string) => HTMLElement;
+  updateHtml: (root: HTMLElement) => string;
   handleHtml: (html: string) => string;
 };
 
@@ -124,14 +126,14 @@ export default function createCSPHandler({
   const createCSPTag = () =>
     `<meta http-equiv="Content-Security-Policy" content="${createCSP()}">`;
 
-  const handleHtml = (html: string) => {
+  const processHtml = (html: string) => {
     const root = parse(html, {
       comment: true,
     });
 
     if (!root) {
       throw new Error(
-        `Unable to parse HTML in order to create CSP tag. Check the following output of renderDocument for invalid HTML.\n${
+        `Unable to parse HTML in order to create CSP. Check the following output of renderDocument for invalid HTML.\n${
           html.length > 250 ? `${html.substring(0, 200)}...` : html
         }`,
       );
@@ -139,8 +141,14 @@ export default function createCSPHandler({
 
     root.querySelectorAll('script').forEach(processScriptNode);
 
+    return root;
+  };
+
+  const updateHtml = (root: HTMLElement) => {
     const headElement = root.querySelector('head');
     if (!headElement) {
+      const html = root.toString();
+
       throw new Error(
         `Unable to find 'head' element in HTML in order to create CSP tag. Check the following output of renderDocument for invalid HTML.\n${
           html.length > 250 ? `${html.substring(0, 200)}...` : html
@@ -153,11 +161,15 @@ export default function createCSPHandler({
     return root.toString();
   };
 
+  const handleHtml = (html: string) => updateHtml(processHtml(html));
+
   return {
     registerScript,
     createCSP,
     createCSPTag,
     createUnsafeNonce,
+    processHtml,
+    updateHtml,
     handleHtml,
   };
 }

--- a/packages/sku/src/services/webpack/entry/csp.ts
+++ b/packages/sku/src/services/webpack/entry/csp.ts
@@ -17,6 +17,7 @@ interface CreateCSPHandlerOptions {
 
 export type CSPHandler = {
   registerScript: (script: string) => void;
+  createCSP: () => string;
   createCSPTag: () => string;
   createUnsafeNonce: () => string;
   handleHtml: (html: string) => string;
@@ -26,7 +27,7 @@ export default function createCSPHandler({
   extraHosts = [],
   isDevelopment = false,
 }: CreateCSPHandlerOptions = {}): CSPHandler {
-  let tagReturned = false;
+  let cspCreated = false;
   const hosts = new Set();
   const shas = new Set();
   const nonces = new Set();
@@ -38,7 +39,7 @@ export default function createCSPHandler({
   };
 
   const createUnsafeNonce = () => {
-    if (tagReturned) {
+    if (cspCreated) {
       throw new Error(
         `Unable to add nonce. Content Security Policy already sent. Try adding nonces before calling flushHeadTags.`,
       );
@@ -74,7 +75,7 @@ export default function createCSPHandler({
   };
 
   const registerScript: RenderCallbackParams['registerScript'] = (script) => {
-    if (tagReturned) {
+    if (cspCreated) {
       throw new Error(
         `Unable to register script. Content Security Policy already sent. Try registering scripts before calling flushHeadTags. Script: ${script.substr(
           0,
@@ -90,8 +91,8 @@ export default function createCSPHandler({
     parse(script).querySelectorAll('script').forEach(processScriptNode);
   };
 
-  const createCSPTag = () => {
-    tagReturned = true;
+  const createCSP = () => {
+    cspCreated = true;
 
     const inlineCspShas = [];
 
@@ -117,10 +118,11 @@ export default function createCSPHandler({
       scriptSrcPolicy.push(`'unsafe-eval'`);
     }
 
-    return `<meta http-equiv="Content-Security-Policy" content="${scriptSrcPolicy.join(
-      ' ',
-    )};">`;
+    return `${scriptSrcPolicy.join(' ')};`;
   };
+
+  const createCSPTag = () =>
+    `<meta http-equiv="Content-Security-Policy" content="${createCSP()}">`;
 
   const handleHtml = (html: string) => {
     const root = parse(html, {
@@ -153,6 +155,7 @@ export default function createCSPHandler({
 
   return {
     registerScript,
+    createCSP,
     createCSPTag,
     createUnsafeNonce,
     handleHtml,

--- a/packages/sku/src/types/types.ts
+++ b/packages/sku/src/types/types.ts
@@ -540,7 +540,7 @@ export interface ViteSkuConfig {
   vitePlugins?: PluginOption[];
 
   /**
-   * The way the content security policy is delivered.  Only relevant if {@link SkuConfigBase#cspEnabled} is set to `true`.
+   * The way the content security policy is delivered. Only relevant if {@link SkuConfigBase#cspEnabled} is set to `true`.
    *
    * @default 'tag'
    * @link https://seek-oss.github.io/sku/docs/configuration#cspdelivery

--- a/packages/sku/src/types/types.ts
+++ b/packages/sku/src/types/types.ts
@@ -540,6 +540,14 @@ export interface ViteSkuConfig {
   vitePlugins?: PluginOption[];
 
   /**
+   * The way the content security policy is delivered.  Only relevant if {@link SkuConfigBase#cspEnabled} is set to `true`.
+   *
+   * @default 'tag'
+   * @link https://seek-oss.github.io/sku/docs/configuration#cspdelivery
+   */
+  cspDelivery?: 'tag' | 'header';
+
+  /**
    * This function provides a way to modify sku's Vite configuration.
    * It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
    *

--- a/private/playwright/appSnapshot.ts
+++ b/private/playwright/appSnapshot.ts
@@ -23,6 +23,7 @@ export const getAppSnapshot = async ({ url }: AppSnapshotOptions) => {
 
   const response = await page.goto(url);
 
+  const headers = (await response?.allHeaders()) ?? {};
   const sourceHtml = (await response?.text()) || '';
   const clientRenderContent = await page.content();
   await page.close();
@@ -30,5 +31,13 @@ export const getAppSnapshot = async ({ url }: AppSnapshotOptions) => {
   expect(errors).toEqual([]);
   expect(warnings).toEqual([]);
 
-  return { sourceHtml, clientRenderContent };
+  return { headers, sourceHtml, clientRenderContent };
 };
+
+export type AppSnapshot = Awaited<ReturnType<typeof getAppSnapshot>>;
+export const isAppSnapshot = (value: unknown): value is AppSnapshot =>
+  typeof value === 'object' &&
+  value !== null &&
+  'headers' in value &&
+  'sourceHtml' in value &&
+  'clientRenderContent' in value;

--- a/private/playwright/serializers/appSnapshotSerializer.ts
+++ b/private/playwright/serializers/appSnapshotSerializer.ts
@@ -1,7 +1,10 @@
 import type { SnapshotSerializer } from 'vitest';
 import { createTwoFilesPatch } from 'diff';
+import { type AppSnapshot, isAppSnapshot } from '../appSnapshot.ts';
 import { formatHtml } from '../formatHtml.ts';
 import { sanitizeString } from '../sanitizeString.ts';
+
+const snapshotHeaders = new Set<string>([]);
 
 const emptyDiff = `===================================================================
 --- sourceHtml
@@ -12,7 +15,7 @@ const emptyDiff = `=============================================================
  * post-hydration HTML
  */
 export const appSnapshotSerializer: SnapshotSerializer = {
-  serialize: ({ sourceHtml, clientRenderContent }) => {
+  serialize: ({ headers, sourceHtml, clientRenderContent }: AppSnapshot) => {
     const formattedSourceHtml = formatHtml(sourceHtml);
     const formattedClientHtml = formatHtml(clientRenderContent);
 
@@ -27,15 +30,19 @@ export const appSnapshotSerializer: SnapshotSerializer = {
     ).trim();
 
     // If there is no difference between the source and client html then we can just return the source html
-    return sanitizeString(
+    const snapshot = sanitizeString(
       htmlDiff === emptyDiff
         ? [emptyDiff, formattedSourceHtml].join('\n')
         : htmlDiff,
     );
+
+    const preamble = Object.entries(headers)
+      .filter(([key]) => snapshotHeaders.has(key))
+      .map(([key, value]) => `${key}: ${value}`)
+      .join('\n');
+
+    return preamble ? [preamble, snapshot].join('\n') : snapshot;
   },
 
-  test: (val) =>
-    val &&
-    val.hasOwnProperty('clientRenderContent') &&
-    val.hasOwnProperty('sourceHtml'),
+  test: isAppSnapshot,
 };

--- a/private/playwright/serializers/appSnapshotSerializer.ts
+++ b/private/playwright/serializers/appSnapshotSerializer.ts
@@ -4,7 +4,7 @@ import { type AppSnapshot, isAppSnapshot } from '../appSnapshot.ts';
 import { formatHtml } from '../formatHtml.ts';
 import { sanitizeString } from '../sanitizeString.ts';
 
-const snapshotHeaders = new Set<string>([]);
+const snapshotHeaders = new Set(['content-security-policy']);
 
 const emptyDiff = `===================================================================
 --- sourceHtml

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -78,6 +78,16 @@ Default: `false`
 
 Enable content security policy feature. See [`Content Security Policy`](./csp.md) for more info.
 
+## cspDelivery
+
+Type: `'tag' | 'header'`
+
+Default: `'tag'`
+
+Bundler: `vite`
+
+The way the content security policy is delivered. Only relevant if `cspEnabled` is set to `true`.
+
 ## cspExtraScriptSrcHosts
 
 Type: `Array<string>`

--- a/site/docs/csp.md
+++ b/site/docs/csp.md
@@ -8,6 +8,18 @@
 
 Set `cspEnabled: true` in your `sku.config.js`.
 
+### Delivery
+
+The `cspDelivery` option controls how the CSP is delivered and can be set to one of two values:
+
+- `tag`: The CSP will be embedded directly in the rendered HTML content via a `<meta http-equiv="Content-Security-Policy" …>` tag.
+  No further action will be required to enable the CSP.
+  This is the default behaviour if no `cspDelivery` option is specified.
+- `header`: The CSP will be written to a JSON file alongside the rendered HTML content (e.g. `index.html.json`) in the `metadata.csp` property, and no `<meta http-equiv="Content-Security-Policy" …>` tag will be generated.
+  Extra steps will be required at deployment and/or request time to ensure the value of this property is returned as a `Content-Security-Policy` header in the response for the rendered HTML content.
+
+The `cspDelivery` option is only available when using Vite.
+
 ### Extra Hosts
 
 If you need to allow scripts that are only known client side (e.g. scripts loaded by tag managers) you can add their URLs to the `cspExtraScriptSrcHosts` array in `sku.config.js`.

--- a/tests/browser/__snapshots__/security-controls.test.ts.snap
+++ b/tests/browser/__snapshots__/security-controls.test.ts.snap
@@ -91,6 +91,100 @@ exports[`security-controls > build-ssr > should start a server with content-secu
 </html>
 `;
 
+exports[`security-controls > bundler vite > csp-delivery > start > should start an app with security controls 1`] = `
+content-security-policy: script-src 'self' https://some-cdn.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' 'sha256-UBWhRaCtYn0qJIs3GeFksNFLt/GkChOdRUDOMGEwb4A=' 'nonce-RANDOM_NONCE';
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -1,68 +1,82 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <script type="module">
+       import { injectIntoGlobalHook } from "/@react-refresh";
+ injectIntoGlobalHook(window);
+ window.$RefreshReg$ = () => {};
+ window.$RefreshSig$ = () => (type) => type;
+     </script>
+     <script
+       type="module"
+       src="/@vite/client"
+     >
+     </script>
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <script
+       type="module"
+-      src="/@id/__x00__/index.html?html-proxy&index=0.js"
++      src="/@id/__x00__/index.html?html-proxy&amp;index=0.js"
+     >
+     </script>
+     <script
+       type="module"
+-      src="/@id/__x00__/index.html?html-proxy&index=1.js"
++      src="/@id/__x00__/index.html?html-proxy&amp;index=1.js"
+     >
+     </script>
+     <link
+       rel="stylesheet"
+       href="/@id/__x00__virtual:ssr-css.css"
+       data-ssr-css
+     >
+     <script type="module">
+       import { createHotContext } from "/@vite/client";
+               const hot = createHotContext("/__clear_ssr_css");
+               hot.on("vite:afterUpdate", () => {
+                 document
+                   .querySelectorAll("[data-ssr-css]")
+                   .forEach(node => node.remove());
+               });
+     </script>
++    <style
++      type="text/css"
++      data-vite-dev-id="{cwd}/fixtures/security-controls/src/styles.css.js.vanilla.css"
++    >
++      .styles_root__14y9ssh0 {
++  display: flex;
++}
++.styles_root__14y9ssh0 .styles_nested__14y9ssh1 {
++  font-size: 32px;
++}
++    </style>
+   </head>
+   <body>
+     <div id="app">
+       <div class="styles_root__14y9ssh0">
+         <div class="styles_nested__14y9ssh1">
+-          Initial
++          Client
+         </div>
+       </div>
+     </div>
+     <script
+       type="module"
+       src="{cwd}/packages/sku/dist/entries/vite-client.mjs"
+     >
+     </script>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"environment":"","dynamicScriptNonce":"RANDOM_NONCE"}
+     </script>
++    <script nonce>
++      console.log("Hello from dynamically created script")
++    </script>
+   </body>
+ </html>
+\\ No newline at end of file
+`;
+
 exports[`security-controls > bundler vite > start > should start an app with security controls 1`] = `
 ===================================================================
 --- sourceHtml

--- a/tests/browser/security-controls.test.ts
+++ b/tests/browser/security-controls.test.ts
@@ -1,4 +1,4 @@
-import { describe, beforeAll, it, expect, beforeEach } from 'vitest';
+import { describe, beforeAll, it, expect } from 'vitest';
 import { getAppSnapshot } from '@sku-private/playwright';
 
 import {
@@ -46,9 +46,7 @@ describe('security-controls', () => {
       beforeAll(async () => {
         const build = await sku('build', [...args[bundler]]);
         await build.findByText('Sku build complete');
-      });
 
-      beforeEach(async () => {
         const indexPath = fixturePath('dist/index.html');
         const content = await readFile(indexPath, 'utf-8');
         const root = parse(content);
@@ -75,6 +73,63 @@ describe('security-controls', () => {
 
       it('should generate a CSP with nonce value', async () => {
         expect(cspTag.getAttribute('content')).match(/nonce-RANDOM_NONCE/);
+      });
+    });
+
+    describe.runIf(bundler === 'vite')('csp-delivery', () => {
+      describe('start', async () => {
+        const port = await getPort();
+        const url = `http://localhost:${port}`;
+
+        beforeAll(async () => {
+          const start = await sku('start', [
+            '--config=sku.config.vite.csp-delivery.ts',
+            '--strict-port',
+            `--port=${port}`,
+          ]);
+          await start.findByText('Starting development server');
+        });
+
+        it('should start an app with security controls', async () => {
+          const app = await getAppSnapshot({
+            url,
+          });
+          expect(app).toMatchSnapshot();
+        });
+      });
+
+      describe('build', async () => {
+        let cspHeader: string;
+
+        beforeAll(async () => {
+          const build = await sku('build', [
+            '--config=sku.config.vite.csp-delivery.ts',
+          ]);
+          await build.findByText('Sku build complete');
+
+          const indexJsonPath = fixturePath('dist/index.html.json');
+          const content = await readFile(indexJsonPath, 'utf-8');
+          const data = JSON.parse(content);
+          const metadata = data.metadata?.csp ?? null;
+
+          if (!metadata) {
+            throw new Error('Unable to select CSP metadata');
+          }
+
+          cspHeader = metadata;
+        });
+
+        it('should generate a CSP header', async () => {
+          expect(cspHeader).not.toBeNull();
+        });
+
+        it('should include the extra hosts in the CSP', async () => {
+          expect(cspHeader).toContain('https://some-cdn.com');
+        });
+
+        it('should generate a CSP with nonce value', async () => {
+          expect(cspHeader).match(/nonce-RANDOM_NONCE/);
+        });
       });
     });
   });


### PR DESCRIPTION
This change adds a new configuration option, `cspDelivery`, that allows control of how the Content Security Policy is delivered. It can be set to one of two values:

- `tag`: The CSP will be embedded directly in the rendered HTML content via a `<meta http-equiv="Content-Security-Policy" …>` tag. This is the default and matches the previous behaviour.
- `header`: The CSP will be written to a JSON metadata file alongside the rendered HTML content. This metadata can be used at deployment and/or request time to include a `Content-Security-Policy` header in the response for the rendered HTML content.

Note: This change will be released alongside #1631 which adds support for a report-only Content Security Policy.
