### PR TITLE
`vite`: Update Vanilla Extract plugin

### DIFF
--- a/.changeset/solid-cooks-live.md
+++ b/.changeset/solid-cooks-live.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+Update `@vanilla-extract/vite-plugin` dependency to `^5.2.4`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ catalogs:
       version: 19.2.3
     '@vanilla-extract/css':
       specifier: ^1.20.1
-      version: 1.20.1
+      version: 1.21.1
     '@vanilla-extract/integration':
       specifier: ^8.0.9
       version: 8.0.10
@@ -50,8 +50,8 @@ catalogs:
       specifier: ^1.1.21
       version: 1.1.22
     '@vanilla-extract/vite-plugin':
-      specifier: ^5.2.1
-      version: 5.2.2
+      specifier: ^5.2.4
+      version: 5.2.4
     '@vanilla-extract/webpack-plugin':
       specifier: ^2.3.26
       version: 2.3.27
@@ -234,7 +234,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.20.1(babel-plugin-macros@3.1.0)
+        version: 1.21.1(babel-plugin-macros@3.1.0)
       sku:
         specifier: workspace:*
         version: link:../../packages/sku
@@ -362,7 +362,7 @@ importers:
         version: link:../../private/test-utils
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.20.1(babel-plugin-macros@3.1.0)
+        version: 1.21.1(babel-plugin-macros@3.1.0)
       dedent:
         specifier: ^1.5.1
         version: 1.7.2(babel-plugin-macros@3.1.0)
@@ -377,7 +377,7 @@ importers:
         version: link:../../private/test-utils
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.20.1(babel-plugin-macros@3.1.0)
+        version: 1.21.1(babel-plugin-macros@3.1.0)
       dedent:
         specifier: ^1.5.1
         version: 1.7.2(babel-plugin-macros@3.1.0)
@@ -404,7 +404,7 @@ importers:
     dependencies:
       '@vanilla-extract/css':
         specifier: ^1.17.1
-        version: 1.20.1(babel-plugin-macros@3.1.0)
+        version: 1.21.1(babel-plugin-macros@3.1.0)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -457,7 +457,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vanilla-extract/css':
         specifier: 'catalog:'
-        version: 1.20.1(babel-plugin-macros@3.1.0)
+        version: 1.21.1(babel-plugin-macros@3.1.0)
       sku:
         specifier: workspace:*
         version: link:../../packages/sku
@@ -510,7 +510,7 @@ importers:
         version: link:../../private/test-utils
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.20.1(babel-plugin-macros@3.1.0)
+        version: 1.21.1(babel-plugin-macros@3.1.0)
       dedent:
         specifier: ^1.5.1
         version: 1.7.2(babel-plugin-macros@3.1.0)
@@ -554,7 +554,7 @@ importers:
         version: link:../../private/test-utils
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.20.1(babel-plugin-macros@3.1.0)
+        version: 1.21.1(babel-plugin-macros@3.1.0)
       dedent:
         specifier: ^1.5.1
         version: 1.7.2(babel-plugin-macros@3.1.0)
@@ -665,7 +665,7 @@ importers:
         version: link:../../private/test-utils
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.20.1(babel-plugin-macros@3.1.0)
+        version: 1.21.1(babel-plugin-macros@3.1.0)
       dedent:
         specifier: ^1.5.1
         version: 1.7.2(babel-plugin-macros@3.1.0)
@@ -727,7 +727,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.20.1(babel-plugin-macros@3.1.0)
+        version: 1.21.1(babel-plugin-macros@3.1.0)
       http-server:
         specifier: ^14.1.1
         version: 14.1.1
@@ -764,7 +764,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.20.1(babel-plugin-macros@3.1.0)
+        version: 1.21.1(babel-plugin-macros@3.1.0)
       http-server:
         specifier: ^14.1.1
         version: 14.1.1
@@ -804,7 +804,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.20.1(babel-plugin-macros@3.1.0)
+        version: 1.21.1(babel-plugin-macros@3.1.0)
       dedent:
         specifier: ^1.5.1
         version: 1.7.2(babel-plugin-macros@3.1.0)
@@ -906,7 +906,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vanilla-extract/css':
         specifier: ^1.0.0
-        version: 1.20.1(babel-plugin-macros@3.1.0)
+        version: 1.21.1(babel-plugin-macros@3.1.0)
       dedent:
         specifier: ^1.5.1
         version: 1.7.2(babel-plugin-macros@3.1.0)
@@ -1238,7 +1238,7 @@ importers:
         version: 1.1.22(babel-plugin-macros@3.1.0)
       '@vanilla-extract/vite-plugin':
         specifier: 'catalog:'
-        version: 5.2.2(@types/node@22.20.0)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(vite@8.0.16)(yaml@2.9.0)
+        version: 5.2.4(@types/node@22.20.0)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(vite@8.0.16)(yaml@2.9.0)
       '@vanilla-extract/webpack-plugin':
         specifier: 'catalog:'
         version: 2.3.27(babel-plugin-macros@3.1.0)(webpack@5.107.2)
@@ -1521,7 +1521,7 @@ importers:
         version: 3.0.4(@swc/core@1.15.41)(cssnano@7.1.9)(esbuild@0.28.1)(postcss@8.5.15)
       '@vanilla-extract/css':
         specifier: 'catalog:'
-        version: 1.20.1(babel-plugin-macros@3.1.0)
+        version: 1.21.1(babel-plugin-macros@3.1.0)
       fs-fixture:
         specifier: ^2.6.0
         version: 2.14.0
@@ -4950,14 +4950,14 @@ packages:
   '@vanilla-extract/babel-plugin-debug-ids@1.2.2':
     resolution: {integrity: sha512-MeDWGICAF9zA/OZLOKwhoRlsUW+fiMwnfuOAqFVohL31Agj7Q/RBWAYweqjHLgFBCsdnr6XIfwjJnmb2znEWxw==}
 
-  '@vanilla-extract/compiler@0.7.0':
-    resolution: {integrity: sha512-rZQ40HVmsxfGLjoflwwsaUBLfpbpKDoZC19oiDA0FHq4LdrYtyVbFkc0MfqkNo/qBCvaZfsRezCqk0QQxCqZ8w==}
+  '@vanilla-extract/compiler@0.7.1':
+    resolution: {integrity: sha512-mOokbA2k1Lx3BO1/Qa9rpSWiIWeOHBt4aRHX0e5WMDu53//ifojeZJAvdXj/YkZI8z2AruxXYaLX6YlL8jfzyQ==}
 
   '@vanilla-extract/css-utils@0.1.6':
     resolution: {integrity: sha512-iICpaHma0s2EEnQDw/JRqudQJwYw1JERyWfIllNQplps226KVphjGb3jyGMiBK5Waw69RD3q4gulgRVQAQmKmA==}
 
-  '@vanilla-extract/css@1.20.1':
-    resolution: {integrity: sha512-5I9RNo5uZW9tsBnqrWzJqELegOqTHBrZyDFnES0gR9gJJHBB9dom1N0bwITM9tKwBcfKrTX4a6DHVeQdJ2ubQA==}
+  '@vanilla-extract/css@1.21.1':
+    resolution: {integrity: sha512-T6z6oeT+o0OwqukE6kLs9w5ooB75b8NPRadyU9pPTml83l40TPN+mscPt2OQ9P9cYfwEBMfsfivwiJujs2mzmg==}
 
   '@vanilla-extract/dynamic@2.1.5':
     resolution: {integrity: sha512-QGIFGb1qyXQkbzx6X6i3+3LMc/iv/ZMBttMBL+Wm/DetQd36KsKsFg5CtH3qy+1hCA/5w93mEIIAiL4fkM8ycw==}
@@ -4976,8 +4976,8 @@ packages:
     peerDependencies:
       '@vanilla-extract/css': ^1.0.0
 
-  '@vanilla-extract/vite-plugin@5.2.2':
-    resolution: {integrity: sha512-AUyB4fDR2b/Mo0lcXhhlf6RxnDPYwFMyKKopalJ4BwQNKYzZSoTwHJ1PLPO9SKhpz7lzXc0Z18GHQZOewzl3YA==}
+  '@vanilla-extract/vite-plugin@5.2.4':
+    resolution: {integrity: sha512-KXm+Hghpr7/BNIPirsSVD7otMDCwjj9vfgc02CmtYoJ5t4shxQU0QbCRHc9YxlVvAeGvZfE2TmGkvhw2N/L/aw==}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
@@ -11702,10 +11702,10 @@ snapshots:
 
   '@capsizecss/metrics@4.1.0': {}
 
-  '@capsizecss/vanilla-extract@2.0.4(@vanilla-extract/css@1.20.1)':
+  '@capsizecss/vanilla-extract@2.0.4(@vanilla-extract/css@1.21.1)':
     dependencies:
       '@capsizecss/core': 4.1.3
-      '@vanilla-extract/css': 1.20.1(babel-plugin-macros@3.1.0)
+      '@vanilla-extract/css': 1.21.1(babel-plugin-macros@3.1.0)
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
@@ -14171,9 +14171,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vanilla-extract/compiler@0.7.0(@types/node@22.20.0)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)':
+  '@vanilla-extract/compiler@0.7.1(@types/node@22.20.0)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)':
     dependencies:
-      '@vanilla-extract/css': 1.20.1(babel-plugin-macros@3.1.0)
+      '@vanilla-extract/css': 1.21.1(babel-plugin-macros@3.1.0)
       '@vanilla-extract/integration': 8.0.10(babel-plugin-macros@3.1.0)
       vite: 8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-node: 6.0.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -14195,7 +14195,7 @@ snapshots:
 
   '@vanilla-extract/css-utils@0.1.6': {}
 
-  '@vanilla-extract/css@1.20.1(babel-plugin-macros@3.1.0)':
+  '@vanilla-extract/css@1.21.1(babel-plugin-macros@3.1.0)':
     dependencies:
       '@emotion/hash': 0.9.2
       '@vanilla-extract/private': 1.0.9
@@ -14220,7 +14220,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
       '@vanilla-extract/babel-plugin-debug-ids': 1.2.2
-      '@vanilla-extract/css': 1.20.1(babel-plugin-macros@3.1.0)
+      '@vanilla-extract/css': 1.21.1(babel-plugin-macros@3.1.0)
       dedent: 1.7.2(babel-plugin-macros@3.1.0)
       esbuild: 0.28.1
       eval: 0.1.8
@@ -14241,13 +14241,13 @@ snapshots:
 
   '@vanilla-extract/private@1.0.9': {}
 
-  '@vanilla-extract/sprinkles@1.6.5(@vanilla-extract/css@1.20.1)':
+  '@vanilla-extract/sprinkles@1.6.5(@vanilla-extract/css@1.21.1)':
     dependencies:
-      '@vanilla-extract/css': 1.20.1(babel-plugin-macros@3.1.0)
+      '@vanilla-extract/css': 1.21.1(babel-plugin-macros@3.1.0)
 
-  '@vanilla-extract/vite-plugin@5.2.2(@types/node@22.20.0)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(vite@8.0.16)(yaml@2.9.0)':
+  '@vanilla-extract/vite-plugin@5.2.4(@types/node@22.20.0)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(vite@8.0.16)(yaml@2.9.0)':
     dependencies:
-      '@vanilla-extract/compiler': 0.7.0(@types/node@22.20.0)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      '@vanilla-extract/compiler': 0.7.1(@types/node@22.20.0)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       '@vanilla-extract/integration': 8.0.10(babel-plugin-macros@3.1.0)
       vite: 8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -14958,12 +14958,12 @@ snapshots:
     dependencies:
       '@capsizecss/core': 4.1.3
       '@capsizecss/metrics': 4.1.0
-      '@capsizecss/vanilla-extract': 2.0.4(@vanilla-extract/css@1.20.1)
+      '@capsizecss/vanilla-extract': 2.0.4(@vanilla-extract/css@1.21.1)
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7)(react@19.2.7)
-      '@vanilla-extract/css': 1.20.1(babel-plugin-macros@3.1.0)
+      '@vanilla-extract/css': 1.21.1(babel-plugin-macros@3.1.0)
       '@vanilla-extract/css-utils': 0.1.6
       '@vanilla-extract/dynamic': 2.1.5
-      '@vanilla-extract/sprinkles': 1.6.5(@vanilla-extract/css@1.20.1)
+      '@vanilla-extract/sprinkles': 1.6.5(@vanilla-extract/css@1.21.1)
       assert: 2.1.0
       autosuggest-highlight: 3.3.4
       clsx: 2.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,7 +33,7 @@ catalog:
   '@vanilla-extract/css': '^1.20.1'
   '@vanilla-extract/integration': '^8.0.9'
   '@vanilla-extract/jest-transform': '^1.1.21'
-  '@vanilla-extract/vite-plugin': ^5.2.1
+  '@vanilla-extract/vite-plugin': ^5.2.4
   '@vanilla-extract/webpack-plugin': '^2.3.26'
   '@vocab/vite': ^1.0.4
   braid-design-system: ^34.0.0

--- a/tests/browser/__snapshots__/braid-design-system.test.ts.snap
+++ b/tests/browser/__snapshots__/braid-design-system.test.ts.snap
@@ -21,7 +21,7 @@ exports[`braid-design-system > bundler vite > build > should generate the expect
         <div id="app"><style type="text/css">
             html,body{margin:0;padding:0;background:#fff}
             html.r2i18210,html.r2i18210 body{color-scheme:dark;background:#1C2330}
-          </style><div class="ylnqo70 fx8zm710 fx8zm713"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 z1t4tb4">Hello <!-- -->jobStreet<!-- --> <span class="_19azws30 r2i18255"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 _716eoa0 r2i18255 r2i1825d _16185310 _16185312 _16185313 _16185314" aria-hidden="true"><path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z"></path></svg></span></span><div class="_19azws30 r2i1828p r2i1827l r2i182ax r2i1829t r2i1825d r2i18269 r2i182i9 r2i1824j r2i1824c fx8zm710 fx8zm713 r2i18233 r2i18236"><div class="_19azws30 r2i1825d"><div class="_19azws30 r2i18259 r2i182i9"><input class="_19azws30 _19azws3e _19azws39 _19azws31 _19azws36 _19azws37 _19azws38 _19azws3d r2i1825h r2i1828 r2i182h r2i1826 _1hw07lg4 _1hw07lg2" type="checkbox" id="id_1" aria-checked="false"/><div class="_19azws30 r2i182hx r2i1825d r2i18265 _1hw07lg5 _1hw07lg2 fx8zm710  r2i18233"><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lg9 fx8zm711 fx8zm713 r2i18221 r2i18222"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1823x r2i1823y"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 r2i1823p r2i1823u"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lgb r2i1823z r2i18244"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span></div><div class="_19azws30 r2i182b5 r2i182i5"><div class="_19azws30 r2i18259 _1hw07lg2 _1hw07lg6"><label class="_19azws30 r2i1824 r2i1824x r2i182h _9kzhon0" for="id_1"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 z1t4tb4">This is a checkbox</span></label></div></div></div></div></div><div class="_19azws30 inn18b0">🧁 Vanilla content <!-- -->Initial</div></div></div>
+          </style><div class="ylnqo70 fx8zm710 fx8zm713"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 _1x6fthg4">Hello <!-- -->jobStreet<!-- --> <span class="_19azws30 r2i18255"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 _716eoa0 r2i18255 r2i1825d _16185310 _16185312 _16185313 _16185314" aria-hidden="true"><path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z"></path></svg></span></span><div class="_19azws30 r2i1828p r2i1827l r2i182ax r2i1829t r2i1825d r2i18269 r2i182i9 r2i1824j r2i1824c fx8zm710 fx8zm713 r2i18233 r2i18236"><div class="_19azws30 r2i1825d"><div class="_19azws30 r2i18259 r2i182i9"><input class="_19azws30 _19azws3e _19azws39 _19azws31 _19azws36 _19azws37 _19azws38 _19azws3d r2i1825h r2i1828 r2i182h r2i1826 _1hw07lg4 _1hw07lg2" type="checkbox" id="id_1" aria-checked="false"/><div class="_19azws30 r2i182hx r2i1825d r2i18265 _1hw07lg5 _1hw07lg2 fx8zm710  r2i18233"><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lg9 fx8zm711 fx8zm713 r2i18221 r2i18222"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1823x r2i1823y"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 r2i1823p r2i1823u"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lgb r2i1823z r2i18244"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span></div><div class="_19azws30 r2i182b5 r2i182i5"><div class="_19azws30 r2i18259 _1hw07lg2 _1hw07lg6"><label class="_19azws30 r2i1824 r2i1824x r2i182h _9kzhon0" for="id_1"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 _1x6fthg4">This is a checkbox</span></label></div></div></div></div></div><div class="_19azws30 inn18b0">🧁 Vanilla content <!-- -->Initial</div></div></div>
         <script id="__SKU_CLIENT_CONTEXT__" type="application/json">{"site":"jobStreet"}</script>
 <script type="module" src="/vite-client.js" ></script>
       </body>
@@ -46,7 +46,7 @@ exports[`braid-design-system > bundler vite > build > should generate the expect
         <div id="app"><style type="text/css">
             html,body{margin:0;padding:0;background:#fff}
             html.r2i18210,html.r2i18210 body{color-scheme:dark;background:#1C2330}
-          </style><div class="ylnqo70 fx8zm710 fx8zm713"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 z1t4tb4">Hello <!-- -->seekAnz<!-- --> <span class="_19azws30 r2i18255"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 _716eoa0 r2i18255 r2i1825d _16185310 _16185312 _16185313 _16185314" aria-hidden="true"><path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z"></path></svg></span></span><div class="_19azws30 r2i1828p r2i1827l r2i182ax r2i1829t r2i1825d r2i18269 r2i182i9 r2i1824j r2i1824c fx8zm710 fx8zm713 r2i18233 r2i18236"><div class="_19azws30 r2i1825d"><div class="_19azws30 r2i18259 r2i182i9"><input class="_19azws30 _19azws3e _19azws39 _19azws31 _19azws36 _19azws37 _19azws38 _19azws3d r2i1825h r2i1828 r2i182h r2i1826 _1hw07lg4 _1hw07lg2" type="checkbox" id="id_1" aria-checked="false"/><div class="_19azws30 r2i182hx r2i1825d r2i18265 _1hw07lg5 _1hw07lg2 fx8zm710  r2i18233"><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lg9 fx8zm711 fx8zm713 r2i18221 r2i18222"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1823x r2i1823y"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 r2i1823p r2i1823u"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lgb r2i1823z r2i18244"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span></div><div class="_19azws30 r2i182b5 r2i182i5"><div class="_19azws30 r2i18259 _1hw07lg2 _1hw07lg6"><label class="_19azws30 r2i1824 r2i1824x r2i182h _9kzhon0" for="id_1"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 z1t4tb4">This is a checkbox</span></label></div></div></div></div></div><div class="_19azws30 inn18b0">🧁 Vanilla content <!-- -->Initial</div></div></div>
+          </style><div class="ylnqo70 fx8zm710 fx8zm713"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 _1x6fthg4">Hello <!-- -->seekAnz<!-- --> <span class="_19azws30 r2i18255"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 _716eoa0 r2i18255 r2i1825d _16185310 _16185312 _16185313 _16185314" aria-hidden="true"><path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z"></path></svg></span></span><div class="_19azws30 r2i1828p r2i1827l r2i182ax r2i1829t r2i1825d r2i18269 r2i182i9 r2i1824j r2i1824c fx8zm710 fx8zm713 r2i18233 r2i18236"><div class="_19azws30 r2i1825d"><div class="_19azws30 r2i18259 r2i182i9"><input class="_19azws30 _19azws3e _19azws39 _19azws31 _19azws36 _19azws37 _19azws38 _19azws3d r2i1825h r2i1828 r2i182h r2i1826 _1hw07lg4 _1hw07lg2" type="checkbox" id="id_1" aria-checked="false"/><div class="_19azws30 r2i182hx r2i1825d r2i18265 _1hw07lg5 _1hw07lg2 fx8zm710  r2i18233"><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lg9 fx8zm711 fx8zm713 r2i18221 r2i18222"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1823x r2i1823y"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 r2i1823p r2i1823u"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lgb r2i1823z r2i18244"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span></div><div class="_19azws30 r2i182b5 r2i182i5"><div class="_19azws30 r2i18259 _1hw07lg2 _1hw07lg6"><label class="_19azws30 r2i1824 r2i1824x r2i182h _9kzhon0" for="id_1"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 _1x6fthg4">This is a checkbox</span></label></div></div></div></div></div><div class="_19azws30 inn18b0">🧁 Vanilla content <!-- -->Initial</div></div></div>
         <script id="__SKU_CLIENT_CONTEXT__" type="application/json">{"site":"seekAnz"}</script>
 <script type="module" src="/vite-client.js" ></script>
       </body>
@@ -2004,18 +2004,18 @@ html.r2i18210 .r2i1824s {
     text-align: right;
   }
 }
-.z1t4tb4 {
-  font-size: var(--z1t4tb0);
-  line-height: var(--z1t4tb1);
+._1x6fthg4 {
+  font-size: var(--_1x6fthg0);
+  line-height: var(--_1x6fthg1);
 }
-.z1t4tb4:before {
+._1x6fthg4:before {
   content: "";
-  margin-bottom: var(--z1t4tb2);
+  margin-bottom: var(--_1x6fthg2);
   display: table;
 }
-.z1t4tb4:after {
+._1x6fthg4:after {
   content: "";
-  margin-top: var(--z1t4tb3);
+  margin-top: var(--_1x6fthg3);
   display: table;
 }
 .fx8zm70 {
@@ -2031,28 +2031,28 @@ html.r2i18210 .r2i1824s {
   font-weight: var(--_9h6w0d47);
 }
 .fx8zm74 {
-  --z1t4tb0: var(--_9h6w0d31);
-  --z1t4tb1: var(--_9h6w0d32);
-  --z1t4tb2: var(--_9h6w0d34);
-  --z1t4tb3: var(--_9h6w0d35);
+  --_1x6fthg0: var(--_9h6w0d31);
+  --_1x6fthg1: var(--_9h6w0d32);
+  --_1x6fthg2: var(--_9h6w0d34);
+  --_1x6fthg3: var(--_9h6w0d35);
 }
 .fx8zm76 {
-  --z1t4tb0: var(--_9h6w0d3b);
-  --z1t4tb1: var(--_9h6w0d3c);
-  --z1t4tb2: var(--_9h6w0d3e);
-  --z1t4tb3: var(--_9h6w0d3f);
+  --_1x6fthg0: var(--_9h6w0d3b);
+  --_1x6fthg1: var(--_9h6w0d3c);
+  --_1x6fthg2: var(--_9h6w0d3e);
+  --_1x6fthg3: var(--_9h6w0d3f);
 }
 .fx8zm78 {
-  --z1t4tb0: var(--_9h6w0d3l);
-  --z1t4tb1: var(--_9h6w0d3m);
-  --z1t4tb2: var(--_9h6w0d3o);
-  --z1t4tb3: var(--_9h6w0d3p);
+  --_1x6fthg0: var(--_9h6w0d3l);
+  --_1x6fthg1: var(--_9h6w0d3m);
+  --_1x6fthg2: var(--_9h6w0d3o);
+  --_1x6fthg3: var(--_9h6w0d3p);
 }
 .fx8zm7a {
-  --z1t4tb0: var(--_9h6w0d3v);
-  --z1t4tb1: var(--_9h6w0d3w);
-  --z1t4tb2: var(--_9h6w0d3y);
-  --z1t4tb3: var(--_9h6w0d3z);
+  --_1x6fthg0: var(--_9h6w0d3v);
+  --_1x6fthg1: var(--_9h6w0d3w);
+  --_1x6fthg2: var(--_9h6w0d3y);
+  --_1x6fthg3: var(--_9h6w0d3z);
 }
 .fx8zm7c {
   font-size: var(--_9h6w0d31);
@@ -2077,28 +2077,28 @@ html.r2i18210 .r2i1824s {
   font-weight: var(--_9h6w0d5d);
 }
 .fx8zm7i {
-  --z1t4tb0: var(--_9h6w0d48);
-  --z1t4tb1: var(--_9h6w0d49);
-  --z1t4tb2: var(--_9h6w0d4b);
-  --z1t4tb3: var(--_9h6w0d4c);
+  --_1x6fthg0: var(--_9h6w0d48);
+  --_1x6fthg1: var(--_9h6w0d49);
+  --_1x6fthg2: var(--_9h6w0d4b);
+  --_1x6fthg3: var(--_9h6w0d4c);
 }
 .fx8zm7k {
-  --z1t4tb0: var(--_9h6w0d4i);
-  --z1t4tb1: var(--_9h6w0d4j);
-  --z1t4tb2: var(--_9h6w0d4l);
-  --z1t4tb3: var(--_9h6w0d4m);
+  --_1x6fthg0: var(--_9h6w0d4i);
+  --_1x6fthg1: var(--_9h6w0d4j);
+  --_1x6fthg2: var(--_9h6w0d4l);
+  --_1x6fthg3: var(--_9h6w0d4m);
 }
 .fx8zm7m {
-  --z1t4tb0: var(--_9h6w0d4s);
-  --z1t4tb1: var(--_9h6w0d4t);
-  --z1t4tb2: var(--_9h6w0d4v);
-  --z1t4tb3: var(--_9h6w0d4w);
+  --_1x6fthg0: var(--_9h6w0d4s);
+  --_1x6fthg1: var(--_9h6w0d4t);
+  --_1x6fthg2: var(--_9h6w0d4v);
+  --_1x6fthg3: var(--_9h6w0d4w);
 }
 .fx8zm7o {
-  --z1t4tb0: var(--_9h6w0d52);
-  --z1t4tb1: var(--_9h6w0d53);
-  --z1t4tb2: var(--_9h6w0d55);
-  --z1t4tb3: var(--_9h6w0d56);
+  --_1x6fthg0: var(--_9h6w0d52);
+  --_1x6fthg1: var(--_9h6w0d53);
+  --_1x6fthg2: var(--_9h6w0d55);
+  --_1x6fthg3: var(--_9h6w0d56);
 }
 html:not(.r2i18210) .fx8zm710 {
   --fx8zm7q: var(--_9h6w0d19);
@@ -2234,28 +2234,28 @@ html.r2i18210 .fx8zm71l {
 }
 @media screen and (min-width: 740px) {
   .fx8zm74 {
-    --z1t4tb0: var(--_9h6w0d36);
-    --z1t4tb1: var(--_9h6w0d37);
-    --z1t4tb2: var(--_9h6w0d39);
-    --z1t4tb3: var(--_9h6w0d3a);
+    --_1x6fthg0: var(--_9h6w0d36);
+    --_1x6fthg1: var(--_9h6w0d37);
+    --_1x6fthg2: var(--_9h6w0d39);
+    --_1x6fthg3: var(--_9h6w0d3a);
   }
   .fx8zm76 {
-    --z1t4tb0: var(--_9h6w0d3g);
-    --z1t4tb1: var(--_9h6w0d3h);
-    --z1t4tb2: var(--_9h6w0d3j);
-    --z1t4tb3: var(--_9h6w0d3k);
+    --_1x6fthg0: var(--_9h6w0d3g);
+    --_1x6fthg1: var(--_9h6w0d3h);
+    --_1x6fthg2: var(--_9h6w0d3j);
+    --_1x6fthg3: var(--_9h6w0d3k);
   }
   .fx8zm78 {
-    --z1t4tb0: var(--_9h6w0d3q);
-    --z1t4tb1: var(--_9h6w0d3r);
-    --z1t4tb2: var(--_9h6w0d3t);
-    --z1t4tb3: var(--_9h6w0d3u);
+    --_1x6fthg0: var(--_9h6w0d3q);
+    --_1x6fthg1: var(--_9h6w0d3r);
+    --_1x6fthg2: var(--_9h6w0d3t);
+    --_1x6fthg3: var(--_9h6w0d3u);
   }
   .fx8zm7a {
-    --z1t4tb0: var(--_9h6w0d40);
-    --z1t4tb1: var(--_9h6w0d41);
-    --z1t4tb2: var(--_9h6w0d43);
-    --z1t4tb3: var(--_9h6w0d44);
+    --_1x6fthg0: var(--_9h6w0d40);
+    --_1x6fthg1: var(--_9h6w0d41);
+    --_1x6fthg2: var(--_9h6w0d43);
+    --_1x6fthg3: var(--_9h6w0d44);
   }
   .fx8zm7c {
     font-size: var(--_9h6w0d36);
@@ -2274,28 +2274,28 @@ html.r2i18210 .fx8zm71l {
     line-height: var(--_9h6w0d41);
   }
   .fx8zm7i {
-    --z1t4tb0: var(--_9h6w0d4d);
-    --z1t4tb1: var(--_9h6w0d4e);
-    --z1t4tb2: var(--_9h6w0d4g);
-    --z1t4tb3: var(--_9h6w0d4h);
+    --_1x6fthg0: var(--_9h6w0d4d);
+    --_1x6fthg1: var(--_9h6w0d4e);
+    --_1x6fthg2: var(--_9h6w0d4g);
+    --_1x6fthg3: var(--_9h6w0d4h);
   }
   .fx8zm7k {
-    --z1t4tb0: var(--_9h6w0d4n);
-    --z1t4tb1: var(--_9h6w0d4o);
-    --z1t4tb2: var(--_9h6w0d4q);
-    --z1t4tb3: var(--_9h6w0d4r);
+    --_1x6fthg0: var(--_9h6w0d4n);
+    --_1x6fthg1: var(--_9h6w0d4o);
+    --_1x6fthg2: var(--_9h6w0d4q);
+    --_1x6fthg3: var(--_9h6w0d4r);
   }
   .fx8zm7m {
-    --z1t4tb0: var(--_9h6w0d4x);
-    --z1t4tb1: var(--_9h6w0d4y);
-    --z1t4tb2: var(--_9h6w0d50);
-    --z1t4tb3: var(--_9h6w0d51);
+    --_1x6fthg0: var(--_9h6w0d4x);
+    --_1x6fthg1: var(--_9h6w0d4y);
+    --_1x6fthg2: var(--_9h6w0d50);
+    --_1x6fthg3: var(--_9h6w0d51);
   }
   .fx8zm7o {
-    --z1t4tb0: var(--_9h6w0d57);
-    --z1t4tb1: var(--_9h6w0d58);
-    --z1t4tb2: var(--_9h6w0d5a);
-    --z1t4tb3: var(--_9h6w0d5b);
+    --_1x6fthg0: var(--_9h6w0d57);
+    --_1x6fthg1: var(--_9h6w0d58);
+    --_1x6fthg2: var(--_9h6w0d5a);
+    --_1x6fthg3: var(--_9h6w0d5b);
   }
   .fx8zm71w {
     padding-top: calc((var(--_9h6w0d9) - var(--_9h6w0d37)) / 2);
@@ -2846,7 +2846,7 @@ exports[`braid-design-system > bundler vite > build > should return built jobStr
              html.r2i18210,html.r2i18210 body{color-scheme:dark;background:#1C2330}
        </style>
        <div class="ylnqo70 fx8zm710 fx8zm713">
-         <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 z1t4tb4">
+         <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 _1x6fthg4">
            Hello
            jobStreet
            <span class="_19azws30 r2i18255">
@@ -2959,7 +2959,7 @@ exports[`braid-design-system > bundler vite > build > should return built jobStr
                      class="_19azws30 r2i1824 r2i1824x r2i182h _9kzhon0"
                      for="id_1"
                    >
-                     <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 z1t4tb4">
+                     <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 _1x6fthg4">
                        This is a checkbox
                      </span>
                    </label>
@@ -3028,7 +3028,7 @@ exports[`braid-design-system > bundler vite > build > should return built seekAn
              html.r2i18210,html.r2i18210 body{color-scheme:dark;background:#1C2330}
        </style>
        <div class="ylnqo70 fx8zm710 fx8zm713">
-         <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 z1t4tb4">
+         <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 _1x6fthg4">
            Hello
            seekAnz
            <span class="_19azws30 r2i18255">
@@ -3141,7 +3141,7 @@ exports[`braid-design-system > bundler vite > build > should return built seekAn
                      class="_19azws30 r2i1824 r2i1824x r2i182h _9kzhon0"
                      for="id_1"
                    >
-                     <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 z1t4tb4">
+                     <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm79 fx8zm78 _1x6fthg4">
                        This is a checkbox
                      </span>
                    </label>
@@ -3177,7 +3177,7 @@ exports[`braid-design-system > bundler vite > start > should return development 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -1,198 +1,5103 @@
+@@ -1,198 +1,5093 @@
  <!DOCTYPE html>
  <html>
    <head>
@@ -5323,25 +5323,20 @@ exports[`braid-design-system > bundler vite > start > should return development 
 +    </style>
 +    <style
 +      type="text/css"
-+      data-vite-dev-id="{cwd}/node_modules/braid-design-system/dist/lib/themes/vars.css.mjs.vanilla.css"
-+    >
-+    </style>
-+    <style
-+      type="text/css"
 +      data-vite-dev-id="{cwd}/node_modules/@capsizecss/vanilla-extract/dist/capsize.css.mjs.vanilla.css"
 +    >
-+      .capsize_capsizeStyle__z1t4tb4 {
-+  font-size: var(--fontSize__z1t4tb0);
-+  line-height: var(--lineHeight__z1t4tb1);
++      .capsize_capsizeStyle__1x6fthg4 {
++  font-size: var(--fontSize__1x6fthg0);
++  line-height: var(--lineHeight__1x6fthg1);
 +}
-+.capsize_capsizeStyle__z1t4tb4::before {
++.capsize_capsizeStyle__1x6fthg4::before {
 +  content: '';
-+  margin-bottom: var(--capHeightTrim__z1t4tb2);
++  margin-bottom: var(--capHeightTrim__1x6fthg2);
 +  display: table;
 +}
-+.capsize_capsizeStyle__z1t4tb4::after {
++.capsize_capsizeStyle__1x6fthg4::after {
 +  content: '';
-+  margin-top: var(--baselineTrim__z1t4tb3);
++  margin-top: var(--baselineTrim__1x6fthg3);
 +  display: table;
 +}
 +    </style>
@@ -5362,28 +5357,28 @@ exports[`braid-design-system > bundler vite > start > should return development 
 +  font-weight: var(--textWeight-strong__9h6w0d47);
 +}
 +.typography_textSize_xsmall__fx8zm74 {
-+  --fontSize__z1t4tb0: var(--textSize-xsmall-mobile-fontSize__9h6w0d31);
-+  --lineHeight__z1t4tb1: var(--textSize-xsmall-mobile-lineHeight__9h6w0d32);
-+  --capHeightTrim__z1t4tb2: var(--textSize-xsmall-mobile-capsizeTrims-capHeightTrim__9h6w0d34);
-+  --baselineTrim__z1t4tb3: var(--textSize-xsmall-mobile-capsizeTrims-baselineTrim__9h6w0d35);
++  --fontSize__1x6fthg0: var(--textSize-xsmall-mobile-fontSize__9h6w0d31);
++  --lineHeight__1x6fthg1: var(--textSize-xsmall-mobile-lineHeight__9h6w0d32);
++  --capHeightTrim__1x6fthg2: var(--textSize-xsmall-mobile-capsizeTrims-capHeightTrim__9h6w0d34);
++  --baselineTrim__1x6fthg3: var(--textSize-xsmall-mobile-capsizeTrims-baselineTrim__9h6w0d35);
 +}
 +.typography_textSize_small__fx8zm76 {
-+  --fontSize__z1t4tb0: var(--textSize-small-mobile-fontSize__9h6w0d3b);
-+  --lineHeight__z1t4tb1: var(--textSize-small-mobile-lineHeight__9h6w0d3c);
-+  --capHeightTrim__z1t4tb2: var(--textSize-small-mobile-capsizeTrims-capHeightTrim__9h6w0d3e);
-+  --baselineTrim__z1t4tb3: var(--textSize-small-mobile-capsizeTrims-baselineTrim__9h6w0d3f);
++  --fontSize__1x6fthg0: var(--textSize-small-mobile-fontSize__9h6w0d3b);
++  --lineHeight__1x6fthg1: var(--textSize-small-mobile-lineHeight__9h6w0d3c);
++  --capHeightTrim__1x6fthg2: var(--textSize-small-mobile-capsizeTrims-capHeightTrim__9h6w0d3e);
++  --baselineTrim__1x6fthg3: var(--textSize-small-mobile-capsizeTrims-baselineTrim__9h6w0d3f);
 +}
 +.typography_textSize_standard__fx8zm78 {
-+  --fontSize__z1t4tb0: var(--textSize-standard-mobile-fontSize__9h6w0d3l);
-+  --lineHeight__z1t4tb1: var(--textSize-standard-mobile-lineHeight__9h6w0d3m);
-+  --capHeightTrim__z1t4tb2: var(--textSize-standard-mobile-capsizeTrims-capHeightTrim__9h6w0d3o);
-+  --baselineTrim__z1t4tb3: var(--textSize-standard-mobile-capsizeTrims-baselineTrim__9h6w0d3p);
++  --fontSize__1x6fthg0: var(--textSize-standard-mobile-fontSize__9h6w0d3l);
++  --lineHeight__1x6fthg1: var(--textSize-standard-mobile-lineHeight__9h6w0d3m);
++  --capHeightTrim__1x6fthg2: var(--textSize-standard-mobile-capsizeTrims-capHeightTrim__9h6w0d3o);
++  --baselineTrim__1x6fthg3: var(--textSize-standard-mobile-capsizeTrims-baselineTrim__9h6w0d3p);
 +}
 +.typography_textSize_large__fx8zm7a {
-+  --fontSize__z1t4tb0: var(--textSize-large-mobile-fontSize__9h6w0d3v);
-+  --lineHeight__z1t4tb1: var(--textSize-large-mobile-lineHeight__9h6w0d3w);
-+  --capHeightTrim__z1t4tb2: var(--textSize-large-mobile-capsizeTrims-capHeightTrim__9h6w0d3y);
-+  --baselineTrim__z1t4tb3: var(--textSize-large-mobile-capsizeTrims-baselineTrim__9h6w0d3z);
++  --fontSize__1x6fthg0: var(--textSize-large-mobile-fontSize__9h6w0d3v);
++  --lineHeight__1x6fthg1: var(--textSize-large-mobile-lineHeight__9h6w0d3w);
++  --capHeightTrim__1x6fthg2: var(--textSize-large-mobile-capsizeTrims-capHeightTrim__9h6w0d3y);
++  --baselineTrim__1x6fthg3: var(--textSize-large-mobile-capsizeTrims-baselineTrim__9h6w0d3z);
 +}
 +.typography_textSizeUntrimmed_xsmall__fx8zm7c {
 +  font-size: var(--textSize-xsmall-mobile-fontSize__9h6w0d31);
@@ -5408,28 +5403,28 @@ exports[`braid-design-system > bundler vite > start > should return development 
 +  font-weight: var(--headingWeight-regular__9h6w0d5d);
 +}
 +.typography_heading_1__fx8zm7i {
-+  --fontSize__z1t4tb0: var(--headingLevel-1-mobile-fontSize__9h6w0d48);
-+  --lineHeight__z1t4tb1: var(--headingLevel-1-mobile-lineHeight__9h6w0d49);
-+  --capHeightTrim__z1t4tb2: var(--headingLevel-1-mobile-capsizeTrims-capHeightTrim__9h6w0d4b);
-+  --baselineTrim__z1t4tb3: var(--headingLevel-1-mobile-capsizeTrims-baselineTrim__9h6w0d4c);
++  --fontSize__1x6fthg0: var(--headingLevel-1-mobile-fontSize__9h6w0d48);
++  --lineHeight__1x6fthg1: var(--headingLevel-1-mobile-lineHeight__9h6w0d49);
++  --capHeightTrim__1x6fthg2: var(--headingLevel-1-mobile-capsizeTrims-capHeightTrim__9h6w0d4b);
++  --baselineTrim__1x6fthg3: var(--headingLevel-1-mobile-capsizeTrims-baselineTrim__9h6w0d4c);
 +}
 +.typography_heading_2__fx8zm7k {
-+  --fontSize__z1t4tb0: var(--headingLevel-2-mobile-fontSize__9h6w0d4i);
-+  --lineHeight__z1t4tb1: var(--headingLevel-2-mobile-lineHeight__9h6w0d4j);
-+  --capHeightTrim__z1t4tb2: var(--headingLevel-2-mobile-capsizeTrims-capHeightTrim__9h6w0d4l);
-+  --baselineTrim__z1t4tb3: var(--headingLevel-2-mobile-capsizeTrims-baselineTrim__9h6w0d4m);
++  --fontSize__1x6fthg0: var(--headingLevel-2-mobile-fontSize__9h6w0d4i);
++  --lineHeight__1x6fthg1: var(--headingLevel-2-mobile-lineHeight__9h6w0d4j);
++  --capHeightTrim__1x6fthg2: var(--headingLevel-2-mobile-capsizeTrims-capHeightTrim__9h6w0d4l);
++  --baselineTrim__1x6fthg3: var(--headingLevel-2-mobile-capsizeTrims-baselineTrim__9h6w0d4m);
 +}
 +.typography_heading_3__fx8zm7m {
-+  --fontSize__z1t4tb0: var(--headingLevel-3-mobile-fontSize__9h6w0d4s);
-+  --lineHeight__z1t4tb1: var(--headingLevel-3-mobile-lineHeight__9h6w0d4t);
-+  --capHeightTrim__z1t4tb2: var(--headingLevel-3-mobile-capsizeTrims-capHeightTrim__9h6w0d4v);
-+  --baselineTrim__z1t4tb3: var(--headingLevel-3-mobile-capsizeTrims-baselineTrim__9h6w0d4w);
++  --fontSize__1x6fthg0: var(--headingLevel-3-mobile-fontSize__9h6w0d4s);
++  --lineHeight__1x6fthg1: var(--headingLevel-3-mobile-lineHeight__9h6w0d4t);
++  --capHeightTrim__1x6fthg2: var(--headingLevel-3-mobile-capsizeTrims-capHeightTrim__9h6w0d4v);
++  --baselineTrim__1x6fthg3: var(--headingLevel-3-mobile-capsizeTrims-baselineTrim__9h6w0d4w);
 +}
 +.typography_heading_4__fx8zm7o {
-+  --fontSize__z1t4tb0: var(--headingLevel-4-mobile-fontSize__9h6w0d52);
-+  --lineHeight__z1t4tb1: var(--headingLevel-4-mobile-lineHeight__9h6w0d53);
-+  --capHeightTrim__z1t4tb2: var(--headingLevel-4-mobile-capsizeTrims-capHeightTrim__9h6w0d55);
-+  --baselineTrim__z1t4tb3: var(--headingLevel-4-mobile-capsizeTrims-baselineTrim__9h6w0d56);
++  --fontSize__1x6fthg0: var(--headingLevel-4-mobile-fontSize__9h6w0d52);
++  --lineHeight__1x6fthg1: var(--headingLevel-4-mobile-lineHeight__9h6w0d53);
++  --capHeightTrim__1x6fthg2: var(--headingLevel-4-mobile-capsizeTrims-capHeightTrim__9h6w0d55);
++  --baselineTrim__1x6fthg3: var(--headingLevel-4-mobile-capsizeTrims-baselineTrim__9h6w0d56);
 +}
 +html:not(.sprinkles_darkMode__r2i18210) .typography_lightModeTone_light__fx8zm710 {
 +  --critical__fx8zm7q: var(--foregroundColor-critical__9h6w0d19);
@@ -5581,28 +5576,28 @@ exports[`braid-design-system > bundler vite > start > should return development 
 +}
 +@media screen and (min-width: 740px) {
 +  .typography_textSize_xsmall__fx8zm74 {
-+    --fontSize__z1t4tb0: var(--textSize-xsmall-tablet-fontSize__9h6w0d36);
-+    --lineHeight__z1t4tb1: var(--textSize-xsmall-tablet-lineHeight__9h6w0d37);
-+    --capHeightTrim__z1t4tb2: var(--textSize-xsmall-tablet-capsizeTrims-capHeightTrim__9h6w0d39);
-+    --baselineTrim__z1t4tb3: var(--textSize-xsmall-tablet-capsizeTrims-baselineTrim__9h6w0d3a);
++    --fontSize__1x6fthg0: var(--textSize-xsmall-tablet-fontSize__9h6w0d36);
++    --lineHeight__1x6fthg1: var(--textSize-xsmall-tablet-lineHeight__9h6w0d37);
++    --capHeightTrim__1x6fthg2: var(--textSize-xsmall-tablet-capsizeTrims-capHeightTrim__9h6w0d39);
++    --baselineTrim__1x6fthg3: var(--textSize-xsmall-tablet-capsizeTrims-baselineTrim__9h6w0d3a);
 +  }
 +  .typography_textSize_small__fx8zm76 {
-+    --fontSize__z1t4tb0: var(--textSize-small-tablet-fontSize__9h6w0d3g);
-+    --lineHeight__z1t4tb1: var(--textSize-small-tablet-lineHeight__9h6w0d3h);
-+    --capHeightTrim__z1t4tb2: var(--textSize-small-tablet-capsizeTrims-capHeightTrim__9h6w0d3j);
-+    --baselineTrim__z1t4tb3: var(--textSize-small-tablet-capsizeTrims-baselineTrim__9h6w0d3k);
++    --fontSize__1x6fthg0: var(--textSize-small-tablet-fontSize__9h6w0d3g);
++    --lineHeight__1x6fthg1: var(--textSize-small-tablet-lineHeight__9h6w0d3h);
++    --capHeightTrim__1x6fthg2: var(--textSize-small-tablet-capsizeTrims-capHeightTrim__9h6w0d3j);
++    --baselineTrim__1x6fthg3: var(--textSize-small-tablet-capsizeTrims-baselineTrim__9h6w0d3k);
 +  }
 +  .typography_textSize_standard__fx8zm78 {
-+    --fontSize__z1t4tb0: var(--textSize-standard-tablet-fontSize__9h6w0d3q);
-+    --lineHeight__z1t4tb1: var(--textSize-standard-tablet-lineHeight__9h6w0d3r);
-+    --capHeightTrim__z1t4tb2: var(--textSize-standard-tablet-capsizeTrims-capHeightTrim__9h6w0d3t);
-+    --baselineTrim__z1t4tb3: var(--textSize-standard-tablet-capsizeTrims-baselineTrim__9h6w0d3u);
++    --fontSize__1x6fthg0: var(--textSize-standard-tablet-fontSize__9h6w0d3q);
++    --lineHeight__1x6fthg1: var(--textSize-standard-tablet-lineHeight__9h6w0d3r);
++    --capHeightTrim__1x6fthg2: var(--textSize-standard-tablet-capsizeTrims-capHeightTrim__9h6w0d3t);
++    --baselineTrim__1x6fthg3: var(--textSize-standard-tablet-capsizeTrims-baselineTrim__9h6w0d3u);
 +  }
 +  .typography_textSize_large__fx8zm7a {
-+    --fontSize__z1t4tb0: var(--textSize-large-tablet-fontSize__9h6w0d40);
-+    --lineHeight__z1t4tb1: var(--textSize-large-tablet-lineHeight__9h6w0d41);
-+    --capHeightTrim__z1t4tb2: var(--textSize-large-tablet-capsizeTrims-capHeightTrim__9h6w0d43);
-+    --baselineTrim__z1t4tb3: var(--textSize-large-tablet-capsizeTrims-baselineTrim__9h6w0d44);
++    --fontSize__1x6fthg0: var(--textSize-large-tablet-fontSize__9h6w0d40);
++    --lineHeight__1x6fthg1: var(--textSize-large-tablet-lineHeight__9h6w0d41);
++    --capHeightTrim__1x6fthg2: var(--textSize-large-tablet-capsizeTrims-capHeightTrim__9h6w0d43);
++    --baselineTrim__1x6fthg3: var(--textSize-large-tablet-capsizeTrims-baselineTrim__9h6w0d44);
 +  }
 +  .typography_textSizeUntrimmed_xsmall__fx8zm7c {
 +    font-size: var(--textSize-xsmall-tablet-fontSize__9h6w0d36);
@@ -5621,28 +5616,28 @@ exports[`braid-design-system > bundler vite > start > should return development 
 +    line-height: var(--textSize-large-tablet-lineHeight__9h6w0d41);
 +  }
 +  .typography_heading_1__fx8zm7i {
-+    --fontSize__z1t4tb0: var(--headingLevel-1-tablet-fontSize__9h6w0d4d);
-+    --lineHeight__z1t4tb1: var(--headingLevel-1-tablet-lineHeight__9h6w0d4e);
-+    --capHeightTrim__z1t4tb2: var(--headingLevel-1-tablet-capsizeTrims-capHeightTrim__9h6w0d4g);
-+    --baselineTrim__z1t4tb3: var(--headingLevel-1-tablet-capsizeTrims-baselineTrim__9h6w0d4h);
++    --fontSize__1x6fthg0: var(--headingLevel-1-tablet-fontSize__9h6w0d4d);
++    --lineHeight__1x6fthg1: var(--headingLevel-1-tablet-lineHeight__9h6w0d4e);
++    --capHeightTrim__1x6fthg2: var(--headingLevel-1-tablet-capsizeTrims-capHeightTrim__9h6w0d4g);
++    --baselineTrim__1x6fthg3: var(--headingLevel-1-tablet-capsizeTrims-baselineTrim__9h6w0d4h);
 +  }
 +  .typography_heading_2__fx8zm7k {
-+    --fontSize__z1t4tb0: var(--headingLevel-2-tablet-fontSize__9h6w0d4n);
-+    --lineHeight__z1t4tb1: var(--headingLevel-2-tablet-lineHeight__9h6w0d4o);
-+    --capHeightTrim__z1t4tb2: var(--headingLevel-2-tablet-capsizeTrims-capHeightTrim__9h6w0d4q);
-+    --baselineTrim__z1t4tb3: var(--headingLevel-2-tablet-capsizeTrims-baselineTrim__9h6w0d4r);
++    --fontSize__1x6fthg0: var(--headingLevel-2-tablet-fontSize__9h6w0d4n);
++    --lineHeight__1x6fthg1: var(--headingLevel-2-tablet-lineHeight__9h6w0d4o);
++    --capHeightTrim__1x6fthg2: var(--headingLevel-2-tablet-capsizeTrims-capHeightTrim__9h6w0d4q);
++    --baselineTrim__1x6fthg3: var(--headingLevel-2-tablet-capsizeTrims-baselineTrim__9h6w0d4r);
 +  }
 +  .typography_heading_3__fx8zm7m {
-+    --fontSize__z1t4tb0: var(--headingLevel-3-tablet-fontSize__9h6w0d4x);
-+    --lineHeight__z1t4tb1: var(--headingLevel-3-tablet-lineHeight__9h6w0d4y);
-+    --capHeightTrim__z1t4tb2: var(--headingLevel-3-tablet-capsizeTrims-capHeightTrim__9h6w0d50);
-+    --baselineTrim__z1t4tb3: var(--headingLevel-3-tablet-capsizeTrims-baselineTrim__9h6w0d51);
++    --fontSize__1x6fthg0: var(--headingLevel-3-tablet-fontSize__9h6w0d4x);
++    --lineHeight__1x6fthg1: var(--headingLevel-3-tablet-lineHeight__9h6w0d4y);
++    --capHeightTrim__1x6fthg2: var(--headingLevel-3-tablet-capsizeTrims-capHeightTrim__9h6w0d50);
++    --baselineTrim__1x6fthg3: var(--headingLevel-3-tablet-capsizeTrims-baselineTrim__9h6w0d51);
 +  }
 +  .typography_heading_4__fx8zm7o {
-+    --fontSize__z1t4tb0: var(--headingLevel-4-tablet-fontSize__9h6w0d57);
-+    --lineHeight__z1t4tb1: var(--headingLevel-4-tablet-lineHeight__9h6w0d58);
-+    --capHeightTrim__z1t4tb2: var(--headingLevel-4-tablet-capsizeTrims-capHeightTrim__9h6w0d5a);
-+    --baselineTrim__z1t4tb3: var(--headingLevel-4-tablet-capsizeTrims-baselineTrim__9h6w0d5b);
++    --fontSize__1x6fthg0: var(--headingLevel-4-tablet-fontSize__9h6w0d57);
++    --lineHeight__1x6fthg1: var(--headingLevel-4-tablet-lineHeight__9h6w0d58);
++    --capHeightTrim__1x6fthg2: var(--headingLevel-4-tablet-capsizeTrims-capHeightTrim__9h6w0d5a);
++    --baselineTrim__1x6fthg3: var(--headingLevel-4-tablet-capsizeTrims-baselineTrim__9h6w0d5b);
 +  }
 +  .typography_touchableText_xsmall__fx8zm71w {
 +    padding-top: calc((var(--touchableSize__9h6w0d9) - var(--textSize-xsmall-tablet-lineHeight__9h6w0d37)) / 2);
@@ -8119,11 +8114,6 @@ exports[`braid-design-system > bundler vite > start > should return development 
 +    </style>
 +    <style
 +      type="text/css"
-+      data-vite-dev-id="{cwd}/fixtures/braid-design-system/src/vars.css.ts.vanilla.css"
-+    >
-+    </style>
-+    <style
-+      type="text/css"
 +      data-vite-dev-id="{cwd}/fixtures/braid-design-system/src/App.css.ts.vanilla.css"
 +    >
 +      .App_vanillaBox__inn18b0 {
@@ -8142,7 +8132,7 @@ exports[`braid-design-system > bundler vite > start > should return development 
              html.sprinkles_darkMode__r2i18210,html.sprinkles_darkMode__r2i18210 body{color-scheme:dark;background:#1C2330}
        </style>
        <div class="seekJobs_seekJobs__ylnqo70 typography_lightModeTone_light__fx8zm710 typography_darkModeTone_dark__fx8zm713">
-         <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSizeTrimmed_standard__fx8zm79 typography_textSize_standard__fx8zm78 capsize_capsizeStyle__z1t4tb4">
+         <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSizeTrimmed_standard__fx8zm79 typography_textSize_standard__fx8zm78 capsize_capsizeStyle__1x6fthg4">
            Hello
            jobStreet
            <span class="reset_base__19azws30 sprinkles_display_inlineBlock_mobile__r2i18255">
@@ -8255,7 +8245,7 @@ exports[`braid-design-system > bundler vite > start > should return development 
                      class="reset_base__19azws30 sprinkles_userSelect_none__r2i1824 sprinkles_display_block_mobile__r2i1824x sprinkles_cursor_pointer__r2i182h virtualTouchable_virtualTouchable__9kzhon0"
                      for="id_1"
                    >
-                     <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSizeTrimmed_standard__fx8zm79 typography_textSize_standard__fx8zm78 capsize_capsizeStyle__z1t4tb4">
+                     <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSizeTrimmed_standard__fx8zm79 typography_textSize_standard__fx8zm78 capsize_capsizeStyle__1x6fthg4">
                        This is a checkbox
                      </span>
                    </label>
@@ -8291,7 +8281,7 @@ exports[`braid-design-system > bundler vite > start > should return development 
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-@@ -1,198 +1,5103 @@
+@@ -1,198 +1,5093 @@
  <!DOCTYPE html>
  <html>
    <head>
@@ -10437,25 +10427,20 @@ exports[`braid-design-system > bundler vite > start > should return development 
 +    </style>
 +    <style
 +      type="text/css"
-+      data-vite-dev-id="{cwd}/node_modules/braid-design-system/dist/lib/themes/vars.css.mjs.vanilla.css"
-+    >
-+    </style>
-+    <style
-+      type="text/css"
 +      data-vite-dev-id="{cwd}/node_modules/@capsizecss/vanilla-extract/dist/capsize.css.mjs.vanilla.css"
 +    >
-+      .capsize_capsizeStyle__z1t4tb4 {
-+  font-size: var(--fontSize__z1t4tb0);
-+  line-height: var(--lineHeight__z1t4tb1);
++      .capsize_capsizeStyle__1x6fthg4 {
++  font-size: var(--fontSize__1x6fthg0);
++  line-height: var(--lineHeight__1x6fthg1);
 +}
-+.capsize_capsizeStyle__z1t4tb4::before {
++.capsize_capsizeStyle__1x6fthg4::before {
 +  content: '';
-+  margin-bottom: var(--capHeightTrim__z1t4tb2);
++  margin-bottom: var(--capHeightTrim__1x6fthg2);
 +  display: table;
 +}
-+.capsize_capsizeStyle__z1t4tb4::after {
++.capsize_capsizeStyle__1x6fthg4::after {
 +  content: '';
-+  margin-top: var(--baselineTrim__z1t4tb3);
++  margin-top: var(--baselineTrim__1x6fthg3);
 +  display: table;
 +}
 +    </style>
@@ -10476,28 +10461,28 @@ exports[`braid-design-system > bundler vite > start > should return development 
 +  font-weight: var(--textWeight-strong__9h6w0d47);
 +}
 +.typography_textSize_xsmall__fx8zm74 {
-+  --fontSize__z1t4tb0: var(--textSize-xsmall-mobile-fontSize__9h6w0d31);
-+  --lineHeight__z1t4tb1: var(--textSize-xsmall-mobile-lineHeight__9h6w0d32);
-+  --capHeightTrim__z1t4tb2: var(--textSize-xsmall-mobile-capsizeTrims-capHeightTrim__9h6w0d34);
-+  --baselineTrim__z1t4tb3: var(--textSize-xsmall-mobile-capsizeTrims-baselineTrim__9h6w0d35);
++  --fontSize__1x6fthg0: var(--textSize-xsmall-mobile-fontSize__9h6w0d31);
++  --lineHeight__1x6fthg1: var(--textSize-xsmall-mobile-lineHeight__9h6w0d32);
++  --capHeightTrim__1x6fthg2: var(--textSize-xsmall-mobile-capsizeTrims-capHeightTrim__9h6w0d34);
++  --baselineTrim__1x6fthg3: var(--textSize-xsmall-mobile-capsizeTrims-baselineTrim__9h6w0d35);
 +}
 +.typography_textSize_small__fx8zm76 {
-+  --fontSize__z1t4tb0: var(--textSize-small-mobile-fontSize__9h6w0d3b);
-+  --lineHeight__z1t4tb1: var(--textSize-small-mobile-lineHeight__9h6w0d3c);
-+  --capHeightTrim__z1t4tb2: var(--textSize-small-mobile-capsizeTrims-capHeightTrim__9h6w0d3e);
-+  --baselineTrim__z1t4tb3: var(--textSize-small-mobile-capsizeTrims-baselineTrim__9h6w0d3f);
++  --fontSize__1x6fthg0: var(--textSize-small-mobile-fontSize__9h6w0d3b);
++  --lineHeight__1x6fthg1: var(--textSize-small-mobile-lineHeight__9h6w0d3c);
++  --capHeightTrim__1x6fthg2: var(--textSize-small-mobile-capsizeTrims-capHeightTrim__9h6w0d3e);
++  --baselineTrim__1x6fthg3: var(--textSize-small-mobile-capsizeTrims-baselineTrim__9h6w0d3f);
 +}
 +.typography_textSize_standard__fx8zm78 {
-+  --fontSize__z1t4tb0: var(--textSize-standard-mobile-fontSize__9h6w0d3l);
-+  --lineHeight__z1t4tb1: var(--textSize-standard-mobile-lineHeight__9h6w0d3m);
-+  --capHeightTrim__z1t4tb2: var(--textSize-standard-mobile-capsizeTrims-capHeightTrim__9h6w0d3o);
-+  --baselineTrim__z1t4tb3: var(--textSize-standard-mobile-capsizeTrims-baselineTrim__9h6w0d3p);
++  --fontSize__1x6fthg0: var(--textSize-standard-mobile-fontSize__9h6w0d3l);
++  --lineHeight__1x6fthg1: var(--textSize-standard-mobile-lineHeight__9h6w0d3m);
++  --capHeightTrim__1x6fthg2: var(--textSize-standard-mobile-capsizeTrims-capHeightTrim__9h6w0d3o);
++  --baselineTrim__1x6fthg3: var(--textSize-standard-mobile-capsizeTrims-baselineTrim__9h6w0d3p);
 +}
 +.typography_textSize_large__fx8zm7a {
-+  --fontSize__z1t4tb0: var(--textSize-large-mobile-fontSize__9h6w0d3v);
-+  --lineHeight__z1t4tb1: var(--textSize-large-mobile-lineHeight__9h6w0d3w);
-+  --capHeightTrim__z1t4tb2: var(--textSize-large-mobile-capsizeTrims-capHeightTrim__9h6w0d3y);
-+  --baselineTrim__z1t4tb3: var(--textSize-large-mobile-capsizeTrims-baselineTrim__9h6w0d3z);
++  --fontSize__1x6fthg0: var(--textSize-large-mobile-fontSize__9h6w0d3v);
++  --lineHeight__1x6fthg1: var(--textSize-large-mobile-lineHeight__9h6w0d3w);
++  --capHeightTrim__1x6fthg2: var(--textSize-large-mobile-capsizeTrims-capHeightTrim__9h6w0d3y);
++  --baselineTrim__1x6fthg3: var(--textSize-large-mobile-capsizeTrims-baselineTrim__9h6w0d3z);
 +}
 +.typography_textSizeUntrimmed_xsmall__fx8zm7c {
 +  font-size: var(--textSize-xsmall-mobile-fontSize__9h6w0d31);
@@ -10522,28 +10507,28 @@ exports[`braid-design-system > bundler vite > start > should return development 
 +  font-weight: var(--headingWeight-regular__9h6w0d5d);
 +}
 +.typography_heading_1__fx8zm7i {
-+  --fontSize__z1t4tb0: var(--headingLevel-1-mobile-fontSize__9h6w0d48);
-+  --lineHeight__z1t4tb1: var(--headingLevel-1-mobile-lineHeight__9h6w0d49);
-+  --capHeightTrim__z1t4tb2: var(--headingLevel-1-mobile-capsizeTrims-capHeightTrim__9h6w0d4b);
-+  --baselineTrim__z1t4tb3: var(--headingLevel-1-mobile-capsizeTrims-baselineTrim__9h6w0d4c);
++  --fontSize__1x6fthg0: var(--headingLevel-1-mobile-fontSize__9h6w0d48);
++  --lineHeight__1x6fthg1: var(--headingLevel-1-mobile-lineHeight__9h6w0d49);
++  --capHeightTrim__1x6fthg2: var(--headingLevel-1-mobile-capsizeTrims-capHeightTrim__9h6w0d4b);
++  --baselineTrim__1x6fthg3: var(--headingLevel-1-mobile-capsizeTrims-baselineTrim__9h6w0d4c);
 +}
 +.typography_heading_2__fx8zm7k {
-+  --fontSize__z1t4tb0: var(--headingLevel-2-mobile-fontSize__9h6w0d4i);
-+  --lineHeight__z1t4tb1: var(--headingLevel-2-mobile-lineHeight__9h6w0d4j);
-+  --capHeightTrim__z1t4tb2: var(--headingLevel-2-mobile-capsizeTrims-capHeightTrim__9h6w0d4l);
-+  --baselineTrim__z1t4tb3: var(--headingLevel-2-mobile-capsizeTrims-baselineTrim__9h6w0d4m);
++  --fontSize__1x6fthg0: var(--headingLevel-2-mobile-fontSize__9h6w0d4i);
++  --lineHeight__1x6fthg1: var(--headingLevel-2-mobile-lineHeight__9h6w0d4j);
++  --capHeightTrim__1x6fthg2: var(--headingLevel-2-mobile-capsizeTrims-capHeightTrim__9h6w0d4l);
++  --baselineTrim__1x6fthg3: var(--headingLevel-2-mobile-capsizeTrims-baselineTrim__9h6w0d4m);
 +}
 +.typography_heading_3__fx8zm7m {
-+  --fontSize__z1t4tb0: var(--headingLevel-3-mobile-fontSize__9h6w0d4s);
-+  --lineHeight__z1t4tb1: var(--headingLevel-3-mobile-lineHeight__9h6w0d4t);
-+  --capHeightTrim__z1t4tb2: var(--headingLevel-3-mobile-capsizeTrims-capHeightTrim__9h6w0d4v);
-+  --baselineTrim__z1t4tb3: var(--headingLevel-3-mobile-capsizeTrims-baselineTrim__9h6w0d4w);
++  --fontSize__1x6fthg0: var(--headingLevel-3-mobile-fontSize__9h6w0d4s);
++  --lineHeight__1x6fthg1: var(--headingLevel-3-mobile-lineHeight__9h6w0d4t);
++  --capHeightTrim__1x6fthg2: var(--headingLevel-3-mobile-capsizeTrims-capHeightTrim__9h6w0d4v);
++  --baselineTrim__1x6fthg3: var(--headingLevel-3-mobile-capsizeTrims-baselineTrim__9h6w0d4w);
 +}
 +.typography_heading_4__fx8zm7o {
-+  --fontSize__z1t4tb0: var(--headingLevel-4-mobile-fontSize__9h6w0d52);
-+  --lineHeight__z1t4tb1: var(--headingLevel-4-mobile-lineHeight__9h6w0d53);
-+  --capHeightTrim__z1t4tb2: var(--headingLevel-4-mobile-capsizeTrims-capHeightTrim__9h6w0d55);
-+  --baselineTrim__z1t4tb3: var(--headingLevel-4-mobile-capsizeTrims-baselineTrim__9h6w0d56);
++  --fontSize__1x6fthg0: var(--headingLevel-4-mobile-fontSize__9h6w0d52);
++  --lineHeight__1x6fthg1: var(--headingLevel-4-mobile-lineHeight__9h6w0d53);
++  --capHeightTrim__1x6fthg2: var(--headingLevel-4-mobile-capsizeTrims-capHeightTrim__9h6w0d55);
++  --baselineTrim__1x6fthg3: var(--headingLevel-4-mobile-capsizeTrims-baselineTrim__9h6w0d56);
 +}
 +html:not(.sprinkles_darkMode__r2i18210) .typography_lightModeTone_light__fx8zm710 {
 +  --critical__fx8zm7q: var(--foregroundColor-critical__9h6w0d19);
@@ -10695,28 +10680,28 @@ exports[`braid-design-system > bundler vite > start > should return development 
 +}
 +@media screen and (min-width: 740px) {
 +  .typography_textSize_xsmall__fx8zm74 {
-+    --fontSize__z1t4tb0: var(--textSize-xsmall-tablet-fontSize__9h6w0d36);
-+    --lineHeight__z1t4tb1: var(--textSize-xsmall-tablet-lineHeight__9h6w0d37);
-+    --capHeightTrim__z1t4tb2: var(--textSize-xsmall-tablet-capsizeTrims-capHeightTrim__9h6w0d39);
-+    --baselineTrim__z1t4tb3: var(--textSize-xsmall-tablet-capsizeTrims-baselineTrim__9h6w0d3a);
++    --fontSize__1x6fthg0: var(--textSize-xsmall-tablet-fontSize__9h6w0d36);
++    --lineHeight__1x6fthg1: var(--textSize-xsmall-tablet-lineHeight__9h6w0d37);
++    --capHeightTrim__1x6fthg2: var(--textSize-xsmall-tablet-capsizeTrims-capHeightTrim__9h6w0d39);
++    --baselineTrim__1x6fthg3: var(--textSize-xsmall-tablet-capsizeTrims-baselineTrim__9h6w0d3a);
 +  }
 +  .typography_textSize_small__fx8zm76 {
-+    --fontSize__z1t4tb0: var(--textSize-small-tablet-fontSize__9h6w0d3g);
-+    --lineHeight__z1t4tb1: var(--textSize-small-tablet-lineHeight__9h6w0d3h);
-+    --capHeightTrim__z1t4tb2: var(--textSize-small-tablet-capsizeTrims-capHeightTrim__9h6w0d3j);
-+    --baselineTrim__z1t4tb3: var(--textSize-small-tablet-capsizeTrims-baselineTrim__9h6w0d3k);
++    --fontSize__1x6fthg0: var(--textSize-small-tablet-fontSize__9h6w0d3g);
++    --lineHeight__1x6fthg1: var(--textSize-small-tablet-lineHeight__9h6w0d3h);
++    --capHeightTrim__1x6fthg2: var(--textSize-small-tablet-capsizeTrims-capHeightTrim__9h6w0d3j);
++    --baselineTrim__1x6fthg3: var(--textSize-small-tablet-capsizeTrims-baselineTrim__9h6w0d3k);
 +  }
 +  .typography_textSize_standard__fx8zm78 {
-+    --fontSize__z1t4tb0: var(--textSize-standard-tablet-fontSize__9h6w0d3q);
-+    --lineHeight__z1t4tb1: var(--textSize-standard-tablet-lineHeight__9h6w0d3r);
-+    --capHeightTrim__z1t4tb2: var(--textSize-standard-tablet-capsizeTrims-capHeightTrim__9h6w0d3t);
-+    --baselineTrim__z1t4tb3: var(--textSize-standard-tablet-capsizeTrims-baselineTrim__9h6w0d3u);
++    --fontSize__1x6fthg0: var(--textSize-standard-tablet-fontSize__9h6w0d3q);
++    --lineHeight__1x6fthg1: var(--textSize-standard-tablet-lineHeight__9h6w0d3r);
++    --capHeightTrim__1x6fthg2: var(--textSize-standard-tablet-capsizeTrims-capHeightTrim__9h6w0d3t);
++    --baselineTrim__1x6fthg3: var(--textSize-standard-tablet-capsizeTrims-baselineTrim__9h6w0d3u);
 +  }
 +  .typography_textSize_large__fx8zm7a {
-+    --fontSize__z1t4tb0: var(--textSize-large-tablet-fontSize__9h6w0d40);
-+    --lineHeight__z1t4tb1: var(--textSize-large-tablet-lineHeight__9h6w0d41);
-+    --capHeightTrim__z1t4tb2: var(--textSize-large-tablet-capsizeTrims-capHeightTrim__9h6w0d43);
-+    --baselineTrim__z1t4tb3: var(--textSize-large-tablet-capsizeTrims-baselineTrim__9h6w0d44);
++    --fontSize__1x6fthg0: var(--textSize-large-tablet-fontSize__9h6w0d40);
++    --lineHeight__1x6fthg1: var(--textSize-large-tablet-lineHeight__9h6w0d41);
++    --capHeightTrim__1x6fthg2: var(--textSize-large-tablet-capsizeTrims-capHeightTrim__9h6w0d43);
++    --baselineTrim__1x6fthg3: var(--textSize-large-tablet-capsizeTrims-baselineTrim__9h6w0d44);
 +  }
 +  .typography_textSizeUntrimmed_xsmall__fx8zm7c {
 +    font-size: var(--textSize-xsmall-tablet-fontSize__9h6w0d36);
@@ -10735,28 +10720,28 @@ exports[`braid-design-system > bundler vite > start > should return development 
 +    line-height: var(--textSize-large-tablet-lineHeight__9h6w0d41);
 +  }
 +  .typography_heading_1__fx8zm7i {
-+    --fontSize__z1t4tb0: var(--headingLevel-1-tablet-fontSize__9h6w0d4d);
-+    --lineHeight__z1t4tb1: var(--headingLevel-1-tablet-lineHeight__9h6w0d4e);
-+    --capHeightTrim__z1t4tb2: var(--headingLevel-1-tablet-capsizeTrims-capHeightTrim__9h6w0d4g);
-+    --baselineTrim__z1t4tb3: var(--headingLevel-1-tablet-capsizeTrims-baselineTrim__9h6w0d4h);
++    --fontSize__1x6fthg0: var(--headingLevel-1-tablet-fontSize__9h6w0d4d);
++    --lineHeight__1x6fthg1: var(--headingLevel-1-tablet-lineHeight__9h6w0d4e);
++    --capHeightTrim__1x6fthg2: var(--headingLevel-1-tablet-capsizeTrims-capHeightTrim__9h6w0d4g);
++    --baselineTrim__1x6fthg3: var(--headingLevel-1-tablet-capsizeTrims-baselineTrim__9h6w0d4h);
 +  }
 +  .typography_heading_2__fx8zm7k {
-+    --fontSize__z1t4tb0: var(--headingLevel-2-tablet-fontSize__9h6w0d4n);
-+    --lineHeight__z1t4tb1: var(--headingLevel-2-tablet-lineHeight__9h6w0d4o);
-+    --capHeightTrim__z1t4tb2: var(--headingLevel-2-tablet-capsizeTrims-capHeightTrim__9h6w0d4q);
-+    --baselineTrim__z1t4tb3: var(--headingLevel-2-tablet-capsizeTrims-baselineTrim__9h6w0d4r);
++    --fontSize__1x6fthg0: var(--headingLevel-2-tablet-fontSize__9h6w0d4n);
++    --lineHeight__1x6fthg1: var(--headingLevel-2-tablet-lineHeight__9h6w0d4o);
++    --capHeightTrim__1x6fthg2: var(--headingLevel-2-tablet-capsizeTrims-capHeightTrim__9h6w0d4q);
++    --baselineTrim__1x6fthg3: var(--headingLevel-2-tablet-capsizeTrims-baselineTrim__9h6w0d4r);
 +  }
 +  .typography_heading_3__fx8zm7m {
-+    --fontSize__z1t4tb0: var(--headingLevel-3-tablet-fontSize__9h6w0d4x);
-+    --lineHeight__z1t4tb1: var(--headingLevel-3-tablet-lineHeight__9h6w0d4y);
-+    --capHeightTrim__z1t4tb2: var(--headingLevel-3-tablet-capsizeTrims-capHeightTrim__9h6w0d50);
-+    --baselineTrim__z1t4tb3: var(--headingLevel-3-tablet-capsizeTrims-baselineTrim__9h6w0d51);
++    --fontSize__1x6fthg0: var(--headingLevel-3-tablet-fontSize__9h6w0d4x);
++    --lineHeight__1x6fthg1: var(--headingLevel-3-tablet-lineHeight__9h6w0d4y);
++    --capHeightTrim__1x6fthg2: var(--headingLevel-3-tablet-capsizeTrims-capHeightTrim__9h6w0d50);
++    --baselineTrim__1x6fthg3: var(--headingLevel-3-tablet-capsizeTrims-baselineTrim__9h6w0d51);
 +  }
 +  .typography_heading_4__fx8zm7o {
-+    --fontSize__z1t4tb0: var(--headingLevel-4-tablet-fontSize__9h6w0d57);
-+    --lineHeight__z1t4tb1: var(--headingLevel-4-tablet-lineHeight__9h6w0d58);
-+    --capHeightTrim__z1t4tb2: var(--headingLevel-4-tablet-capsizeTrims-capHeightTrim__9h6w0d5a);
-+    --baselineTrim__z1t4tb3: var(--headingLevel-4-tablet-capsizeTrims-baselineTrim__9h6w0d5b);
++    --fontSize__1x6fthg0: var(--headingLevel-4-tablet-fontSize__9h6w0d57);
++    --lineHeight__1x6fthg1: var(--headingLevel-4-tablet-lineHeight__9h6w0d58);
++    --capHeightTrim__1x6fthg2: var(--headingLevel-4-tablet-capsizeTrims-capHeightTrim__9h6w0d5a);
++    --baselineTrim__1x6fthg3: var(--headingLevel-4-tablet-capsizeTrims-baselineTrim__9h6w0d5b);
 +  }
 +  .typography_touchableText_xsmall__fx8zm71w {
 +    padding-top: calc((var(--touchableSize__9h6w0d9) - var(--textSize-xsmall-tablet-lineHeight__9h6w0d37)) / 2);
@@ -13233,11 +13218,6 @@ exports[`braid-design-system > bundler vite > start > should return development 
 +    </style>
 +    <style
 +      type="text/css"
-+      data-vite-dev-id="{cwd}/fixtures/braid-design-system/src/vars.css.ts.vanilla.css"
-+    >
-+    </style>
-+    <style
-+      type="text/css"
 +      data-vite-dev-id="{cwd}/fixtures/braid-design-system/src/App.css.ts.vanilla.css"
 +    >
 +      .App_vanillaBox__inn18b0 {
@@ -13256,7 +13236,7 @@ exports[`braid-design-system > bundler vite > start > should return development 
              html.sprinkles_darkMode__r2i18210,html.sprinkles_darkMode__r2i18210 body{color-scheme:dark;background:#1C2330}
        </style>
        <div class="seekJobs_seekJobs__ylnqo70 typography_lightModeTone_light__fx8zm710 typography_darkModeTone_dark__fx8zm713">
-         <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSizeTrimmed_standard__fx8zm79 typography_textSize_standard__fx8zm78 capsize_capsizeStyle__z1t4tb4">
+         <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSizeTrimmed_standard__fx8zm79 typography_textSize_standard__fx8zm78 capsize_capsizeStyle__1x6fthg4">
            Hello
            seekAnz
            <span class="reset_base__19azws30 sprinkles_display_inlineBlock_mobile__r2i18255">
@@ -13369,7 +13349,7 @@ exports[`braid-design-system > bundler vite > start > should return development 
                      class="reset_base__19azws30 sprinkles_userSelect_none__r2i1824 sprinkles_display_block_mobile__r2i1824x sprinkles_cursor_pointer__r2i182h virtualTouchable_virtualTouchable__9kzhon0"
                      for="id_1"
                    >
-                     <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSizeTrimmed_standard__fx8zm79 typography_textSize_standard__fx8zm78 capsize_capsizeStyle__z1t4tb4">
+                     <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSizeTrimmed_standard__fx8zm79 typography_textSize_standard__fx8zm78 capsize_capsizeStyle__1x6fthg4">
                        This is a checkbox
                      </span>
                    </label>
@@ -13403,7 +13383,7 @@ exports[`braid-design-system > bundler vite > start > should return development 
 
 exports[`braid-design-system > bundler webpack > build > should generate the expected files 1`] = `
 {
-  "2-f89c63c35e9a744838a1.css": ._19azws30 {
+  "2-466afdb3eeda6ab3ca44.css": ._19azws30 {
   border: 0;
   box-sizing: border-box;
   font-size: 100%;
@@ -15352,19 +15332,19 @@ html:not(.r2i18210) .r2i1824r {
     text-align: right;
   }
 }
-.z1t4tb4 {
-  font-size: var(--z1t4tb0);
-  line-height: var(--z1t4tb1);
+._1x6fthg4 {
+  font-size: var(--_1x6fthg0);
+  line-height: var(--_1x6fthg1);
 }
-.z1t4tb4:before {
+._1x6fthg4:before {
   content: "";
   display: table;
-  margin-bottom: var(--z1t4tb2);
+  margin-bottom: var(--_1x6fthg2);
 }
-.z1t4tb4:after {
+._1x6fthg4:after {
   content: "";
   display: table;
-  margin-top: var(--z1t4tb3);
+  margin-top: var(--_1x6fthg3);
 }
 .fx8zm70 {
   font-family: var(--_9h6w0d2v);
@@ -15379,28 +15359,28 @@ html:not(.r2i18210) .r2i1824r {
   font-weight: var(--_9h6w0d47);
 }
 .fx8zm74 {
-  --z1t4tb0: var(--_9h6w0d31);
-  --z1t4tb1: var(--_9h6w0d32);
-  --z1t4tb2: var(--_9h6w0d34);
-  --z1t4tb3: var(--_9h6w0d35);
+  --_1x6fthg0: var(--_9h6w0d31);
+  --_1x6fthg1: var(--_9h6w0d32);
+  --_1x6fthg2: var(--_9h6w0d34);
+  --_1x6fthg3: var(--_9h6w0d35);
 }
 .fx8zm76 {
-  --z1t4tb0: var(--_9h6w0d3b);
-  --z1t4tb1: var(--_9h6w0d3c);
-  --z1t4tb2: var(--_9h6w0d3e);
-  --z1t4tb3: var(--_9h6w0d3f);
+  --_1x6fthg0: var(--_9h6w0d3b);
+  --_1x6fthg1: var(--_9h6w0d3c);
+  --_1x6fthg2: var(--_9h6w0d3e);
+  --_1x6fthg3: var(--_9h6w0d3f);
 }
 .fx8zm78 {
-  --z1t4tb0: var(--_9h6w0d3l);
-  --z1t4tb1: var(--_9h6w0d3m);
-  --z1t4tb2: var(--_9h6w0d3o);
-  --z1t4tb3: var(--_9h6w0d3p);
+  --_1x6fthg0: var(--_9h6w0d3l);
+  --_1x6fthg1: var(--_9h6w0d3m);
+  --_1x6fthg2: var(--_9h6w0d3o);
+  --_1x6fthg3: var(--_9h6w0d3p);
 }
 .fx8zm7a {
-  --z1t4tb0: var(--_9h6w0d3v);
-  --z1t4tb1: var(--_9h6w0d3w);
-  --z1t4tb2: var(--_9h6w0d3y);
-  --z1t4tb3: var(--_9h6w0d3z);
+  --_1x6fthg0: var(--_9h6w0d3v);
+  --_1x6fthg1: var(--_9h6w0d3w);
+  --_1x6fthg2: var(--_9h6w0d3y);
+  --_1x6fthg3: var(--_9h6w0d3z);
 }
 .fx8zm7c {
   font-size: var(--_9h6w0d31);
@@ -15425,28 +15405,28 @@ html:not(.r2i18210) .r2i1824r {
   font-weight: var(--_9h6w0d5d);
 }
 .fx8zm7i {
-  --z1t4tb0: var(--_9h6w0d48);
-  --z1t4tb1: var(--_9h6w0d49);
-  --z1t4tb2: var(--_9h6w0d4b);
-  --z1t4tb3: var(--_9h6w0d4c);
+  --_1x6fthg0: var(--_9h6w0d48);
+  --_1x6fthg1: var(--_9h6w0d49);
+  --_1x6fthg2: var(--_9h6w0d4b);
+  --_1x6fthg3: var(--_9h6w0d4c);
 }
 .fx8zm7k {
-  --z1t4tb0: var(--_9h6w0d4i);
-  --z1t4tb1: var(--_9h6w0d4j);
-  --z1t4tb2: var(--_9h6w0d4l);
-  --z1t4tb3: var(--_9h6w0d4m);
+  --_1x6fthg0: var(--_9h6w0d4i);
+  --_1x6fthg1: var(--_9h6w0d4j);
+  --_1x6fthg2: var(--_9h6w0d4l);
+  --_1x6fthg3: var(--_9h6w0d4m);
 }
 .fx8zm7m {
-  --z1t4tb0: var(--_9h6w0d4s);
-  --z1t4tb1: var(--_9h6w0d4t);
-  --z1t4tb2: var(--_9h6w0d4v);
-  --z1t4tb3: var(--_9h6w0d4w);
+  --_1x6fthg0: var(--_9h6w0d4s);
+  --_1x6fthg1: var(--_9h6w0d4t);
+  --_1x6fthg2: var(--_9h6w0d4v);
+  --_1x6fthg3: var(--_9h6w0d4w);
 }
 .fx8zm7o {
-  --z1t4tb0: var(--_9h6w0d52);
-  --z1t4tb1: var(--_9h6w0d53);
-  --z1t4tb2: var(--_9h6w0d55);
-  --z1t4tb3: var(--_9h6w0d56);
+  --_1x6fthg0: var(--_9h6w0d52);
+  --_1x6fthg1: var(--_9h6w0d53);
+  --_1x6fthg2: var(--_9h6w0d55);
+  --_1x6fthg3: var(--_9h6w0d56);
 }
 html:not(.r2i18210) .fx8zm710 {
   --fx8zm7q: var(--_9h6w0d19);
@@ -15582,28 +15562,28 @@ html.r2i18210 .fx8zm71l {
 }
 @media screen and (min-width: 740px) {
   .fx8zm74 {
-    --z1t4tb0: var(--_9h6w0d36);
-    --z1t4tb1: var(--_9h6w0d37);
-    --z1t4tb2: var(--_9h6w0d39);
-    --z1t4tb3: var(--_9h6w0d3a);
+    --_1x6fthg0: var(--_9h6w0d36);
+    --_1x6fthg1: var(--_9h6w0d37);
+    --_1x6fthg2: var(--_9h6w0d39);
+    --_1x6fthg3: var(--_9h6w0d3a);
   }
   .fx8zm76 {
-    --z1t4tb0: var(--_9h6w0d3g);
-    --z1t4tb1: var(--_9h6w0d3h);
-    --z1t4tb2: var(--_9h6w0d3j);
-    --z1t4tb3: var(--_9h6w0d3k);
+    --_1x6fthg0: var(--_9h6w0d3g);
+    --_1x6fthg1: var(--_9h6w0d3h);
+    --_1x6fthg2: var(--_9h6w0d3j);
+    --_1x6fthg3: var(--_9h6w0d3k);
   }
   .fx8zm78 {
-    --z1t4tb0: var(--_9h6w0d3q);
-    --z1t4tb1: var(--_9h6w0d3r);
-    --z1t4tb2: var(--_9h6w0d3t);
-    --z1t4tb3: var(--_9h6w0d3u);
+    --_1x6fthg0: var(--_9h6w0d3q);
+    --_1x6fthg1: var(--_9h6w0d3r);
+    --_1x6fthg2: var(--_9h6w0d3t);
+    --_1x6fthg3: var(--_9h6w0d3u);
   }
   .fx8zm7a {
-    --z1t4tb0: var(--_9h6w0d40);
-    --z1t4tb1: var(--_9h6w0d41);
-    --z1t4tb2: var(--_9h6w0d43);
-    --z1t4tb3: var(--_9h6w0d44);
+    --_1x6fthg0: var(--_9h6w0d40);
+    --_1x6fthg1: var(--_9h6w0d41);
+    --_1x6fthg2: var(--_9h6w0d43);
+    --_1x6fthg3: var(--_9h6w0d44);
   }
   .fx8zm7c {
     font-size: var(--_9h6w0d36);
@@ -15622,28 +15602,28 @@ html.r2i18210 .fx8zm71l {
     line-height: var(--_9h6w0d41);
   }
   .fx8zm7i {
-    --z1t4tb0: var(--_9h6w0d4d);
-    --z1t4tb1: var(--_9h6w0d4e);
-    --z1t4tb2: var(--_9h6w0d4g);
-    --z1t4tb3: var(--_9h6w0d4h);
+    --_1x6fthg0: var(--_9h6w0d4d);
+    --_1x6fthg1: var(--_9h6w0d4e);
+    --_1x6fthg2: var(--_9h6w0d4g);
+    --_1x6fthg3: var(--_9h6w0d4h);
   }
   .fx8zm7k {
-    --z1t4tb0: var(--_9h6w0d4n);
-    --z1t4tb1: var(--_9h6w0d4o);
-    --z1t4tb2: var(--_9h6w0d4q);
-    --z1t4tb3: var(--_9h6w0d4r);
+    --_1x6fthg0: var(--_9h6w0d4n);
+    --_1x6fthg1: var(--_9h6w0d4o);
+    --_1x6fthg2: var(--_9h6w0d4q);
+    --_1x6fthg3: var(--_9h6w0d4r);
   }
   .fx8zm7m {
-    --z1t4tb0: var(--_9h6w0d4x);
-    --z1t4tb1: var(--_9h6w0d4y);
-    --z1t4tb2: var(--_9h6w0d50);
-    --z1t4tb3: var(--_9h6w0d51);
+    --_1x6fthg0: var(--_9h6w0d4x);
+    --_1x6fthg1: var(--_9h6w0d4y);
+    --_1x6fthg2: var(--_9h6w0d50);
+    --_1x6fthg3: var(--_9h6w0d51);
   }
   .fx8zm7o {
-    --z1t4tb0: var(--_9h6w0d57);
-    --z1t4tb1: var(--_9h6w0d58);
-    --z1t4tb2: var(--_9h6w0d5a);
-    --z1t4tb3: var(--_9h6w0d5b);
+    --_1x6fthg0: var(--_9h6w0d57);
+    --_1x6fthg1: var(--_9h6w0d58);
+    --_1x6fthg2: var(--_9h6w0d5a);
+    --_1x6fthg3: var(--_9h6w0d5b);
   }
   .fx8zm71w {
     padding-bottom: calc((var(--_9h6w0d9) - var(--_9h6w0d37)) / 2);
@@ -16155,9 +16135,9 @@ html.r2i18210 ._1hw07lgd {
   padding: 100px;
 }
 
-/*# sourceMappingURL=2-f89c63c35e9a744838a1.css.map*/
+/*# sourceMappingURL=2-466afdb3eeda6ab3ca44.css.map*/
 ,
-  "2-f89c63c35e9a744838a1.css.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "2-466afdb3eeda6ab3ca44.css.map": "CONTENTS IGNORED IN SNAPSHOT TEST",
   "externals.json": "[
   "async_hooks",
   "crypto",
@@ -16178,7 +16158,7 @@ html.r2i18210 ._1hw07lgd {
         <meta charset="UTF-8">
         <title>My Awesome Project</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link data-chunk="main" rel="stylesheet" href="/2-f89c63c35e9a744838a1.css">
+        <link data-chunk="main" rel="stylesheet" href="/2-466afdb3eeda6ab3ca44.css">
 <link data-chunk="main" rel="preload" as="script" href="/runtime.js">
 <link data-chunk="main" rel="preload" as="script" href="/main.js">
         <script>
@@ -16189,7 +16169,7 @@ html.r2i18210 ._1hw07lgd {
         <div id="app"><style type="text/css">
             html,body{margin:0;padding:0;background:#fff}
             html.r2i18210,html.r2i18210 body{color-scheme:dark;background:#1C2330}
-          </style><div class="ylnqo70 fx8zm710 fx8zm713"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 z1t4tb4">Hello <!-- -->jobStreet<!-- --> <span class="_19azws30 r2i18255"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 _716eoa0 r2i18255 r2i1825d _16185310 _16185312 _16185313 _16185314" aria-hidden="true"><path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z"></path></svg></span></span><div class="_19azws30 r2i1828p r2i1827l r2i182ax r2i1829t r2i1825d r2i18269 r2i182i9 r2i1824j r2i1824c fx8zm710 fx8zm713 r2i18233 r2i18236"><div class="_19azws30 r2i1825d"><div class="_19azws30 r2i18259 r2i182i9"><input class="_19azws30 _19azws31 _19azws36 _19azws37 _19azws38 _19azws3d r2i1825h r2i1828 r2i182h r2i1826 _1hw07lg4 _1hw07lg2" type="checkbox" id="id_1" aria-checked="false"/><div class="_19azws30 r2i182hx r2i1825d r2i18265 _1hw07lg5 _1hw07lg2 fx8zm710  r2i18233"><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lg9 fx8zm711 fx8zm713 r2i18221 r2i18222"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1823x r2i1823y"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 r2i1823p r2i1823u"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lgb r2i1823z r2i18244"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span></div><div class="_19azws30 r2i182b5 r2i182i5"><div class="_19azws30 r2i18259 _1hw07lg2 _1hw07lg6"><label class="_19azws30 r2i1824 r2i1824x r2i182h _9kzhon0" for="id_1"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 z1t4tb4">This is a checkbox</span></label></div></div></div></div></div><div class="_19azws30 inn18b0">🧁 Vanilla content <!-- -->Initial</div></div></div>
+          </style><div class="ylnqo70 fx8zm710 fx8zm713"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 _1x6fthg4">Hello <!-- -->jobStreet<!-- --> <span class="_19azws30 r2i18255"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 _716eoa0 r2i18255 r2i1825d _16185310 _16185312 _16185313 _16185314" aria-hidden="true"><path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z"></path></svg></span></span><div class="_19azws30 r2i1828p r2i1827l r2i182ax r2i1829t r2i1825d r2i18269 r2i182i9 r2i1824j r2i1824c fx8zm710 fx8zm713 r2i18233 r2i18236"><div class="_19azws30 r2i1825d"><div class="_19azws30 r2i18259 r2i182i9"><input class="_19azws30 _19azws31 _19azws36 _19azws37 _19azws38 _19azws3d r2i1825h r2i1828 r2i182h r2i1826 _1hw07lg4 _1hw07lg2" type="checkbox" id="id_1" aria-checked="false"/><div class="_19azws30 r2i182hx r2i1825d r2i18265 _1hw07lg5 _1hw07lg2 fx8zm710  r2i18233"><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lg9 fx8zm711 fx8zm713 r2i18221 r2i18222"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1823x r2i1823y"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 r2i1823p r2i1823u"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lgb r2i1823z r2i18244"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span></div><div class="_19azws30 r2i182b5 r2i182i5"><div class="_19azws30 r2i18259 _1hw07lg2 _1hw07lg6"><label class="_19azws30 r2i1824 r2i1824x r2i182h _9kzhon0" for="id_1"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 _1x6fthg4">This is a checkbox</span></label></div></div></div></div></div><div class="_19azws30 inn18b0">🧁 Vanilla content <!-- -->Initial</div></div></div>
         <script id="__SKU_CLIENT_CONTEXT__" type="application/json">{"site":"jobStreet"}</script>
 <script id="__LOADABLE_REQUIRED_CHUNKS__" type="application/json">[]</script><script id="__LOADABLE_REQUIRED_CHUNKS___ext" type="application/json">{"namedChunks":[]}</script>
 <script async data-chunk="main" src="/runtime.js"></script>
@@ -16208,7 +16188,7 @@ html.r2i18210 ._1hw07lgd {
         <meta charset="UTF-8">
         <title>My Awesome Project</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link data-chunk="main" rel="stylesheet" href="/2-f89c63c35e9a744838a1.css">
+        <link data-chunk="main" rel="stylesheet" href="/2-466afdb3eeda6ab3ca44.css">
 <link data-chunk="main" rel="preload" as="script" href="/runtime.js">
 <link data-chunk="main" rel="preload" as="script" href="/main.js">
         <script>
@@ -16219,7 +16199,7 @@ html.r2i18210 ._1hw07lgd {
         <div id="app"><style type="text/css">
             html,body{margin:0;padding:0;background:#fff}
             html.r2i18210,html.r2i18210 body{color-scheme:dark;background:#1C2330}
-          </style><div class="ylnqo70 fx8zm710 fx8zm713"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 z1t4tb4">Hello <!-- -->seekAnz<!-- --> <span class="_19azws30 r2i18255"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 _716eoa0 r2i18255 r2i1825d _16185310 _16185312 _16185313 _16185314" aria-hidden="true"><path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z"></path></svg></span></span><div class="_19azws30 r2i1828p r2i1827l r2i182ax r2i1829t r2i1825d r2i18269 r2i182i9 r2i1824j r2i1824c fx8zm710 fx8zm713 r2i18233 r2i18236"><div class="_19azws30 r2i1825d"><div class="_19azws30 r2i18259 r2i182i9"><input class="_19azws30 _19azws31 _19azws36 _19azws37 _19azws38 _19azws3d r2i1825h r2i1828 r2i182h r2i1826 _1hw07lg4 _1hw07lg2" type="checkbox" id="id_1" aria-checked="false"/><div class="_19azws30 r2i182hx r2i1825d r2i18265 _1hw07lg5 _1hw07lg2 fx8zm710  r2i18233"><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lg9 fx8zm711 fx8zm713 r2i18221 r2i18222"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1823x r2i1823y"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 r2i1823p r2i1823u"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lgb r2i1823z r2i18244"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span></div><div class="_19azws30 r2i182b5 r2i182i5"><div class="_19azws30 r2i18259 _1hw07lg2 _1hw07lg6"><label class="_19azws30 r2i1824 r2i1824x r2i182h _9kzhon0" for="id_1"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 z1t4tb4">This is a checkbox</span></label></div></div></div></div></div><div class="_19azws30 inn18b0">🧁 Vanilla content <!-- -->Initial</div></div></div>
+          </style><div class="ylnqo70 fx8zm710 fx8zm713"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 _1x6fthg4">Hello <!-- -->seekAnz<!-- --> <span class="_19azws30 r2i18255"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 _716eoa0 r2i18255 r2i1825d _16185310 _16185312 _16185313 _16185314" aria-hidden="true"><path d="M20.7 7.3c-.4-.4-1-.4-1.4 0L12 14.6 4.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l8 8c.2.2.5.3.7.3s.5-.1.7-.3l8-8c.4-.4.4-1 0-1.4z"></path></svg></span></span><div class="_19azws30 r2i1828p r2i1827l r2i182ax r2i1829t r2i1825d r2i18269 r2i182i9 r2i1824j r2i1824c fx8zm710 fx8zm713 r2i18233 r2i18236"><div class="_19azws30 r2i1825d"><div class="_19azws30 r2i18259 r2i182i9"><input class="_19azws30 _19azws31 _19azws36 _19azws37 _19azws38 _19azws3d r2i1825h r2i1828 r2i182h r2i1826 _1hw07lg4 _1hw07lg2" type="checkbox" id="id_1" aria-checked="false"/><div class="_19azws30 r2i182hx r2i1825d r2i18265 _1hw07lg5 _1hw07lg2 fx8zm710  r2i18233"><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lg9 fx8zm711 fx8zm713 r2i18221 r2i18222"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71t" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1823x r2i1823y"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 r2i1823p r2i1823u"></span><span class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182i r2i18265 r2i182x r2i1826 _1hw07lgb r2i1823z r2i18244"><div class="_19azws30 r2i182n r2i182x r2i1825d _1hw07lgc _1hw07lge"><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x r2i1826"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M18 11H6c-.6 0-1 .4-1 1s.4 1 1 1h12c.6 0 1-.4 1-1s-.4-1-1-1z"></path></svg></div><div class="_19azws30 r2i182j r2i182k r2i182l r2i182m r2i1825h r2i182x"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve" focusable="false" fill="currentColor" width="16" height="16" class="_19azws30 r2i182p r2i182n r2i1824x fx8zm71s" aria-hidden="true"><path d="M19.7 6.3c-.4-.4-1-.4-1.4 0L9 15.6l-3.3-3.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l4 4c.2.2.4.3.7.3s.5-.1.7-.3l10-10c.4-.4.4-1 0-1.4z"></path></svg></div></div></span></div><div class="_19azws30 r2i182b5 r2i182i5"><div class="_19azws30 r2i18259 _1hw07lg2 _1hw07lg6"><label class="_19azws30 r2i1824 r2i1824x r2i182h _9kzhon0" for="id_1"><span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 _1x6fthg4">This is a checkbox</span></label></div></div></div></div></div><div class="_19azws30 inn18b0">🧁 Vanilla content <!-- -->Initial</div></div></div>
         <script id="__SKU_CLIENT_CONTEXT__" type="application/json">{"site":"seekAnz"}</script>
 <script id="__LOADABLE_REQUIRED_CHUNKS__" type="application/json">[]</script><script id="__LOADABLE_REQUIRED_CHUNKS___ext" type="application/json">{"namedChunks":[]}</script>
 <script async data-chunk="main" src="/runtime.js"></script>
@@ -16249,7 +16229,7 @@ exports[`braid-design-system > bundler webpack > build > should return built job
      <link
        data-chunk="main"
        rel="stylesheet"
-       href="/2-f89c63c35e9a744838a1.css"
+       href="/2-466afdb3eeda6ab3ca44.css"
      >
      <link
        data-chunk="main"
@@ -16274,7 +16254,7 @@ exports[`braid-design-system > bundler webpack > build > should return built job
              html.r2i18210,html.r2i18210 body{color-scheme:dark;background:#1C2330}
        </style>
        <div class="ylnqo70 fx8zm710 fx8zm713">
-         <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 z1t4tb4">
+         <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 _1x6fthg4">
            Hello
            jobStreet
            <span class="_19azws30 r2i18255">
@@ -16387,7 +16367,7 @@ exports[`braid-design-system > bundler webpack > build > should return built job
                      class="_19azws30 r2i1824 r2i1824x r2i182h _9kzhon0"
                      for="id_1"
                    >
-                     <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 z1t4tb4">
+                     <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 _1x6fthg4">
                        This is a checkbox
                      </span>
                    </label>
@@ -16457,7 +16437,7 @@ exports[`braid-design-system > bundler webpack > build > should return built see
      <link
        data-chunk="main"
        rel="stylesheet"
-       href="/2-f89c63c35e9a744838a1.css"
+       href="/2-466afdb3eeda6ab3ca44.css"
      >
      <link
        data-chunk="main"
@@ -16482,7 +16462,7 @@ exports[`braid-design-system > bundler webpack > build > should return built see
              html.r2i18210,html.r2i18210 body{color-scheme:dark;background:#1C2330}
        </style>
        <div class="ylnqo70 fx8zm710 fx8zm713">
-         <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 z1t4tb4">
+         <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 _1x6fthg4">
            Hello
            seekAnz
            <span class="_19azws30 r2i18255">
@@ -16595,7 +16575,7 @@ exports[`braid-design-system > bundler webpack > build > should return built see
                      class="_19azws30 r2i1824 r2i1824x r2i182h _9kzhon0"
                      for="id_1"
                    >
-                     <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 z1t4tb4">
+                     <span class="_19azws30 r2i1824x fx8zm70 fx8zm71 fx8zm71t fx8zm78 _1x6fthg4">
                        This is a checkbox
                      </span>
                    </label>
@@ -16696,7 +16676,7 @@ exports[`braid-design-system > bundler webpack > start > should return developme
              html.sprinkles_darkMode__r2i18210,html.sprinkles_darkMode__r2i18210 body{color-scheme:dark;background:#1C2330}
        </style>
        <div class="seekJobs_seekJobs__ylnqo70 typography_lightModeTone_light__fx8zm710 typography_darkModeTone_dark__fx8zm713">
-         <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSize_standard__fx8zm78 capsize_capsizeStyle__z1t4tb4">
+         <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSize_standard__fx8zm78 capsize_capsizeStyle__1x6fthg4">
            Hello
            jobStreet
            <span class="reset_base__19azws30 sprinkles_display_inlineBlock_mobile__r2i18255">
@@ -16809,7 +16789,7 @@ exports[`braid-design-system > bundler webpack > start > should return developme
                      class="reset_base__19azws30 sprinkles_userSelect_none__r2i1824 sprinkles_display_block_mobile__r2i1824x sprinkles_cursor_pointer__r2i182h virtualTouchable_virtualTouchable__9kzhon0"
                      for="id_1"
                    >
-                     <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSize_standard__fx8zm78 capsize_capsizeStyle__z1t4tb4">
+                     <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSize_standard__fx8zm78 capsize_capsizeStyle__1x6fthg4">
                        This is a checkbox
                      </span>
                    </label>
@@ -16916,7 +16896,7 @@ exports[`braid-design-system > bundler webpack > start > should return developme
              html.sprinkles_darkMode__r2i18210,html.sprinkles_darkMode__r2i18210 body{color-scheme:dark;background:#1C2330}
        </style>
        <div class="seekJobs_seekJobs__ylnqo70 typography_lightModeTone_light__fx8zm710 typography_darkModeTone_dark__fx8zm713">
-         <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSize_standard__fx8zm78 capsize_capsizeStyle__z1t4tb4">
+         <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSize_standard__fx8zm78 capsize_capsizeStyle__1x6fthg4">
            Hello
            seekAnz
            <span class="reset_base__19azws30 sprinkles_display_inlineBlock_mobile__r2i18255">
@@ -17029,7 +17009,7 @@ exports[`braid-design-system > bundler webpack > start > should return developme
                      class="reset_base__19azws30 sprinkles_userSelect_none__r2i1824 sprinkles_display_block_mobile__r2i1824x sprinkles_cursor_pointer__r2i182h virtualTouchable_virtualTouchable__9kzhon0"
                      for="id_1"
                    >
-                     <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSize_standard__fx8zm78 capsize_capsizeStyle__z1t4tb4">
+                     <span class="reset_base__19azws30 sprinkles_display_block_mobile__r2i1824x typography_fontFamily__fx8zm70 typography_fontWeight_regular__fx8zm71 typography_tone_neutral__fx8zm71t typography_textSize_standard__fx8zm78 capsize_capsizeStyle__1x6fthg4">
                        This is a checkbox
                      </span>
                    </label>

--- a/tests/browser/__snapshots__/sku-webpack-plugin.test.ts.snap
+++ b/tests/browser/__snapshots__/sku-webpack-plugin.test.ts.snap
@@ -35,7 +35,7 @@ exports[`sku-webpack-plugin > build > should create valid app 1`] = `
 +      </style>
 +      <div class="_121uhli0 _115b53m10 _115b53m13">
 +        <div class="m8hx7y0 nsymv18p nsymv17l nsymv1ax nsymv19t nsymv15d nsymv169 nsymv1i9 nsymv14j nsymv14c _115b53m10 _115b53m13 nsymv133 nsymv136">
-+          <span class="m8hx7y0 nsymv14x _115b53m0 _115b53m1 _115b53m1t _115b53ma _17i4nh34">
++          <span class="m8hx7y0 nsymv14x _115b53m0 _115b53m1 _115b53m1t _115b53ma _1170cum4">
 +            Is it working?
 +          </span>
 +        </div>
@@ -2206,19 +2206,19 @@ html:not(.nsymv110) .nsymv14r {
   --_1u46xyh5m:
     0 0 12px 0 rgba(28, 35, 48, 0.08), 0 12px 24px -6px rgba(28, 35, 48, 0.08);
 }
-._17i4nh34 {
-  font-size: var(--_17i4nh30);
-  line-height: var(--_17i4nh31);
+._1170cum4 {
+  font-size: var(--_1170cum0);
+  line-height: var(--_1170cum1);
 }
-._17i4nh34:before {
+._1170cum4:before {
   content: "";
   display: table;
-  margin-bottom: var(--_17i4nh32);
+  margin-bottom: var(--_1170cum2);
 }
-._17i4nh34:after {
+._1170cum4:after {
   content: "";
   display: table;
-  margin-top: var(--_17i4nh33);
+  margin-top: var(--_1170cum3);
 }
 ._115b53m0 {
   font-family: var(--_1u46xyh2v);
@@ -2233,28 +2233,28 @@ html:not(.nsymv110) .nsymv14r {
   font-weight: var(--_1u46xyh47);
 }
 ._115b53m4 {
-  --_17i4nh30: var(--_1u46xyh31);
-  --_17i4nh31: var(--_1u46xyh32);
-  --_17i4nh32: var(--_1u46xyh34);
-  --_17i4nh33: var(--_1u46xyh35);
+  --_1170cum0: var(--_1u46xyh31);
+  --_1170cum1: var(--_1u46xyh32);
+  --_1170cum2: var(--_1u46xyh34);
+  --_1170cum3: var(--_1u46xyh35);
 }
 ._115b53m6 {
-  --_17i4nh30: var(--_1u46xyh3b);
-  --_17i4nh31: var(--_1u46xyh3c);
-  --_17i4nh32: var(--_1u46xyh3e);
-  --_17i4nh33: var(--_1u46xyh3f);
+  --_1170cum0: var(--_1u46xyh3b);
+  --_1170cum1: var(--_1u46xyh3c);
+  --_1170cum2: var(--_1u46xyh3e);
+  --_1170cum3: var(--_1u46xyh3f);
 }
 ._115b53m8 {
-  --_17i4nh30: var(--_1u46xyh3l);
-  --_17i4nh31: var(--_1u46xyh3m);
-  --_17i4nh32: var(--_1u46xyh3o);
-  --_17i4nh33: var(--_1u46xyh3p);
+  --_1170cum0: var(--_1u46xyh3l);
+  --_1170cum1: var(--_1u46xyh3m);
+  --_1170cum2: var(--_1u46xyh3o);
+  --_1170cum3: var(--_1u46xyh3p);
 }
 ._115b53ma {
-  --_17i4nh30: var(--_1u46xyh3v);
-  --_17i4nh31: var(--_1u46xyh3w);
-  --_17i4nh32: var(--_1u46xyh3y);
-  --_17i4nh33: var(--_1u46xyh3z);
+  --_1170cum0: var(--_1u46xyh3v);
+  --_1170cum1: var(--_1u46xyh3w);
+  --_1170cum2: var(--_1u46xyh3y);
+  --_1170cum3: var(--_1u46xyh3z);
 }
 ._115b53mc {
   font-size: var(--_1u46xyh31);
@@ -2279,28 +2279,28 @@ html:not(.nsymv110) .nsymv14r {
   font-weight: var(--_1u46xyh5d);
 }
 ._115b53mi {
-  --_17i4nh30: var(--_1u46xyh48);
-  --_17i4nh31: var(--_1u46xyh49);
-  --_17i4nh32: var(--_1u46xyh4b);
-  --_17i4nh33: var(--_1u46xyh4c);
+  --_1170cum0: var(--_1u46xyh48);
+  --_1170cum1: var(--_1u46xyh49);
+  --_1170cum2: var(--_1u46xyh4b);
+  --_1170cum3: var(--_1u46xyh4c);
 }
 ._115b53mk {
-  --_17i4nh30: var(--_1u46xyh4i);
-  --_17i4nh31: var(--_1u46xyh4j);
-  --_17i4nh32: var(--_1u46xyh4l);
-  --_17i4nh33: var(--_1u46xyh4m);
+  --_1170cum0: var(--_1u46xyh4i);
+  --_1170cum1: var(--_1u46xyh4j);
+  --_1170cum2: var(--_1u46xyh4l);
+  --_1170cum3: var(--_1u46xyh4m);
 }
 ._115b53mm {
-  --_17i4nh30: var(--_1u46xyh4s);
-  --_17i4nh31: var(--_1u46xyh4t);
-  --_17i4nh32: var(--_1u46xyh4v);
-  --_17i4nh33: var(--_1u46xyh4w);
+  --_1170cum0: var(--_1u46xyh4s);
+  --_1170cum1: var(--_1u46xyh4t);
+  --_1170cum2: var(--_1u46xyh4v);
+  --_1170cum3: var(--_1u46xyh4w);
 }
 ._115b53mo {
-  --_17i4nh30: var(--_1u46xyh52);
-  --_17i4nh31: var(--_1u46xyh53);
-  --_17i4nh32: var(--_1u46xyh55);
-  --_17i4nh33: var(--_1u46xyh56);
+  --_1170cum0: var(--_1u46xyh52);
+  --_1170cum1: var(--_1u46xyh53);
+  --_1170cum2: var(--_1u46xyh55);
+  --_1170cum3: var(--_1u46xyh56);
 }
 html:not(.nsymv110) ._115b53m10 {
   --_115b53mq: var(--_1u46xyh19);
@@ -2436,28 +2436,28 @@ html.nsymv110 ._115b53m1l {
 }
 @media screen and (min-width: 740px) {
   ._115b53m4 {
-    --_17i4nh30: var(--_1u46xyh36);
-    --_17i4nh31: var(--_1u46xyh37);
-    --_17i4nh32: var(--_1u46xyh39);
-    --_17i4nh33: var(--_1u46xyh3a);
+    --_1170cum0: var(--_1u46xyh36);
+    --_1170cum1: var(--_1u46xyh37);
+    --_1170cum2: var(--_1u46xyh39);
+    --_1170cum3: var(--_1u46xyh3a);
   }
   ._115b53m6 {
-    --_17i4nh30: var(--_1u46xyh3g);
-    --_17i4nh31: var(--_1u46xyh3h);
-    --_17i4nh32: var(--_1u46xyh3j);
-    --_17i4nh33: var(--_1u46xyh3k);
+    --_1170cum0: var(--_1u46xyh3g);
+    --_1170cum1: var(--_1u46xyh3h);
+    --_1170cum2: var(--_1u46xyh3j);
+    --_1170cum3: var(--_1u46xyh3k);
   }
   ._115b53m8 {
-    --_17i4nh30: var(--_1u46xyh3q);
-    --_17i4nh31: var(--_1u46xyh3r);
-    --_17i4nh32: var(--_1u46xyh3t);
-    --_17i4nh33: var(--_1u46xyh3u);
+    --_1170cum0: var(--_1u46xyh3q);
+    --_1170cum1: var(--_1u46xyh3r);
+    --_1170cum2: var(--_1u46xyh3t);
+    --_1170cum3: var(--_1u46xyh3u);
   }
   ._115b53ma {
-    --_17i4nh30: var(--_1u46xyh40);
-    --_17i4nh31: var(--_1u46xyh41);
-    --_17i4nh32: var(--_1u46xyh43);
-    --_17i4nh33: var(--_1u46xyh44);
+    --_1170cum0: var(--_1u46xyh40);
+    --_1170cum1: var(--_1u46xyh41);
+    --_1170cum2: var(--_1u46xyh43);
+    --_1170cum3: var(--_1u46xyh44);
   }
   ._115b53mc {
     font-size: var(--_1u46xyh36);
@@ -2476,28 +2476,28 @@ html.nsymv110 ._115b53m1l {
     line-height: var(--_1u46xyh41);
   }
   ._115b53mi {
-    --_17i4nh30: var(--_1u46xyh4d);
-    --_17i4nh31: var(--_1u46xyh4e);
-    --_17i4nh32: var(--_1u46xyh4g);
-    --_17i4nh33: var(--_1u46xyh4h);
+    --_1170cum0: var(--_1u46xyh4d);
+    --_1170cum1: var(--_1u46xyh4e);
+    --_1170cum2: var(--_1u46xyh4g);
+    --_1170cum3: var(--_1u46xyh4h);
   }
   ._115b53mk {
-    --_17i4nh30: var(--_1u46xyh4n);
-    --_17i4nh31: var(--_1u46xyh4o);
-    --_17i4nh32: var(--_1u46xyh4q);
-    --_17i4nh33: var(--_1u46xyh4r);
+    --_1170cum0: var(--_1u46xyh4n);
+    --_1170cum1: var(--_1u46xyh4o);
+    --_1170cum2: var(--_1u46xyh4q);
+    --_1170cum3: var(--_1u46xyh4r);
   }
   ._115b53mm {
-    --_17i4nh30: var(--_1u46xyh4x);
-    --_17i4nh31: var(--_1u46xyh4y);
-    --_17i4nh32: var(--_1u46xyh50);
-    --_17i4nh33: var(--_1u46xyh51);
+    --_1170cum0: var(--_1u46xyh4x);
+    --_1170cum1: var(--_1u46xyh4y);
+    --_1170cum2: var(--_1u46xyh50);
+    --_1170cum3: var(--_1u46xyh51);
   }
   ._115b53mo {
-    --_17i4nh30: var(--_1u46xyh57);
-    --_17i4nh31: var(--_1u46xyh58);
-    --_17i4nh32: var(--_1u46xyh5a);
-    --_17i4nh33: var(--_1u46xyh5b);
+    --_1170cum0: var(--_1u46xyh57);
+    --_1170cum1: var(--_1u46xyh58);
+    --_1170cum2: var(--_1u46xyh5a);
+    --_1170cum3: var(--_1u46xyh5b);
   }
   ._115b53m1w {
     padding-bottom: calc((var(--_1u46xyh9) - var(--_1u46xyh37)) / 2);
@@ -2684,7 +2684,7 @@ exports[`sku-webpack-plugin > start > should start a development server 1`] = `
 +      </style>
 +      <div class="seekJobs_seekJobs__121uhli0 typography_lightModeTone_light__115b53m10 typography_darkModeTone_dark__115b53m13">
 +        <div class="reset_base__m8hx7y0 sprinkles_paddingBottom_gutter_mobile__nsymv18p sprinkles_paddingTop_gutter_mobile__nsymv17l sprinkles_paddingLeft_gutter_mobile__nsymv1ax sprinkles_paddingRight_gutter_mobile__nsymv19t sprinkles_position_relative_mobile__nsymv15d sprinkles_borderRadius_large_mobile__nsymv169 sprinkles_textAlign_left_mobile__nsymv1i9 sprinkles_boxShadow_borderNeutralLight_lightMode__nsymv14j sprinkles_boxShadow_borderNeutral_darkMode__nsymv14c typography_lightModeTone_light__115b53m10 typography_darkModeTone_dark__115b53m13 sprinkles_background_surface_lightMode__nsymv133 sprinkles_background_surfaceDark_darkMode__nsymv136">
-+          <span class="reset_base__m8hx7y0 sprinkles_display_block_mobile__nsymv14x typography_fontFamily__115b53m0 typography_fontWeight_regular__115b53m1 typography_tone_neutral__115b53m1t typography_textSize_large__115b53ma capsize_capsizeStyle__17i4nh34">
++          <span class="reset_base__m8hx7y0 sprinkles_display_block_mobile__nsymv14x typography_fontFamily__115b53m0 typography_fontWeight_regular__115b53m1 typography_tone_neutral__115b53m1t typography_textSize_large__115b53ma capsize_capsizeStyle__1170cum4">
 +            Is it working?
 +          </span>
 +        </div>


### PR DESCRIPTION
5.2.4 contains [this fix](https://github.com/vanilla-extract-css/vanilla-extract/pull/1765), which stops empty CSS chunks being emitted. This would sometimes manifest as a race condition in the `braid-design-system` fixture snapshots causing an empty CSS chunk to sometimes be emitted.

> [!NOTE]
> The empty chunks were only present during local dev, and even then they didn't cause any issues for users; they only affected test snapshots.