### PR TITLE
Enable Detailed View by default for site search

### DIFF
--- a/site/.vitepress/config.mjs
+++ b/site/.vitepress/config.mjs
@@ -32,6 +32,10 @@ export default defineConfig({
     socialLinks: [{ icon: 'github', link: 'https://github.com/seek-oss/sku' }],
     search: {
       provider: 'local',
+      options: {
+        // Enable Detailed View by default
+        detailedView: true,
+      },
     },
     outline: [2, 3],
     sidebar: {


### PR DESCRIPTION
- Enable VitePress local search Detailed View by default so docs search shows text excerpts without toggling
- User can still toggle off, and this persists in Local Storage
