### PR TITLE
docs: Rename `Alternate runner` to `Migration guides`

### DIFF
--- a/docs/docs/_sidebar.md
+++ b/docs/docs/_sidebar.md
@@ -4,7 +4,7 @@
 - [API](./docs/api.md)
 - [FAQ](./docs/faq)
 - [Debugging](./docs/debugging.md)
-- **Alternate runners**
+- **Migration guides**
 - [Vite](./docs/vite.md)
 - [Vitest](./docs/vitest.md)
 - **Project types**


### PR DESCRIPTION
Over time this section has morphed into a migration guides section, so I've renamed it as such.