### PR TITLE
Fix `webpack-dev-server` dev dep versions

### DIFF
--- a/fixtures/sku-webpack-plugin/package.json
+++ b/fixtures/sku-webpack-plugin/package.json
@@ -18,7 +18,7 @@
     "sku": "workspace:*",
     "webpack": "^5.52.0",
     "webpack-cli": "^6.0.0",
-    "webpack-dev-server": "<=5.2.0",
+    "webpack-dev-server": "catalog:",
     "http-server": "^14.1.1"
   },
   "skuSkipValidatePeerDeps": true

--- a/packages/sku/package.json
+++ b/packages/sku/package.json
@@ -161,7 +161,7 @@
     "vite-plugin-cjs-interop": "^3.0.0",
     "webpack": "^5.105.4",
     "webpack-bundle-analyzer": "^5.1.1",
-    "webpack-dev-server": "^5.2.4",
+    "webpack-dev-server": "catalog:",
     "webpack-merge": "^6.0.1",
     "webpack-node-externals": "^3.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ catalogs:
     vitest:
       specifier: ^4.1.0
       version: 4.1.9
+    webpack-dev-server:
+      specifier: ^5.2.4
+      version: 5.2.4
 
 overrides:
   esbuild: ~0.28.0
@@ -675,10 +678,10 @@ importers:
         version: 5.107.2(esbuild@0.28.1)(webpack-cli@6.0.1)
       webpack-cli:
         specifier: ^6.0.0
-        version: 6.0.1(webpack-dev-server@5.2.0)(webpack@5.107.2)
+        version: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.107.2)
       webpack-dev-server:
-        specifier: <=5.2.0
-        version: 5.2.0(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.107.2)
+        specifier: 'catalog:'
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.107.2)
 
   fixtures/sku-with-https:
     dependencies:
@@ -1452,7 +1455,7 @@ importers:
         specifier: ^5.1.1
         version: 5.3.0
       webpack-dev-server:
-        specifier: ^5.2.4
+        specifier: 'catalog:'
         version: 5.2.4(tslib@2.8.1)(webpack@5.107.2)
       webpack-merge:
         specifier: ^6.0.1
@@ -1706,10 +1709,10 @@ importers:
         version: 5.107.2(esbuild@0.28.1)(webpack-cli@6.0.1)
       webpack-cli:
         specifier: ^6.0.0
-        version: 6.0.1(webpack-dev-server@5.2.0)(webpack@5.107.2)
+        version: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.107.2)
       webpack-dev-server:
-        specifier: <=5.2.0
-        version: 5.2.0(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.107.2)
+        specifier: 'catalog:'
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.107.2)
       yaml:
         specifier: ^2.8.1
         version: 2.9.0
@@ -4652,9 +4655,6 @@ packages:
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
-
-  '@types/node-forge@1.3.14':
-    resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -9193,10 +9193,6 @@ packages:
   select-hose@2.0.0:
     resolution: {integrity: sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==}
 
-  selfsigned@2.4.1:
-    resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
-    engines: {node: '>=10'}
-
   selfsigned@3.0.1:
     resolution: {integrity: sha512-6U6w6kSLrM9Zxo0D7mC7QdGS6ZZytMWBnj/vhF9p+dAHx6CwGezuRcO4VclTbrrI7mg7SD6zNiqXUuBHOVopNQ==}
     engines: {node: '>=10'}
@@ -10195,19 +10191,6 @@ packages:
       webpack: ^5.0.0
     peerDependenciesMeta:
       webpack:
-        optional: true
-
-  webpack-dev-server@5.2.0:
-    resolution: {integrity: sha512-90SqqYXA2SK36KcT6o1bvwvZfJFcmoamqeJY7+boioffX9g9C0wjjJRGUrQIuh43pb0ttX7+ssavmj/WN2RHtA==}
-    engines: {node: '>= 18.12.0'}
-    hasBin: true
-    peerDependencies:
-      webpack: ^5.0.0
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack:
-        optional: true
-      webpack-cli:
         optional: true
 
   webpack-dev-server@5.2.4:
@@ -13651,10 +13634,6 @@ snapshots:
 
   '@types/mime@1.3.5': {}
 
-  '@types/node-forge@1.3.14':
-    dependencies:
-      '@types/node': 26.0.0
-
   '@types/node@12.20.55': {}
 
   '@types/node@24.12.4':
@@ -14312,19 +14291,19 @@ snapshots:
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
       webpack: 5.107.2(esbuild@0.28.1)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.0)(webpack@5.107.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.107.2)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
       webpack: 5.107.2(esbuild@0.28.1)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.0)(webpack@5.107.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.107.2)
 
-  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.0)(webpack@5.107.2)':
+  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.107.2)':
     dependencies:
       webpack: 5.107.2(esbuild@0.28.1)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.0)(webpack@5.107.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.107.2)
     optionalDependencies:
-      webpack-dev-server: 5.2.0(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.107.2)
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.107.2)
 
   '@wry/caches@1.0.1':
     dependencies:
@@ -18981,11 +18960,6 @@ snapshots:
 
   select-hose@2.0.0: {}
 
-  selfsigned@2.4.1:
-    dependencies:
-      '@types/node-forge': 1.3.14
-      node-forge: 1.4.0
-
   selfsigned@3.0.1:
     dependencies:
       node-forge: 1.4.0
@@ -20030,12 +20004,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-cli@6.0.1(webpack-dev-server@5.2.0)(webpack@5.107.2):
+  webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.107.2):
     dependencies:
       '@discoveryjs/json-ext': 0.6.3
       '@webpack-cli/configtest': 3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)
       '@webpack-cli/info': 3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)
-      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.0)(webpack@5.107.2)
+      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.107.2)
       colorette: 2.0.20
       commander: 12.1.0
       cross-spawn: 7.0.6
@@ -20047,7 +20021,7 @@ snapshots:
       webpack: 5.107.2(esbuild@0.28.1)(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
     optionalDependencies:
-      webpack-dev-server: 5.2.0(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.107.2)
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.107.2)
 
   webpack-dev-middleware@6.1.3(webpack@5.107.2):
     dependencies:
@@ -20072,11 +20046,12 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.0(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.107.2):
+  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.107.2):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
       '@types/express': 4.17.25
+      '@types/express-serve-static-core': 4.19.8
       '@types/serve-index': 1.9.4
       '@types/serve-static': 1.15.10
       '@types/sockjs': 0.3.36
@@ -20095,7 +20070,7 @@ snapshots:
       open: 10.2.0
       p-retry: 6.2.1
       schema-utils: 4.3.3
-      selfsigned: 2.4.1
+      selfsigned: 5.5.0
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
@@ -20103,7 +20078,7 @@ snapshots:
       ws: 8.21.0
     optionalDependencies:
       webpack: 5.107.2(esbuild@0.28.1)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.0)(webpack@5.107.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.107.2)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -20274,7 +20249,7 @@ snapshots:
       watchpack: 2.5.2
       webpack-sources: 3.5.0
     optionalDependencies:
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.0)(webpack@5.107.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.107.2)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,6 +47,7 @@ catalog:
   typescript: ~6.0.3
   vite: ^8.0.1
   vitest: ^4.1.0
+  webpack-dev-server: ^5.2.4
 
 configDependencies:
   pnpm-plugin-sku: 0.0.3+sha512-XPcqT+jnn4oGgkUCMLSmlj3R367WTD6O8TlIufxAej7TfE28h4IOVWaJdqVWIq2QRqGoJxjCCXUhlT5Y0vIHaQ==

--- a/tests/package.json
+++ b/tests/package.json
@@ -13,7 +13,7 @@
     "node-html-parser": "^7.0.1",
     "webpack": "^5.52.0",
     "webpack-cli": "^6.0.0",
-    "webpack-dev-server": "<=5.2.0",
+    "webpack-dev-server": "catalog:",
     "yaml": "^2.8.1"
   }
 }


### PR DESCRIPTION
Missed a few `webpack-dev-server` versions in #1623. I've moved it to a catalog dep.