### PR TITLE
`csp`: Add support for report-only Content Security Policy

### DIFF
--- a/.changeset/dry-boats-chew.md
+++ b/.changeset/dry-boats-chew.md
@@ -1,0 +1,9 @@
+---
+'sku': minor
+---
+
+`csp`: Add support for report-only Content Security Policy.
+
+Two new configuration options, `cspReportOnlyEnabled` and `cspReportOnlyExtraScriptSrcHosts`, allow the generation of a "report-only" CSP delivered via the `Content-Security-Policy-Report-Only` header.
+
+See the [Content Security Policy](https://seek-oss.github.io/sku/docs/csp#report-only-content-security-policy) section of the sku docs for more details.

--- a/fixtures/security-controls/sku.config.vite.csp-report-only.ts
+++ b/fixtures/security-controls/sku.config.vite.csp-report-only.ts
@@ -1,0 +1,7 @@
+import viteConfig from './sku.config.vite.ts';
+
+export default {
+  ...viteConfig,
+  cspReportOnlyEnabled: true,
+  cspReportOnlyExtraScriptSrcHosts: ['https://some-report-only-cdn.com'],
+};

--- a/packages/sku/src/context/configSchema.ts
+++ b/packages/sku/src/context/configSchema.ts
@@ -188,6 +188,12 @@ export default validator.compile({
     type: 'array',
     items: { type: 'string' },
   },
+  cspReportOnlyEnabled: { type: 'boolean' },
+  cspReportOnlyExtraScriptSrcHosts: {
+    type: 'array',
+    items: { type: 'string' },
+    optional: true,
+  },
   httpsDevServer: {
     type: 'boolean',
   },

--- a/packages/sku/src/context/createSkuContext.ts
+++ b/packages/sku/src/context/createSkuContext.ts
@@ -215,6 +215,9 @@ export const createSkuContext = async ({
   const cspEnabled = skuConfig.cspEnabled;
   const cspDelivery = skuConfig.cspDelivery;
   const cspExtraScriptSrcHosts = skuConfig.cspExtraScriptSrcHosts;
+  const cspReportOnlyEnabled = skuConfig.cspReportOnlyEnabled;
+  const cspReportOnlyExtraScriptSrcHosts =
+    skuConfig.cspReportOnlyExtraScriptSrcHosts ?? cspExtraScriptSrcHosts;
   const httpsDevServer = skuConfig.httpsDevServer;
   const languages = normalizedLanguages;
   const skipPackageCompatibilityCompilation =
@@ -274,6 +277,8 @@ export const createSkuContext = async ({
     cspEnabled,
     cspDelivery,
     cspExtraScriptSrcHosts,
+    cspReportOnlyEnabled,
+    cspReportOnlyExtraScriptSrcHosts,
     httpsDevServer,
     languages,
     initialPath,

--- a/packages/sku/src/context/defaultSkuConfig.ts
+++ b/packages/sku/src/context/defaultSkuConfig.ts
@@ -41,6 +41,8 @@ export default {
   cspEnabled: false,
   cspDelivery: 'tag',
   cspExtraScriptSrcHosts: [],
+  cspReportOnlyEnabled: false,
+  cspReportOnlyExtraScriptSrcHosts: undefined,
   httpsDevServer: false,
   devServerMiddleware: undefined,
   languages: undefined,

--- a/packages/sku/src/services/vite/helpers/prerender/prerenderConcurrently.ts
+++ b/packages/sku/src/services/vite/helpers/prerender/prerenderConcurrently.ts
@@ -21,6 +21,8 @@ export type SharedWorkerData = {
   cspEnabled: boolean;
   cspDelivery: 'tag' | 'header';
   cspExtraScriptSrcHosts: string[];
+  cspReportOnlyEnabled: boolean;
+  cspReportOnlyExtraScriptSrcHosts: string[];
   targetPath: string;
   manifest: Manifest;
 };
@@ -105,6 +107,9 @@ export const prerenderConcurrently = async (skuContext: SkuContext) => {
     cspEnabled: skuContext.cspEnabled,
     cspDelivery: skuContext.cspDelivery,
     cspExtraScriptSrcHosts: skuContext.cspExtraScriptSrcHosts,
+    cspReportOnlyEnabled: skuContext.cspReportOnlyEnabled,
+    cspReportOnlyExtraScriptSrcHosts:
+      skuContext.cspReportOnlyExtraScriptSrcHosts,
     targetPath,
     manifest: JSON.parse(rawManifest) as Manifest,
   };

--- a/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
+++ b/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
@@ -29,6 +29,8 @@ const {
     cspEnabled,
     cspDelivery,
     cspExtraScriptSrcHosts,
+    cspReportOnlyEnabled,
+    cspReportOnlyExtraScriptSrcHosts,
     manifest,
     publicPath,
     targetPath,
@@ -62,14 +64,19 @@ await Promise.all(
 
       let cspHandler: CSPHandler | undefined;
 
-      if (cspEnabled) {
+      if (cspEnabled || cspReportOnlyEnabled) {
         cspHandler = createCSPHandler({
-          extraHosts: [publicPath, ...cspExtraScriptSrcHosts],
+          extraHosts: cspEnabled
+            ? [publicPath, ...cspExtraScriptSrcHosts]
+            : undefined,
+          reportOnlyExtraHosts: cspReportOnlyEnabled
+            ? [publicPath, ...cspReportOnlyExtraScriptSrcHosts]
+            : undefined,
           isDevelopment: process.env.NODE_ENV === 'development',
         });
       }
 
-      const metadata: { csp?: string } = {};
+      const metadata: { csp?: string; cspReportOnly?: string } = {};
       let html = '';
       try {
         html = await createPreRenderedHtml({
@@ -88,10 +95,16 @@ await Promise.all(
         if (cspHandler) {
           const root = cspHandler.processHtml(html);
 
-          if (cspDelivery === 'tag') {
-            html = cspHandler.updateHtml(root);
-          } else if (cspDelivery === 'header') {
-            metadata.csp = cspHandler.createCSP();
+          if (cspEnabled) {
+            if (cspDelivery === 'tag') {
+              html = cspHandler.updateHtml(root);
+            } else if (cspDelivery === 'header') {
+              metadata.csp = cspHandler.createCSP();
+            }
+          }
+
+          if (cspReportOnlyEnabled) {
+            metadata.cspReportOnly = cspHandler.createReportOnlyCSP();
           }
         }
       } catch (e) {

--- a/packages/sku/src/services/vite/plugins/middleware.ts
+++ b/packages/sku/src/services/vite/plugins/middleware.ts
@@ -106,12 +106,20 @@ export const middlewarePlugin = ({
 
         let cspHandler: CSPHandler | undefined;
 
-        if (skuContext.cspEnabled) {
+        if (skuContext.cspEnabled || skuContext.cspReportOnlyEnabled) {
           cspHandler = createCSPHandler({
-            extraHosts: [
-              skuContext.paths.publicPath,
-              ...skuContext.cspExtraScriptSrcHosts,
-            ],
+            extraHosts: skuContext.cspEnabled
+              ? [
+                  skuContext.paths.publicPath,
+                  ...skuContext.cspExtraScriptSrcHosts,
+                ]
+              : undefined,
+            reportOnlyExtraHosts: skuContext.cspReportOnlyEnabled
+              ? [
+                  skuContext.paths.publicPath,
+                  ...skuContext.cspReportOnlyExtraScriptSrcHosts,
+                ]
+              : undefined,
             isDevelopment: process.env.NODE_ENV === 'development',
           });
         }
@@ -137,10 +145,17 @@ export const middlewarePlugin = ({
           if (cspHandler) {
             const root = cspHandler.processHtml(html);
 
-            if (skuContext.cspDelivery === 'tag') {
-              html = cspHandler.updateHtml(root);
-            } else if (skuContext.cspDelivery === 'header') {
-              headers['content-security-policy'] = cspHandler.createCSP();
+            if (skuContext.cspEnabled) {
+              if (skuContext.cspDelivery === 'tag') {
+                html = cspHandler.updateHtml(root);
+              } else if (skuContext.cspDelivery === 'header') {
+                headers['content-security-policy'] = cspHandler.createCSP();
+              }
+            }
+
+            if (skuContext.cspReportOnlyEnabled) {
+              headers['content-security-policy-report-only'] =
+                cspHandler.createReportOnlyCSP();
             }
           }
 

--- a/packages/sku/src/services/webpack/entry/csp.ts
+++ b/packages/sku/src/services/webpack/entry/csp.ts
@@ -12,6 +12,7 @@ const hashScriptContents = (scriptContents: BinaryLike) =>
 
 interface CreateCSPHandlerOptions {
   extraHosts?: string[];
+  reportOnlyExtraHosts?: string[];
   isDevelopment?: boolean;
 }
 
@@ -19,6 +20,7 @@ export type CSPHandler = {
   registerScript: (script: string) => void;
   createCSP: () => string;
   createCSPTag: () => string;
+  createReportOnlyCSP: () => string;
   createUnsafeNonce: () => string;
   processHtml: (html: string) => HTMLElement;
   updateHtml: (root: HTMLElement) => string;
@@ -27,12 +29,14 @@ export type CSPHandler = {
 
 export default function createCSPHandler({
   extraHosts = [],
+  reportOnlyExtraHosts = [],
   isDevelopment = false,
 }: CreateCSPHandlerOptions = {}): CSPHandler {
   let cspCreated = false;
-  const hosts = new Set();
-  const shas = new Set();
-  const nonces = new Set();
+  const hosts = new Set<string>();
+  const reportOnlyHosts = new Set<string>();
+  const shas = new Set<string>();
+  const nonces = new Set<string>();
 
   const addScriptContents = (contents: BinaryLike | undefined) => {
     if (contents) {
@@ -60,13 +64,23 @@ export default function createCSPHandler({
     }
   };
 
+  const addReportOnlyScriptUrl = (src: string) => {
+    const { origin } = new URL(src, defaultBaseName);
+
+    if (origin !== defaultBaseName) {
+      reportOnlyHosts.add(origin);
+    }
+  };
+
   extraHosts.forEach((host) => addScriptUrl(host));
+  reportOnlyExtraHosts.forEach((host) => addReportOnlyScriptUrl(host));
 
   const processScriptNode = (scriptNode: HTMLElement) => {
     const src = scriptNode.getAttribute('src');
 
     if (src) {
       addScriptUrl(src);
+      addReportOnlyScriptUrl(src);
       return;
     }
 
@@ -93,7 +107,7 @@ export default function createCSPHandler({
     parse(script).querySelectorAll('script').forEach(processScriptNode);
   };
 
-  const createCSP = () => {
+  const createCSPForHosts = (set: Set<string>) => {
     cspCreated = true;
 
     const inlineCspShas = [];
@@ -111,7 +125,7 @@ export default function createCSPHandler({
     const scriptSrcPolicy = [
       'script-src',
       `'self'`,
-      ...hosts.values(),
+      ...set.values(),
       ...inlineCspShas,
       ...inlineCspNonces,
     ];
@@ -123,8 +137,12 @@ export default function createCSPHandler({
     return `${scriptSrcPolicy.join(' ')};`;
   };
 
+  const createCSP = () => createCSPForHosts(hosts);
+
   const createCSPTag = () =>
     `<meta http-equiv="Content-Security-Policy" content="${createCSP()}">`;
+
+  const createReportOnlyCSP = () => createCSPForHosts(reportOnlyHosts);
 
   const processHtml = (html: string) => {
     const root = parse(html, {
@@ -167,6 +185,7 @@ export default function createCSPHandler({
     registerScript,
     createCSP,
     createCSPTag,
+    createReportOnlyCSP,
     createUnsafeNonce,
     processHtml,
     updateHtml,

--- a/packages/sku/src/types/types.ts
+++ b/packages/sku/src/types/types.ts
@@ -548,6 +548,24 @@ export interface ViteSkuConfig {
   cspDelivery?: 'tag' | 'header';
 
   /**
+   * **Unavailable for libraries**
+   *
+   * Enable report-only content security policy feature. More info at https://seek-oss.github.io/sku/docs/csp
+   *
+   * @default false
+   * @link https://seek-oss.github.io/sku/docs/configuration#cspreportonlyenabled
+   */
+  cspReportOnlyEnabled?: boolean;
+
+  /**
+   * Extra external hosts to allow in your `script-src` report-only content security policy. Only relevant if {@link cspReportOnlyEnabled} is set to `true`.
+   *
+   * @default {@link SkuConfigBase#cspExtraScriptSrcHosts}
+   * @link https://seek-oss.github.io/sku/docs/configuration#cspreportonlyextrascriptsrchosts
+   */
+  cspReportOnlyExtraScriptSrcHosts?: string[];
+
+  /**
    * This function provides a way to modify sku's Vite configuration.
    * It should only be used in exceptional circumstances where a solution cannot be achieved by adjusting standard configuration options.
    *

--- a/private/playwright/serializers/appSnapshotSerializer.ts
+++ b/private/playwright/serializers/appSnapshotSerializer.ts
@@ -4,7 +4,10 @@ import { type AppSnapshot, isAppSnapshot } from '../appSnapshot.ts';
 import { formatHtml } from '../formatHtml.ts';
 import { sanitizeString } from '../sanitizeString.ts';
 
-const snapshotHeaders = new Set(['content-security-policy']);
+const snapshotHeaders = new Set([
+  'content-security-policy',
+  'content-security-policy-report-only',
+]);
 
 const emptyDiff = `===================================================================
 --- sourceHtml

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -96,6 +96,28 @@ Default: `[]`
 
 Extra external hosts to allow in your `script-src` [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). Only relevant if `cspEnabled` is set to `true`.
 
+## cspReportOnlyEnabled
+
+Type: `boolean`
+
+**Unavailable for libraries**
+
+Default: `false`
+
+Bundler: `vite`
+
+Enable report-only content security policy feature. See [`Content Security Policy`](./csp.md) for more info.
+
+## cspReportOnlyExtraScriptSrcHosts
+
+Type: `Array<string>`
+
+Default: `cspExtraScriptSrcHosts`
+
+Bundler: `vite`
+
+Extra external hosts to allow in your `script-src` report-only [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). Only relevant if `cspReportOnlyEnabled` is set to `true`.
+
 ## dangerouslySetESLintConfig
 
 Type: `function`

--- a/site/docs/csp.md
+++ b/site/docs/csp.md
@@ -121,3 +121,19 @@ const renderCallback: Server['renderCallback'] = (
     </html>`);
 };
 ```
+
+### Report-only Content Security Policy
+
+A "report-only" Content Security Policy can be enabled by setting `cspReportOnlyEnabled: true` in your `sku.config.js`.
+This will cause a [`Content-Security-Policy-Report-Only`] header to be generated.
+
+By default the report-only CSP will have the same content as the standard CSP, including the same [extra hosts](#extra-hosts).
+This can be changed by setting the `cspReportOnlyExtraScriptSrcHosts` array in `sku.config.js` to contain the script URLs for the report-only CSP.
+
+Unlike the standard CSP, a report-only CSP can only be delivered via an HTTP header and not via a `<meta http-equiv>` tag.
+As such there is no explicit [delivery option](#delivery) for a report-only CSP and the behaviour matches that of `header` CSP delivery, with the policy being written to the `metadata.cspReportOnly` property.
+As a consequence, and like the delivery option itself, a report-only CSP is only available when using Vite.
+
+A report-only CSP can be enabled or disabled independently of the standard CSP, and vice versa.
+
+[`Content-Security-Policy-Report-Only`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy-Report-Only

--- a/tests/browser/__snapshots__/security-controls.test.ts.snap
+++ b/tests/browser/__snapshots__/security-controls.test.ts.snap
@@ -185,6 +185,104 @@ content-security-policy: script-src 'self' https://some-cdn.com 'sha256-Z2/iFzh9
 \\ No newline at end of file
 `;
 
+exports[`security-controls > bundler vite > csp-report-only > start > should start an app with security controls 1`] = `
+content-security-policy-report-only: script-src 'self' https://some-report-only-cdn.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' 'sha256-UBWhRaCtYn0qJIs3GeFksNFLt/GkChOdRUDOMGEwb4A=' 'nonce-RANDOM_NONCE';
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -1,72 +1,86 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta
+       http-equiv="Content-Security-Policy"
+       content="script-src 'self' https://some-cdn.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' 'sha256-UBWhRaCtYn0qJIs3GeFksNFLt/GkChOdRUDOMGEwb4A=' 'nonce-RANDOM_NONCE';"
+     >
+     <script type="module">
+       import { injectIntoGlobalHook } from "/@react-refresh";
+ injectIntoGlobalHook(window);
+ window.$RefreshReg$ = () => {};
+ window.$RefreshSig$ = () => (type) => type;
+     </script>
+     <script
+       type="module"
+       src="/@vite/client"
+     >
+     </script>
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <script
+       type="module"
+-      src="/@id/__x00__/index.html?html-proxy&index=0.js"
++      src="/@id/__x00__/index.html?html-proxy&amp;index=0.js"
+     >
+     </script>
+     <script
+       type="module"
+-      src="/@id/__x00__/index.html?html-proxy&index=1.js"
++      src="/@id/__x00__/index.html?html-proxy&amp;index=1.js"
+     >
+     </script>
+     <link
+       rel="stylesheet"
+       href="/@id/__x00__virtual:ssr-css.css"
+       data-ssr-css
+     >
+     <script type="module">
+       import { createHotContext } from "/@vite/client";
+               const hot = createHotContext("/__clear_ssr_css");
+               hot.on("vite:afterUpdate", () => {
+                 document
+                   .querySelectorAll("[data-ssr-css]")
+                   .forEach(node => node.remove());
+               });
+     </script>
++    <style
++      type="text/css"
++      data-vite-dev-id="{cwd}/fixtures/security-controls/src/styles.css.js.vanilla.css"
++    >
++      .styles_root__14y9ssh0 {
++  display: flex;
++}
++.styles_root__14y9ssh0 .styles_nested__14y9ssh1 {
++  font-size: 32px;
++}
++    </style>
+   </head>
+   <body>
+     <div id="app">
+       <div class="styles_root__14y9ssh0">
+         <div class="styles_nested__14y9ssh1">
+-          Initial
++          Client
+         </div>
+       </div>
+     </div>
+     <script
+       type="module"
+       src="{cwd}/packages/sku/dist/entries/vite-client.mjs"
+     >
+     </script>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"environment":"","dynamicScriptNonce":"RANDOM_NONCE"}
+     </script>
++    <script nonce>
++      console.log("Hello from dynamically created script")
++    </script>
+   </body>
+ </html>
+\\ No newline at end of file
+`;
+
 exports[`security-controls > bundler vite > start > should start an app with security controls 1`] = `
 ===================================================================
 --- sourceHtml

--- a/tests/browser/security-controls.test.ts
+++ b/tests/browser/security-controls.test.ts
@@ -132,6 +132,63 @@ describe('security-controls', () => {
         });
       });
     });
+
+    describe.runIf(bundler === 'vite')('csp-report-only', () => {
+      describe('start', async () => {
+        const port = await getPort();
+        const url = `http://localhost:${port}`;
+
+        beforeAll(async () => {
+          const start = await sku('start', [
+            '--config=sku.config.vite.csp-report-only.ts',
+            '--strict-port',
+            `--port=${port}`,
+          ]);
+          await start.findByText('Starting development server');
+        });
+
+        it('should start an app with security controls', async () => {
+          const app = await getAppSnapshot({
+            url,
+          });
+          expect(app).toMatchSnapshot();
+        });
+      });
+
+      describe('build', async () => {
+        let cspHeader: string;
+
+        beforeAll(async () => {
+          const build = await sku('build', [
+            '--config=sku.config.vite.csp-report-only.ts',
+          ]);
+          await build.findByText('Sku build complete');
+
+          const indexJsonPath = fixturePath('dist/index.html.json');
+          const content = await readFile(indexJsonPath, 'utf-8');
+          const data = JSON.parse(content);
+          const metadata = data.metadata?.cspReportOnly ?? null;
+
+          if (!metadata) {
+            throw new Error('Unable to select report-only CSP metadata');
+          }
+
+          cspHeader = metadata;
+        });
+
+        it('should generate a report-only CSP header', async () => {
+          expect(cspHeader).not.toBeNull();
+        });
+
+        it('should include the extra hosts in the report-only CSP', async () => {
+          expect(cspHeader).toContain('https://some-report-only-cdn.com');
+        });
+
+        it('should generate a report-only CSP with nonce value', async () => {
+          expect(cspHeader).match(/nonce-RANDOM_NONCE/);
+        });
+      });
+    });
   });
 
   describe('build-ssr', async () => {


### PR DESCRIPTION
This change adds two new configuration options, `cspReportOnlyEnabled` and `cspReportOnlyExtraScriptSrcHosts`, that allow the generation of a "report-only" CSP delivered via the `Content-Security-Policy-Report-Only` header.

Note: This change will be released alongside #1630 which adds support for Content Security Policy delivery via HTTP header.