### PR TITLE
Improve package manager detection

### DIFF
--- a/.changeset/wild-moons-attend.md
+++ b/.changeset/wild-moons-attend.md
@@ -1,0 +1,8 @@
+---
+'sku': patch
+'@sku-lib/create': patch
+---
+
+Improve package manager detection
+
+Sku now works out which package manager your project uses from its `packageManager` field or lockfile, before falling back to the package manager that invoked sku. This should improve the accuracy of sku's output when running from a coding agent.

--- a/.changeset/wild-moons-attend.md
+++ b/.changeset/wild-moons-attend.md
@@ -5,4 +5,4 @@
 
 Improve package manager detection
 
-Sku now works out which package manager your project uses from its `packageManager` field or lockfile, before falling back to the package manager that invoked sku. This should improve the accuracy of sku's output when running from a coding agent.
+The package manager detection has been improved, and should now correctly detect the package manager your project uses, even when running from a coding agent.

--- a/.changeset/wild-moons-attend.md
+++ b/.changeset/wild-moons-attend.md
@@ -5,4 +5,4 @@
 
 Improve package manager detection
 
-The package manager detection has been improved, and should now correctly detect the package manager your project uses, even when running from a coding agent.
+Package manager detection has been improved, and should now correctly detect the package manager your project uses, even when running from a coding agent.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1674,7 +1674,7 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       package-manager-detector:
-        specifier: ^0.2.6
+        specifier: ^0.2.11
         version: 0.2.11
       semver:
         specifier: ^7.6.3

--- a/private/utils/package.json
+++ b/private/utils/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "empathic": "^2.0.1",
     "indent-string": "^5.0.0",
-    "package-manager-detector": "^0.2.6",
+    "package-manager-detector": "^0.2.11",
     "semver": "^7.6.3",
     "wrap-ansi": "^9.0.0"
   },

--- a/private/utils/src/packageManager/packageManager.ts
+++ b/private/utils/src/packageManager/packageManager.ts
@@ -69,6 +69,46 @@ const getFallbackPackageManager = (): SupportedPackageManager => {
   return fallback;
 };
 
+const resolveDetectedPackageManager = () => {
+  const projectPackageManager = getProjectPackageManager();
+  const runningPackageManager = getRunningPackageManager();
+
+  const name =
+    projectPackageManager?.name ??
+    runningPackageManager?.name ??
+    getFallbackPackageManager(); // some edge cases might use this fallback, but unlikely
+
+  if (!isSupportedPackageManager(name)) {
+    throw new Error(
+      `Unsupported package manager: ${name}. Supported package managers are: ${supportedPackageManagers.join(
+        ', ',
+      )}`,
+    );
+  }
+
+  const isRunningResolvedPackageManager = runningPackageManager?.name === name;
+
+  if (
+    projectPackageManager &&
+    runningPackageManager &&
+    !isRunningResolvedPackageManager
+  ) {
+    console.warn(
+      caution(
+        `Package manager mismatch: sku was run with ${strong(runningPackageManager.name)}, but this project uses ${strong(name)}`,
+      ),
+    );
+  }
+
+  // The running version is the most accurate source of the version, so we use it if it's available.
+  const version =
+    (isRunningResolvedPackageManager ? runningPackageManager.version : null) ??
+    projectPackageManager?.version ??
+    null;
+
+  return { name, version };
+};
+
 /**
  * Get the package manager and root directory of the project.
  */
@@ -78,50 +118,12 @@ const resolvePackageManager = () => {
   // No lockfile can be found during `@sku-lib/create`.
   const rootDir = lockfilePath ? dirname(lockfilePath) : null;
 
-  const projectPackageManager = getProjectPackageManager();
-  const runningPackageManager = getRunningPackageManager();
-
-  // The project is the source of truth.
-  // Fall back to the running package manager if no project is detected.
-  const packageManager =
-    projectPackageManager?.name ??
-    runningPackageManager?.name ??
-    getFallbackPackageManager();
-
-  if (!isSupportedPackageManager(packageManager)) {
-    throw new Error(
-      `Unsupported package manager: ${packageManager}. Supported package managers are: ${supportedPackageManagers.join(
-        ', ',
-      )}`,
-    );
-  }
-
-  const isRunningResolvedPackageManager =
-    runningPackageManager?.name === packageManager;
-
-  if (
-    projectPackageManager &&
-    runningPackageManager &&
-    !isRunningResolvedPackageManager
-  ) {
-    console.warn(
-      caution(
-        `Package manager mismatch: sku was run with ${strong(runningPackageManager.name)}, but this project uses ${strong(packageManager)}`,
-      ),
-    );
-  }
-
-  // A running package manager's version is only meaningful when it is the
-  // package manager we resolved to.
-  const packageManagerVersion =
-    (isRunningResolvedPackageManager ? runningPackageManager.version : null) ??
-    projectPackageManager?.version ??
-    null;
+  const { name, version } = resolveDetectedPackageManager();
 
   return {
-    packageManager,
+    packageManager: name,
     rootDir,
-    packageManagerVersion,
+    packageManagerVersion: version,
   };
 };
 

--- a/private/utils/src/packageManager/packageManager.ts
+++ b/private/utils/src/packageManager/packageManager.ts
@@ -1,9 +1,9 @@
 import * as find from 'empathic/find';
 import { dirname } from 'node:path';
-import type { Command } from 'package-manager-detector';
+import type { Agent, Command } from 'package-manager-detector';
 import { resolveCommand } from 'package-manager-detector/commands';
-import { INSTALL_PAGE } from 'package-manager-detector/constants';
-import { detectSync, getUserAgent } from 'package-manager-detector/detect';
+import { AGENTS, INSTALL_PAGE } from 'package-manager-detector/constants';
+import { detectSync } from 'package-manager-detector/detect';
 import semver from 'semver';
 import { caution, strong } from '../console/styles.ts';
 
@@ -32,15 +32,18 @@ const lockfileByPackageManager: Record<SupportedPackageManager, string> = {
  * This is unset when sku is run without a package manager, e.g. `./node_modules/.bin/sku`.
  */
 const getRunningPackageManager = () => {
-  const name = getUserAgent();
-
-  if (!name) {
+  const userAgent = process.env.npm_config_user_agent;
+  if (!userAgent) {
     return null;
   }
 
   // User agents typically look like `pnpm/9.12.1 npm/? node/v20.17.0 linux x64`
-  const version =
-    process.env.npm_config_user_agent?.split(' ')[0].split('/')[1] || null;
+  const [agentPart] = userAgent.split(' ');
+  const [name, version] = agentPart.split('/');
+
+  if (!AGENTS.includes(name as Agent)) {
+    return null;
+  }
 
   return { name, version };
 };

--- a/private/utils/src/packageManager/packageManager.ts
+++ b/private/utils/src/packageManager/packageManager.ts
@@ -1,49 +1,24 @@
 import * as find from 'empathic/find';
-import path, { dirname } from 'node:path';
+import { dirname } from 'node:path';
 import type { Command } from 'package-manager-detector';
 import { resolveCommand } from 'package-manager-detector/commands';
 import { INSTALL_PAGE } from 'package-manager-detector/constants';
+import { detectSync, getUserAgent } from 'package-manager-detector/detect';
 import semver from 'semver';
 import { caution, strong } from '../console/styles.ts';
 
 export type SupportedPackageManager = 'yarn' | 'pnpm' | 'npm';
 
-const supportedPackageManagers = ['yarn', 'pnpm', 'npm'];
+const supportedPackageManagers: SupportedPackageManager[] = [
+  'yarn',
+  'pnpm',
+  'npm',
+];
 
-const validatePackageManager = (packageManager: string) => {
-  if (!supportedPackageManagers.includes(packageManager)) {
-    throw new Error(
-      `Unsupported package manager: ${packageManager}. Supported package managers are: ${supportedPackageManagers.join(
-        ', ',
-      )}`,
-    );
-  }
-
-  return packageManager as SupportedPackageManager;
-};
-
-const getPackageManagerFromUserAgent = () => {
-  const userAgent = process.env.npm_config_user_agent || '';
-
-  // Default to 'npm'
-  let packageManager = 'npm';
-
-  let version = null;
-  if (userAgent) {
-    // User agents typically look like `pnpm/9.12.1 npm/? node/v20.17.0 linux x64`
-    version = userAgent.split(' ')?.[0].split('/')?.[1];
-  }
-
-  if (userAgent.includes('yarn')) {
-    packageManager = 'yarn';
-  }
-
-  if (userAgent.includes('pnpm')) {
-    packageManager = 'pnpm';
-  }
-
-  return { packageManager, version };
-};
+const isSupportedPackageManager = (
+  packageManager: string | null | undefined,
+): packageManager is SupportedPackageManager =>
+  supportedPackageManagers.includes(packageManager as SupportedPackageManager);
 
 // lockfiles should be ordered by priority, highest priority first.
 const lockfileByPackageManager: Record<SupportedPackageManager, string> = {
@@ -53,33 +28,100 @@ const lockfileByPackageManager: Record<SupportedPackageManager, string> = {
 };
 
 /**
+ * The package manager that invoked the current process, if any.
+ * This is unset when sku is run without a package manager, e.g. `./node_modules/.bin/sku`.
+ */
+const getRunningPackageManager = () => {
+  const name = getUserAgent();
+
+  if (!name) {
+    return null;
+  }
+
+  // User agents typically look like `pnpm/9.12.1 npm/? node/v20.17.0 linux x64`
+  const version =
+    process.env.npm_config_user_agent?.split(' ')[0].split('/')[1] || null;
+
+  return { name, version };
+};
+
+/**
+ * The project's package manager, resolved from its `packageManager` field or lockfile.
+ * This is unset when there is no project to detect, e.g. during `@sku-lib/create`.
+ */
+const getProjectPackageManager = () => {
+  const detected = detectSync();
+
+  if (!detected) {
+    return null;
+  }
+
+  const { name, version = null } = detected;
+
+  return { name, version };
+};
+
+const getFallbackPackageManager = (): SupportedPackageManager => {
+  const fallback = 'npm';
+  console.warn(
+    caution(`No package manager detected, assuming ${strong(fallback)}`),
+  );
+  return fallback;
+};
+
+/**
  * Get the package manager and root directory of the project.
- * If the project does not have a root directory, `rootDir` will be `null`.
  */
 const resolvePackageManager = () => {
-  const userAgentPackageManager = getPackageManagerFromUserAgent();
-  const packageManager = validatePackageManager(
-    userAgentPackageManager.packageManager,
-  );
+  const lockfilePath = find.any(Object.values(lockfileByPackageManager));
 
-  const expectedLockfile = lockfileByPackageManager[packageManager];
-  const lockFilePath = find.any(Object.values(lockfileByPackageManager));
+  // No lockfile can be found during `@sku-lib/create`.
+  const rootDir = lockfilePath ? dirname(lockfilePath) : null;
 
-  if (lockFilePath && !lockFilePath.includes(expectedLockfile)) {
+  const projectPackageManager = getProjectPackageManager();
+  const runningPackageManager = getRunningPackageManager();
+
+  // The project is the source of truth.
+  // Fall back to the running package manager if no project is detected.
+  const packageManager =
+    projectPackageManager?.name ??
+    runningPackageManager?.name ??
+    getFallbackPackageManager();
+
+  if (!isSupportedPackageManager(packageManager)) {
+    throw new Error(
+      `Unsupported package manager: ${packageManager}. Supported package managers are: ${supportedPackageManagers.join(
+        ', ',
+      )}`,
+    );
+  }
+
+  const isRunningResolvedPackageManager =
+    runningPackageManager?.name === packageManager;
+
+  if (
+    projectPackageManager &&
+    runningPackageManager &&
+    !isRunningResolvedPackageManager
+  ) {
     console.warn(
       caution(
-        `Lockfile mismatch: ${strong(path.basename(lockFilePath))} is not a valid lockfile for ${strong(packageManager)}`,
+        `Package manager mismatch: sku was run with ${strong(runningPackageManager.name)}, but this project uses ${strong(packageManager)}`,
       ),
     );
   }
 
-  // No root found (occurs during `@sku-lib/create`), `rootDir` will be `null`
-  const rootDir = lockFilePath ? dirname(lockFilePath) : null;
+  // A running package manager's version is only meaningful when it is the
+  // package manager we resolved to.
+  const packageManagerVersion =
+    (isRunningResolvedPackageManager ? runningPackageManager.version : null) ??
+    projectPackageManager?.version ??
+    null;
 
   return {
     packageManager,
     rootDir,
-    packageManagerVersion: userAgentPackageManager.version,
+    packageManagerVersion,
   };
 };
 

--- a/private/utils/src/packageManager/packageManager.ts
+++ b/private/utils/src/packageManager/packageManager.ts
@@ -7,25 +7,23 @@ import { detectSync } from 'package-manager-detector/detect';
 import semver from 'semver';
 import { caution, strong } from '../console/styles.ts';
 
-export type SupportedPackageManager = 'yarn' | 'pnpm' | 'npm';
+// lockfiles should be ordered by priority, highest priority first.
+const lockfileByPackageManager = {
+  pnpm: 'pnpm-lock.yaml',
+  yarn: 'yarn.lock',
+  npm: 'package-lock.json',
+} as const satisfies Record<string, string>;
 
-const supportedPackageManagers: SupportedPackageManager[] = [
-  'yarn',
-  'pnpm',
-  'npm',
-];
+export type SupportedPackageManager = keyof typeof lockfileByPackageManager;
+
+const supportedPackageManagers = Object.keys(
+  lockfileByPackageManager,
+) as SupportedPackageManager[];
 
 const isSupportedPackageManager = (
   packageManager: string | null | undefined,
 ): packageManager is SupportedPackageManager =>
   supportedPackageManagers.includes(packageManager as SupportedPackageManager);
-
-// lockfiles should be ordered by priority, highest priority first.
-const lockfileByPackageManager: Record<SupportedPackageManager, string> = {
-  pnpm: 'pnpm-lock.yaml',
-  yarn: 'yarn.lock',
-  npm: 'package-lock.json',
-};
 
 /**
  * The package manager that invoked the current process, if any.


### PR DESCRIPTION
I've refactored the package manager detection to reduce warning when running within an agent. Previously, if you ran skus binary directly from node_modules it would lead to `npm_config_user_agent` not being set. Sku would fall back to npm if this was the case, leading to errors in the terminal.

Obvisouly this is not how people should be running sku, but this can happen with AI agents, and there are other ways for them to run sku without setting a npm_config_user_agent due to sandbox limitations. Ai agent output was how this issue was found.

An example of previous broken output, tested by building the braid fixture with the sku bin directly (`./node_modules/.bin/sku`). This could also happen  inside an AI agent sandbox environment in a few different ways.

<img width="674" height="275" alt="CleanShot 2026-07-29 at 17 32 01" src="https://github.com/user-attachments/assets/55ad349e-f374-477d-962e-645da43082db" />

 <br>
 <br>

After the changes, there  are no errors and we get correct telemetry installation output.

<img width="903" height="555" alt="CleanShot 2026-07-29 at 17 36 30" src="https://github.com/user-attachments/assets/c52edfdf-ce0d-41be-b3ad-1f73235395d5" />

## Code logic changes
- Resolution now uses `package-manager-detector`, which detects the **projects** package manager from it's `packageManager` field or  lockfile. That is now the source of truth for any command run inside a project.
- The **running** package manager is only a fallback for when no project is detected, which is the case for `@sku-lib/create`, where a fresh directory has no lockfile. If neither is available, it still defaults to npm.
- The "Lockfile mismatch" warning became a mismatch between the *running* and *project* package managers, and it only fires when a user agent is actually present.
- `packageManagerVersion` prefers the running agent's version when the running agent matches the project's (so it reflects the actual binary in use), then falls back to the version in the `packageManager` field. 
- A detected but unsupported manager (bun or deno) now throws the existing "Unsupported package manager" error rather than silently behaving like npm.
- I didn't add any tests for this since a pretty tricky one to test nicely without mocking a whole bunch of stuff. I don't think it's worth the effort for the value it brings