### PR TITLE
Add the ability to inject a preamble into the `sku` changelog

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -4,7 +4,11 @@
   "workspaces": {
     ".": {
       // Used in the renovate config
-      "ignoreDependencies": ["renovate-config-seek"],
+      "ignoreDependencies": [
+        "renovate-config-seek",
+        "@sku-private/inject-changelog-preamble",
+      ],
+      "ignoreBinaries": ["inject-changelog-preamble"],
     },
     "packages/sku": {
       "ignoreDependencies": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "format": "eslint --cache --cache-location 'node_modules/.cache/eslint/.eslintcache' --fix . && prettier --cache --experimental-cli --write . ",
     "deploy-docs": "pnpm run --filter @sku-private/docs deploy",
     "release": "pnpm deploy-docs && changeset publish",
-    "version": "changeset version && pnpm install --lockfile-only"
+    "version": "changeset version && pnpm inject-changelog-preamble && pnpm install --lockfile-only"
   },
   "nano-staged": {
     "+(package.json|pnpm-lock.yaml)": [
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.27.0",
     "@changesets/get-github-info": "^0.8.0",
+    "@sku-private/inject-changelog-preamble": "workspace:*",
     "@sku-private/playwright": "workspace:*",
     "@sku-private/test-utils": "workspace:*",
     "@sku-private/testing-library": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@changesets/get-github-info':
         specifier: ^0.8.0
         version: 0.8.0
+      '@sku-private/inject-changelog-preamble':
+        specifier: workspace:*
+        version: link:private/inject-changelog-preamble
       '@sku-private/playwright':
         specifier: workspace:*
         version: link:private/playwright
@@ -1571,6 +1574,16 @@ importers:
       tsx:
         specifier: ^4.19.4
         version: 4.22.4
+
+  private/inject-changelog-preamble:
+    dependencies:
+      '@sku-private/utils':
+        specifier: workspace:*
+        version: link:../utils
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.4
 
   private/playwright:
     devDependencies:

--- a/private/inject-changelog-preamble/README.md
+++ b/private/inject-changelog-preamble/README.md
@@ -1,0 +1,13 @@
+# inject-changelog-preamble
+
+Injects the contents of `.changeset/.PREAMBLE.md` at the beginning of the latest version in sku's changelog.
+Typically used to summarise or highlight specific changes.
+If `.changeset/.PREAMBLE.md` is missing then the CLI does nothing.
+
+Based off [a similar script in skuba] but with a bit of extra logging and ✨colours✨.
+
+[a similar script in skuba]: https://github.com/seek-oss/skuba/blob/3134fa95252c81b016602ad93a20ba28ff1b9395/packages/changesets-changelog/src/inject.mjs
+
+## API
+
+The package exposes a `sku-inject-changelog` CLI that should be invoked in CI immediately after `changeset version`.

--- a/private/inject-changelog-preamble/package.json
+++ b/private/inject-changelog-preamble/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@sku-private/inject-changelog-preamble",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "sku-inject-changelog": "./src/inject.ts"
+  },
+  "dependencies": {
+    "@sku-private/utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:"
+  }
+}

--- a/private/inject-changelog-preamble/src/inject.ts
+++ b/private/inject-changelog-preamble/src/inject.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import fsp from 'node:fs/promises';
+import fs from 'node:fs';
+import { critical, info, success } from '@sku-private/utils/console';
+
+const PREAMBLE_PATH = '.changeset/.PREAMBLE.md';
+const CHANGELOG_PATH = 'packages/sku/CHANGELOG.md';
+
+if (!fs.existsSync(PREAMBLE_PATH)) {
+  console.log(
+    info(
+      `Missing preamble file at "${PREAMBLE_PATH}". Skipping sku changelog preamble injection.`,
+    ),
+  );
+  process.exit(0);
+}
+
+if (!fs.existsSync(CHANGELOG_PATH)) {
+  console.error(critical(`Missing changelog file at "${CHANGELOG_PATH}"`));
+  process.exit(1);
+}
+
+const [preamble, changelog] = await Promise.all([
+  fsp.readFile(PREAMBLE_PATH, 'utf8'),
+  fsp.readFile(CHANGELOG_PATH, 'utf8'),
+]);
+
+const lines = changelog.split('\n');
+lines.splice(4, 0, preamble);
+await fsp.writeFile(CHANGELOG_PATH, lines.join('\n'));
+await fsp.rm(PREAMBLE_PATH);
+
+console.log(success(`Successfully injected ${lines.length} preamble lines`));

--- a/private/inject-changelog-preamble/tsconfig.json
+++ b/private/inject-changelog-preamble/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@tsconfig/node24/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "target": "ESNext",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["node"]
+  },
+  "include": ["./src/**/*"]
+}


### PR DESCRIPTION
We often want to summarize or highlight (typically breaking) changes in a changelog preamble, but AFAIK changesets only offers a way to aggregate and format individual changesets, and doesn't offer a way to modify the final generated changelog.

This CLI preprends the contents of a preamble markdown file to the latest release within sku's changelog. It's run in CI after `changeset version` as that's when the changelog is updated.