### PR TITLE
`testing-library`: Remove `spawnOpts` from `renderWithEnvironment` call

### DIFF
--- a/private/testing-library/render-create.ts
+++ b/private/testing-library/render-create.ts
@@ -18,13 +18,6 @@ export const scopeToFixture = (dir: string) => {
       renderWithEnvironment(createSkuBin, [projectName, ...args], {
         ...options,
         cwd: fixturePath(options.cwd ?? ''),
-        spawnOpts: {
-          ...options.spawnOpts,
-          env: {
-            ...process.env,
-            ...options.spawnOpts?.env,
-          },
-        },
       }),
     fixturePath,
   };


### PR DESCRIPTION
As per [comment on #1659](https://github.com/seek-oss/sku/pull/1659/changes#r3618993656), `spawnOpts.env` no longer needs to be set when `renderWithEnvironment` is used.