### PR TITLE
`pnpm`: Add scopes to `minimumReleaseAgeExclude`

### DIFF
--- a/.changeset/some-chicken-stop.md
+++ b/.changeset/some-chicken-stop.md
@@ -1,0 +1,8 @@
+---
+'pnpm-plugin-sku': minor
+---
+
+Add the following scopes to `minimumReleaseAgeExclude`:
+  - `@capsizecss/*`
+  - `@vanilla-extract/*`
+  - `@vocab/*`

--- a/packages/pnpm-plugin/src/config.ts
+++ b/packages/pnpm-plugin/src/config.ts
@@ -13,8 +13,11 @@ export const defaultConfig = {
   minimumReleaseAge: 4320,
   minimumReleaseAgeExclude: [
     '@braid-design-system/*',
+    '@capsizecss/*',
     '@seek/*',
     '@sku-lib/*',
+    '@vanilla-extract/*',
+    '@vocab/*',
     'braid-design-system',
     'browserslist-config-seek',
     'eslint-config-seek',

--- a/tests/node/__snapshots__/sku-create.test.ts.snap
+++ b/tests/node/__snapshots__/sku-create.test.ts.snap
@@ -102,6 +102,9 @@ exports[`sku-create vite > should create package.json 1`] = `
     "sku": "VERSION_IGNORED",
     "vitest": "VERSION_IGNORED",
   },
+  "imports": {
+    "#src/*": "./src/*",
+  },
   "name": "new-project",
   "packageManager": "pnpm@11.VERSION_IGNORED",
   "private": true,
@@ -131,8 +134,11 @@ ignorePatchFailures: false
 minimumReleaseAge: 4320 # 3 days
 minimumReleaseAgeExclude:
   - '@braid-design-system/*'
+  - '@capsizecss/*'
   - '@seek/*'
   - '@sku-lib/*'
+  - '@vanilla-extract/*'
+  - '@vocab/*'
   - braid-design-system
   - browserslist-config-seek
   - eslint-config-seek
@@ -483,6 +489,9 @@ exports[`sku-create webpack > should create package.json 1`] = `
     "@vanilla-extract/css": "VERSION_IGNORED",
     "sku": "VERSION_IGNORED",
   },
+  "imports": {
+    "#src/*": "./src/*",
+  },
   "name": "new-project",
   "packageManager": "pnpm@11.VERSION_IGNORED",
   "private": true,
@@ -511,8 +520,11 @@ ignorePatchFailures: false
 minimumReleaseAge: 4320 # 3 days
 minimumReleaseAgeExclude:
   - '@braid-design-system/*'
+  - '@capsizecss/*'
   - '@seek/*'
   - '@sku-lib/*'
+  - '@vanilla-extract/*'
+  - '@vocab/*'
   - braid-design-system
   - browserslist-config-seek
   - eslint-config-seek


### PR DESCRIPTION
Without the vanilla extract exclude, new sku apps will hit a minimum release age error.