### PR TITLE
`sku`: Remove `src/@loadable` directory from published files

### DIFF
--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -34,7 +34,6 @@
     "dist",
     "scripts",
     "CHANGELOG.md",
-    "src/@loadable",
     "bin"
   ],
   "type": "module",


### PR DESCRIPTION
Now that the loadable re-export has a transpiled entrypoint (#1622), the `src/@loadable` item in `package.json#files` is no longer necessary.