### PR TITLE
add requireMock to codemod

### DIFF
--- a/packages/codemod/src/codemods/migrate-root-resolution.ts
+++ b/packages/codemod/src/codemods/migrate-root-resolution.ts
@@ -43,6 +43,7 @@ const transformSource = async (source: string): Promise<string | null> => {
                   { pattern: 'jest.mock', kind: 'member_expression' },
                   { pattern: 'jest.doMock', kind: 'member_expression' },
                   { pattern: 'jest.requireActual', kind: 'member_expression' },
+                  { pattern: 'jest.requireMock', kind: 'member_expression' },
                 ],
               },
             },

--- a/tests/node/codemods/migrate-root-resolution.test.ts
+++ b/tests/node/codemods/migrate-root-resolution.test.ts
@@ -35,6 +35,7 @@ runCodemodTests('migrate-root-resolution', [
       jest.doMock('src/do-mocked');
       jest.requireActual('src/mocked');
       jest.requireActual<typeof import('src/mocked')>('src/mocked');
+      jest.requireMock('src/mocked').foo = originalFoo;
     `,
     output: dedent /* tsx */ `
       import { add } from '#src/utils/add';
@@ -62,6 +63,7 @@ runCodemodTests('migrate-root-resolution', [
       jest.doMock('#src/do-mocked');
       jest.requireActual('#src/mocked');
       jest.requireActual<typeof import('#src/mocked')>('#src/mocked');
+      jest.requireMock('#src/mocked').foo = originalFoo;
     `,
   },
   // Adds a `pathAliases` entry to the sku config


### PR DESCRIPTION
A repo I was testing used `jest.requireMock` so making the codemod handle it too 