### PR TITLE
`csp`: Use fixed nonce value for tests

### DIFF
--- a/packages/sku/src/services/webpack/entry/csp.test.ts
+++ b/packages/sku/src/services/webpack/entry/csp.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import createCSPHandler from './csp.js';
 
 describe('createCSPHandler', () => {
@@ -93,6 +93,10 @@ describe('createCSPHandler', () => {
   });
 
   describe('createUnsafeNonce', () => {
+    beforeEach(() => {
+      vi.stubEnv('SKU_CSP_NONCE', undefined);
+    });
+
     it('should form a valid nonce value', () => {
       const cspHandler = createCSPHandler();
 
@@ -117,6 +121,10 @@ describe('createCSPHandler', () => {
 
       const cspTag = cspHandler.createCSPTag();
       expect(cspTag).toContain(`nonce-${nonce}`);
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
     });
   });
 });

--- a/packages/sku/src/services/webpack/entry/csp.ts
+++ b/packages/sku/src/services/webpack/entry/csp.ts
@@ -44,7 +44,7 @@ export default function createCSPHandler({
       );
     }
 
-    const nonce = randomBytes(16).toString('hex');
+    const nonce = process.env.SKU_CSP_NONCE ?? randomBytes(16).toString('hex');
     nonces.add(nonce);
     return nonce;
   };

--- a/private/playwright/formatHtml.ts
+++ b/private/playwright/formatHtml.ts
@@ -1,16 +1,3 @@
 import diffableHtml from 'diffable-html';
 
-function replaceRandomStrings(html: string): string {
-  // Replace nonce values
-  const nonceMatch = html.match(/nonce-([a-zA-Z0-9+/=]+)/);
-  if (nonceMatch) {
-    const nonceValue = nonceMatch[1];
-    return html.replaceAll(nonceValue, 'RANDOM_NONCE');
-  }
-  return html;
-}
-
-export const formatHtml = (html: string) => {
-  const formatted = diffableHtml(html).trim();
-  return replaceRandomStrings(formatted);
-};
+export const formatHtml = (html: string) => diffableHtml(html).trim();

--- a/tests/browser/security-controls.test.ts
+++ b/tests/browser/security-controls.test.ts
@@ -74,7 +74,7 @@ describe('security-controls', () => {
       });
 
       it('should generate a CSP with nonce value', async () => {
-        expect(cspTag.getAttribute('content')).match(/nonce-([a-zA-Z0-9+/=]+)/);
+        expect(cspTag.getAttribute('content')).match(/nonce-RANDOM_NONCE/);
       });
     });
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
     setupFiles: './vitest-setup.ts',
     // Increasing the number so functions using TEST_TIMEOUT can timeout before the test does.
     testTimeout: TEST_TIMEOUT + 1000,
+    env: {
+      SKU_CSP_NONCE: 'RANDOM_NONCE',
+    },
     projects: [
       {
         extends: true,


### PR DESCRIPTION
This change updates the `createUnsafeNonce` function of the CSP handler to check for a `SKU_CSP_NONCE` environment variable and, should it exist, use that as the value of the returned nonce. In the absence of such an environment variable, a randomly generated nonce value is created and used instead as per the existing behaviour.

This change also updates the Vitest config to set the above environment variable to a fixed value, and backs out the manual replacement of randomly generated nonces with the same fixed value in the formatted HTML snapshots. Since the environment is passed through transparently both to Node worker threads and to the render processes scoped to the test fixtures, these changes together eliminate the randomness of CSP nonce values in the testing environment altogether without the need to update any tests or snapshots[^1].

Partially inspired by #1646.

[^1]: One test has been updated to assert explicitly on the fixed nonce value, however this test would still have passed without this change since (part of) the fixed value conformed to the match pattern.