### PR TITLE
`testing-library`: Always preserve environment when using `render`

### DIFF
--- a/private/testing-library/render-cli.ts
+++ b/private/testing-library/render-cli.ts
@@ -1,6 +1,7 @@
-import { render, waitFor, type RenderOptions } from 'cli-testing-library';
+import { waitFor, type RenderOptions } from 'cli-testing-library';
 import { createRequire } from 'node:module';
 import { makeFixturePathResolver } from './makeFixturePathResolver.ts';
+import { renderWithEnvironment } from './utils.ts';
 
 const require = createRequire(import.meta.url);
 
@@ -39,13 +40,12 @@ export const scopeToFixture = (fixtureFolder: string) => {
       args: string[] = [],
       options: Partial<RenderOptions> = {},
     ) =>
-      render(skuBin, [command, ...args], {
+      renderWithEnvironment(skuBin, [command, ...args], {
         ...options,
         cwd: fixturePath(options.cwd ?? ''),
         spawnOpts: {
           ...options.spawnOpts,
           env: {
-            ...process.env,
             ...skuTestEnv,
             ...options.spawnOpts?.env,
           },
@@ -56,7 +56,7 @@ export const scopeToFixture = (fixtureFolder: string) => {
      * Runs a `node` command scoped to the fixture folder.
      */
     node: (args: string[] = [], options: Partial<RenderOptions> = {}) =>
-      render('node', args, {
+      renderWithEnvironment('node', args, {
         ...options,
         cwd: fixturePath(options.cwd ?? ''),
       }),
@@ -68,7 +68,7 @@ export const scopeToFixture = (fixtureFolder: string) => {
       args: string[] = [],
       options: Partial<RenderOptions> = {},
     ) =>
-      render(command, args, {
+      renderWithEnvironment(command, args, {
         ...options,
         cwd: fixturePath(options.cwd ?? ''),
       }),

--- a/private/testing-library/render-codemod.ts
+++ b/private/testing-library/render-codemod.ts
@@ -1,9 +1,10 @@
-import { render, type RenderOptions } from 'cli-testing-library';
+import type { RenderOptions } from 'cli-testing-library';
 import { createRequire } from 'node:module';
 import fs from 'node:fs/promises';
 import { describe, it, expect } from 'vitest';
 import { createFixture } from 'fs-fixture';
 import type { CodemodName } from '../../packages/codemod/src/utils/constants.js';
+import { renderWithEnvironment } from './utils.ts';
 
 const require = createRequire(import.meta.url);
 const codemodBin = require.resolve('../../packages/codemod/bin.js');
@@ -12,7 +13,7 @@ const renderCodemod = async (
   command: CodemodName,
   args: string[] = [],
   options: Partial<RenderOptions> = {},
-) => render(codemodBin, [command, ...args], options);
+) => renderWithEnvironment(codemodBin, [command, ...args], options);
 
 export const scopeToFixture = (dir: string) => ({
   codemod: (

--- a/private/testing-library/render-create.ts
+++ b/private/testing-library/render-create.ts
@@ -1,6 +1,7 @@
-import { render, type RenderOptions } from 'cli-testing-library';
+import type { RenderOptions } from 'cli-testing-library';
 import { makeFixturePathResolver } from './makeFixturePathResolver.ts';
 import { createRequire } from 'node:module';
+import { renderWithEnvironment } from './utils.ts';
 
 const require = createRequire(import.meta.url);
 const createSkuBin = require.resolve('../../packages/create/bin.js');
@@ -14,7 +15,7 @@ export const scopeToFixture = (dir: string) => {
       args: string[] = [],
       options: Partial<RenderOptions> = {},
     ) =>
-      render(createSkuBin, [projectName, ...args], {
+      renderWithEnvironment(createSkuBin, [projectName, ...args], {
         ...options,
         cwd: fixturePath(options.cwd ?? ''),
       }),

--- a/private/testing-library/utils.ts
+++ b/private/testing-library/utils.ts
@@ -1,4 +1,25 @@
-import { waitFor, type RenderResult } from 'cli-testing-library';
+import {
+  render,
+  type RenderOptions,
+  type RenderResult,
+  waitFor,
+} from 'cli-testing-library';
+
+export const renderWithEnvironment = (
+  command: string,
+  args: string[] = [],
+  opts: Partial<RenderOptions> = {},
+): Promise<RenderResult> =>
+  render(command, args, {
+    ...opts,
+    spawnOpts: {
+      ...opts.spawnOpts,
+      env: {
+        ...process.env,
+        ...opts.spawnOpts?.env,
+      },
+    },
+  });
 
 export const waitForExitCode = async (
   process: RenderResult,


### PR DESCRIPTION
This change adds a new helper function, `renderWithEnvironment`, to the `@sku-private/testing-library` package. This helper will always preserve the current environment when spawning a command using `render` from `cli-testing-library`, even if `spawnOpts.env` is provided which ordinarily would replace the existing environment. This change also updates all usages of `render` in `@sku-private/testing-library` to use `renderWithEnvironment` instead.

See [this comment](https://github.com/seek-oss/sku/pull/1659/changes#r3618574324) for some background on this change.