### PR TITLE
Refactor exit code matching

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -133,5 +133,10 @@ export default [
         browser: true,
       },
     },
+    rules: {
+      // `toMatchExitCode` waits for a command to exit, so it is frequently
+      // asserted from `beforeAll`/`beforeEach` hooks rather than a test body.
+      'vitest/no-standalone-expect': 'off',
+    },
   },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -134,8 +134,7 @@ export default [
       },
     },
     rules: {
-      // `toMatchExitCode` waits for a command to exit, so it is frequently
-      // asserted from `beforeAll`/`beforeEach` hooks rather than a test body.
+      // `toMatchExitCode` is frequently asserted from `beforeAll`/`beforeEach` hooks when testing `sku start` functionality.
       'vitest/no-standalone-expect': 'off',
     },
   },

--- a/private/testing-library/matchers.ts
+++ b/private/testing-library/matchers.ts
@@ -4,8 +4,8 @@ import { expect } from 'vitest';
 declare module 'vitest' {
   interface Matchers {
     /**
-     * Waits for the command to exit, then asserts that it exited with the given
-     * code. Includes the command's output in the failure message.
+     * Waits for the command to exit, then asserts that it exited with the given code.
+     * Includes the command's output in the failure message.
      * @example await expect(command).toMatchExitCode(0)
      */
     toMatchExitCode: (exitCode: number) => Promise<void>;

--- a/private/testing-library/matchers.ts
+++ b/private/testing-library/matchers.ts
@@ -1,0 +1,66 @@
+import { waitFor, type RenderResult } from 'cli-testing-library';
+import { expect } from 'vitest';
+
+declare module 'vitest' {
+  interface Matchers {
+    /**
+     * Waits for the command to exit, then asserts that it exited with the given
+     * code. Includes the command's output in the failure message.
+     * @example await expect(command).toMatchExitCode(0)
+     */
+    toMatchExitCode: (exitCode: number) => Promise<void>;
+  }
+}
+
+/** The tail end of a command's output is the most useful part when debugging a failure. */
+const MAX_OUTPUT_LENGTH = 7000;
+
+const truncateOutput = (output: string) =>
+  output.length > MAX_OUTPUT_LENGTH
+    ? `…${output.slice(-MAX_OUTPUT_LENGTH)}`
+    : output;
+
+expect.extend({
+  async toMatchExitCode(command: RenderResult, expectedExitCode: number) {
+    if (typeof command?.hasExit !== 'function') {
+      throw new TypeError(
+        `toMatchExitCode expects a RenderResult from @sku-private/testing-library, but received ${this.utils.printReceived(command)}`,
+      );
+    }
+
+    try {
+      await waitFor(() => {
+        if (command.hasExit() === null) {
+          throw new Error('Command has not exited');
+        }
+      });
+    } catch {
+      // Fall through so the assertion reports the exit code rather than the timeout.
+    }
+
+    const actualExitCode = command.hasExit()?.exitCode;
+
+    return {
+      pass: actualExitCode === expectedExitCode,
+      actual: actualExitCode,
+      expected: expectedExitCode,
+      message: () =>
+        [
+          this.utils.matcherHint(
+            `${this.isNot ? '.not' : ''}.toMatchExitCode`,
+            'command',
+            'exitCode',
+          ),
+          '',
+          `Expected the command ${this.isNot ? 'not ' : ''}to exit with code ${this.utils.printExpected(expectedExitCode)}, but it ${
+            actualExitCode === undefined
+              ? 'has not exited'
+              : `exited with code ${this.utils.printReceived(actualExitCode)}`
+          }.`,
+          '',
+          'Output:',
+          truncateOutput(command.getStdallStr()),
+        ].join('\n'),
+    };
+  },
+});

--- a/private/testing-library/package.json
+++ b/private/testing-library/package.json
@@ -6,7 +6,8 @@
   "exports": {
     ".": "./index.ts",
     "./codemod": "./render-codemod.ts",
-    "./create": "./render-create.ts"
+    "./create": "./render-create.ts",
+    "./matchers": "./matchers.ts"
   },
   "devDependencies": {
     "cli-testing-library": "^3.0.1",

--- a/private/testing-library/utils.ts
+++ b/private/testing-library/utils.ts
@@ -2,7 +2,6 @@ import {
   render,
   type RenderOptions,
   type RenderResult,
-  waitFor,
 } from 'cli-testing-library';
 
 export const renderWithEnvironment = (
@@ -20,38 +19,3 @@ export const renderWithEnvironment = (
       },
     },
   });
-
-export const waitForExitCode = async (
-  process: RenderResult,
-  exitCode: number,
-  debug: boolean = false,
-) => {
-  await waitFor(() => {
-    const exit = process.hasExit();
-    if (!hasExpectedExitCode(process, exitCode, debug)) {
-      throw new Error(
-        `Expected the command to exit with code ${exitCode} but got ${exit?.exitCode}`,
-      );
-    }
-  });
-};
-
-// TODO refactor the tests to use this in expect. e.g., expect(hasExitCode(process, 0)).toBe(true). Will be done in a different branch.
-/**
- * Checks if a command exited with the given code.
- * Useful in tests since it will output the debug information if it fails.
- */
-export const hasExpectedExitCode = (
-  process: RenderResult,
-  exitCode: number,
-  debug: boolean = true,
-) => {
-  const exit = process.hasExit();
-  if (exit?.exitCode === exitCode) {
-    return true;
-  }
-  if (debug) {
-    process.debug();
-  }
-  return false;
-};

--- a/tests/browser/path-aliases.test.ts
+++ b/tests/browser/path-aliases.test.ts
@@ -2,11 +2,7 @@ import { describe, beforeAll, it, expect } from 'vitest';
 import { readFile } from 'node:fs/promises';
 import * as jsonc from 'jsonc-parser';
 
-import {
-  scopeToFixture,
-  waitFor,
-  waitForExitCode,
-} from '@sku-private/testing-library';
+import { scopeToFixture } from '@sku-private/testing-library';
 import { getPort } from '@sku-private/test-utils';
 import { createPage } from '@sku-private/playwright';
 
@@ -19,7 +15,7 @@ describe('pathAliases', () => {
     beforeAll(async () => {
       const configure = await sku('configure', ['--config=sku.config.vite.ts']);
 
-      await waitForExitCode(configure, 0);
+      await expect(configure).toMatchExitCode(0);
 
       const tsconfigPath = fixturePath('tsconfig.json');
       const tsconfigContents = await readFile(tsconfigPath, 'utf-8');
@@ -51,9 +47,7 @@ describe('pathAliases', () => {
         '--config=sku.config.bad-node-modules.ts',
       ]);
 
-      await waitFor(() => {
-        expect(configure.hasExit()).toMatchObject({ exitCode: 1 });
-      });
+      await expect(configure).toMatchExitCode(1);
 
       expect(
         configure.getByText(
@@ -67,9 +61,7 @@ describe('pathAliases', () => {
         '--config=sku.config.bad-wrong-import.ts',
       ]);
 
-      await waitFor(() => {
-        expect(configure.hasExit()).toMatchObject({ exitCode: 1 });
-      });
+      await expect(configure).toMatchExitCode(1);
 
       expect(
         configure.getByText(

--- a/tests/browser/sku-webpack-plugin.test.ts
+++ b/tests/browser/sku-webpack-plugin.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { getAppSnapshot } from '@sku-private/playwright';
 import { dirContentsToObject } from '@sku-private/test-utils';
-import { scopeToFixture, waitForExitCode } from '@sku-private/testing-library';
+import { scopeToFixture } from '@sku-private/testing-library';
 
 const port = 9876;
 const devServerUrl = `http://localhost:${port}`;
@@ -38,7 +38,7 @@ describe('sku-webpack-plugin', () => {
           },
         },
       );
-      await waitForExitCode(build, 0);
+      await expect(build).toMatchExitCode(0);
     });
 
     it('should create valid app', async () => {

--- a/tests/browser/sku-with-https.test.ts
+++ b/tests/browser/sku-with-https.test.ts
@@ -8,7 +8,6 @@ import {
   type BundlerValues,
   scopeToFixture,
   skipCleanup,
-  waitFor,
 } from '@sku-private/testing-library';
 
 const { sku, fixturePath } = scopeToFixture('sku-with-https');
@@ -131,8 +130,6 @@ describe('sku-with-https', () => {
         `Error: ${invalidMiddlewarePath} does not exist. Please create the file or remove 'devServerMiddleware' from your sku config.`,
       ),
     ).toBeInTheConsole();
-    await waitFor(() => {
-      expect(start.hasExit()).toMatchObject({ exitCode: 1 });
-    });
+    await expect(start).toMatchExitCode(1);
   });
 });

--- a/tests/browser/storybook-config.test.ts
+++ b/tests/browser/storybook-config.test.ts
@@ -6,7 +6,6 @@ import {
   configure,
   scopeToFixture,
   skipCleanup,
-  waitForExitCode,
 } from '@sku-private/testing-library';
 
 const storybookStartedRegex = /Storybook ready!/;
@@ -137,7 +136,7 @@ describe('storybook-config', () => {
 
     beforeAll(async () => {
       const storybook = await exec('pnpm', ['storybook', 'build']);
-      await waitForExitCode(storybook, 0);
+      await expect(storybook).toMatchExitCode(0);
 
       const assetServer = await exec('pnpm', ['run', 'start:asset-server']);
       await assetServer.findByText('serving storybook-static');

--- a/tests/browser/typescript-css-modules.test.ts
+++ b/tests/browser/typescript-css-modules.test.ts
@@ -2,7 +2,7 @@ import { describe, beforeAll, afterAll, it, expect } from 'vitest';
 import { getAppSnapshot } from '@sku-private/playwright';
 import { rm } from 'node:fs/promises';
 import { dirContentsToObject, getPort } from '@sku-private/test-utils';
-import { scopeToFixture, waitFor } from '@sku-private/testing-library';
+import { scopeToFixture } from '@sku-private/testing-library';
 
 const { sku, fixturePath, node, exec } = scopeToFixture(
   'typescript-css-modules',
@@ -97,11 +97,7 @@ describe('typescript-css-modules', () => {
 
       const lint = await sku('lint');
       expect(await lint.findByText('Linting complete')).toBeInTheConsole();
-      await waitFor(() => {
-        expect(lint.hasExit()).toMatchObject({
-          exitCode: 0,
-        });
-      });
+      await expect(lint).toMatchExitCode(0);
     });
   });
 });

--- a/tests/node/cli-arguments.test.ts
+++ b/tests/node/cli-arguments.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { scopeToFixture, waitFor } from '@sku-private/testing-library';
+import { scopeToFixture } from '@sku-private/testing-library';
 
 const { sku } = scopeToFixture('cli-arguments');
 
@@ -12,9 +12,7 @@ describe('cli-arguments', () => {
       await process.findByError("error: unknown option '--foo'"),
     ).toBeInTheConsole();
 
-    await waitFor(() => {
-      expect(process.hasExit()).toMatchObject({ exitCode: 1 });
-    });
+    await expect(process).toMatchExitCode(1);
   });
 
   it('should throw an error if excess arguments are provided', async () => {
@@ -26,8 +24,6 @@ describe('cli-arguments', () => {
       ),
     ).toBeInTheConsole();
 
-    await waitFor(() => {
-      expect(process.hasExit()).toMatchObject({ exitCode: 1 });
-    });
+    await expect(process).toMatchExitCode(1);
   });
 });

--- a/tests/node/codemods/migrate-root-resolution.test.ts
+++ b/tests/node/codemods/migrate-root-resolution.test.ts
@@ -3,7 +3,7 @@ import {
   runCodemodTests,
   scopeToFixture,
 } from '@sku-private/testing-library/codemod';
-import { createFixture, waitFor } from '@sku-private/testing-library';
+import { createFixture } from '@sku-private/testing-library';
 import { it, expect } from 'vitest';
 
 runCodemodTests('migrate-root-resolution', [
@@ -193,9 +193,7 @@ it('should fail on unsupported file', async () => {
 
   const cli = await codemod('migrate-root-resolution', ['.']);
 
-  await waitFor(() => {
-    expect(cli.hasExit()).toMatchObject({ exitCode: 1 });
-  });
+  await expect(cli).toMatchExitCode(1);
 
   expect(
     await cli.findByError('Unsupported sku config shape:'),

--- a/tests/node/config-path.test.ts
+++ b/tests/node/config-path.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, afterEach, describe, it } from 'vitest';
-import { scopeToFixture, waitFor } from '@sku-private/testing-library';
+import { scopeToFixture } from '@sku-private/testing-library';
 import { unlink, writeFile } from 'node:fs/promises';
 
 const { sku, fixturePath } = scopeToFixture('config-path');
@@ -17,9 +17,7 @@ describe('config-paths', () => {
       ),
     ).toBeInTheConsole();
 
-    await waitFor(() => {
-      expect(cli.hasExit()).toMatchObject({ exitCode: 1 });
-    });
+    await expect(cli).toMatchExitCode(1);
   });
 
   describe.each(['ts', 'js', 'mjs'])(

--- a/tests/node/configure.test.ts
+++ b/tests/node/configure.test.ts
@@ -1,4 +1,4 @@
-import { describe, beforeAll, afterAll, it } from 'vitest';
+import { describe, beforeAll, afterAll, it, expect } from 'vitest';
 import { readFile, copyFile, mkdir as makeDir, rm } from 'node:fs/promises';
 import path from 'node:path';
 import * as jsonc from 'jsonc-parser';
@@ -6,10 +6,8 @@ import * as jsonc from 'jsonc-parser';
 import prettierConfig from '../../packages/sku/dist/config/prettier.mjs';
 
 import {
-  waitForExitCode,
   type RenderResult,
   scopeToFixture,
-  waitFor,
 } from '@sku-private/testing-library';
 
 const readFileContents = async (appDir: string, fileName: string) => {
@@ -56,19 +54,19 @@ describe('configure', () => {
         cwd: './App',
       });
 
-      await waitForExitCode(configure, 0);
+      await expect(configure).toMatchExitCode(0);
     });
 
     afterAll(async () => {
       await removeAppDir(appFolder);
     });
 
-    it('should generate a prettier config', async ({ expect }) => {
+    it('should generate a prettier config', async () => {
       const prettierRc = await readJsonC(appFolder, '.prettierrc');
       expect(prettierRc).toEqual(prettierConfig);
     });
 
-    it('should generate a eslint config', async ({ expect }) => {
+    it('should generate a eslint config', async () => {
       const eslintConfig = await readFileContents(
         appFolder,
         'eslint.config.mjs',
@@ -84,17 +82,15 @@ describe('configure', () => {
 
     it.for(['.prettierignore', '.gitignore'])(
       'should generate %s',
-      async (ignore, { expect }) => {
+      async (ignore) => {
         const ignoreContents = await readIgnore(appFolder, ignore);
 
         expect(ignoreContents).toMatchSnapshot();
       },
     );
 
-    it('should not show any warnings in the console', async ({ expect }) => {
-      await waitFor(() => {
-        expect(configure.hasExit()).toMatchObject({ exitCode: 0 });
-      });
+    it('should not show any warnings in the console', async () => {
+      await expect(configure).toMatchExitCode(0);
 
       expect(configure.getStdallStr()).toMatchInlineSnapshot(``);
     });
@@ -115,20 +111,20 @@ describe('configure', () => {
         cwd: './TSApp',
       });
 
-      await waitForExitCode(configure, 0);
+      await expect(configure).toMatchExitCode(0);
     });
 
     afterAll(async () => {
       await removeAppDir(appFolderTS);
     });
 
-    it('should generate a prettier config', async ({ expect }) => {
+    it('should generate a prettier config', async () => {
       const prettierRc = await readJsonC(appFolderTS, '.prettierrc');
 
       expect(prettierRc).toEqual(prettierConfig);
     });
 
-    it('should generate an eslint config', async ({ expect }) => {
+    it('should generate an eslint config', async () => {
       const eslintConfig = await readFileContents(
         appFolderTS,
         'eslint.config.mjs',
@@ -142,7 +138,7 @@ describe('configure', () => {
       `);
     });
 
-    it('should generate tsconfig config', async ({ expect }) => {
+    it('should generate tsconfig config', async () => {
       const tsconfigContents = await readJsonC(appFolderTS, 'tsconfig.json');
 
       expect(Object.keys(tsconfigContents).sort()).toEqual(['compilerOptions']);
@@ -150,17 +146,15 @@ describe('configure', () => {
 
     it.for(['.prettierignore', '.gitignore'])(
       'should generate %s',
-      async (ignore, { expect }) => {
+      async (ignore) => {
         const ignoreContents = await readIgnore(appFolderTS, ignore);
 
         expect(ignoreContents).toMatchSnapshot();
       },
     );
 
-    it('should not show any warnings in the console', async ({ expect }) => {
-      await waitFor(() => {
-        expect(configure.hasExit()).toMatchObject({ exitCode: 0 });
-      });
+    it('should not show any warnings in the console', async () => {
+      await expect(configure).toMatchExitCode(0);
 
       expect(configure.getStdallStr()).toMatchInlineSnapshot(``);
     });

--- a/tests/node/jest-test.test.ts
+++ b/tests/node/jest-test.test.ts
@@ -1,12 +1,10 @@
 import { test, expect } from 'vitest';
-import { scopeToFixture, waitFor } from '@sku-private/testing-library';
+import { scopeToFixture } from '@sku-private/testing-library';
 
 const { node } = scopeToFixture('jest-test');
 
 test('Jest test with preset', async () => {
   const jest = await node(['node_modules/jest/bin/jest.js']);
   expect(await jest.findByError('Ran all test suites.')).toBeInTheConsole();
-  await waitFor(() => {
-    expect(jest.hasExit()).toMatchObject({ exitCode: 0 });
-  });
+  await expect(jest).toMatchExitCode(0);
 });

--- a/tests/node/lint-format.test.ts
+++ b/tests/node/lint-format.test.ts
@@ -5,9 +5,6 @@ import {
   createFixture,
   scopeToFixture,
   type RenderResult,
-  waitForExitCode,
-  hasExpectedExitCode,
-  waitFor,
 } from '@sku-private/testing-library';
 
 const { sku, fixturePath } = scopeToFixture('lint-format');
@@ -50,7 +47,7 @@ describe('lint-format', () => {
         });
         lint = await sku('lint');
 
-        await waitForExitCode(lint, 0);
+        await expect(lint).toMatchExitCode(0);
         fixture.rm();
       });
 
@@ -66,8 +63,8 @@ describe('lint-format', () => {
         ).toBeInTheConsole();
       });
 
-      it('should exit with a zero exit code', () => {
-        expect(hasExpectedExitCode(lint, 0)).toBe(true);
+      it('should exit with a zero exit code', async () => {
+        await expect(lint).toMatchExitCode(0);
       });
 
       it('should report that linting is complete', async () => {
@@ -87,7 +84,7 @@ describe('lint-format', () => {
 
         lint = await sku('lint');
 
-        await waitForExitCode(lint, 1);
+        await expect(lint).toMatchExitCode(1);
         fixture.rm();
       });
 
@@ -103,8 +100,8 @@ describe('lint-format', () => {
         ).toBeInTheConsole();
       });
 
-      it('should exit with a non-zero exit code', () => {
-        expect(hasExpectedExitCode(lint, 1)).toBe(true);
+      it('should exit with a non-zero exit code', async () => {
+        await expect(lint).toMatchExitCode(1);
       });
 
       it('should report that linting failed', async () => {
@@ -160,7 +157,7 @@ describe('lint-format', () => {
 
         lint = await sku('lint', [target]);
 
-        await waitForExitCode(lint, 1);
+        await expect(lint).toMatchExitCode(1);
       });
 
       it('should skip the TypeScript check', async () => {
@@ -195,7 +192,7 @@ describe('lint-format', () => {
       beforeAll(async () => {
         lint = await sku('lint', ['does-not-exist.js']);
 
-        await waitForExitCode(lint, 1);
+        await expect(lint).toMatchExitCode(1);
       });
 
       it('should skip the TypeScript check', async () => {
@@ -235,7 +232,7 @@ describe('lint-format', () => {
           relativePathFromFixture(fixture, 'brokenSyntax.js'),
         ]);
 
-        await waitForExitCode(lint, 1);
+        await expect(lint).toMatchExitCode(1);
       });
 
       it('should skip the TypeScript check', async () => {
@@ -273,7 +270,7 @@ describe('lint-format', () => {
 
         lint = await sku('lint', ['--config', 'sku.config.vitest.ts']);
 
-        await waitForExitCode(lint, 1);
+        await expect(lint).toMatchExitCode(1);
         fixture.rm();
       });
 
@@ -343,9 +340,7 @@ describe('lint-format', () => {
 
       const format = await sku('format');
 
-      await waitFor(() => {
-        expect(format.hasExit()).toMatchObject({ exitCode: 0 });
-      });
+      await expect(format).toMatchExitCode(0);
 
       for (const fileName of Object.keys(filesToFormat)) {
         const result = await fixture.readFile(fileName, { encoding: 'utf-8' });

--- a/tests/node/sku-create.test.ts
+++ b/tests/node/sku-create.test.ts
@@ -8,9 +8,7 @@ import { promisify } from 'node:util';
 
 import {
   configure,
-  hasExpectedExitCode,
   scopeToFixture as scopeToSkuFixture,
-  waitForExitCode,
 } from '@sku-private/testing-library';
 import { scopeToFixture } from '@sku-private/testing-library/create';
 import { normalizePackageManagerVersion } from '@sku-private/test-utils';
@@ -194,8 +192,7 @@ describe.each(['webpack', 'vite'])('sku-create %s', (template) => {
   it('should pass lint', async () => {
     const { sku } = scopeToSkuFixture('sku-create/new-project');
     const result = await sku('lint');
-    await waitForExitCode(result, 0);
-    expect(hasExpectedExitCode(result, 0)).toBe(true);
+    await expect(result).toMatchExitCode(0);
   });
 });
 

--- a/tests/node/test-command.test.ts
+++ b/tests/node/test-command.test.ts
@@ -19,7 +19,7 @@ describe.for(testFrameworks)('[%s]: sku-test', (testRunner) => {
     const process = await sku('test', args[testRunner]);
 
     expect(await process.findByText(/running setup test/i)).toBeInTheConsole();
-    await expect(process).toMatchExitCode(1);
+    await expect(process).toMatchExitCode(0);
   });
 
   it(`should pass through unknown flags`, async () => {

--- a/tests/node/test-command.test.ts
+++ b/tests/node/test-command.test.ts
@@ -4,7 +4,6 @@ import {
   testFrameworks,
   type TestFrameworkValues,
   scopeToFixture,
-  waitFor,
 } from '@sku-private/testing-library';
 
 const { sku } = scopeToFixture('sku-test');
@@ -20,9 +19,7 @@ describe.for(testFrameworks)('[%s]: sku-test', (testRunner) => {
     const process = await sku('test', args[testRunner]);
 
     expect(await process.findByText(/running setup test/i)).toBeInTheConsole();
-    await waitFor(() => {
-      expect(process.hasExit()).toMatchObject({ exitCode: 0 });
-    });
+    await expect(process).toMatchExitCode(1);
   });
 
   it(`should pass through unknown flags`, async () => {
@@ -58,8 +55,6 @@ describe('vitest CJS interop', () => {
     ]);
 
     expect(await process.findByText(/running setup test/i)).toBeInTheConsole();
-    await waitFor(() => {
-      expect(process.hasExit()).toMatchObject({ exitCode: 0 });
-    });
+    await expect(process).toMatchExitCode(0);
   });
 });

--- a/tests/node/vite-loadable-css-order.test.ts
+++ b/tests/node/vite-loadable-css-order.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { parse } from 'node-html-parser';
 
-import { scopeToFixture, waitFor } from '@sku-private/testing-library';
+import { scopeToFixture } from '@sku-private/testing-library';
 import { dirContentsToObject } from '@sku-private/test-utils';
 
 const { sku, fixturePath } = scopeToFixture('vite-loadable-css-order');
@@ -18,9 +18,7 @@ describe('vite loadable CSS ordering', () => {
   it("should emit CSS for a chunk's dependencies (reset) before the emitting its own CSS (rest)", async () => {
     const build = await sku('build');
 
-    await waitFor(() => {
-      expect(build.hasExit()).toMatchObject({ exitCode: 0 });
-    });
+    await expect(build).toMatchExitCode(0);
     expect(await build.findByText('Sku build complete')).toBeInTheConsole();
 
     const distFiles = await dirContentsToObject(fixturePath('dist'), [

--- a/tests/node/vite-plugins.test.ts
+++ b/tests/node/vite-plugins.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { scopeToFixture, waitFor } from '@sku-private/testing-library';
+import { scopeToFixture } from '@sku-private/testing-library';
 
 const { sku } = scopeToFixture('vite-plugins');
 
@@ -8,9 +8,7 @@ describe('vitePlugins', () => {
   it('should run custom Vite plugins during build', async () => {
     const build = await sku('build');
 
-    await waitFor(() => {
-      expect(build.hasExit()).toMatchObject({ exitCode: 0 });
-    });
+    await expect(build).toMatchExitCode(0);
 
     expect(
       await build.findByText('build started with vite plugin'),

--- a/tests/node/vite-render-error.test.ts
+++ b/tests/node/vite-render-error.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { scopeToFixture, waitFor } from '@sku-private/testing-library';
+import { scopeToFixture } from '@sku-private/testing-library';
 
 const { sku } = scopeToFixture('vite-render-error');
 
@@ -21,9 +21,7 @@ describe('vite render error', () => {
   it('should emit an error with the route name and stack trace when a route fails to render', async () => {
     const build = await sku('build');
 
-    await waitFor(() => {
-      expect(build.hasExit()).toMatchObject({ exitCode: 1 });
-    });
+    await expect(build).toMatchExitCode(1);
 
     const stderr = aggregateStdErr(build.stderrArr);
 
@@ -46,9 +44,7 @@ describe('vite render error', () => {
   it('should emit an error with a stack trace when the render entrypoint throws an error', async () => {
     const build = await sku('build', ['--config', 'sku.config.renderError.ts']);
 
-    await waitFor(() => {
-      expect(build.hasExit()).toMatchObject({ exitCode: 1 });
-    });
+    await expect(build).toMatchExitCode(1);
 
     const stderr = aggregateStdErr(build.stderrArr);
 

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -8,6 +8,7 @@ import {
 } from '@sku-private/playwright';
 import { cleanup, configure } from '@sku-private/testing-library';
 import 'cli-testing-library/vitest';
+import '@sku-private/testing-library/matchers';
 
 configure();
 


### PR DESCRIPTION
Refactored the exit code matching so it's consistent across the project. Added a custom vite matcher that waits for the process to exit and then checks the exit code. The process logs are shown if the test fails so you can easily see what's going on.

One improvement is that this waits on the process exiting rather than the exit code (which is what a few tests were doing previously). This means that if the process exits with the wrong exit code it won't wait the whole timeout anymore. 

Example of a failed exit code output (this test is testing tests... maybe a confusing example but the output is coming from the fixtures internal `sku test` run):

<img width="1654" height="974" alt="CleanShot 2026-07-28 at 14 50 25@2x" src="https://github.com/user-attachments/assets/bad93039-cbdd-4374-b3ff-8cbb6d484843" />


The test also bails on a describe block if the error happens in a beforeAll hook, skipping any tests within it. This is good to eliminate extraneous errors that would have happened because of the server not exiting as expected.

<img width="1430" height="380" alt="CleanShot 2026-07-28 at 15 06 06@2x" src="https://github.com/user-attachments/assets/199706c6-7df9-4084-8729-cde7345c8bd8" />