### PR TITLE
Add OpenSpec change for experimental Vite SSR

### DIFF
--- a/openspec/changes/vite-ssr/.openspec.yaml
+++ b/openspec/changes/vite-ssr/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/vite-ssr/design.md
+++ b/openspec/changes/vite-ssr/design.md
@@ -1,0 +1,1452 @@
+## Context
+
+SSR commands are blocked today.
+Webpack SSR uses Express `renderCallback`, string HTML, and CSP meta tags.
+
+This change introduces **Managed Data Mode**.
+Sku owns the server, Document shell, streaming/hydration, assets, and CSP headers.
+Sku wires React Router Data Mode for routing and data.
+Apps own routes, data, and providers.
+
+Managed Data Mode is first shipped as **SSR** (`buildType: 'ssr'` on Vite).
+The same application contract is intended to underpin a future Static path.
+That contract includes `sku/runtime`, request entries, and hooks.
+Render strategy and API surface are separate concerns.
+See Decision 27.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- **Managed Data Mode** first shipped as SSR via `buildType: 'ssr'`.
+- Public import `sku/runtime`.
+- Public types and symbols without an `Ssr` infix.
+- Create template `ssr`.
+- First-class `routesEntry` with a named `routes` export.
+- First-class request-entry contracts.
+- First-class multi-site route trees via flat `routes`, optional `sites`, and `getSite`.
+- Same spirit as first-class multi-language.
+- Full-document streaming with `hydrateRoot(document, …)`.
+- Shell-derived CSP headers.
+- Per-route and vocab chunks via sku-owned `@vocab/vite` resolve.
+- Create template and Migrating docs.
+- Experimental first release.
+- Single config `port` only.
+- Config `serverPort` is rejected.
+- Named `Component` on lazy pages in template and docs.
+- CJS interop docs.
+- Accurate config JSDoc.
+- React Router 8 as an optional peerDependency `^8` for SSR consumers only.
+- No hard sku dependency on React Router.
+- Keep the shared Express dep on 4.
+- No 4 → 5 bump in this change.
+- No Jest transforms for React Router 8 in this change.
+- SSR requires Vitest.
+- Request entries `export default` one object via `defineServerEntry` / `defineClientEntry`.
+- Those helpers are zero-runtime inference helpers.
+- Optional sync getters receive Express `{ req }` where needed.
+- Getters include `getSite`, `getLanguage`, `getClientContext`, and `getReactContext`.
+- Optional entry hooks include `middleware`, `onListen`, `onHydrate`, and `getRouterContext`.
+- Always-on sku `SkuProvider` outside the router.
+- It carries `site`, serialised `clientContext`, and env `reactContext`.
+- Typed hooks via `createSkuContexts<typeof server, typeof client>()` on `sku/runtime`.
+- Sku does not wrap the route tree.
+- `createStaticHandler` is pre-built per site.
+- Three value channels: `getClientContext`, dual-entry `getReactContext`, and dual-entry `getRouterContext`.
+- `getClientContext` is the serialised isomorphic React seed.
+- `getReactContext` may differ per environment.
+- `getRouterContext` supplies values for React Router loaders and actions.
+- Later getters receive already-resolved sibling values.
+- `defineServerEntry` infers types from getter returns.
+- `defineClientEntry<typeof server>` extracts `Site` / `ClientContext` from the server entry.
+- Hooks read types from `typeof` the entry objects.
+- Router-aware isomorphic wrapping lives in the app’s own root layout route in `routesEntry`.
+- That covers Vocab, Apollo provider mount, and page chrome.
+- App-owned streaming data transports via `useInsertHtml` on `sku/runtime`.
+- The hook is nonce-able and a no-op off the SSR path.
+- Apollo streaming hydration is proven by a fixture.
+- Server-run queries are not refetched on hydrate.
+- Post-hydration queries still fetch.
+- Docs prefer render-time React data loading via Suspense.
+- Clients come from `useReactContext` / `useClientContext`.
+- Router-aware providers live in the app’s root layout route.
+- Loaders and `getRouterContext` are opt-in.
+- Docs include a red warning against putting Express `req` into router context.
+- Migrating guidance covers server-only loaders, Braid reset order, client-only libraries via `getReactContext`, Jest → Vitest, and `#` `pathAliases`.
+- Config `polyfills` applies to the SSR browser client.
+- SSR `sku start` covers SSR-CSS via a virtual stylesheet on Document assets.
+- No `transformIndexHtml` on the SSR path.
+- SSR `sku start` telemetry parity for `start.initial` / `start.rebuild`.
+- Optional server-entry `onListen` covers the same post-`listen` window as webpack `onStart`.
+- Opt-in config `expressTrustProxy` is a boolean that sets Express hop count `1`.
+- The create template sets `expressTrustProxy: true`.
+
+**Non-Goals:**
+
+- Webpack mode for this `buildType`, or a Webpack SSR backfill / an updated Webpack-SSR create template.
+- Converting the static `vite` create template.
+- Full infra/deploy product guides (keep sku’s existing docs scope).
+- Framework Mode / RSC.
+- Absolute / `CDN` `publicPath`.
+- First-class React Router basename config.
+- SSR `serverPort`.
+- Expanding baked-in CJS interop defaults beyond Apollo.
+- Consumer Document override.
+- Runtime server↔client route-tree equality checking.
+- Dual-entry `routes` re-exports from `serverEntry` / `clientEntry`.
+- Differing server vs client route modules as a product feature.
+- Sku-owned site resolution from config `hosts` / `sites[].host` (local-dev listen/setup only).
+- Sku-owned per-site path expansion libraries (apps own path shape; sku owns membership filtering).
+- Requiring a non-empty config `sites` array for SSR (empty soft-defaults to `'default'`).
+- Per-site JS bundles.
+- Returning routes from a request-entry getter or bag.
+- A combined request-entry resolver returning site + language + `clientContext` values (see Decision 12).
+- Returning a provider component from request-entry getters (see Decision 12).
+- Sku reading site / language / `clientContext` from a conventional `req` field, or a sku-provided push API such as `setRequestContext(req, …)`.
+- Tolerating a missing `serverEntry` / `clientEntry` file (paths still resolve via normal module resolution).
+- Per-getter named exports on request entries or `defineGet*` per-property helpers.
+- Mounting sku’s provider inside the route tree as a pathless layout (see Decision 12).
+- Consumer-authored Async Local Storage as the documented way to reach request state from React.
+- App-authored dual-entry `Providers` / `SkuProvidersProps` (see Decision 12a).
+- A public `useInitialLanguage` / language-in-React-context hook in v1.
+- Union route tree + site allowlist middleware as the documented multi-site product story.
+- Parent → child inheritance of `sites` (must set explicitly on each divergent route).
+- Overloading config `routes` (static prerender path lists) as the SSR `RouteObject` entry.
+- Sku-owned listen logging by default (apps log in `onListen`).
+- An `onBeforeListen` server-entry hook (module top-level covers pre-bind setup).
+- Soft-defaulting Express `trust proxy` for SSR without config (opt-in via `expressTrustProxy`).
+- Supporting the config `public` assets folder for SSR (until a definitive need).
+- Automatic `*.server.ts` client strip.
+- Auto-injecting Braid reset into sku’s SSR server entry.
+- A new Jest → Vitest codemod beyond existing tooling / docs.
+- Making Express `req` the loader `request` argument (stays Fetch `Request`).
+- Treating Framework Mode’s server-only `getLoadContext(req, res)` as sufficient for sku Data Mode.
+- Requiring `getClientContext`, `getReactContext`, or `getRouterContext` (all optional; omit → `undefined` / empty defaults).
+- Requiring `middleware`, `onListen`, or `onHydrate` (all optional).
+- Requiring `getSite` when config has zero or one site (sku uses the sole resolved name).
+- Passing Fetch `Request` into `getSite` / `getLanguage` / `getClientContext` (Express `req` only).
+- Passing `res` into getters / `getReactContext` / `getRouterContext` in v1.
+- Async request-entry getters (sync-only; `getRouterContext` MAY still be async because it seeds loader context).
+- Treating raw Express `req` (or other non-isomorphic platform objects) in `RouterContextProvider` as a supported pattern.
+- Shipping Jest support for React Router 8 (transforms / ESM interop).
+- Forcing webpack fixtures or non–Vite-SSR apps onto React Router 8.
+- Treating React Router loaders as the default teaching path for page content.
+- Upgrading sku’s shared Express dependency from 4 → 5 (deferred; would break webpack SSR).
+- Supporting `@sku-lib/vite/loadable` (Collector / `LoadableProvider` / `preloadPlugin` module-id injection) as an SSR document-preload source.
+- Supporting `dangerouslySetViteConfig` or `vitePlugins` for SSR (static Vite unchanged).
+- A sku-owned Apollo dependency, provider, config option, or version pin (sku ships `useInsertHtml` and apps own the client / transport).
+- `@apollo/client-integration-react-router`’s loader transport (see Decision 21a).
+- Streaming (turbo-stream) loader-data serialization to carry transported query refs.
+- Two-pass `getDataFromTree` SSR (incompatible with streaming).
+- Sku auto-attaching the CSP nonce to app-injected scripts (transports expose their own script props).
+- Consumer Vite config injection for SSR module identity (sku owns `optimizeDeps.exclude`).
+- Moving Document / route filtering / middleware / stream transform onto the public `sku/runtime` entry (not on the consumer↔sku dual path).
+
+## Decisions
+
+### 1. Webpack alignment principle
+
+When choosing SSR implementation details that overlap webpack SSR (compile-time defines, naming, shapes), two rules apply.
+Do not copy webpack SSR patterns that are a poor fit for SSR.
+Do not diverge from webpack SSR naming or shapes without a concrete reason.
+
+Prefer webpack-aligned defines (`__SKU_CSP__`, `__SKU_DEFAULT_SERVER_PORT__`) over inventing parallel `import.meta.env.SKU_*` knobs.
+Prefer a single CSP object over many flat string defines.
+Prefer dropping unused language allowlisting over baking `SKU_LANGUAGES` “because config exists.”
+No sidecar runtime manifest.
+Webpack-style defines are enough.
+
+### 2. Mode selection via `buildType`
+
+`buildType?: 'ssr' | 'static'` selects render strategy.
+With Vite the commands stay `sku start` / `sku build`.
+Webpack + this `buildType` MUST error, and `-ssr` when `buildType` is set MUST error.
+Webpack SSR without `buildType` keeps `start-ssr` / `build-ssr`.
+
+### 3. Managed Data Mode (Data Mode, not Framework Mode)
+
+Sku’s application contract is **Managed Data Mode**.
+Sku owns Document, the Node server, streaming/hydration bootstrap, CSP, and React Router Data Mode wiring (`createStaticHandler` / `createBrowserRouter` + `lazy`).
+Apps own routes, data, and providers.
+Errors flow through React Router `ErrorBoundary` + `context.statusCode`.
+
+This is **not** React Router Framework Mode (no RR Vite plugin, no file routes, no RSC).
+Sku owns Vite plugins, the Node server, and CSP, so Framework Mode’s Vite plugin would compete.
+
+Managed Data Mode is the temporal product descriptor for this API surface when comparing to older sku APIs (webpack SSR `renderCallback` + string document, today’s static `#app` hydrate).
+It is first released as SSR.
+A future Static path is expected to share the same Managed Data Mode contract (see Decision 27).
+
+### 4. `routesEntry` + request entries
+
+Reuse `serverEntry` / `clientEntry` for request lifecycle.
+Add first-class config `routesEntry` (default `src/routes.tsx`) for the route tree.
+Sku resolves it via `__sku_alias__routesEntry` into **both** the server and client Vite graphs (same alias pattern as `__sku_alias__serverEntry` / `__sku_alias__clientEntry`).
+
+`routesEntry` MUST export named `routes: SkuRouteObject[]`.
+`SkuRouteObject` is a sku type helper only: `RouteObject & { sites?: string[] }`.
+Sku MUST NOT re-export a wrapped React Router `RouteObject` as the product API.
+Consumers still import route primitives from `react-router` and may use `SkuRouteObject` for the optional `sites` field.
+
+Missing or non-array `routes` on `routesEntry` MUST hard-error.
+Sku loads `routes` from `routesEntry` only.
+It does not read `routes` / `routesBySite` from `serverEntry` / `clientEntry`.
+Config `routes` (static prerender path lists) remains unrelated.
+Do not overload that key for SSR `RouteObject` trees.
+
+`serverEntry` / `clientEntry` each **`export default`** one object from `defineServerEntry` / `defineClientEntry` (structural types `SkuServerEntry` / `SkuClientEntry`).
+Sku reads that default export and calls optional properties.
+
+The server object exposes optional sync `getSite` / `getLanguage` / `getClientContext` / `getReactContext`, plus optional `middleware`, `onListen`, and `getRouterContext`.
+The client object exposes optional `onHydrate`, `getReactContext`, and `getRouterContext`.
+`getSite` is required **only** when config `sites` has more than one entry.
+A missing property then hard-errors at init (same class as missing `routes` on `routesEntry`).
+
+Optional properties omitted mean noops / defaults.
+No consumer middleware, no hydrate side effects, sole resolved site name when `getSite` is omitted on a 0–1 site app (empty config soft-defaults to `'default'`), and `clientContext` / `reactContext` `undefined`.
+Hard errors apply only when a required property is missing.
+There is no early file-existence gate.
+Missing entry files fail via normal module resolution.
+
+Getters on the entry object stay **pull** (functions sku calls) rather than an `onRequest`-style bag of already-resolved values.
+Sku always mounts `SkuProvider` outside the router (`Document` → `SkuProvider` → router) with `site`, `clientContext`, and `reactContext`.
+Dual-entry `getReactContext` supplies values that may differ on server vs client.
+Dual-entry `getRouterContext` supplies values for React Router loaders/actions.
+Client `getRouterContext` must be a stable function called on every client navigation / fetcher by `createBrowserRouter`.
+
+One `routesEntry` module is the isomorphic source of truth for both graphs.
+No dual re-export.
+No “implementations MAY diverge” escape hatch as a product feature.
+With Express `req` on the getters plus optional `getReactContext` / `getRouterContext`, shell and loader values no longer need env-split route modules.
+Server-only loader modules remain a docs/convention concern (keep them off the client-imported graph, no automatic `*.server.ts` strip).
+
+SSR wrappers resolve consumer modules via `__sku_alias__serverEntry` / `__sku_alias__clientEntry` / `__sku_alias__routesEntry`.
+
+Note: tsdown/rolldown reorders static imports by specifier shape.
+`#…` sorts after `@vitejs/plugin-react/preamble` while `__…` sorts before it.
+Using `#` entry ids can therefore surface the fragile “preamble must run before consumer JSX” Refresh ordering issue in the published client entry.
+Mitigate with a start-only `#entries/ssr-client.dev` that imports the preamble then dynamically loads the production client entry.
+Production builds keep using `#entries/ssr-client` with no preamble.
+
+**Config `polyfills` (browser client):**
+Sku’s SSR client entry (`ssr-client.tsx`, including the start-only `.dev` wrapper’s production client load) MUST import `virtual:sku/polyfills` before hydrate and before consumer client-entry code.
+It is the same virtual module as static `vite-client.tsx`.
+`polyfillsPlugin` remains on the shared Vite plugin graph.
+It is not static-only.
+Without that import the plugin is inert for SSR.
+Polyfills apply to the **browser** client graph only.
+Do not load them into the Node server entry.
+
+**HTTP middleware layers** (distinct from React Router route `middleware`):
+
+- **Production:** optional server-entry Express/Connect `middleware`. Omitted ⇒ no consumer middleware layer (not an error). Mounted in start and production when present.
+- **Dev-only:** optional config `devServerMiddleware`. Start only, never in the production server graph.
+- **Production order:** request-context → optional `express.static(publicPath)` (only when a sibling `client/` exists) → server-entry `middleware` (if any) → HTML.
+- **Dev order:** request-context → `devServerMiddleware` → server-entry `middleware` (if any) → Vite → HTML.
+
+Document is sku-owned (React document metadata).
+No consumer Document override in v1.
+
+### 4a. Flat `routes` + optional `sites` → pre-built site trees
+
+Multi-site apps need different React Router path sets per site (e.g. site-only pages).
+A single unfiltered `RouteObject[]` either over-matches unsupported paths or registers foreign paths on every host.
+
+Config `hosts` / `sites[].host` are **local-dev listen and setup-hosts only**.
+Sku MUST NOT derive production (or request) site from them for route-tree selection.
+
+**Apps own** site resolution (from Express `req`, headers, app config, etc.) via sync `getSite({ req })`, and per-site **path shape** when paths differ by site (factories remain fine for `/jobs` vs `/emploi`).
+Route membership is declared on routes themselves.
+
+**Sku owns:**
+
+- Typing `SkuRouteObject.sites`.
+- Loading `routes` from `routesEntry`.
+- Pre-building per-site trees from config site names.
+- Stripping `sites` before passing trees to React Router APIs.
+- Creating `createStaticHandler` once per site at init. Sku never wraps the tree because provider mounting sits outside the router.
+- Selecting that handler for the resolved `site`.
+- Serialising `site` into the hydrate bootstrap.
+- Using that same `site` on the client for `createBrowserRouter`.
+
+**Route membership:**
+
+- `routesEntry` exports flat `routes: SkuRouteObject[]`.
+- Optional `sites?: string[]` on a route. Omit or `undefined` ⇒ route is included for **every** config site.
+- Present `sites` ⇒ route is included **only** for those site names (exact string match against config site names).
+- No parent → child inheritance of `sites`. Site-specific deviation MUST set `sites` explicitly on each divergent route. Friction is intentional.
+- The tree walk stays recursive: if a parent is excluded for a site, that parent’s subtree is absent from that site’s tree (structure, not field inheritance).
+
+**Config sites:**
+SSR does **not** require a non-empty config `sites` array.
+Empty or omitted `sites` soft-defaults to a single synthetic site name `'default'` for pre-build + allowlist (same class as other sku empty-config soft paths).
+Apps that care about site names declare real ones.
+Multi-site still needs ≥2 configured names + `getSite`.
+
+**Pre-build:**
+At init (not per request), for each resolved site name (config names, or `['default']` when empty), sku deep-filters `routes` into a site tree and strips `sites` from the objects passed to React Router.
+The client needs the same site-name list (bake from config for production client, same as other `__SKU_*` defines) so both sides pre-build identically from the same `routesEntry` module.
+
+**Resolve site:**
+
+- Zero configured sites (soft-default `'default'`) or one configured site ⇒ sku uses that sole resolved name when `getSite` is omitted. If `getSite` is exported, sku still calls it and validates the return against the resolved name list.
+- Multiple configured sites ⇒ missing `getSite` export is a **hard error at init** (names the export; same treatment as missing `routes` on `routesEntry`).
+- Non-string `site` from `getSite`, or a `site` not among resolved site names / no pre-built entry ⇒ **fail closed** per request (hard error).
+
+**Select tree / handler:** the pre-built tree (and server `createStaticHandler`) for that `site`.
+The client uses the same `site` for `createBrowserRouter`.
+Do **not** call `createStaticHandler` on the per-request hot path.
+Only `query()` / `createStaticRouter` are per request.
+
+`site` is first-class in the hydrate bootstrap.
+It is not stuffed into `clientContext` and not passed into `onHydrate` args.
+`onHydrate` stays `{ clientContext }` only (optional export).
+
+Config `sites[].routes` (static prerender path lists) remains unrelated to SSR `RouteObject` trees.
+
+**Why not alternatives as the product answer:**
+
+| Approach                                  | Why not                                                                                                                      |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Sku host → site via config `sites[].host` | Config hosts are local-dev only; production hostnames are app/platform-owned                                                 |
+| Union tree + site allowlist middleware    | Cross-site paths still match then 404; easy to get wrong on client nav; every migrant reinvents it                           |
+| `routesBySite` map                        | Trialled and rejected; apps hand-build N trees; membership belongs on the route; sku can pre-filter a flat list              |
+| Dual-entry `routes` re-exports            | Redundant once `getRouterContext` / getters cover request-scoped values; hydration mismatch risk; `routesEntry` is one truth |
+| Getter / bag returns routes               | Weaker config-as-data; larger hydrate story; `routesEntry` stays clearer                                                     |
+| Optional path params for “language”       | Matches unsupported prefixes; not site-correct                                                                               |
+| One deploy/process per site               | Does not match multi-host deploys that share a process                                                                       |
+| Inherit `sites` from parents              | Hides site splits; explicit annotation keeps deviation visible                                                               |
+| Overload config `routes`                  | Already means static prerender path lists; keep `routesEntry` for the RR module                                              |
+| Conventional `req` field / sku push API   | Unversioned `string \| undefined`; collides across consumers; fails only on a request — see Decision 12                      |
+| Combined site+language+context resolver   | Reintroduces the return-bag shape Decision 12 pulled apart                                                                   |
+
+Document multi-site SSR via `routesEntry` + flat `routes` + optional `sites` + `getSite`, not these workarounds.
+
+### 5. Commands and deploy shape
+
+Single-port Vite `middlewareMode` + `appType: 'custom'` powers `sku start` (listen on `port`).
+Build emits sibling `client/` and `server/`.
+The production entry is `dist/server/server.js`.
+`httpsDevServer` turns on HTTPS + HMR in start.
+Production remains HTTP.
+
+Webpack SSR’s dual-port mental model (`port` for assets + `serverPort` for the Node app) does **not** apply.
+SSR uses a single config `port` for `sku start` and as the baked production default listen port (`__SKU_DEFAULT_SERVER_PORT__`).
+`process.env.PORT` still overrides at runtime.
+Providing `serverPort` with SSR MUST fail config validation (webpack-only).
+Migrating docs must call this out (drop `serverPort`, map old `serverPort` → `port` or rely on `PORT`).
+
+**Production server self-containment (except hashed static files):**
+
+Document asset URLs come from the Vite client manifest.
+Today the production entry reads `../client/.vite/manifest.json` at startup.
+That hard-fails with `ENOENT` when `client/` is not a sibling of `server/`, even when hashed files are hosted elsewhere.
+
+`sku build` MUST bake or copy the Vite client manifest into the server output.
+The production entry MUST load that server-local manifest.
+It MUST NOT require a sibling `client/` directory (or the hashed files under it) to start or stream HTML.
+
+Hashed files under `client/` remain the static asset payload.
+They are not part of the Node process’s required runtime graph.
+
+The server bundle is **not** a frozen binary.
+Runtime dependencies still resolve from `node_modules` (or an equivalent production install) next to the deployed app.
+Deploy docs MUST say so.
+
+**Recommended production layout:**
+
+1. Run `sku build`.
+2. Upload `dist/client/` (hashed assets) to persistent object storage or an equivalent edge/origin for static files.
+3. Deploy `dist/server/` plus production `node_modules` (or `pnpm deploy` / image install equivalent).
+4. Put a reverse proxy or CDN in front that serves `publicPath` from that storage and forwards everything else to Node.
+
+Productionised services SHOULD NOT treat the Node process as the real origin for hashed assets.
+A reverse proxy or persistent storage serves those files ahead of (or instead of) Node.
+
+**Standalone / experimentation:**
+
+Deploying sibling `client/` + `server/` and letting Node serve assets via `express.static` remains useful for local production smoke tests and edge cases.
+It is not the recommended productionised path.
+Deploy docs MUST distinguish the two.
+
+### 6. `publicPath` is the static asset prefix only (not React Router basename)
+
+`publicPath` is sku’s asset prefix.
+It is the public URL path for static assets (webpack parity via `__SKU_PUBLIC_PATH__`).
+
+**Production / `sku build`:**
+Vite `config.base` is set to `publicPath` so emitted client URLs match.
+HTML injects assets under `publicPath` using the **baked** client manifest (Decision 5).
+
+When a sibling `client/` directory exists next to `server/`, the production server MAY mount `express.static` at `publicPath` **before** server-entry `middleware`.
+That mount is for standalone / local production convenience.
+It MUST NOT be required for Document rendering or process startup.
+
+When no sibling `client/` exists, sku MUST NOT mount `express.static` for that prefix and MUST NOT fail solely because the directory is absent.
+
+SSR requires relative `publicPath`.
+Absolute / CDN `publicPath` remains rejected (Non-Goals).
+Browser asset URLs stay same-origin under `publicPath`.
+The edge layer (or standalone Node static) resolves those paths to files.
+
+When Node static **is** mounted, static under `publicPath` wins over consumer middleware.
+Do **not** treat `unlessStatic('/static/…')` (or equivalent) as the sku fix.
+Migrants should not reinvent that for every catch-all stack.
+Apps that intentionally intercept paths under `publicPath` are rare and own that routing (e.g. platform proxy), not sku’s default mount order.
+
+**Start order is unchanged** for this decision (`… → middleware → Vite → HTML`).
+
+**`sku start`:**
+Ignore config `publicPath` and serve the Vite module graph from `/` (webpack SSR start parity).
+Bootstrap scripts are `/@vite/client` and `/@fs/…`, not under `publicPath`.
+Documents stay on app routes outside any asset prefix either way.
+
+Sku MUST NOT treat Vite’s built-in `import.meta.env.BASE_URL` as a product concept or pass it (or `publicPath`) as React Router `basename`.
+Basename stays unset (effectively `/`).
+Path-prefixed SPA basenames are a discouraged pattern and MUST NOT become a first-class sku config.
+
+Relative `publicPath` values like `/static/my-app` MUST work in production with app HTML served on routes outside that prefix.
+Cover with a fixture or equivalent test (production asset prefix, start bootstrap at `/`).
+Do **not** set Vite `config.base` to `publicPath` for `sku start`.
+That conflates Vite’s app-root with sku’s asset prefix and breaks static SPA start when shared.
+
+### 7. No config `public` assets folder for SSR
+
+Config `public` designates a folder of files copied/served as-is (unhashed).
+That pattern often bypasses content hashing / cache-safe URLs and is used to avoid production-ready asset serving.
+Until there is a definitive need, SSR MUST NOT support it.
+
+Config always has a `public` path (default `'public'`), so the signal is directory existence, not whether the option is set.
+On `sku start` / `sku build` for SSR, if `paths.public` exists on disk, hard-error with guidance to import assets from scripts instead (Vite hashed pipeline).
+
+Implementation MUST also disable the copy/serve path for this mode:
+
+- Do **not** set Vite `publicDir` to `paths.public` (use `false` / unset for SSR).
+- Do **not** call `copyPublicFiles` after the SSR build.
+
+Static Vite and webpack keep today’s `public` behaviour.
+Docs MUST discourage the pattern for SSR and note importing images/assets in modules as the alternative.
+Migrating MUST call out moving off `public` when adopting SSR.
+
+### 8. No `dangerouslySetViteConfig` or `vitePlugins` for SSR
+
+`dangerouslySetViteConfig` and `vitePlugins` are Vite escape hatches.
+Sku opens escape hatches only for known best-practice needs.
+As a new API without legacy to support, SSR does not support these options.
+
+When either is set with SSR, config validation MUST hard-error and point consumers to sku-support channels with their use-case.
+Static Vite keeps today’s behaviour.
+Do not apply the `dangerouslySetViteConfig` decorator plugin on the SSR plugin graph.
+Do not mount consumer `vitePlugins` on the SSR plugin graph.
+Both omissions are redundant once validation rejects, but keep the SSR path explicit.
+
+Docs (`configuration.md` + SSR product / Migrating) MUST state that both options are unsupported for SSR and that exceptional Vite customisation needs should go through support first.
+
+### 9. Full-document streaming
+
+React owns `<html>`, `<head>`, and `<body>`.
+Pipe on `onShellReady`.
+Optional `handle.waitForAll` waits for `onAllReady`.
+Abort on client disconnect.
+Client hydrates via `hydrateRoot(document, …)`.
+
+### 10. No `transformIndexHtml` on the SSR path
+
+The React Refresh preamble is loaded via the client entry.
+The Vite client and app entry come through `bootstrapModules`.
+CSS and modulepreloads come from the manifest into Document.
+State handoff uses a hashable `bootstrapScriptContent`.
+
+Static Vite injects serve-only HTML (SSR-CSS link, telemetry clients) through `transformIndexHtml`.
+SSR MUST NOT call `transformIndexHtml` on document responses.
+Serve-only concerns that still apply to SSR `sku start` (SSR-CSS, telemetry) MUST inject via Document assets and/or the browser client entry / `bootstrapModules` instead.
+See Decisions 10a and 10b.
+Production CSS remains client-manifest → Document (unchanged).
+
+### 10a. SSR-CSS on SSR `sku start`
+
+`vitePluginSsrCss` collects CSS reachable from configured entries into `virtual:ssr-css.css` and (on static Vite) injects a `<link>` plus HMR cleanup via `transformIndexHtml`.
+
+For SSR `sku start`:
+
+- Mount `vitePluginSsrCss` on the SSR plugin graph with entries that reach CSS in the SSR module graph (consumer `serverEntry` and/or sku’s SSR server entry, not static’s `renderEntry`).
+- Put the virtual stylesheet URL into Document `assets.css` so the existing `<link rel="stylesheet">` path emits it (no HTML transform).
+- Move the HMR cleanup that removes stale `[data-ssr-css]` links onto a client-entry / bootstrap-module path (same “no `transformIndexHtml`” rule).
+- Mark the Document link so cleanup can still target it (`data-ssr-css` or equivalent).
+
+Production SSR MUST NOT rely on this plugin.
+CSS comes from the client manifest.
+Goal: avoid an unstyled flash on `sku start` until the client graph loads styles.
+
+### 10b. Telemetry on SSR `sku start`
+
+`telemetryPlugin` is serve-only (`apply: 'serve'`).
+On static Vite it injects page-load + HMR client scripts via `transformIndexHtml` and wires Vite WS handlers / `handleHotUpdate`.
+
+For SSR `sku start`:
+
+- Mount `telemetryPlugin` on the SSR plugin graph with tags such as `type: 'ssr'` (parity with static’s `type: 'static'`).
+- Deliver the page-load and HMR client scripts via the SSR browser client entry and/or a serve-only module in `bootstrapModules`. Not via `transformIndexHtml`, and not as new Document inline scripts (CSP already tracks `bootstrapScriptContent`).
+- Mark `initialPageLoad` when the SSR dev server is ready (static does this in `middlewarePlugin.configureServer`). `skuStart.mark()` in `viteStartHandler` already covers both modes.
+- Keep WS handlers + `handleHotUpdate` behaviour once the plugin is on the middleware-mode server.
+
+Emit the same metrics as static start: `start.initial` and `start.rebuild`.
+
+### 11. CSP: headers from shell
+
+Derive `script-src` before `pipe`.
+Support enforcing and/or Report-Only, each with an optional `report-to` (`cspReportTo` / `cspReportOnlyReportTo`).
+Relative `publicPath` only (asset base; still covered by `'self'`).
+No meta `http-equiv`.
+
+**Coexistence with static Vite CSP (merged from master):**
+Static Vite has `cspDelivery: 'tag' | 'header'` (meta vs `metadata.csp` JSON) and Report-Only via `createCSPHandler` → `metadata.cspReportOnly` / start-time headers.
+That rendering path is separate from SSR, which keeps its own `buildCspHeaders` (real response headers, lazy single nonce).
+Do not route SSR through `cspDelivery` or the static HTML CSP handler.
+
+The `report-to` config surface is shared, however.
+`createSkuContext` normalises `cspReportTo` / `cspReportOnlyReportTo` (endpoint name, URL, or tuple) into a `ReportingEndpoint` via `parseCspReportTo` from `utils/csp.ts`, and Report-Only falls back to the enforcing value.
+SSR consumes those resolved endpoints, appends `report-to <endpoint>` to the matching policy, and emits a `Reporting-Endpoints` response header for whichever endpoints carry a URL.
+That header is built with the shared `stringifyReportingEndpoints`.
+Static writes the same value to `metadata.reportingEndpoints` instead.
+
+### 12. Request-entry and routesEntry shapes
+
+```ts
+// sku public type (lighter option — not a wrapped RR re-export)
+type SkuRouteObject = RouteObject & { sites?: string[] };
+
+// routesEntry (config `routesEntry`, default `src/routes.tsx`)
+export const routes: SkuRouteObject[];
+
+// serverEntry — default export; getSite required only when config has >1 site
+import { defineServerEntry } from 'sku/runtime';
+
+export default defineServerEntry({
+  getSite?(args: { req: Express.Request }): /* inferred Site */;
+  getLanguage?(args: { req: Express.Request }): /* inferred Language */;
+  getClientContext?(args: { req: Express.Request }): /* inferred ClientContext */; // JSON-serialisable
+  getReactContext?(args: {
+    req: Express.Request;
+    site: /* NoInfer<Site> */;
+    clientContext: /* NoInfer<ClientContext> */ | undefined;
+  }): /* inferred ReactContext */; // MAY be non-JSON (apiClient, makeClient, …)
+  middleware?: RequestHandler[];
+  onListen?(args: {
+    app: Express;
+    httpServer: http.Server | https.Server;
+    port: number;
+  }): void | Promise<void>;
+  getRouterContext?(args: {
+    request: Request; // Fetch — same shape as query()/loaders
+    req: Express.Request;
+    site: /* NoInfer<Site> */;
+    clientContext: /* NoInfer<ClientContext> */ | undefined;
+    reactContext: /* NoInfer<ReactContext> */ | undefined;
+  }): RouterContextProvider | Promise<RouterContextProvider>;
+});
+
+// clientEntry — default export; all properties optional
+// Pass typeof the server entry so ClientContext / Site match getClientContext / getSite
+import type server from './server.js';
+import { defineClientEntry } from 'sku/runtime';
+
+export default defineClientEntry<typeof server>()({
+  onHydrate?(args: {
+    clientContext: /* ClientContext from ServerEntry */ | undefined;
+  }): void;
+  getReactContext?(args: {
+    site: /* Site from ServerEntry */;
+    clientContext: /* NoInfer<ClientContext> */ | undefined;
+  }): /* inferred ReactContext */;
+  getRouterContext?(args: {
+    site: /* Site from ServerEntry */;
+    clientContext: /* NoInfer<ClientContext> */ | undefined;
+    reactContext: /* NoInfer<ReactContext> */ | undefined;
+  }): RouterContextProvider;
+});
+```
+
+**Why getters on a default-exported object (not `onRequest`, not per-getter named exports):**
+
+`onRequest` returned a bag of already-resolved values.
+That is push style, one combined resolver, and hard to type sibling projection.
+Per-getter named exports would split one entry contract across the module surface and force ugly per-property typing helpers.
+
+The v1 contract is one default-exported object of optional getters (pull), wrapped in `defineServerEntry` / `defineClientEntry` so TypeScript can infer types from getter returns and apply them to later sibling args (`NoInfer` on input positions, same idea as inferring within a generic function).
+
+Shared libraries contribute properties apps spread into the object:
+
+```ts
+export default defineServerEntry({
+  ...seekHostResolvers, // { getSite, getLanguage }
+  getClientContext({ req }) {
+    /* … */
+  },
+});
+```
+
+Sku holds **no** opinion about where values live on `req`.
+There is no conventional key and no default getter reading one.
+
+Accepted cost: site and language often derive from one parse, so two getters can parse twice.
+Libraries can memoise on `req`.
+A single combined **value** resolver was rejected because it reintroduces the `onRequest` return-bag shape.
+
+Getters are **sync-only** and SHOULD stay pure/simple.
+Docs recommend that.
+Optional `getRouterContext` MAY still be async because it seeds loader context next to `query`.
+
+**Call order (all before `query()`):**
+`getSite` (or sole resolved site) → `getLanguage` → `getClientContext` → `getReactContext` → optional server `getRouterContext` → `query()`.
+Later getters receive already-resolved sibling values (`site`, `clientContext`, `reactContext`) so apps project instead of re-deriving.
+`getClientContext` runs before render so its value reaches the hydrate bootstrap and `SkuProvider`.
+Keep the existing docs warning that `clientContext` is serialised after shell-ready into the bootstrap script.
+
+Tree: `Document` → always-on `SkuProvider` → router (pre-built tree for `site`) → that site’s routes, whose root layout route is app-owned.
+`site` from `getSite` (or the sole resolved site) selects the pre-built handler/tree and is serialized into the hydrate bootstrap for the client router.
+It is **not** an `onHydrate` argument.
+
+`language` from `getLanguage` is server-local for Document vocab preload only (not Async Local Storage, not `onHydrate`, not a React hook in v1).
+Its return type is still inferred as `L` on the server entry object for typed entry surfaces.
+It does not reach `SkuProvider` or `createSkuContexts`.
+
+`clientContext` from `getClientContext` reaches the hydrate bootstrap and `useClientContext` (same value on both sides).
+Omitted / `undefined` MUST serialise as JS `undefined` in the bootstrap (not JSON `null`).
+An explicit `null` return stays `null`.
+
+`reactContext` from dual-entry `getReactContext` reaches `useReactContext` and MAY differ per environment (not serialised).
+
+Omit `middleware` ⇒ no consumer middleware layer.
+Omit `onListen` ⇒ no post-listen callback (see Decision 25).
+Omit `onHydrate` ⇒ no hydrate side effects.
+
+### 12a. Always-on SkuProvider, three value channels, root layout for wrapping
+
+Two wrapping concerns were previously conflated into one sku-owned `AppWrapper` / app `Providers` mount:
+
+1. **Router-aware, isomorphic wrapping**. Needs `useLocation` / loader data (e.g. `VocabProvider` keyed on pathname, mounting Apollo around the outlet, page chrome).
+2. **Environment-scoped dependency values**. Server and client need _different_ modules or constructions (API clients, `makeClient`, client-only `window` SDKs). `routesEntry` is one shared module, so it cannot express the construction, only the consumption.
+
+**Pass-through `Providers` was the wrong seam.**
+Fixtures showed apps reinventing React context solely to pipe `site` / `clientContext` that sku already owned, while the rare env-differing case (Apollo `makeClient`) still needed a dual-entry component.
+Sku now owns the isomorphic React bag, env-differing **values** come from dual-entry getters, and isomorphic **wrapping** lives in the root layout.
+
+**Three channels.**
+Docs MUST diagram this.
+Prefer a Markdown table or nested list.
+VitePress has no built-in Mermaid, and the site does not ship a Mermaid plugin today.
+
+| Channel                      | Entry export       | React / RR consumer        | Same on server & client?           | Serialised?             |
+| ---------------------------- | ------------------ | -------------------------- | ---------------------------------- | ----------------------- |
+| Wire / isomorphic React seed | `getClientContext` | `useClientContext()`       | Yes (by construction)              | Yes → hydrate bootstrap |
+| Env-differing React values   | `getReactContext`  | `useReactContext()`        | **May differ**                     | No                      |
+| Loader / action context      | `getRouterContext` | `context.get()` in loaders | Same keys; construction may differ | No                      |
+
+```
+Document
+  └── SkuProvider   ← always (site, clientContext, reactContext)
+        └── Router
+              └── root layout route   ← Vocab, Apollo wrap, chrome
+                    └── pages
+```
+
+**Split accordingly:**
+
+- **Concern 1 → the app’s own root layout route in `routesEntry`.** Plain React Router + sku hooks. Route hooks, loader data, and Suspense all work normally, and it is isomorphic by construction. Prefer a pathless layout route over `path: '/'`. Matching is identical (relative children join against `/` either way), it reads as a layout rather than a URL, and it keeps wrapping any root-level sibling added later. Env-specific providers that need a component wrapper (e.g. Apollo’s `WrapApolloProvider` with `makeClient`) mount here and read `useReactContext()`. They do not need a dual-entry component export.
+- **Concern 2 → optional dual-entry `getReactContext`.** Server and client MAY return different bags (`makeClient`, `apiClient`, `extraScriptProps`, window SDK handles). Sku puts the result on `SkuProvider`, and the isomorphic tree consumes it via hooks.
+
+**Consequences:**
+
+- Sku never wraps the **route tree**. There is no pathless sku wrapper route, no sku-owned route id, and no hydration-shape alignment concern.
+- `createStaticHandler` per site at init falls out for free. Nothing on the request path can touch the tree.
+- No app-authored `Providers` export. An optional compose slot above the router is deferred until a real need appears that root-layout + `getReactContext` cannot cover.
+- No `Providers` markup probe / identical-DOM warning. Sku’s provider is context-only by construction, and app wrappers in the root layout are isomorphic.
+- Request-scoped values need no smuggling channel: no consumer-authored Async Local Storage, no module-level `let` set by `onHydrate`.
+
+**Typing: `define*Entry` inference + `createSkuContexts<typeof server, typeof client>`.**
+
+Bare `export default { … }` has no generic inference scope, so sibling methods cannot see each other’s return types.
+`defineServerEntry` / `defineClientEntry` are zero-runtime identity helpers that create that scope: infer returns, apply them to later sibling args via `NoInfer` on input positions.
+
+`defineServerEntry` infers `Site` / `Language` / `ClientContext` / `ReactContext` from `getSite` / `getLanguage` / `getClientContext` / `getReactContext`.
+Server later getters receive `site: NoInfer<Site>`.
+
+`defineClientEntry<ServerEntry>` extracts `Site` / `ClientContext` from that server entry (`string` / `undefined` when the corresponding getter is omitted) and infers `ReactContext` from client `getReactContext`.
+Client sibling `site` / `clientContext` args use those extracted types.
+The hydrate bootstrap carries the same values the server produced.
+Reuse the same extractors as `createSkuContexts` (do not invent a second `ClientContextOf` shape).
+
+`defineClientEntry` cannot infer `ClientContext` from the client object alone.
+Those values only appear as callback inputs (`onHydrate` / `getReactContext` / `getRouterContext`), so TypeScript has nothing to infer from and falls back to `undefined`.
+Apps pass `defineClientEntry<typeof server>()({ … })` curried.
+TypeScript cannot partially infer type parameters when `ServerEntry` is explicit.
+Omit the type argument and call `defineClientEntry({ … })` directly ⇒ `ClientContext` is `undefined` and `site` stays `string`.
+
+The helpers are identity functions at runtime.
+Annotating app getters with the loose public aliases (`SkuGetSite` / `SkuGetLanguage` / …) widens returns to `string` and defeats literal inference.
+Prefer letting `defineServerEntry` infer, or narrow inside the getter body.
+
+Sku still exports `SkuServerEntry` / `SkuClientEntry` as the structural types behind those helpers (and for advanced `satisfies` use).
+Apps are not required to declare `ClientContext` / `ReactContext` / site aliases up front.
+
+```ts
+// server.tsx
+import { defineServerEntry, getCspNonce } from 'sku/runtime';
+
+const server = defineServerEntry({
+  getSite({ req }) {
+    // Narrow here — do not annotate as SkuGetSite (widens to string)
+    return req.site === 'nz' ? 'nz' : 'au';
+  },
+  getLanguage({ req }) {
+    return req.language === 'fr' ? 'fr' : 'en';
+  },
+  getClientContext({ req }) {
+    return { fromServer: true, userId: req.skuUserId ?? null };
+  },
+  getReactContext({ site, clientContext }) {
+    // site inferred as 'au' | 'nz'; clientContext from getClientContext
+    return {
+      makeClient: serverMakeClient,
+      extraScriptProps: { nonce: getCspNonce() },
+    };
+  },
+  getRouterContext({ clientContext, reactContext }) {
+    // reactContext inferred from getReactContext return
+    const ctx = new RouterContextProvider();
+    ctx.set(userIdContext, clientContext?.userId ?? null);
+    if (reactContext) ctx.set(apiClientContext, reactContext.makeClient());
+    return ctx;
+  },
+});
+export default server;
+
+// client.tsx — type-only import of server; no runtime cycle
+import type server from './server';
+import { defineClientEntry } from 'sku/runtime';
+
+const client = defineClientEntry<typeof server>()({
+  onHydrate({ clientContext }) {
+    // clientContext typed from server getClientContext
+  },
+  getReactContext({ site, clientContext }) {
+    // site: 'au' | 'nz'; clientContext from server
+    return { makeClient: clientMakeClient };
+  },
+});
+export default client;
+
+// ssrContext.ts — type-only imports; no runtime cycle with entries
+import type server from './server';
+import type client from './client';
+import { createSkuContexts } from 'sku/runtime';
+
+export const { useSite, useClientContext, useReactContext } = createSkuContexts<
+  typeof server,
+  typeof client
+>();
+```
+
+`createSkuContexts` is a typed facade over one well-known React context module that sku’s render also uses.
+Shared identity for that module (and the same class of problem for `useInsertHtml` / preload registry / CSP nonce storage) is Decision 26.
+Prefer one public specifier `sku/runtime` for app and sku runtime, keep `unbundle: true` for separate dist modules, and `optimizeDeps.exclude` so Vite does not clone published packages.
+
+It extracts:
+
+- `Site` from the server entry’s `getSite` return (or `string` if `getSite` is omitted on a 0–1 site app / sole resolved name).
+- `ClientContext` from the server entry’s `getClientContext` return (or `undefined` if omitted).
+- `ReactContext` from both entries’ `getReactContext` returns as a union. Server may include fields the client omits (e.g. `extraScriptProps`).
+
+`useSite()` returns that `Site` union.
+No consumer cast is required.
+Language is not extracted into a React hook (see Non-Goals / Deferred).
+Hand-written `ClientContext` / `ReactContext` / site aliases remain optional style when an app prefers them.
+They are not required.
+
+Rejected alternatives:
+
+- Module augmentation alone (easy to drift from the entry object).
+- Per-property `defineGet*` helpers (ugly; one entry object is enough).
+- Requiring apps to declare context interfaces before writing getters.
+- Per-getter named exports (splits one contract; worse typing ergonomics).
+- Declaring `sites` on the server entry object or importing `sku.config` into the React graph for typing. Duplicates config and creates a layering smell. Apps narrow in `getSite` instead.
+- Expecting `defineClientEntry` to infer `ClientContext` from client callback parameters alone. Inputs are not inference sources. Pass `typeof server`.
+- Hand-rolling a `ClientContext` type alias solely for `defineClientEntry<ClientContext>` when `typeof server` already carries it (optional style only; not required).
+- Generic `SkuRouteObject<S>` for route membership in this pass (follow-on).
+
+React Router `createContext` keys for loaders remain a separate typing layer (RR already types `context.get(key)`).
+They are not fields extracted from the entry objects.
+
+**Getters and sibling projection:**
+
+- `getSite` / `getLanguage` / `getClientContext` receive `{ req }` only (Express after consumer middleware). Do not pass Fetch `Request` or `res`.
+- Server `getReactContext` receives `{ req, site, clientContext }`.
+- Client `getReactContext` receives `{ site, clientContext }` from the hydrate bootstrap (no Express).
+- Server `getRouterContext` receives `{ request, req, site, clientContext, reactContext }`.
+- Client `getRouterContext` receives `{ site, clientContext, reactContext }`. Sku wraps RR’s zero-arg `getContext` to pass those args.
+- Typical projection: put serialisable seeds in `clientContext`, put `apiClient` / `makeClient` in `reactContext`, and have `getRouterContext` do `ctx.set(userId, clientContext.userId)` rather than re-reading `req`.
+
+**Typing middleware-attached fields on `req`:**
+Product docs MUST show Express `Request` augmentation (same approach as `getCspNonce`), shared by `middleware`, getters, and server `getRouterContext`.
+
+**Optional dual-entry `getRouterContext`:**
+Same typed keys (`createContext` + `RouterContextProvider`), different construction per environment when needed.
+Omit either property ⇒ empty/default context behaviour.
+
+The three channels cannot collapse into one.
+React Router 8 exposes no public hook for reading `RouterContextProvider` from components, and serialisable wire state must not be forced to carry non-JSON clients.
+Docs MUST state which channel to use for which consumer.
+
+Do **not** teach consumer-authored Async Local Storage, module-level mutable state, or “return a wrapper component from a request-entry export” as the way to pass request-scoped values into React.
+
+`clientContext` and `reactContext` are page-load seeds and do not change across client navigations.
+Values that must track navigation belong in the root layout (concern 1).
+
+### 13. Request-scoped nonce (lazy, single value)
+
+At most one CSP nonce per render, minted only when requested.
+Async Local Storage holds **CSP nonce only**.
+
+### 14. Vocab / language chunks
+
+When `languages` is set, `@vocab/vite` handles splitting at build time.
+
+**Resolve ownership:**
+`@vocab/vite` is a sku dependency.
+Consumers MUST NOT need a direct `@vocab/vite` dep for resolve to succeed.
+
+When the vocab plugin or `languages` is active, sku’s shared Vite config (`packages/sku/src/services/vite/plugins/config.ts`) MUST:
+
+1. Resolve `@vocab/vite` from **sku’s** install tree (`createRequire(import.meta.url)`), not the app’s `node_modules`.
+2. Pin bare imports onto that copy via `resolve.alias`:
+   - `@vocab/vite/runtime` → absolute file from `require.resolve('@vocab/vite/runtime')`. Prefer the export file, not only the package name (more reliable under Rolldown/Vite).
+   - Do not alias the `@vocab/vite` package root. That breaks subpath imports such as `@vocab/vite/chunks` (sku’s own SSR render imports it).
+3. Apply aliases in the shared Vite config (covers both client and SSR builds today).
+
+That forces injected imports (including ones `@vocab/vite` injects into `.vocab` files) onto sku’s copy — one instance, aligned with the plugin sku loaded.
+
+**Shared packages:**
+The alias is project-wide.
+It also covers bare `@vocab/vite/runtime` from shared React packages (e.g. Header/Footer with `.vocab`) when those modules are in the Vite graph — the usual sku path via `compilePackages` (SSR `noExternal`).
+Vocab’s compile ignore already skips only `node_modules/sku/**` and `node_modules/vocab/**`, so dependency `.vocab` folders remain discoverable.
+Sku separately compiles configured `compilePackages` roots because Vocab’s own compile ignores `node_modules`.
+
+Out of scope / does not help: packages left as true SSR externals where Node resolves `@vocab/vite/runtime` at runtime outside Vite (uncommon for sku shared UI).
+If a consumer also installs `@vocab/vite`, the alias still prefers sku’s copy.
+Do **not** enable these aliases when vocab / `languages` is inactive (avoid resolving unused).
+
+At render time, register `getChunkName(language)` on Document assets **only** when `getLanguage` returns `language`.
+Language is optional — if `getLanguage` is omitted or returns `undefined`, sku does not register a language chunk.
+Sku does **not** validate the returned language against config, and does **not** default to a sole configured language.
+No `getSkuLanguage` / `__SKU_LANGUAGE__` / baked `SKU_LANGUAGES` define.
+Migrating / Vocab docs MUST **not** tell consumers to install `@vocab/vite` solely so `@vocab/vite/runtime` resolves.
+
+### 15. Production runtime defines (webpack-aligned)
+
+Production `server.js` has no live `skuContext`.
+Bake the values it needs with webpack-style defines (no sidecar JSON):
+
+- `__SKU_DEFAULT_SERVER_PORT__` — default listen port from config `port` (same value as `sku start`). Keep the webpack-aligned define name. Do not introduce a second SSR port knob. `process.env.PORT` still wins at runtime. Providing `serverPort` with SSR MUST error.
+- `__SKU_PUBLIC_PATH__` — static asset prefix from config `publicPath` (webpack SSR parity). Do not use Vite’s `import.meta.env.BASE_URL` in sku runtime code.
+- `__SKU_CSP__` — single object aligned with webpack’s `{ enabled, extraHosts }`, extended for Vite Report-Only fields (e.g. `reportOnlyEnabled`, `reportOnlyExtraHosts`, `reportOnlyReportTo`).
+
+Dev continues to pass these from live `skuContext` (no defines required on the start path).
+
+### 16. Lazy-route `moduleId` (SSR preload source)
+
+Auto-derive `moduleId` for idiomatic `lazy: () => import('…')`.
+Never overwrite explicit values.
+Skip non-idiomatic factories.
+Warn in dev on miss.
+
+SSR Document CSS and `modulepreload` links come **only** from matched-route `handle.moduleId` values (plus optional vocab language chunks) resolved against the Vite client manifest.
+
+`@sku-lib/vite/loadable` remains the static / prerender code-splitting and preload API (`createPreRenderedHtml` + Collector / `LoadableProvider` + `preloadPlugin` third-arg `moduleId` injection).
+SSR does **not** wire that collector into the streamed Document.
+
+Rationale: React Router Data Mode already owns route-level splitting via `lazy`.
+A second loadable-based preload channel would duplicate the API, leave Document assets out of sync with “I used loadable,” and complicate Migrating from webpack SSR (which already requires a route-model rewrite).
+
+Nested component splits inside a route are not first-class Document preloads in v1.
+Consumers can still use client-side lazy loading without sku injecting those chunks into the initial HTML.
+
+### 17. Intent module preload (`usePreloadRoute`)
+
+Document `modulepreload` covers the _matched_ route.
+Warming the _next_ route’s lazy chunks on hover / focus / touch is a separate concern — Data Mode has no `<Link prefetch>` (Framework Mode only).
+
+Sku owns it, because sku already owns the tree the warm-up must match against.
+The client entry selects the site tree with `selectForSite` before creating the router, and registers it on a shared module.
+Module identity for that registry (same class as `getCspNonce` / `SkuProvider` / `useInsertHtml`) is Decision 26: consolidate sku runtime onto `sku/runtime`, keep `unbundle: true` so dist keeps one physical module per shared file, and `optimizeDeps.exclude` so Vite does not clone published `sku` / `sku/runtime`.
+
+The hook lives on its own subpath so the main `sku` entry never pulls in the optional `react-router` peer for webpack / static consumers:
+
+```tsx
+import { usePreloadRoute } from 'sku/runtime';
+
+const preload = usePreloadRoute(to); // resolves `to` via `useHref` at render
+<Link
+  to={to}
+  onMouseEnter={preload}
+  onFocus={preload}
+  onTouchStart={preload}
+/>;
+```
+
+`usePreloadRoute(to)` returns a `() => void`.
+It is fire-and-forget: `lazy()` returns a promise, and a failed warm-up must not surface as an unhandled rejection — the real navigation reports the error.
+Matching runs against the site-filtered tree, so a path belonging to another site never warms.
+
+Sku handles both `lazy` shapes (a function, or an object of per-property lazy functions).
+Calling `lazy()` is enough — the module cache serves the navigation’s later call.
+No route-tree mutation.
+
+Outside SSR, and during server render, no tree is registered and the returned function is a silent no-op.
+Invoking it on the client with no registered tree warns in development.
+
+Rejected: exposing the tree itself (a routes context or `useRoutes()`).
+Every consumer would re-implement the same `matchRoutes` + `lazy()` loop, and an unfiltered tree is easy to pass by mistake.
+Owning the loop also leaves room to skip already-warmed matches, warm route CSS from the client manifest, and respect `navigator.connection.saveData`.
+
+Loader-data prefetch stays out of scope.
+
+### 18. Shared HTML middleware + loader/action headers
+
+Dev/prod share abort-before-write.
+On streamed HTML, forward `loaderHeaders` / `actionHeaders` (append; preserve `Set-Cookie`), then sku `Content-Type` / CSP.
+
+### 19. Hydration payload safety
+
+Promise-scrub `loaderData` / `actionData`.
+Production route errors omit `Error.stack`.
+
+### 20. Create template + Migrating docs
+
+Template `ssr` MAY omit config `sites` (sku soft-defaults to `'default'`), with `expressTrustProxy: true` in `sku.config` (visible Melways/SEEK-shaped trust proxy — see Decision 25), a `routesEntry` + flat `routes` scaffold (optional route-level `sites` only when membership differs), and `defineServerEntry` / `defineClientEntry` + `createSkuContexts<typeof …>` + optional `getClientContext` / `getReactContext` / `onHydrate` properties.
+The template omits `getSite` (sku uses the sole resolved site name).
+Multi-site examples declare ≥2 config sites and include `getSite` on the server entry object.
+Request entries do not re-export `routes`.
+
+The template’s `routesEntry` scaffolds an app-owned pathless root layout (`src/RootLayout.tsx`) so router-aware wrapping (and Apollo-style provider mounts) have an idiomatic home.
+Typed hooks live in `src/ssrContext.ts`.
+The home page calls `useSite()` (soft-default `'default'` when config `sites` is omitted).
+There is no `src/App/` shell — page content lives under `src/pages/`.
+
+Lazy page modules MUST use React Router Data Mode named `export function Component` (not `export default`) so they typecheck with `lazy: () => import('…')`.
+
+Migrating docs cover Static App and Older / Webpack SSR App, not under `docs/migration-guides/`.
+
+Migrating MUST cover:
+
+- Named `Component` on lazy pages.
+- `routesEntry` + flat `routes` + optional `sites` + `getSite` (required when config has >1 site; fail closed on unknown / non-string site; sole resolved site — soft-default `'default'` when config `sites` is empty — when omitted on 0–1 site).
+- Multi-site membership via `sites` on routes (optional language path params, union tree + allowlist, or sku host matching as the product story).
+- Webpack dual-port → SSR single `port` (reject `serverPort`; `PORT` still overrides prod).
+- `dist/server/server.js` + sibling build `client/` / `server/`.
+- Baked server-local Vite client manifest (no sibling `client/` required to start).
+- Recommended production: host hashed assets via reverse proxy / persistent storage; ship `server/` with runtime `node_modules`.
+- Standalone Node `express.static` of sibling `client/` as experimentation / edge case only.
+- CJS interop for `sku start`.
+- Express 4 typing (shared sku major; no Express 5 in this change).
+- React Router 8 as optional peerDependency `^8` for Data Mode / route typing (SSR template/fixtures install it).
+- Moving off config `public` / public assets folder (import assets instead).
+- `dangerouslySetViteConfig` and `vitePlugins` unsupported for SSR (hard-error; raise use-cases via sku-support).
+- Server-only loaders vs client route graph (+ explicit `moduleId` when needed).
+- Prefer render-time data loading with clients from `useReactContext` / `useClientContext`. Reach for loaders on waterfalls, document redirects, headers, or opt-in `getRouterContext`.
+- Apollo apps replace two-pass `getDataFromTree` with a streaming transport over `useInsertHtml`. Dual-entry `getReactContext` supplies `makeClient` / server `extraScriptProps`. The isomorphic Apollo provider mounts in the root layout via `useReactContext()`.
+- The three value channels (`getClientContext` / `getReactContext` / `getRouterContext`) plus always-on `SkuProvider` + `createSkuContexts<typeof server, typeof client>()`, vs router-aware wrapping in the app’s own root layout route.
+- Optional dual-entry `getRouterContext` patterns (Data Mode vs Framework Mode). Red warning against putting Express `req` in `RouterContextProvider`.
+- Express `Request` module augmentation for middleware-appended fields (`express-serve-static-core`, shared by `middleware` / getters / server `getRouterContext`).
+- Default-exported request-entry objects via `defineServerEntry` / `defineClientEntry` replacing `onRequest`. Optional `middleware` / `onListen` / `onHydrate` properties.
+- Webpack `onStart` → server-entry `onListen({ app, httpServer, port })` (bound `port`, plus `httpServer` for keep-alive timeouts). Trust proxy via config `expressTrustProxy`, not `onStart`.
+- Braid reset-before-Braid on `sku start` (Braid apps; no sku auto-inject).
+- Client-only / `window`-touching libraries via client `getReactContext` (omit or return stubs on server) + root-layout / `useEffect` consumers — not a dual-entry component export.
+- Jest → Vitest prerequisite (link existing docs / codemod).
+- `#` `pathAliases` / `migrate-root-resolution` for bare `src/…`.
+- Sku-owned `@vocab/vite` resolve (no consumer pin for `@vocab/vite/runtime`).
+
+#### Server-only loaders vs client route graph
+
+Because `routesEntry` is imported into both graphs, dynamic imports inside it (e.g. `import('./loadHomeData')`) can pull server-only modules into the client build.
+Keep server-only loader modules off the client-imported graph (e.g. separate `*.server.ts` pages, or avoid attaching those loaders on the shared tree).
+When the lazy factory is no longer a bare `() => import('./home')`, set `handle.moduleId` explicitly so modulepreload still works.
+
+Do **not** ship an automatic `*.server.ts` client strip in this change — convention + docs only.
+Prefer not to rely on server-only loaders for page content — see data-loading guidance below.
+With Express `req` on getters / `getRouterContext`, prefer projecting isomorphic values rather than env-split route trees.
+
+#### Braid reset evaluation order (`sku start`)
+
+On `sku start`, Vite’s SSR module graph can evaluate a loader → page → Braid before `App.tsx`’s `import 'braid-design-system/reset'`, throwing “Braid components imported before reset.”
+Production build may succeed with a different order.
+
+Apps that use Braid must ensure reset runs before any Braid-touching server module (e.g. top of `serverEntry` and any early-imported loader that pulls Braid).
+Do **not** auto-inject Braid reset into sku’s SSR server entry — Braid is optional per app.
+
+#### Client-only / window-touching libraries during Document SSR
+
+Values that construct against `window` (e.g. analytics SDKs) throw during full-document SSR.
+Webpack SSR often only mounted those on `#app` client hydrate.
+
+Put construction in **client** `getReactContext` (server returns `undefined` / omits the field).
+Consume from the root layout or a small client-only wrapper (`useEffect` mount) via `useReactContext()`.
+Do **not** reintroduce a dual-entry component export for this in v1.
+
+#### Jest → Vitest prerequisite
+
+SSR apps are expected to use `testRunner: 'vitest'`.
+Migrating MUST call this out as a prerequisite and point at existing Vitest docs / `@sku-lib/codemod jest-to-vitest` / checklist (mock shapes, RTL, platform singletons).
+No new Jest → Vitest codemod in this change.
+
+#### Path aliases: bare `src/…` → `#src/…`
+
+Webpack `baseUrl: '.'` allowed `import 'src/…'`.
+SSR `pathAliases` require `#` subpath imports.
+Migrating MUST point at `pathAliases` + the existing `migrate-root-resolution` codemod / changelog guidance.
+
+### 21. Data loading guidance (docs-led)
+
+Prefer **render-time** data loading in React for page content:
+
+- Inject an env-specific API / Experience / Apollo client via dual-entry `getReactContext` and read it with `useReactContext()` (serialisable seeds via `getClientContext` / `useClientContext`; `site` via `useSite()` — not a component returned from a getter, not consumer-authored Async Local Storage).
+- Fetch in the React tree with Suspense (e.g. `useQuery`) so the same components work on SSR and client navigations.
+- When the client has a cache that must survive the stream (Apollo), pair it with a streaming transport over `useInsertHtml` — see Decision 21a.
+
+Rationale: portable shared UI without per-app loader wiring, aligned with streaming Document and isomorphic backends.
+
+Reach for React Router **loaders** when you need to:
+
+- Start work before the suspending subtree renders (waterfall / parallelisation).
+- Issue a real **document** `redirect()` / response headers (`Cache-Control`, `Set-Cookie`, …).
+- Use advanced loader/action context via optional dual-entry `getRouterContext` (same `createContext` keys on both sides; project from `clientContext` / `reactContext` when possible).
+
+`<Navigate />` on static initial render is a no-op — it is not a document HTTP redirect.
+Loaders receive a Fetch `Request`, not Express `req`.
+Sku does **not** make Express `req` the loader `request` argument.
+
+#### Data Mode vs Framework Mode `getLoadContext`
+
+Sku is **Data Mode**, not Framework Mode:
+
+|                    | Framework Mode                     | Sku Data Mode                                                                    |
+| ------------------ | ---------------------------------- | -------------------------------------------------------------------------------- |
+| Server seed        | Adapter `getLoadContext(req, res)` | Entry `getRouterContext({ request, req })` into `query(..., { requestContext })` |
+| Client nav loaders | Often still server (`.data`)       | Browser via `createBrowserRouter`                                                |
+| Client seed        | Needed for client-only paths       | Needed for **every** client nav if loader context is used                        |
+
+Copying only Framework’s server-half adapter into sku leaves client-nav loaders without context.
+If loader context is offered at all, prefer dual entry.
+
+Document clearly:
+
+- Server seeds from Express middleware bag + Fetch `request`; client seeds from browser-visible state (`clientContext`, `reactContext`, cookies, memory, etc.).
+- Cadence: server once per document `query`; client every nav/fetcher.
+- Relation to Express `middleware` vs RR route `middleware` vs entry `getRouterContext`.
+- Relation of the three value channels (`getClientContext` / `getReactContext` / `getRouterContext`) vs the app’s root layout route (router-aware wrapping + isomorphic provider mounts) — they compose. Getters / optional `onHydrate` are for values and hydrate side effects, not for returning wrappers.
+
+**Red warning (MUST ship in product docs):**
+Never put Express `req` (or other non-isomorphic platform objects) into `RouterContextProvider`.
+Project **values** / isomorphic-capable dependencies that both server and client `getRouterContext` can supply.
+Raw `req` is `undefined` on client navs and becomes a landmine.
+
+**Required docs example:**
+Client `getRouterContext` (or a loader using context) loading data for a **different location than the initial SSR location** — after client navigation — showing the client seed must work without Express and must not assume document-SSR-only state (e.g. user/logger from `req` on server, re-derived on client, navigate, loader still gets context).
+
+Product + Migrating docs MUST encode this hierarchy and rebalance any wording that implied loaders are the default for content.
+
+### 21a. Streaming data transports: `useInsertHtml`
+
+Render-time data loading (Decision 21) is only credible if a real client cache can survive the stream.
+Apollo Client is the case that matters for sku consumers, and its streaming hydration is a critical adoption requirement: queries that ran during SSR must populate the browser cache instead of refetching, while queries issued after hydration still fetch normally.
+
+Every streaming transport works the same way — serialize query events during SSR and inject them as `<script>` chunks **between** React’s stream chunks, so they execute before hydration.
+`@apollo/client-react-streaming`’s `buildManualDataTransport` therefore requires one thing from the framework: `useInsertHtml(): (callback: () => ReactNode) => void`.
+Next.js satisfies it with `ServerInsertedHTMLContext`.
+Apollo’s own Vite example satisfies it by having the server harness create a transform stream and pass `injectIntoStream` down through app-owned context.
+
+Sku owns `renderToPipeableStream` and the response pipe, so an app cannot reach the stream at all.
+This is the same argument that justifies sku-owned request-scoped values (Decision 12a): sku owns the render call, so the seam has to be sku’s.
+
+**Sku owns** a render-scoped injection queue, a React context carrying `insertHtml`, flushing queued nodes into the byte stream at chunk boundaries, the `useInsertHtml` hook, and always-on `SkuProvider` for `site` / `clientContext` / `reactContext`.
+**Apps own** the transport and the client (`WrapApolloProvider(buildManualDataTransport({ useInsertHtml }))`), with dual-entry `getReactContext` supplying `makeClient` (and server `extraScriptProps`), mounted isomorphically in the **root layout** via `useReactContext()`.
+
+Sku ships no Apollo dependency, provider, or config.
+The seam is transport-agnostic.
+
+```tsx
+// app-owned transport — shared isomorphic module
+import { useInsertHtml } from 'sku/runtime';
+import { WrapApolloProvider } from '@apollo/client-react-streaming';
+import { buildManualDataTransport } from '@apollo/client-react-streaming/manual-transport';
+
+export const ApolloProvider = WrapApolloProvider(
+  buildManualDataTransport({ useInsertHtml }),
+);
+
+// root layout — isomorphic; values differ because getReactContext differed
+const { makeClient, extraScriptProps } = useReactContext();
+return (
+  <ApolloProvider makeClient={makeClient} extraScriptProps={extraScriptProps}>
+    <Outlet />
+  </ApolloProvider>
+);
+```
+
+Do not share one `makeClient` with `typeof window` — that is what separate entry `getReactContext` exports are for.
+
+`useInsertHtml` lives on `sku/runtime` next to `usePreloadRoute` and `createSkuContexts`.
+The app’s transport module is imported by **both** graphs, so the export must be browser-safe, and the main `sku` entry must stay free of the optional `react-router` peer.
+Module identity (sku `render` + consumer `sku/runtime` → one insert-html context instance) is Decision 26 — the same dual fix as `getCspNonce` and the preload registry.
+
+**Contract:**
+
+- During document SSR, the returned function queues `() => ReactNode` for the current render.
+- Sku renders queued nodes to static markup and writes them into the response **before the next React chunk**, and flushes any remainder at stream end. Injection therefore lands after the shell but before hydration runs.
+- Anywhere there is no sku SSR render around it — including the client graph — it is a silent no-op. It MUST NOT throw. Apollo’s Next.js implementation throws on a missing context; sku’s must not.
+- Under `handle.waitForAll`, injection still happens; the whole document is buffered to `onAllReady` and written in order.
+
+**CSP:**
+Injected script bodies are not known when headers are derived from the shell, so they cannot be hashed — they MUST carry the nonce.
+`buildManualDataTransport` supports this through the wrapped provider’s `extraScriptProps`, and `render` already mints a nonce before `pipe`, so `'nonce-…'` is in `script-src` for every SSR document.
+Server `getReactContext` returns `extraScriptProps={{ nonce: getCspNonce() }}`; the client omits it.
+Server-only `getCspNonce` stays on the main `sku` entry — only the transport module is shared.
+
+**Hydration ordering is already safe.**
+Injected scripts arrive after sku’s `bootstrapModules` tag in document order, but module scripts are deferred and the transport’s late-initializing queue starts life as a plain array (`window[…].push` before the reader exists), so nothing is dropped.
+
+**Why not `@apollo/client-integration-react-router`:**
+It is alpha, peers `react-router@^7` (sku is on 8), and its `apolloLoader` / `preloadQuery` path returns transported query refs that carry a promise chain (`promiscade`) through loader data.
+Sku serializes loader data as JSON and promise-scrubs it (Decision 19), so those refs cannot survive hydration without streaming (turbo-stream) loader data — a much larger change, and one that would pull sku toward Framework Mode.
+Its `ApolloHydrationHelper` needs only `useMatches`, so it would work in Data Mode, but it exists to revive loader-transported refs and is unnecessary on the render-time path.
+Render-time `useSuspenseQuery` under the app’s root-layout provider is the supported path, which is where Decision 21 already points.
+
+**Why not depend on Apollo’s `stream-utils`:**
+`createInjectionTransformStream` is a Web `TransformStream` built for `renderToReadableStream`, and sku uses `renderToPipeableStream` with Node streams.
+Sku implements the equivalent Node transform itself and stays transport-agnostic.
+
+**Rejected alternatives:**
+
+| Approach                                      | Why not                                                                                                                 |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| App dual-entry `Providers` for Apollo         | Pass-through ceremony for values sku already owns; env-specific values belong in `getReactContext`, wrap in root layout |
+| `insertHtml` as a server-only React prop      | Every app re-creates the same context to reach a module-scope `buildManualDataTransport`; unavailable to route code     |
+| Async Local Storage instead of React context  | Decision 13 keeps ALS to the nonce; resumed suspended work is not reliably inside the render’s ALS scope                |
+| Sku owning an Apollo provider / config option | Sku would own a client lifecycle, link chain, and cache config it cannot version independently                          |
+| Sku auto-adding the nonce to injected scripts | Sku does not render those nodes’ props; `extraScriptProps` is already the transport’s supported channel                 |
+| Two-pass `getDataFromTree`                    | Incompatible with streaming; the pattern SSR exists to replace                                                          |
+
+### 22. Experimental first release
+
+Docs warning + changeset: available for testing, not for production.
+No runtime experimental gate.
+
+### 23. CJS default-export interop (docs only)
+
+Keep existing `vite-plugin-cjs-interop` + `__UNSAFE_EXPERIMENTAL__cjsInteropDependencies` and Apollo-only baked defaults.
+Do **not** expand sku’s default interop list for this change.
+
+Document the start-vs-build failure mode (“Element type is invalid … got: object”) and how to extend the config list, with common open-source offender examples.
+Do **not** rewrite or wrap React render errors at runtime — docs are enough.
+
+### 24. Express 4 (shared) + React Router 8 (optional peer)
+
+SSR mounts consumer middleware into sku’s **shared** Express app — the same `express` / `@types/express` dependency webpack SSR and `sku serve` use.
+This change keeps that major on Express 4.
+It does **not** upgrade Express 4 → 5.
+
+A single Express major cannot be Express 5 for SSR and Express 4 for webpack SSR without splitting the package.
+Upgrading would be a breaking change for webpack SSR middleware / `onStart` / `devServerMiddleware` and related typings.
+Static Vite is unaffected (Connect), but webpack SSR is in the blast radius.
+
+SSR targets React Router 8 via an optional peerDependency `react-router: ^8` (not a hard sku dependency).
+RR is SSR-scoped and is not shared the way Express is.
+The SSR template and fixtures install React Router 8.
+Webpack / static apps do not need it and MUST NOT be forced onto RR8 by this change (do not bump webpack fixtures solely to RR8).
+
+Sku MUST NOT ship Jest transforms for `react-router` / `cookie-es` / `import.meta` in this change.
+SSR requires Vitest.
+React Router 8 + Jest for webpack consumers is out of scope.
+
+Document Express 4 for middleware typing (`middleware` / `SkuMiddleware`) and React Router 8 for Data Mode / route typing consumers rely on.
+Document Express `Request` module augmentation (`express-serve-static-core`) so middleware-appended fields type-check in `middleware`, the getters, and server `getRouterContext` — same pattern as sku’s `getCspNonce` augmentation.
+
+Align any React Router 8 peer baselines sku already owns (Node / React / Vite) where the catalog or engines need a bump.
+Do not expand sku’s supported React range solely for packages that still support React 18 unless required by the upgrade.
+
+Sku owns the Express app that mounts consumer middleware and the React Router Data Mode wiring for SSR.
+Those packages are not opaque transitive deps — their majors are part of the SSR product contract (Express via the shared sku server; React Router via Data Mode peer + consumer install).
+Keep majors pinned in docs and release notes, and call out major bumps in changesets as potentially breaking for SSR consumers.
+
+**Breaking-change policy (later releases):**
+Bumping the Express or React Router major that SSR integrates may be a breaking change.
+Consumer `middleware` / `devServerMiddleware` mount into sku’s Express app, and consumer routes/entries use React Router Data Mode APIs (`routes` + optional `sites`, `lazy` + named `Component`, loaders/actions, etc.).
+Minor/patch upgrades within the documented major remain non-breaking when APIs stay compatible.
+
+**Deferred:**
+Express 5 as a separate sku-wide breaking change (webpack SSR + SSR + `sku serve` together).
+Jest support for React Router 8 (if ever needed for webpack) is a separate concern.
+
+### 25. Server-entry `onListen` + config `expressTrustProxy`
+
+Webpack SSR’s `onStart({ app })` was the post-listen hook for server setup (logging, timeouts, Express knobs).
+Migration spikes (CBS was the only app still on webpack `onStart`) showed the real gaps were:
+
+1. Express `trust proxy` behind Melways / reverse proxies.
+2. `httpServer.keepAliveTimeout` (webpack only passed `app`, so timeouts never applied).
+3. Readiness logging with the **bound** port.
+
+**`onListen` (server entry):**
+
+```ts
+onListen?: (args: {
+  app: Express;
+  httpServer: http.Server | https.Server;
+  port: number;
+}) => void | Promise<void>;
+```
+
+Sku calls `onListen` once after middleware + HTML pipeline are mounted **and** `listen` has succeeded — the same window as webpack `onStart`, in both `sku start` and production.
+
+- Await the callback if it returns a promise. Failure MUST fail startup.
+- Call **once** (not on every server-entry HMR reload in start).
+- Do **not** add `onBeforeListen` — process-wide setup before bind stays at module top-level.
+- Do **not** add sku-owned listen logging by default — apps log in `onListen` if they want.
+
+Wire the call from shared production `listen` and `createDevSsrServer` (start).
+
+**`expressTrustProxy` (sku config):**
+
+- Type: optional boolean named `expressTrustProxy` (SSR).
+- When `true`, sku sets `app.set('trust proxy', 1)` (hop count **`1`**, despite the boolean name — safer single-hop than Express boolean `true`).
+- When omitted / `false`: leave Express default (`false`). Not magically on.
+- Not a silent sku default — opt-in via config.
+- Create template MUST set `expressTrustProxy: true` so new apps get SEEK/Melways-shaped behaviour visibly in config.
+- Any other trust-proxy value (`false`, `2`, IP list, …) → override in `onListen` via `app.set('trust proxy', …)`.
+
+Rejected alternatives:
+
+| Approach                                  | Why not                                                                                  |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Invisible sku default for `trust proxy`   | Hides Melways behaviour; hard to discover; rejected in favour of named config + template |
+| Express `app.set('trust proxy', true)`    | Boolean `true` trusts all hops; hop count `1` is the common SEEK case                    |
+| `onBeforeListen` hook                     | Module top-level already covers process-wide setup before bind                           |
+| Sku-owned listen logging                  | Apps own logging; `onListen` + bound `port` is enough                                    |
+| Pass only `app` (webpack `onStart` shape) | Blocks `httpServer.keepAliveTimeout`; migrants need the server handle                    |
+
+Example:
+
+```ts
+// sku.config.ts
+export default {
+  bundler: 'vite',
+  buildType: 'ssr',
+  expressTrustProxy: true, // → app.set('trust proxy', 1)
+} satisfies SkuConfig;
+
+// server entry
+defineServerEntry({
+  onListen({ app, httpServer, port }) {
+    httpServer.keepAliveTimeout = 20_000;
+    logger.info({ port }, 'App has started');
+    // rare: app.set('trust proxy', 2) or false
+  },
+  // …middleware / getters
+});
+```
+
+Docs: `entries.md` (`onListen`), `configuration.md` (`expressTrustProxy` → sets hop count `1`), migrate-from-webpack (`onStart` → `onListen` bag; trust proxy via config not `onStart`).
+
+### 26. Shared SSR module identity: consolidate onto `sku/runtime` + `optimizeDeps.exclude`
+
+Published / tarball installs put `sku/runtime` into `.vite/deps` (e.g. `sku_runtime.js`).
+App code then gets Context A from that prebundle, while sku’s `SkuProvider` (via relative imports in the SSR client / render entries) uses Context B from the unbundled context module.
+Hooks throw “must be used within SkuProvider.”
+
+```
+App createSkuContexts()  →  .vite/deps/sku_runtime.js Context A
+SkuProvider in render/client  →  unbundled context module Context B
+useSite()  →  A
+provider writes  →  B
+```
+
+Fixtures work because Vite skips prebundling `workspace:*` packages.
+Design previously documented only tsdown `unbundle: true` — that keeps dist files as separate modules, but does **not** stop Vite dep-optimization of published packages.
+
+The same class of bug applies to `useInsertHtml`, the preload registry, and CSP nonce storage.
+
+**Chosen approach: both** — they solve different layers:
+
+| Layer                          | What it does                                                                                                                                                    |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Consolidate onto `sku/runtime` | Cohesive runtime entry: app + sku runtime share one specifier, so even if something were prebundled, provider/hooks/registries land in the same optimized chunk |
+| `optimizeDeps.exclude`         | Defense in depth: Vite never clones `sku` / `sku/runtime` into `.vite/deps`, so a future relative import or new shared module cannot reintroduce the split      |
+
+Exclude alone is the minimal bugfix.
+Consolidate alone is the cleaner architecture.
+Together: better module story and not vulnerable if someone later reaches a shared module via a second path.
+
+Self-import risk (`#entries/*` → `sku/runtime` via package exports) is accepted and verified by existing SSR browser tests after the change.
+If self-import mis-resolves under `@fs` / tarball, those tests fail loudly.
+
+**1. Consolidate SSR identity onto `sku/runtime`**
+
+Already public: `createSkuContexts`, `useInsertHtml`, `usePreloadRoute`, `getCspNonce`, entry helpers + types.
+
+Re-export internals for sku-runtime use; mark `@internal` in JSDoc:
+
+| Module              | Symbols                                       | Call sites to flip to `'sku/runtime'` |
+| ------------------- | --------------------------------------------- | ------------------------------------- |
+| Context module      | `SkuProvider`                                 | SSR client entry, `render.tsx`        |
+| `insertHtml.tsx`    | `InsertHtmlProvider`, `createInsertHtmlQueue` | `render.tsx`                          |
+| `preloadRoute.ts`   | `registerSiteRouteTree`                       | SSR client entry                      |
+| `requestContext.ts` | `runWithSsrRequestContext`                    | `render.tsx`                          |
+
+Leave type-only imports, Node middleware helpers, and unit tests on relative paths.
+Do **not** move Document / route filtering / middleware / stream transform onto the public entry — they are not on the consumer↔sku dual path.
+
+**2. Exclude from Vite `optimizeDeps`**
+
+In `packages/sku/src/services/vite/plugins/config.ts` (shared config plugin, not SSR-only):
+
+```ts
+exclude: [
+  'sku',
+  'sku/runtime',
+  ...skuContext.skipPackageCompatibilityCompilation,
+],
+```
+
+Extract `SKU_VITE_OPTIMIZE_DEPS_EXCLUDE` for the plugin + a Node assert test.
+
+**3. Docs / identity comments**
+
+Update identity comments on the four shared modules + `ssr.ts`:
+
+- Prefer one specifier (`sku/runtime`) for app and sku runtime that touch shared state.
+- `unbundle: true` keeps one physical module in dist.
+- `optimizeDeps.exclude` stops Vite from cloning published `sku` / `sku/runtime`.
+
+**4. Regression coverage**
+
+- Node assert: `optimizeDeps.exclude` always includes `'sku'` and `'sku/runtime'`.
+- Existing SSR browser tests stay green (catches self-import breakage under workspace link).
+- Skip new tarball `sku start` e2e for now; exclude is what published installs need, consolidate is structural.
+
+**Validate:** `pnpm format` → `pnpm build` → `pnpm lint` → scoped tests (new assert + SSR browser).
+
+**Out of scope for this decision:** consumer Vite config injection, and moving non-identity Managed Data Mode helpers onto `sku/runtime`.
+
+### 27. Naming: Managed Data Mode, `sku/runtime`, SSR render type
+
+Separate naming layers — do not collapse them into one word:
+
+| Layer                          | Name                  | Role                                                                                                                                                                                                 |
+| ------------------------------ | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OpenSpec change / git branch   | `vite-ssr`            | Historical workstream id only — do **not** use in product docs, templates, public APIs, or user-facing copy                                                                                          |
+| Architecture / docs descriptor | **Managed Data Mode** | Sku-owned Document + React Router Data Mode contract (Decision 3). Use when describing the kind of API, comparing to webpack SSR / today’s static, or noting what SSR and a future Static path share |
+| Render strategy                | **SSR** / **Static**  | Selected by `buildType`. Product copy says “SSR”, never “Vite SSR”                                                                                                                                   |
+| Create template                | **`ssr`**             | `@sku-lib/create --template ssr` (not `vite-ssr`)                                                                                                                                                    |
+| Public import                  | **`sku/runtime`**     | Browser-safe Managed Data Mode entry (Decision 26 consolidate + `optimizeDeps.exclude` target)                                                                                                       |
+| Public types / symbols         | Drop `Ssr`            | e.g. `SkuProvider`, `createSkuContexts`, `SkuRouteObject`, `SkuServerEntry` / `SkuClientEntry`, `SkuGetSite`, …                                                                                      |
+
+**Why not `sku/runtime`:**
+The import carries contract APIs that are not SSR-specific (`define*Entry`, `createSkuContexts`, `useSite`, …).
+SSR is a render strategy; the entry is the application runtime.
+
+**Why not `sku/react-router`:**
+Bad branding, couples the public surface to a peer, misses Document/CSP/entries, and is awkward when Managed Data Mode is the default path.
+
+**Why `sku/runtime`:**
+Matches sku owning more in-app runtime code, is strategy- and bundler-agnostic, and survives Static adoption and “becomes the only API.”
+
+**Docs language:**
+
+- Prefer **Managed Data Mode** when describing the API shape shared by new SSR and (eventually) new Static.
+- Prefer **SSR** when referring only to `buildType: 'ssr'` / streaming HTML per request.
+- Prefer **Webpack SSR** when referring to the older `renderCallback` path.
+- Do not lead with “Vite SSR” outside this change’s OpenSpec / branch name.
+
+**End state (this change has not shipped):**
+Public contracts use the names above.
+No compatibility aliases for prior in-branch names are required in product docs.
+
+## Risks / Trade-offs
+
+| Risk                                              | Mitigation                                                                                                                                                                                             |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Dual `routes` hydration mismatch                  | Eliminated by first-class `routesEntry` (one module in both graphs). No runtime tree checker.                                                                                                          |
+| Wrong-site tree / foreign path match              | Pre-filter `sites` into per-site trees before RR. `getSite` (or sole resolved site) selects. Serialize `site` for client. Fail closed on invalid or unknown site.                                      |
+| App omits or invents `site`                       | Empty config `sites` soft-defaults to `'default'`. Multi-site requires `getSite` at init. Hard-error if return is non-string or not a resolved site name. 0–1 site uses sole name when getter omitted. |
+| Duplicate parse across getters                    | Accepted. Docs say keep getters sync/pure. Shared libs memoise on `req`.                                                                                                                               |
+| Accidental site splits                            | No `sites` inheritance. Site-specific routes must set `sites` explicitly.                                                                                                                              |
+| Shell-only CSP / late scripts                     | Lazy single nonce. Hash known bootstrap bodies.                                                                                                                                                        |
+| Absolute / `CDN` `publicPath`                     | Config rejects. Relative-only docs. No browser e2e for this edge case.                                                                                                                                 |
+| `publicPath` coupled to basename                  | Never pass `publicPath` as RR basename. Bake `__SKU_PUBLIC_PATH__`. Fixture for `/static/...` assets.                                                                                                  |
+| Start vs prod asset URLs                          | Start: Vite graph at `/`. Build/prod: `base` + Document URLs under `publicPath` from baked manifest. Optional Node static only when sibling `client/` exists.                                          |
+| Sibling `client/` required for manifest           | Bake/copy Vite client manifest into `server/` at build. Production entry loads server-local manifest. No `ENOENT` on missing sibling `client/`.                                                        |
+| Catch-all middleware eats `publicPath` assets     | When Node static is mounted, mount it before server-entry middleware. Middleware + Migrating docs state the order.                                                                                     |
+| Server-only deploy missing runtime deps           | Deploy docs: ship `server/` with production `node_modules` (or equivalent). Server is self-contained except hashed static files, not a frozen binary.                                                  |
+| Node treated as production asset origin           | Docs: recommended path is reverse proxy / object storage for `client/`. Sibling `express.static` is standalone / experimentation only.                                                                 |
+| Unhashed `public` folder assets                   | Hard-error if `paths.public` exists. Disable `publicDir` / `copyPublicFiles` for SSR. Migrating + docs cover the move.                                                                                 |
+| `dangerouslySetViteConfig` / `vitePlugins` on SSR | Hard-error when set. Omit decorator plugin and consumer `vitePlugins` on SSR graph. Docs + sku-support for use-cases.                                                                                  |
+| CJS “got: object” on `sku start`                  | Docs. Consumer extends interop list (no new defaults, no runtime error rewrite).                                                                                                                       |
+| Mock deps ship in prod                            | `devServerMiddleware` only. Never from server entry.                                                                                                                                                   |
+| Early production use                              | Experimental docs + changeset.                                                                                                                                                                         |
+| Express / RR major drift                          | Keep shared Express on 4. RR 8 optional peer for SSR only. Docs + changeset mark later major bumps as potentially breaking. Express 5 deferred.                                                        |
+| RR 8 peer baselines                               | Optional peer `^8`. Align engines with RR 8 minimums sku already meets. Document consumer React/Node expectations. Template installs RR 8.                                                             |
+| Jest + RR 8 (webpack)                             | Out of scope: no Jest transforms in this change. SSR requires Vitest. Do not force webpack fixtures onto RR 8.                                                                                         |
+| Server loaders leak to client                     | Migrating: split server-only modules. Explicit `moduleId` when lazy is non-idiomatic.                                                                                                                  |
+| Braid reset before Braid on start                 | Docs: reset early on server graph. No sku auto-inject.                                                                                                                                                 |
+| `window` providers in Document SSR                | Migrating: client `getReactContext` + root-layout / `useEffect` consumers.                                                                                                                             |
+| Jest apps on SSR                                  | Migrating: Vitest prerequisite. Link existing Vitest docs / codemod.                                                                                                                                   |
+| Nested `@vocab/vite/runtime`                      | Sku `createRequire` + `resolve.alias`. Validate translations SSR without consumer pin.                                                                                                                 |
+| Bare `src/` imports under Vite                    | Migrating: `#` `pathAliases` + `migrate-root-resolution`.                                                                                                                                              |
+| Per-request `createStaticHandler`                 | `SkuProvider` sits outside the router so sku never wraps the tree. Pre-build handler per site at init. Assert `render` does not import `createStaticHandler`.                                          |
+| `createSkuContexts` / render context split        | Decision 26: consolidate sku runtime onto `sku/runtime` + `optimizeDeps.exclude`. `unbundle: true` alone is not enough for published installs. Node assert + browser tests.                            |
+| Express `req` stuffed into context                | Red warning: project values via dual `getRouterContext` (from `clientContext` / `reactContext` when possible). Never put raw `req` in `RouterContextProvider`.                                         |
+| Framework-only `getLoadContext` copy              | Dual entry required for Data Mode client navs. Server-only API is a non-goal.                                                                                                                          |
+| Server-only loaders as default                    | Docs steer render-time content loading. Loaders for waterfalls / document redirects / headers / opt-in `getRouterContext` only.                                                                        |
+| Start FOUC without SSR-CSS                        | Document `assets.css` gets the virtual stylesheet on `sku start`. Production stays on manifest CSS.                                                                                                    |
+| Telemetry missing on SSR start                    | Mount `telemetryPlugin` on SSR graph. Client scripts via client entry / bootstrap. Mark `initialPageLoad` on ready.                                                                                    |
+| Apps cannot reach the stream                      | `useInsertHtml` on `sku/runtime`. Sku flushes queued nodes between React chunks. `stream-insert-html` fixture proves Apollo hydration end to end.                                                      |
+| Transport scripts blocked by CSP                  | Injected bodies are unhashable post-shell. Nonce already minted before `pipe`. Docs show server `getReactContext` returning `extraScriptProps={{ nonce: getCspNonce() }}`.                             |
+| `useInsertHtml` throws off the SSR path           | Silent no-op with no injection context — client graph included. Covered by tests.                                                                                                                      |
+| Duplicate queries after hydration                 | Fixture asserts server-run queries are served from the transported cache and that a post-hydration query still fetches.                                                                                |
+| Wrong transport build resolved                    | Apollo ships separate `browser` / `node` condition builds and asserts on mismatch. Fixture exercises both `sku start` and production.                                                                  |
+| Injection lost under `waitForAll`                 | Buffer to `onAllReady` and write injected nodes in stream order. Covered by tests.                                                                                                                     |
+| Transport module duplicated in graph              | Decision 26 dual fix (same as `getCspNonce` / preload / `SkuProvider`). Exclude stops `.vite/deps` clone. Consolidate keeps one specifier.                                                             |
+| Self-import `#entries/*` → `sku/runtime`          | Accepted. SSR browser tests fail loudly if package exports / `@fs` mis-resolve under workspace or tarball-like layouts.                                                                                |
+| Published install dual React context              | `optimizeDeps.exclude` for `sku` + `sku/runtime`. Consolidate so provider and hooks share one entry. Skip dedicated tarball e2e this pass.                                                             |
+| Trust proxy off unless configured                 | Opt-in `expressTrustProxy`. Template sets `true`. Other values via `onListen`.                                                                                                                         |
+| `onListen` re-fired on server-entry HMR           | Call once after successful listen. Do not re-invoke on every start HMR reload of the server entry.                                                                                                     |
+
+## Migration Plan
+
+Adoption is opt-in via `buildType` + Vite.
+Webpack SSR apps that leave `buildType` unset stay on the existing path.
+Rollback is a config-only revert: remove `buildType`.
+
+New apps scaffold from `--template ssr`.
+The template uses named `Component` on lazy pages and sets `expressTrustProxy: true` in config.
+
+Existing apps follow Migrating docs.
+Key topics include:
+
+- Ports and deploy layout (single `port`, `dist/server/server.js`, baked server-local manifest, recommended external assets vs standalone Node static, production `node_modules`).
+- CJS interop for `sku start`.
+- Express 4 typing and React Router 8 as an optional peer.
+- Named `Component` on lazy pages.
+- `routesEntry` + flat `routes` + optional `sites` + `getSite`.
+- `defineServerEntry` / `defineClientEntry` replacing `onRequest`, plus optional `middleware` / `onListen` / `onHydrate`.
+- Webpack `onStart` → `onListen` + config `expressTrustProxy`.
+- `createSkuContexts<typeof …>` + three value channels + root-layout wrapping.
+- Moving off config `public`.
+- The data-loading hierarchy, optional `getRouterContext`, and the red warning against Express `req` in router context.
+- Apollo streaming transport via `useInsertHtml` + root-layout provider instead of `getDataFromTree`.
+- Server-only loaders, Braid reset order, and client-only libraries via `getReactContext`.
+- Jest → Vitest, `#` `pathAliases`, and sku-owned `@vocab/vite`.
+
+## Open Questions
+
+- **Docs diagram format for the three channels?** Prefer a Markdown table (and optional nested list) in product docs. VitePress has no built-in Mermaid; the site does not ship `vitepress-plugin-mermaid` today. Adding Mermaid is optional polish later — do not block docs on it.

--- a/openspec/changes/vite-ssr/proposal.md
+++ b/openspec/changes/vite-ssr/proposal.md
@@ -1,0 +1,126 @@
+## Why
+
+When using Vite, SSR is disabled today.
+Webpack SSR’s low-level `renderCallback` + string document + `#app` hydrate cannot stream Suspense HTML.
+It also cannot let React own `<html>`/`<head>`/`<body>`.
+
+This change introduces **Managed Data Mode**.
+Sku owns Document, streaming/hydration, the Node server, and CSP.
+Sku wires React Router Data Mode for routing and data.
+Apps own routes, data, and providers.
+
+Managed Data Mode is first shipped as **SSR** (`buildType: 'ssr'`).
+The same contract is intended to be shareable later by a new Static path.
+That contract includes `sku/runtime`, request entries, and typed context hooks.
+Render strategy (`ssr` / `static`) and the Managed Data Mode API are separate concerns.
+It ships **experimental** (not for production).
+
+Multi-site apps need different path sets per site.
+A single unfiltered route list either over-matches or registers foreign paths on every host.
+This change makes site-scoped trees first-class via `routesEntry` + optional route `sites` + app `getSite`.
+That matches the spirit of first-class multi-language.
+Details: `design.md` Decision 4a.
+
+With Express `req` on entry getters / optional `getRouterContext`, apps have no need to separate server vs client route modules.
+A single `routesEntry` is the source of truth for both graphs.
+
+Streaming data transports must inject `<script>` chunks between React stream chunks.
+That lets SSR queries hydrate the browser cache instead of refetching.
+Apollo Client streaming hydration is the main adoption case.
+Sku owns the stream pipe.
+Apps cannot reach it.
+Sku opens one seam (`useInsertHtml`).
+The transport itself stays with the app.
+Details: `design.md` Decision 21a.
+
+Pass-through app `Providers` that only re-piped `site` / `clientContext` proved awkward in fixtures.
+Sku always mounts `SkuProvider` and exposes typed hooks via `createSkuContexts`.
+Env-differing values come from dual-entry `getReactContext`.
+Isomorphic mounts (Apollo, Vocab) live in the app’s root layout route.
+Details: `design.md` Decision 12a.
+
+## What Changes
+
+- Experimental SSR uses `buildType: 'ssr' | 'static'`.
+- Commands are `sku start` / `sku build`.
+- Webpack-style `-ssr` is not used.
+- First-class `routesEntry` defaults to `src/routes.tsx`.
+- It exports flat `routes` with optional `sites`.
+- Sku pre-builds per-site trees.
+- Apps resolve the site via `getSite` when multi-site.
+- Config `routes` (static prerender paths) stays separate.
+- Request entries (`serverEntry` / `clientEntry`) default-export objects via `defineServerEntry` / `defineClientEntry`.
+- Optional getters include `getSite`, `getLanguage`, `getClientContext`, and `getReactContext`.
+- Optional entry hooks include `middleware`, `onListen`, `onHydrate`, and dual-entry `getRouterContext`.
+- Sku owns Document, streaming, assets, CSP, and always-on `SkuProvider` outside the router.
+- There is no app-authored dual-entry `Providers`.
+- Three value channels replace it: `getClientContext`, `getReactContext`, and `getRouterContext`.
+- Typed hooks come from `createSkuContexts` on `sku/runtime`.
+- Router-aware wrapping lives in the app’s root layout route.
+- `useInsertHtml()` on `sku/runtime` supports app-owned streaming data transports.
+- It is a no-op off the SSR path.
+- Optional server-entry `onListen` covers the webpack `onStart` window.
+- Opt-in config `expressTrustProxy` is a boolean that sets Express hop count `1`.
+- The create template sets `expressTrustProxy: true`.
+- Docs describe **Managed Data Mode** as the API and **SSR** as the render strategy.
+- They cover multi-site routing, the three value channels, and an Apollo streaming walkthrough.
+- Create template `ssr` ships with product and Migrating docs.
+- SSR uses the same Express 4 server runtime.
+- React Router 8 becomes an optional peer `^8` that is required for SSR consumers.
+- Later major bumps of Express or React Router that SSR integrates may be breaking.
+
+Out of scope includes webpack SSR backfill, Framework Mode / RSC, Express 5, absolute/`CDN` `publicPath`, app-authored `Providers`, and sku-owned Apollo.
+Related items are deferred too.
+Full list: `design.md` Non-Goals.
+
+## Capabilities
+
+### New Capabilities
+
+- `vite-ssr`: Managed Data Mode SSR lifecycle. Covers `buildType`, `routesEntry`, request entries, streaming Document, create template `ssr`, `sku/runtime`, and docs.
+- `vite-ssr-csp`: Shell-derived CSP headers, lazy single nonce, and optional report-only.
+
+### Modified Capabilities
+
+- (none)
+
+Bundler and command constraints for this mode live under `vite-ssr`.
+
+## Impact
+
+**Public API**
+
+- `buildType`
+- `routesEntry` and request entries via `defineServerEntry` / `defineClientEntry`
+- `sku/runtime` hooks: `createSkuContexts`, `useInsertHtml`, `usePreloadRoute`
+- `onListen` and `expressTrustProxy`
+- create template `ssr`
+
+Full contract: `design.md` Decisions 12 / 12a / 25.
+
+**Deps**
+
+- `react-router` is an optional peer `^8`.
+- Express 4 stays shared with webpack SSR.
+- There is no 4 → 5 bump in this change.
+
+**Docs / release**
+
+- Product and Migrating docs describe Managed Data Mode vs SSR.
+- They cover multi-site, the three value channels, and Apollo streaming.
+- Deploy docs cover a self-contained production server and recommended external hosting of hashed assets.
+- Release includes an experimental warning and a changeset.
+
+**Fixtures / tests**
+
+- SSR fixture covers streaming, CSP, multi-site, and hooks.
+- `stream-insert-html` proves Apollo end to end.
+- Coverage includes `onListen` and `expressTrustProxy`.
+- Create template tests are included.
+- Module identity is covered per Decision 26.
+
+**Adopt**
+
+- Adoption is opt-in via `buildType`.
+- `publicPath` stays relative and asset-only.
+- There is no `public` folder, `dangerouslySetViteConfig`, or `vitePlugins` for SSR.

--- a/openspec/changes/vite-ssr/specs/vite-ssr-csp/spec.md
+++ b/openspec/changes/vite-ssr/specs/vite-ssr-csp/spec.md
@@ -1,0 +1,148 @@
+## ADDED Requirements
+
+### Requirement: SSR CSP is delivered as HTTP headers
+
+When CSP is enabled for an SSR app, sku MUST set Content Security Policy via HTTP response headers, not HTML `http-equiv` meta tags.
+
+#### Scenario: Enforcing CSP header on HTML responses
+
+- **WHEN** CSP is enabled and sku begins streaming an HTML document response
+- **THEN** the response includes a `Content-Security-Policy` header before the body is sent
+
+#### Scenario: No meta http-equiv CSP
+
+- **WHEN** CSP is enabled for an SSR app
+- **THEN** sku MUST NOT inject a `Content-Security-Policy` meta `http-equiv` tag as the policy delivery mechanism
+
+### Requirement: CSP is derived from shell HTML plus dynamic values
+
+sku MUST generate the SSR CSP from the rendered document shell (known script tags and origins).
+
+Sku MUST allow dynamic values such as nonces and hashes of known bootstrap script bodies.
+
+#### Scenario: Shell scripts are allowed
+
+- **WHEN** the document shell includes sku bootstrap or other shell script tags
+- **THEN** those scripts are permitted by the generated `script-src` policy
+
+#### Scenario: Hashable bootstrap script bodies
+
+- **WHEN** CSP is enabled and sku emits known inline bootstrap script content
+- **THEN** those exact script bodies are available for hashing into the CSP policy
+
+### Requirement: SSR uses at most one CSP nonce per render, only when requested
+
+For an SSR HTML response, sku MUST generate at most one CSP nonce, only when explicitly requested (by consumer code or by sku when attaching a `nonce` to scripts).
+
+When requested, sku MUST reuse that same value everywhere for the response.
+
+Sku MUST NOT provide an SSR API that creates additional distinct nonces for the same response (unlike static/webpack `createUnsafeNonce`).
+
+Sku MUST include `'nonce-…'` in the CSP header only if a nonce was requested.
+
+If CSP is enabled but nothing requested a nonce, the CSP header MUST still be emitted without a nonce allowance.
+
+#### Scenario: Nonce omitted from CSP when never requested
+
+- **WHEN** CSP is enabled for an SSR HTML response
+- **AND** neither consumer code nor sku requested a nonce during that request
+- **THEN** the CSP header does not include a `'nonce-…'` source
+
+#### Scenario: Requested nonce appears once in CSP and is reused
+
+- **WHEN** a nonce is requested during an SSR render
+- **THEN** sku generates exactly one nonce for that request
+- **AND** the CSP header includes that nonce
+- **AND** every subsequent request for the nonce on that response returns the same value
+- **AND** sku-owned nonce-bearing scripts for that response use that same value
+
+#### Scenario: Consumer requests the shared nonce
+
+- **WHEN** consumer middleware or loaders explicitly request the SSR CSP nonce during a request
+- **THEN** they receive the request nonce
+- **AND** that nonce matches the nonce used in the CSP header and React stream for that response (when the header includes a nonce)
+
+#### Scenario: No multi-nonce factory on SSR
+
+- **WHEN** an SSR app needs CSP nonces
+- **THEN** consumers MUST NOT use webpack/static `createUnsafeNonce` as the SSR API
+- **AND** sku MUST NOT expose an SSR helper that returns a new distinct nonce on each call for the same response
+
+### Requirement: Report-Only CSP may coexist with an enforcing policy
+
+SSR apps MUST support a Report-Only CSP that can be set in addition to an enforcing CSP.
+
+#### Scenario: Report-Only header alongside enforcing policy
+
+- **WHEN** both enforcing CSP and Report-Only CSP are enabled
+- **THEN** the response includes both `Content-Security-Policy` and `Content-Security-Policy-Report-Only` headers
+
+#### Scenario: Report-Only only
+
+- **WHEN** only Report-Only CSP is enabled
+- **THEN** the response includes `Content-Security-Policy-Report-Only` and does not require an enforcing `Content-Security-Policy` header
+
+### Requirement: SSR report-to matches static Vite semantics
+
+SSR MUST accept `cspReportTo` and `cspReportOnlyReportTo` in the same forms static Vite accepts: an endpoint name, a URL, or a tuple of both. `cspReportOnlyReportTo` MUST default to `cspReportTo`.
+
+Sku MUST include the resolved endpoint name as the `report-to` directive of the corresponding policy, and MUST emit a `Reporting-Endpoints` response header covering every resolved endpoint that carries a URL.
+
+Because SSR ignores `cspDelivery` and always uses HTTP headers, `cspReportTo` MUST apply whenever CSP is enabled, rather than being gated on `header` delivery.
+
+#### Scenario: Configurable report-to on either policy
+
+- **WHEN** a `report-to` value is configured for the enforcing and/or Report-Only policy
+- **THEN** the corresponding `Content-Security-Policy` and/or `Content-Security-Policy-Report-Only` header includes a `report-to` directive using the resolved endpoint name
+
+#### Scenario: Reporting-Endpoints emitted for URL-bearing endpoints
+
+- **WHEN** a configured `report-to` value resolves to an endpoint that carries a URL
+- **THEN** the response includes a `Reporting-Endpoints` header mapping that endpoint name to its URL
+
+#### Scenario: No Reporting-Endpoints header without URLs
+
+- **WHEN** every configured `report-to` value is an endpoint name only
+- **THEN** sku MUST NOT emit a `Reporting-Endpoints` header, leaving the endpoint group for the app or its infrastructure to define
+
+### Requirement: SSR CSP assumes relative publicPath only
+
+SSR CSP MUST assume a relative `publicPath` so Document assets are covered by `'self'`.
+
+Absolute `http(s)` / CDN `publicPath` is not supported.
+
+Consumer `cspExtraScriptSrcHosts` remains for third-party script hosts.
+
+#### Scenario: Relative publicPath with CSP enabled
+
+- **WHEN** CSP is enabled and `publicPath` is a relative path
+- **AND** sku streams an HTML document whose assets use that relative path
+- **THEN** the CSP header allows those assets via `'self'` (and nonces/hashes as applicable)
+- **AND** sku does not require an absolute/`CDN` origin allowance for sku-owned Document assets
+
+### Requirement: Webpack SSR and static CSP behavior are unchanged by this capability
+
+This SSR CSP capability MUST NOT change CSP delivery for webpack SSR apps or static apps.
+
+Static Vite may independently support `cspDelivery` (`tag` / `header` metadata) and Report-Only via the static HTML CSP path; `cspDelivery` MUST NOT control SSR CSP, which always uses HTTP headers.
+
+The `report-to` config options are shared with static Vite and MUST resolve identically for both paths; only the delivery of the resulting `Reporting-Endpoints` differs (a response header for SSR, `metadata.reportingEndpoints` for static).
+
+Static and webpack apps MAY continue to allow multiple `createUnsafeNonce` calls per render.
+
+#### Scenario: Static app CSP unchanged by SSR path
+
+- **WHEN** a static app has CSP enabled
+- **THEN** its existing static CSP behavior remains as for that app mode (meta tag and/or metadata / start headers as configured)
+- **AND** SSR does not rewrite that static delivery model
+
+#### Scenario: Static multi-nonce API unchanged
+
+- **WHEN** a static or webpack render calls `createUnsafeNonce` more than once
+- **THEN** existing multi-nonce behavior remains as today
+
+#### Scenario: cspDelivery does not apply to SSR
+
+- **WHEN** an SSR app sets `cspDelivery`
+- **THEN** sku ignores that option for SSR responses
+- **AND** CSP is still delivered as HTTP headers (not meta `http-equiv`)

--- a/openspec/changes/vite-ssr/specs/vite-ssr/spec.md
+++ b/openspec/changes/vite-ssr/specs/vite-ssr/spec.md
@@ -1,0 +1,1310 @@
+## ADDED Requirements
+
+### Requirement: Managed Data Mode naming
+
+Product docs and public APIs MUST describe this architecture as **Managed Data Mode** (sku-owned Document + React Router Data Mode wiring; apps own routes, data, and providers).
+
+**SSR** MUST refer only to the render strategy selected by `buildType: 'ssr'`.
+
+Docs MUST note that Managed Data Mode is intended to be shared later by a new Static path on the same contract.
+
+The public import MUST be `sku/runtime` (not `sku/runtime`).
+
+Public type and helper names MUST NOT use an `Ssr` infix (e.g. `SkuProvider`, `createSkuContexts`, `SkuRouteObject`, `SkuServerEntry` / `SkuClientEntry`).
+
+The create template MUST be named `ssr` (not `vite-ssr`).
+
+Product docs, templates, and public APIs MUST NOT use the label `vite-ssr` (that name is reserved for this OpenSpec change / branch only).
+
+#### Scenario: Docs describe Managed Data Mode vs SSR
+
+- **WHEN** a reader opens SSR getting-started or Migrating docs
+- **THEN** docs describe the architecture as Managed Data Mode
+- **AND** use SSR for the `buildType: 'ssr'` render strategy
+- **AND** note that a future Static path is expected to share the same Managed Data Mode APIs
+
+#### Scenario: Public import is sku/runtime
+
+- **WHEN** an app imports Managed Data Mode helpers (`defineServerEntry`, `createSkuContexts`, `useInsertHtml`, …)
+- **THEN** the import specifier is `sku/runtime`
+
+#### Scenario: Create template is ssr
+
+- **WHEN** a user scaffolds an SSR app with `@sku-lib/create`
+- **THEN** the template id is `ssr`
+
+### Requirement: SSR mode is selected via buildType
+
+SSR MUST be enabled with `bundler: 'vite'` and `buildType: 'ssr'`, using `sku start` / `sku build`.
+
+Omitting `buildType` or using `static` MUST leave static / existing webpack-SSR behaviour unchanged.
+
+#### Scenario: buildType enables SSR
+
+- **WHEN** config sets `bundler: 'vite'` and `buildType: 'ssr'`
+- **AND** `routesEntry` exports named `routes`
+- **AND** `serverEntry` / `clientEntry` each default-export an entry object
+- **THEN** `sku start` and `sku build` treat the project as an SSR app
+
+#### Scenario: static remains static
+
+- **WHEN** config sets `buildType: 'static'` (or omits `buildType` with today’s static default)
+- **THEN** sku does not treat the project as an SSR app
+
+### Requirement: Webpack is rejected for ssr mode
+
+`buildType: 'ssr'` MUST only be valid with the Vite bundler.
+
+This edge case MUST NOT require a dedicated browser e2e fixture.
+
+#### Scenario: webpack plus ssr errors
+
+- **WHEN** config sets webpack and `buildType: 'ssr'`
+- **THEN** config validation fails stating that mode is not supported with webpack
+
+### Requirement: Suffixed SSR commands error when buildType is set
+
+When `buildType` is set, `sku start-ssr` and `sku build-ssr` MUST fail.
+
+Consumers MUST use `sku start` and `sku build`.
+
+This edge case MUST NOT require a dedicated browser e2e fixture.
+
+#### Scenario: -ssr commands error when buildType is set
+
+- **WHEN** `buildType` is set and the user runs `sku start-ssr` or `sku build-ssr`
+- **THEN** the command fails and points to `sku start` / `sku build`
+
+### Requirement: Production build emits sibling client and server directories
+
+`sku build` for an SSR app MUST produce sibling `client/` and `server/` directories under the build target (neither nested).
+
+`sku build` MUST bake or copy the Vite client manifest into the server output so the production server entry can resolve Document assets without reading a sibling `client/` path at runtime.
+
+#### Scenario: Production build layout
+
+- **WHEN** a consumer runs `sku build` for an SSR app
+- **THEN** sku produces sibling `client/` and `server/` under the build target
+- **AND** neither directory is nested inside the other
+- **AND** the server output includes a Vite client manifest usable without a sibling `client/` directory
+
+#### Scenario: Production server starts without sibling client assets
+
+- **WHEN** a consumer runs the production server entry with `server/` deployed and no sibling `client/` directory
+- **AND** the baked server-local manifest is present
+- **THEN** the process starts and can stream HTML Document responses
+- **AND** it does not fail with `ENOENT` opening `client/.vite/manifest.json`
+
+### Requirement: routesEntry exports flat routes
+
+Config MUST support `routesEntry` (default `src/routes.tsx`) for SSR.
+
+Sku MUST resolve `routesEntry` into both the server and client graphs via `__sku_alias__routesEntry`.
+
+`routesEntry` MUST export named `routes` as `SkuRouteObject[]` (flat array).
+
+`SkuRouteObject` MUST be a sku type helper `RouteObject & { sites?: string[] }` (not a wrapped React Router re-export).
+
+Missing or non-array `routes` on `routesEntry` MUST hard-error.
+
+Sku MUST load `routes` from `routesEntry` only.
+
+Config `routes` (static prerender path lists) MUST NOT be used as the SSR `RouteObject` entry.
+
+#### Scenario: routesEntry supplies routes for both graphs
+
+- **WHEN** an SSR app is started or built
+- **AND** `routesEntry` exports `routes`
+- **THEN** sku pre-builds per-site trees from that array for document / `query` (server) and hydrate (client)
+
+#### Scenario: Missing or invalid routes hard-error
+
+- **WHEN** `routesEntry` omits named `routes`, or exports a non-array value
+- **THEN** sku fails with a hard error naming the entry/export
+- **AND** does not use `default` or soft-skip
+
+### Requirement: Optional sites membership and getSite select site-scoped route tree
+
+Optional `sites?: string[]` on a `SkuRouteObject` declares membership:
+
+- Omit / undefined ⇒ the route is included for **every** resolved site
+- Present ⇒ the route is included **only** for those site names (exact match against resolved site names)
+
+Sku MUST NOT inherit `sites` from parent routes to children.
+Site-specific routes MUST set `sites` explicitly.
+
+Sku MUST pre-build per-site trees from resolved site names + `routesEntry` `routes` at init (not per request), strip `sites` before React Router APIs, and select the pre-built tree for the resolved `site`.
+
+Sku MUST create each site’s React Router static handler once at init and MUST NOT call `createStaticHandler` on the per-request path — per request sku only selects the pre-built handler and calls `query()` / `createStaticRouter`.
+
+Sku MUST NOT wrap or otherwise modify the route tree to mount consumer providers (provider mounting happens outside the router — see the request-exports requirement).
+
+SSR MUST NOT require a non-empty config `sites` array.
+Empty or omitted `sites` MUST soft-default to a single synthetic site name `'default'` for pre-build + allowlist.
+
+**Resolve `site`:**
+
+- Zero configured sites (soft-default `'default'`) or one configured site ⇒ when `getSite` is omitted, sku MUST use that sole resolved site name; when `getSite` is present on the server entry object, sku MUST call it and validate the return against the resolved name list.
+- Multiple configured sites ⇒ missing `getSite` property MUST hard-error at init (naming the property; same class as missing `routes` on `routesEntry`).
+- Non-string `site` from `getSite`, or a `site` that is not a resolved site name / has no pre-built tree, MUST fail closed per request (hard error).
+
+Sku MUST serialize that `site` into the hydrate bootstrap and select the same pre-built tree for client `createBrowserRouter`.
+
+Sku MUST NOT derive site from config `hosts` / `sites[].host` for route-tree selection (those remain local-dev listen / setup-hosts only).
+
+Apps own site resolution (from Express `req`, headers, app config, etc.) via sync `getSite({ req })` and per-site path _shape_ when paths differ by site.
+
+Config `sites[].routes` (static prerender path lists) MUST NOT drive SSR `RouteObject` trees.
+
+`site` MUST NOT be passed into `onHydrate` args (`onHydrate` stays `{ clientContext }` only when exported).
+
+#### Scenario: Empty config sites soft-defaults
+
+- **WHEN** an SSR app has an empty or omitted config `sites` array
+- **THEN** sku soft-defaults to the synthetic site name `'default'` for the pre-built tree and allowlist
+- **AND** does not hard-error at config/init for empty `sites`
+
+#### Scenario: Route without sites is on every site
+
+- **WHEN** a route omits `sites`
+- **AND** config defines multiple sites
+- **THEN** that route is present in every pre-built site tree
+
+#### Scenario: Route with sites is membership-filtered
+
+- **WHEN** a route sets `sites: ['au']`
+- **AND** config defines sites `au` and `nz`
+- **THEN** the route is present only in the `au` pre-built tree
+
+#### Scenario: No sites inheritance from parent
+
+- **WHEN** a parent route sets `sites: ['au']`
+- **AND** a child omits `sites`
+- **THEN** sku does not copy the parent’s `sites` onto the child
+- **AND** structural exclusion still applies (if the parent is absent for a site, its subtree is absent)
+
+#### Scenario: Zero or one site without getSite uses that site
+
+- **WHEN** config defines zero sites (soft-default `'default'`) or exactly one site
+- **AND** the server entry omits `getSite`
+- **THEN** sku uses that sole resolved site name for the server handler and hydrate bootstrap
+
+#### Scenario: getSite selects the tree
+
+- **WHEN** `getSite` returns `site`
+- **AND** that name is a resolved site with a pre-built tree
+- **THEN** sku uses that site’s tree for the server handler
+- **AND** hydrates the client router with the same site’s tree
+
+#### Scenario: Static handler is built once per site
+
+- **WHEN** an SSR app serves multiple document requests for the same site
+- **THEN** sku reuses the static handler built for that site at init
+- **AND** does not call `createStaticHandler` on the request path
+
+#### Scenario: Multi-site missing getSite hard-errors at init
+
+- **WHEN** config defines more than one site
+- **AND** the server entry omits `getSite`
+- **THEN** sku fails with a hard error at init naming the `getSite` property
+
+#### Scenario: Non-string getSite fails closed
+
+- **WHEN** `getSite` returns a non-string value
+- **THEN** sku fails closed with a hard error for that request
+
+#### Scenario: Unknown site fails closed
+
+- **WHEN** `getSite` returns a `site` that is not a resolved site name
+- **THEN** sku fails closed with a hard error for that request
+
+#### Scenario: Foreign-site paths are not registered
+
+- **WHEN** a route is membership-filtered out of site A’s tree
+- **AND** the resolved `site` is A
+- **THEN** React Router does not match that path on site A’s tree
+
+#### Scenario: Config hosts do not select the tree
+
+- **WHEN** config defines `sites[].host` values
+- **THEN** sku still resolves `site` via `getSite` (or the sole resolved site)
+- **AND** does not choose the tree from the request `Host` header alone
+
+### Requirement: Optional server and client request exports
+
+`serverEntry` / `clientEntry` MUST each **`export default`** one object.
+Sku MUST read that default export and call optional properties on it.
+
+Sku MUST export `defineServerEntry` / `defineClientEntry` from `sku/runtime` as zero-runtime identity helpers that infer types from getter returns and type later sibling args (`NoInfer` on input positions).
+`defineServerEntry` MUST infer `Site` from `getSite`, `Language` from `getLanguage`, `ClientContext` from `getClientContext`, and `ReactContext` from `getReactContext`, and MUST type later sibling `site` args as that `Site`.
+`defineClientEntry` MUST accept an optional `ServerEntry` type argument (`defineClientEntry<typeof server>`).
+When that argument is provided, it MUST extract `Site` from the server entry’s `getSite` return (`string` when omitted) and `ClientContext` from `getClientContext` (`undefined` when omitted), reuse the same extractors as `createSkuContexts`, and MUST type client sibling `site` / `clientContext` args (including `onHydrate`) from those extracted types.
+`defineClientEntry` MUST still infer `ReactContext` from the client entry’s own `getReactContext` return.
+When the `ServerEntry` type argument is omitted, `ClientContext` MUST be `undefined` and client `site` args MUST be `string`.
+Sku MUST also export structural types `SkuServerEntry` / `SkuClientEntry` (the shapes behind those helpers).
+
+Server entry object MAY include sync getters `getSite`, `getLanguage`, `getClientContext`, and `getReactContext`; optional `middleware`, `onListen`, and `getRouterContext`.
+
+Client entry object MAY include optional `onHydrate`, `getReactContext`, and `getRouterContext`.
+
+`getSite` is required **only** when config `sites` has more than one entry (init hard-error when missing — see the site-selection requirement).
+All other listed properties are optional.
+
+Sku MUST NOT specially gate on entry file existence; a missing file fails via normal module resolution.
+
+Sku MUST call getters in this order before `query()`: `getSite` (when present or required) → `getLanguage` → `getClientContext` → `getReactContext` → optional server `getRouterContext`.
+
+Later getters MUST receive already-resolved sibling values so apps can project without re-deriving:
+
+- `getSite` / `getLanguage` / `getClientContext` receive `{ req }` only (Express after consumer middleware)
+- Server `getReactContext` receives `{ req, site, clientContext }`
+- Client `getReactContext` receives `{ site, clientContext }` from the hydrate bootstrap
+- Server `getRouterContext` receives `{ request, req, site, clientContext, reactContext }`
+- Client `getRouterContext` receives `{ site, clientContext, reactContext }`
+
+Getters other than optional `getRouterContext` MUST be synchronous.
+Sku MUST NOT pass `res` into getters or `getRouterContext`.
+Sku MUST NOT pass Fetch `Request` into `getSite` / `getLanguage` / `getClientContext` (Fetch stays on `query()` and optional server `getRouterContext`).
+
+When `getLanguage` is omitted or returns `undefined`, sku MUST NOT register a vocab language chunk.
+When `getClientContext` is omitted or returns `undefined`, `clientContext` is `undefined` on both SSR and hydrate — the bootstrap MUST emit JS `undefined` (not JSON `null`). An explicit `null` return MUST serialise as JSON `null`.
+When `getReactContext` is omitted, `reactContext` is `undefined`.
+Sku MUST NOT forward `language` to the client.
+Sku MUST NOT serialise `reactContext` into the hydrate bootstrap.
+
+When the client entry includes `onHydrate`, sku MUST invoke it with `{ clientContext }` only — the same value from `getClientContext`.
+Omitting `onHydrate` MUST mean no hydrate side effects (not an error).
+
+Omitting `middleware` MUST mean no consumer middleware layer (not an error).
+
+Omitting `onListen` MUST mean no post-listen callback (not an error). See the `onListen` requirement for call timing.
+
+Sku MUST always render `SkuProvider` outside the router — `Document` → `SkuProvider` → router — with `site`, `clientContext`, and `reactContext` for that document.
+
+Sku MUST export `createSkuContexts<typeof server, typeof client>()` from `sku/runtime` so apps can obtain typed `useSite` / `useClientContext` / `useReactContext` bound to that provider.
+`createSkuContexts` MUST extract `Site` from the server entry’s `getSite` return (`string` when `getSite` is omitted), `ClientContext` from `getClientContext`, and `ReactContext` from both entries’ `getReactContext` returns (union when they differ).
+`useSite()` MUST return that `Site` type.
+`createSkuContexts` MUST NOT extract a language React hook from `getLanguage` in this change.
+Apps MUST NOT be required to declare hand-written `ClientContext` / `ReactContext` / site aliases.
+`createSkuContexts` MUST NOT ship per-property `defineGet*` helpers.
+
+Sku MUST NOT support an app-authored dual-entry `Providers` / `SkuProvidersProps` export in this change.
+
+Router-aware wrapping and isomorphic provider mounts (e.g. Apollo reading `useReactContext()`) are **not** a sku concern: apps express them as their own root layout route in `routesEntry`.
+
+Request-entry getters / `onHydrate` MUST NOT return a provider component.
+
+When the server entry includes `getRouterContext`, sku MUST call it before `query()` with the sibling args above and pass the returned `RouterContextProvider` as `requestContext` to `query()`.
+
+When the client entry includes `getRouterContext`, sku MUST map it into `createBrowserRouter({ getContext })`, wrapping RR’s zero-arg API to pass `{ site, clientContext, reactContext }`.
+
+Omitting either `getRouterContext` MUST preserve today’s empty/default context behaviour.
+
+Sku MUST NOT make Express `req` the loader `request` argument (`query()` continues to use Fetch `Request` only).
+
+#### Scenario: Default export is the request-entry contract
+
+- **WHEN** sku loads `serverEntry` or `clientEntry`
+- **THEN** it uses the module’s default export as the entry object
+- **AND** calls optional getter / middleware / hydrate properties on that object
+
+#### Scenario: Getters run before query with sibling projection
+
+- **WHEN** an SSR app handles a document request
+- **THEN** sku invokes present getters in order before `query()`
+- **AND** later getters receive already-resolved `site` / `clientContext` / `reactContext`
+- **AND** sku uses those values for site selection, vocab preload, `SkuProvider`, and the hydrate bootstrap (`clientContext` + `site` only)
+
+#### Scenario: Getters can read middleware-attached Express state
+
+- **WHEN** consumer Express middleware attaches fields on `req` (e.g. `req.user`, `req.log`)
+- **AND** getters run for that document request
+- **THEN** getters that receive `req` can read those fields to build `site` / `language` / `clientContext` / `reactContext`
+
+#### Scenario: Omitting middleware is not an error
+
+- **WHEN** the server entry omits `middleware`
+- **THEN** sku does not require it
+- **AND** mounts no consumer middleware layer
+
+#### Scenario: Omitting onListen is not an error
+
+- **WHEN** the server entry omits `onListen`
+- **THEN** sku does not require it
+- **AND** listen and document serving still succeed
+
+#### Scenario: Omitting onHydrate hydrates successfully
+
+- **WHEN** the client entry omits `onHydrate`
+- **THEN** sku hydrates the document without calling a hydrate callback
+
+#### Scenario: Optional onHydrate receives clientContext only
+
+- **WHEN** the client entry includes `onHydrate`
+- **THEN** sku invokes it with deserialized `clientContext` only (no `language`, no `reactContext`)
+
+#### Scenario: Optional getReactContext seeds SkuProvider
+
+- **WHEN** an entry includes `getReactContext`
+- **THEN** sku calls it with the sibling args for that environment
+- **AND** passes the result to `SkuProvider` as `reactContext`
+- **AND** does not serialise it into the hydrate bootstrap
+
+#### Scenario: Optional server getRouterContext seeds query requestContext
+
+- **WHEN** the server entry includes `getRouterContext`
+- **AND** a document request is handled
+- **THEN** sku calls server `getRouterContext` with `{ request, req, site, clientContext, reactContext }` before `query()`
+- **AND** passes the result as `requestContext` to `query()`
+
+#### Scenario: Optional client getRouterContext seeds createBrowserRouter
+
+- **WHEN** the client entry includes `getRouterContext`
+- **AND** the browser router is created
+- **THEN** sku maps that function into `createBrowserRouter({ getContext })`
+- **AND** each call receives `{ site, clientContext, reactContext }`
+
+#### Scenario: Omitting getRouterContext keeps default behaviour
+
+- **WHEN** an entry omits `getRouterContext`
+- **THEN** sku does not require it
+- **AND** React Router uses today’s empty/default context behaviour
+
+#### Scenario: SkuProvider always wraps the router
+
+- **WHEN** sku renders an SSR document (server or client)
+- **THEN** it renders `SkuProvider` between `Document` and the router provider
+- **AND** the route tree is unchanged
+- **AND** apps can read `site` / `clientContext` / `reactContext` via `createSkuContexts` hooks
+
+#### Scenario: Omitting getClientContext and getReactContext is not an error
+
+- **WHEN** an entry omits `getClientContext` and/or `getReactContext`
+- **THEN** sku does not require them
+- **AND** the corresponding provider values are `undefined`
+
+#### Scenario: Router-aware wrapping is an app route
+
+- **WHEN** an app needs wrapping that uses React Router hooks, loader data, or isomorphic provider mounts from `useReactContext`
+- **THEN** it declares its own root layout route in `routesEntry`
+- **AND** sku provides no dual-entry component export for that case
+
+#### Scenario: Entry type params type sibling getter args
+
+- **WHEN** an app wraps its server default export in `defineServerEntry`
+- **THEN** later server getters’ sibling args are typed from earlier getters’ return types
+- **AND** `createSkuContexts<typeof server, typeof client>()` exposes matching hook return types without hand-written context aliases
+
+#### Scenario: defineClientEntry types from ServerEntry
+
+- **WHEN** an app wraps its client default export in `defineClientEntry<typeof server>`
+- **AND** the server entry’s `getClientContext` returns a narrowed shape (e.g. `{ fromServer: true; userId: string | null }`)
+- **AND** `getSite` returns a narrowed site union (e.g. `'au' | 'nz'`)
+- **THEN** `onHydrate` / client `getReactContext` / client `getRouterContext` receive `clientContext` typed as that shape
+- **AND** client sibling `site` args are typed as that site union
+- **AND** client `ReactContext` is still inferred from the client’s own `getReactContext` return
+
+#### Scenario: Omitting ServerEntry on defineClientEntry
+
+- **WHEN** an app calls `defineClientEntry` without a `ServerEntry` type argument
+- **THEN** `clientContext` args are typed as `undefined`
+- **AND** client `site` args are typed as `string`
+
+#### Scenario: useSite typed from getSite return
+
+- **WHEN** `getSite` returns a narrowed site union (e.g. `'au' | 'nz'`) without a widening `SkuGetSite` annotation
+- **AND** the app uses `createSkuContexts<typeof server, typeof client>()`
+- **THEN** `useSite()` is typed as that union
+- **AND** later server sibling getters receive `site` typed as that union
+- **AND** `defineClientEntry<typeof server>` client sibling `site` args are typed as that union
+
+#### Scenario: Omitting getSite leaves useSite as string
+
+- **WHEN** the server entry omits `getSite` (single-site)
+- **THEN** `useSite()` is typed as `string`
+
+### Requirement: Shared SSR modules keep one identity under Vite
+
+App code that imports shared SSR state from `sku/runtime` (hooks from `createSkuContexts`, `useInsertHtml`, `usePreloadRoute`, CSP nonce helpers) and sku’s own SSR runtime (`SkuProvider`, insert-html queue/provider, preload registry, request-context runner) MUST observe the **same** module instances.
+
+Sku MUST:
+
+1. Prefer the public `sku/runtime` specifier for sku runtime call sites that touch that shared state (re-export `@internal` symbols as needed), and
+2. Exclude `'sku'` and `'sku/runtime'` from Vite `optimizeDeps` in the shared Vite config plugin so published installs are not cloned into `.vite/deps`.
+
+tsdown `unbundle: true` alone MUST NOT be treated as sufficient for published-package identity.
+
+Sku MUST NOT require consumers to inject their own Vite `optimizeDeps` config for this identity.
+
+#### Scenario: Hooks read values from SkuProvider
+
+- **WHEN** an app uses `createSkuContexts` hooks under sku’s always-on `SkuProvider`
+- **THEN** the hooks receive the provider values for that document (no dual-context “must be used within SkuProvider” failure solely from Vite prebundling `sku/runtime`)
+
+#### Scenario: optimizeDeps excludes sku and sku/runtime
+
+- **WHEN** sku builds the shared Vite config used by SSR (and static Vite)
+- **THEN** `optimizeDeps.exclude` includes `'sku'` and `'sku/runtime'`
+
+### Requirement: Full-document streaming and document hydration
+
+SSR MUST stream a React-owned HTML document.
+
+Hydration MUST target the document root (not `#app` / `#root`).
+
+Default pipe is `onShellReady`.
+
+#### Scenario: Shell streams then deferred content
+
+- **WHEN** a route suspends after the shell is ready
+- **THEN** sku sends the shell first and streams the rest as it resolves
+
+#### Scenario: Document-level hydration
+
+- **WHEN** the client hydrates an SSR response
+- **THEN** hydration targets the document root (not `#app` / `#root`)
+
+### Requirement: Apps can insert HTML into the response stream
+
+Streaming data transports must inject serialized state into the response between React's stream chunks so it executes before hydration. Sku owns the render call and the response pipe, so sku MUST provide that seam.
+
+Sku MUST export `useInsertHtml()` from the browser-safe `sku/runtime` subpath, returning a function that accepts `() => ReactNode`.
+
+During document SSR, sku MUST render queued nodes to markup and write them into the response before the next React chunk, flushing any remainder at stream end.
+
+Where no sku SSR render surrounds it, the returned function MUST be a silent no-op and MUST NOT throw.
+
+Sku MUST NOT ship a dependency on, or configuration for, any specific data-transport or GraphQL client.
+
+#### Scenario: Injected nodes reach the browser before hydration
+
+- **WHEN** a component calls the function returned by `useInsertHtml` during document SSR
+- **THEN** sku writes that markup into the response ahead of the next React chunk
+- **AND** it appears before the client hydrates
+
+#### Scenario: Injected scripts can carry the CSP nonce
+
+- **WHEN** an app injects a `<script>` carrying the nonce from `getCspNonce()`
+- **THEN** the response `script-src` includes that `'nonce-…'`
+- **AND** the script is not required to be hashable at header-derivation time
+
+#### Scenario: No-op off the SSR path
+
+- **WHEN** `useInsertHtml` is called in the browser
+- **THEN** the returned function does nothing and does not throw
+
+#### Scenario: Injection survives waitForAll
+
+- **WHEN** a matched route sets `handle.waitForAll` and the app injects nodes
+- **THEN** the buffered document still contains the injected markup in stream order
+
+### Requirement: Apollo streaming hydration is proven by a fixture
+
+A fixture MUST demonstrate Apollo Client streaming hydration on SSR, using an app-owned transport built on `useInsertHtml`, dual-entry `getReactContext` for `makeClient` / server `extraScriptProps`, and an isomorphic Apollo provider mounted in the app’s root layout via `useReactContext()`.
+
+#### Scenario: Server-run queries hydrate from the transported cache
+
+- **WHEN** a page runs a query during document SSR and the browser hydrates
+- **THEN** the rendered data survives hydration unchanged
+- **AND** the browser does not refetch that query
+
+#### Scenario: Queries issued after hydration still fetch
+
+- **WHEN** the app issues a new query after hydration (for example on client navigation)
+- **THEN** that query fetches from the GraphQL endpoint normally
+
+### Requirement: SSR client loads config polyfills
+
+Sku’s SSR browser client entry MUST import `virtual:sku/polyfills` before hydrate / consumer client-entry code, so config `polyfills` are included in the client graph (parity with static Vite and webpack SSR client entries).
+
+`polyfillsPlugin` MAY remain on the shared Vite plugin graph. Polyfills MUST NOT be loaded into the Node server entry solely for this requirement.
+
+#### Scenario: Configured polyfills load on the SSR client
+
+- **WHEN** an SSR app configures non-empty `polyfills`
+- **AND** the browser loads the SSR client entry
+- **THEN** those polyfill modules are imported before hydrate / consumer client-entry code
+
+#### Scenario: Empty polyfills remain a no-op
+
+- **WHEN** an SSR app uses the default empty `polyfills` array
+- **THEN** the client entry still imports `virtual:sku/polyfills`
+- **AND** that virtual module contributes no polyfill imports
+
+### Requirement: Streaming SSR responses do not use transformIndexHtml
+
+SSR document responses MUST NOT call `transformIndexHtml`.
+
+#### Scenario: Stream path skips HTML transform
+
+- **WHEN** an SSR document response is generated
+- **THEN** the body is the React render stream
+- **AND** `transformIndexHtml` is not invoked for that response
+
+### Requirement: SSR start injects collected SSR CSS via Document assets
+
+On SSR `sku start`, sku MUST mount `vitePluginSsrCss` (or equivalent) so CSS reachable from the SSR module graph is available as the virtual stylesheet used by static Vite start.
+
+Sku MUST include that virtual stylesheet URL in Document `assets.css` so the streamed document emits a stylesheet `<link>` without calling `transformIndexHtml`.
+
+Sku MUST provide HMR cleanup for that start-only stylesheet via the browser client entry and/or `bootstrapModules` (not via `transformIndexHtml`).
+
+Production SSR MUST obtain CSS from the client manifest → Document path and MUST NOT depend on this start-only virtual stylesheet for production responses.
+
+#### Scenario: sku start document includes virtual SSR CSS link
+
+- **WHEN** an SSR app that imports CSS runs `sku start`
+- **AND** a document response is streamed
+- **THEN** the document includes a stylesheet link for the SSR-CSS virtual module
+- **AND** `transformIndexHtml` is not invoked for that response
+
+#### Scenario: Production CSS does not use the start-only virtual stylesheet
+
+- **WHEN** an SSR app runs `sku build` / production
+- **THEN** document CSS links come from the client manifest
+- **AND** the start-only SSR-CSS virtual stylesheet is not required for those responses
+
+### Requirement: SSR start emits page-load and HMR telemetry
+
+On SSR `sku start`, sku MUST mount serve-only telemetry comparable to static Vite start, including Vite WS handlers for page-load and HMR timing.
+
+Sku MUST deliver the page-load and HMR client scripts via the SSR browser client entry and/or `bootstrapModules` (not via `transformIndexHtml`, and not as new Document inline scripts solely for telemetry).
+
+Sku MUST mark `initialPageLoad` when the SSR dev server is ready (parity with static start), and MUST emit `start.initial` and `start.rebuild` metrics with SSR-identifying tags (e.g. `type: 'ssr'`).
+
+#### Scenario: Initial page-load telemetry on SSR start
+
+- **WHEN** an SSR app runs `sku start` with tab open enabled
+- **AND** the browser completes the initial document load with HMR connected
+- **THEN** sku emits `start.initial` telemetry tagged for SSR
+
+#### Scenario: HMR rebuild telemetry on SSR start
+
+- **WHEN** an SSR app runs `sku start`
+- **AND** an HMR update completes in the browser
+- **THEN** sku emits `start.rebuild` telemetry tagged for SSR
+
+#### Scenario: Telemetry clients are not injected via transformIndexHtml
+
+- **WHEN** an SSR document response is generated during `sku start`
+- **THEN** telemetry client scripts are not delivered through `transformIndexHtml`
+
+### Requirement: waitForAll buffers until onAllReady
+
+When a matched route sets `handle.waitForAll: true`, sku MUST wait for `onAllReady` before starting the HTML response body.
+
+#### Scenario: waitForAll buffers until onAllReady
+
+- **WHEN** a matched route has `handle.waitForAll: true`
+- **THEN** sku pipes the HTML body only after `onAllReady`
+
+### Requirement: Client disconnect aborts render before write
+
+When the client disconnects before HTML headers are committed, sku MUST abort the stream and MUST NOT write the document body.
+
+Dev and production MUST share this abort-before-write behaviour.
+
+#### Scenario: Disconnect before headers
+
+- **WHEN** the client disconnects before HTML headers are committed
+- **THEN** sku aborts the stream and does not write the document body
+
+### Requirement: Loader and action Responses are forwarded
+
+When React Router returns a `Response` from `query` (for example a redirect), sku MUST forward that response instead of streaming HTML.
+
+#### Scenario: Loader redirect Response
+
+- **WHEN** a loader returns a redirect `Response`
+- **THEN** sku forwards that status/headers/body and does not stream HTML
+
+### Requirement: Document responses forward loader and action headers
+
+On streamed HTML (not a short-circuit `Response`), sku MUST forward `loaderHeaders` / `actionHeaders` (including `Set-Cookie`) plus sku-owned headers such as `Content-Type` and CSP.
+
+#### Scenario: Loader Set-Cookie on HTML response
+
+- **WHEN** a loader contributes `Set-Cookie` and sku streams HTML
+- **THEN** those headers are present alongside document `Content-Type` and CSP
+
+### Requirement: Errored routes use the static handler status code
+
+Errored routes MUST use `context.statusCode` and the nearest `ErrorBoundary` (or React Router’s default).
+
+Sku MUST NOT provide a separate error-page API.
+
+#### Scenario: Errored route uses statusCode
+
+- **WHEN** React Router records a route error on the static handler context
+- **THEN** the HTML response status is `context.statusCode`
+- **AND** the body is the nearest `ErrorBoundary`
+
+### Requirement: Hydration bootstrap is production-safe
+
+Sku MUST scrub Promises from loader/action data before bootstrap stringify.
+
+Sku MUST omit `Error.stack` from production hydration error payloads.
+
+When `clientContext` is omitted or `undefined`, the hydrate bootstrap MUST assign `window.__SKU_CLIENT_CONTEXT__=undefined` (JS `undefined`, not JSON `null`) so SSR and hydrate agree with the typed omit contract. An explicit `null` `clientContext` MUST still serialise as JSON `null`.
+
+#### Scenario: Promises do not break serialization
+
+- **WHEN** loader or action data contains Promises at serialize time
+- **THEN** sku scrubs them and serialization does not throw solely because of them
+
+#### Scenario: Production route errors omit stacks
+
+- **WHEN** a route error is serialized into the hydration bootstrap in production
+- **THEN** the payload MUST NOT include `Error.stack`
+
+#### Scenario: Omitted clientContext stays undefined across hydrate
+
+- **WHEN** `getClientContext` is omitted or returns `undefined`
+- **THEN** the bootstrap emits `window.__SKU_CLIENT_CONTEXT__=undefined`
+- **AND** SSR and hydrate `SkuProvider` both receive `undefined` (not `null`)
+
+### Requirement: Server-entry onListen runs after successful listen
+
+When the server entry includes optional `onListen`, sku MUST call it once after middleware + HTML pipeline are mounted **and** `listen` has succeeded — in both `sku start` and production.
+
+```ts
+onListen?: (args: {
+  app: Express;
+  httpServer: http.Server | https.Server;
+  port: number;
+}) => void | Promise<void>;
+```
+
+Sku MUST pass `{ app, httpServer, port }` where `port` is the bound listen port.
+
+If `onListen` returns a promise, sku MUST await it.
+If the callback throws or the promise rejects, startup MUST fail.
+
+Sku MUST call `onListen` **once** (not on every server-entry HMR reload in start).
+
+Sku MUST NOT provide an `onBeforeListen` hook.
+Sku MUST NOT add sku-owned listen logging by default (apps MAY log in `onListen`).
+
+Omitting `onListen` MUST NOT be an error.
+
+#### Scenario: onListen receives app, httpServer, and bound port
+
+- **WHEN** the server entry includes `onListen`
+- **AND** the server has successfully listened
+- **THEN** sku invokes `onListen` once with `{ app, httpServer, port }`
+- **AND** `port` is the bound listen port
+
+#### Scenario: onListen failure fails startup
+
+- **WHEN** `onListen` throws or returns a rejected promise
+- **THEN** startup fails
+
+#### Scenario: onListen is not re-invoked on server-entry HMR
+
+- **WHEN** `sku start` reloads the server entry via HMR after the initial successful listen
+- **THEN** sku does not call `onListen` again for that process
+
+### Requirement: expressTrustProxy opts into Express trust proxy hop count 1
+
+SSR MUST support optional config `expressTrustProxy` as a boolean.
+
+When `expressTrustProxy` is `true`, sku MUST set `app.set('trust proxy', 1)` (hop count `1`, not Express boolean `true`).
+
+When `expressTrustProxy` is omitted or `false`, sku MUST leave Express’s default (`false`) — it MUST NOT enable trust proxy magically.
+
+`expressTrustProxy` MUST NOT be a silent sku default; it is opt-in via config.
+
+The create `ssr` template MUST set `expressTrustProxy: true` in `sku.config`.
+
+Apps that need any other trust-proxy value (`false`, `2`, IP list, etc.) MUST override in `onListen` via `app.set('trust proxy', …)`.
+
+#### Scenario: expressTrustProxy true sets hop count 1
+
+- **WHEN** an SSR app sets `expressTrustProxy: true`
+- **AND** the Express app is created for start or production
+- **THEN** `app.get('trust proxy')` is `1`
+
+#### Scenario: omitted expressTrustProxy leaves Express default
+
+- **WHEN** an SSR app omits `expressTrustProxy` (or sets `false`)
+- **THEN** sku does not enable trust proxy
+- **AND** Express keeps its default (`false`)
+
+#### Scenario: Create template opts into expressTrustProxy
+
+- **WHEN** a user scaffolds with the `ssr` create template
+- **THEN** the generated `sku.config` sets `expressTrustProxy: true`
+
+### Requirement: Server-entry middleware runs before HTML render
+
+When the server entry includes Express/Connect `middleware`, sku MUST mount it before the HTML render path in start and production.
+
+Omitting `middleware` MUST NOT be an error.
+
+#### Scenario: Server-entry middleware before HTML
+
+- **WHEN** the server entry includes `middleware`
+- **THEN** it handles matching requests before sku streams HTML
+
+#### Scenario: Omitting server-entry middleware
+
+- **WHEN** the server entry omits `middleware`
+- **THEN** sku mounts no consumer middleware layer
+- **AND** HTML render still succeeds
+
+### Requirement: Dev middleware mounts first and stays out of production
+
+When config `devServerMiddleware` is set, `sku start` MUST mount it before server-entry `middleware`, and MUST NOT include that module in the production server bundle.
+
+`devServerMiddleware` MUST remain optional.
+
+#### Scenario: Dev middleware first and out of production
+
+- **WHEN** config sets `devServerMiddleware` and the user runs `sku start`
+- **THEN** that middleware runs before server-entry `middleware`
+- **AND** the production server build does not include that module
+
+### Requirement: Per-route async chunks are supported
+
+SSR MUST support lazy route modules as separate async chunks.
+
+The SSR fixture MUST demonstrate at least two lazy routes that resolve to distinct client chunks.
+
+#### Scenario: Distinct lazy route chunks
+
+- **WHEN** the SSR fixture defines ≥2 lazy route modules
+- **THEN** they resolve to distinct client chunks that participate in SSR and hydration
+
+### Requirement: Lazy-route moduleId is auto-derived
+
+For idiomatic `lazy: () => import('…')`, sku MUST auto-derive `handle.moduleId`.
+
+Explicit `handle.moduleId` MUST take precedence.
+
+Non-idiomatic shapes MUST be skipped.
+
+In development, a missing or unknown `moduleId` MUST produce a warning.
+
+#### Scenario: Idiomatic lazy route gets modulepreload
+
+- **WHEN** a matched route uses idiomatic `lazy` without `handle.moduleId`
+- **THEN** production document assets include a modulepreload for that chunk
+
+#### Scenario: Explicit moduleId is preserved
+
+- **WHEN** a lazy route already sets `handle.moduleId`
+- **THEN** sku does not overwrite it
+
+### Requirement: SSR Document preloads use route moduleIds only
+
+Production SSR Document CSS and `modulepreload` links MUST come from matched-route `handle.moduleId` values (and optional vocab language chunks) resolved against the Vite client manifest.
+
+SSR MUST NOT register Document preloads from `@sku-lib/vite/loadable` (Collector / `LoadableProvider` / `preloadPlugin` module-id injection).
+
+That loadable path remains for static Vite / prerender only.
+
+#### Scenario: Route moduleId drives Document assets
+
+- **WHEN** a matched SSR route has `handle.moduleId` present in the client manifest
+- **THEN** production Document assets include that chunk’s CSS and/or modulepreload as applicable
+
+#### Scenario: Loadable does not feed SSR Document preloads
+
+- **WHEN** an SSR app renders a `@sku-lib/vite/loadable` component whose module id is registered only via the loadable collector
+- **THEN** sku does not add Document CSS or modulepreload links for that module id from the collector path
+
+### Requirement: Intent route preloading is a sku API
+
+Sku MUST expose a `usePreloadRoute(to)` hook returning a zero-argument function that warms the lazy modules for `to`.
+
+Matching MUST run against the current site's filtered route tree.
+
+The returned function MUST NOT throw or reject when warming fails.
+
+When no route tree is registered, the returned function MUST be a no-op.
+
+Sku MUST NOT expose the route tree itself as a public API.
+
+#### Scenario: Intent warms the destination chunk
+
+- **WHEN** the returned function is invoked for a lazy destination route that is not yet loaded
+- **THEN** sku requests that route’s client chunk before navigation
+
+#### Scenario: Foreign-site path is not warmed
+
+- **WHEN** the returned function is invoked for a path outside the current site’s tree
+- **THEN** sku requests no chunk
+
+#### Scenario: Server render is inert
+
+- **WHEN** a component calls `usePreloadRoute` during document SSR
+- **THEN** rendering succeeds and no preloading occurs
+
+### Requirement: Vocab language chunks are supported
+
+When `languages` is configured for build-time vocab splitting, sku MUST register a vocab language chunk on the Document only when server `getLanguage` returns `language`.
+
+Language is optional: if `getLanguage` is omitted or returns `undefined`, sku MUST NOT register a language chunk.
+
+Sku MUST NOT validate the returned language against config and MUST NOT default to a sole configured language.
+
+Language MUST be server-local for Document registration only (no client forward, no `getSkuLanguage` / `__SKU_LANGUAGE__` / baked languages define).
+
+When vocab / `languages` is active, sku MUST resolve `@vocab/vite` from sku’s install tree and MUST alias bare `@vocab/vite/runtime` (prefer the export file) onto that copy in the shared Vite `resolve.alias` (client and SSR).
+
+Sku MUST NOT alias the `@vocab/vite` package root (breaks subpath imports such as `@vocab/vite/chunks`).
+
+Consumers MUST NOT need a direct `@vocab/vite` dependency for those bare imports to resolve.
+
+#### Scenario: Language chunk from getLanguage
+
+- **WHEN** `getLanguage` returns `language`
+- **THEN** sku registers that language’s vocab chunk on the Document
+- **AND** does not pass `language` to `onHydrate` or request-context
+
+#### Scenario: No language means no language chunk
+
+- **WHEN** `getLanguage` is omitted or returns `undefined`
+- **THEN** sku does not register a vocab language chunk and the SSR response still succeeds
+
+#### Scenario: Vocab runtime resolves from sku without consumer direct dep
+
+- **WHEN** `languages` is set and a consumer module (including `@vocab/vite`-injected `.vocab` output) imports `@vocab/vite/runtime`
+- **AND** the app does not declare a direct `@vocab/vite` dependency
+- **THEN** Vite resolves that specifier to sku’s installed `@vocab/vite` via `resolve.alias`
+
+### Requirement: SSR publicPath is relative only and is the static asset prefix only
+
+SSR apps MUST use a relative `publicPath`.
+
+Absolute `http(s)` / CDN `publicPath` MUST fail at config validation.
+
+`publicPath` MUST configure the static asset prefix only (webpack-aligned `__SKU_PUBLIC_PATH__`).
+
+For `sku build` / production, Vite `config.base` is an implementation detail and MUST be set to that prefix so emitted client URLs match.
+
+Production Document asset URLs MUST come from the baked server-local Vite client manifest (see the production build layout requirement).
+
+In production, when a sibling `client/` directory exists next to `server/`, sku MUST mount `express.static` for `publicPath` **before** server-entry `middleware`, so existing client assets are served even when that middleware would otherwise handle (or return for) the same path.
+
+When no sibling `client/` directory exists, sku MUST NOT mount `express.static` for that prefix and MUST NOT fail solely because the directory is absent.
+
+Node serving hashed assets via `express.static` is a standalone / experimentation convenience.
+Productionised deploys MUST be documented as hosting those assets via a reverse proxy or persistent storage ahead of (or instead of) the Node process.
+
+For `sku start`, sku MUST ignore config `publicPath` and serve the Vite module graph from `/` (bootstrap at `/@vite/client`, etc.).
+Sku MUST NOT set Vite `config.base` to `publicPath` during start.
+
+Sku MUST NOT pass `publicPath` as the React Router `basename`, and MUST NOT treat Vite’s `import.meta.env.BASE_URL` as a product API.
+
+Router basename MUST remain unset (effectively `/`).
+
+Sku MUST NOT expose a first-class router-basename config option.
+
+Absolute/CDN rejection MUST NOT require a dedicated browser e2e fixture.
+
+The decoupled asset-prefix case MUST be covered by a fixture or equivalent test
+(production document assets under `publicPath`; start bootstrap from `/`).
+
+#### Scenario: Absolute publicPath rejected
+
+- **WHEN** SSR is enabled with an absolute `http(s)` `publicPath`
+- **THEN** config validation fails stating that SSR requires a relative `publicPath`
+
+#### Scenario: publicPath does not become React Router basename
+
+- **WHEN** an SSR app sets a relative `publicPath` such as `/static/my-app`
+- **AND** the browser requests an app route that does not start with that `publicPath`
+- **THEN** sku streams HTML for that route (not a basename mismatch 404)
+- **AND** in production, document asset URLs use that `publicPath` prefix
+
+#### Scenario: Production static assets before server-entry middleware when client exists
+
+- **WHEN** an SSR production server has a sibling `client/` directory
+- **AND** server-entry `middleware` that handles every request without calling `next`
+- **AND** a client asset exists under `publicPath`
+- **THEN** that asset is still served from the static mount
+- **AND** the middleware does not handle that asset request
+
+#### Scenario: Missing sibling client does not fail startup
+
+- **WHEN** an SSR production server runs without a sibling `client/` directory
+- **AND** the baked server-local manifest is present
+- **THEN** the process starts successfully
+- **AND** sku does not mount `express.static` for `publicPath`
+
+#### Scenario: sku start serves Vite bootstrap from root
+
+- **WHEN** an SSR app sets a relative `publicPath` such as `/static/my-app` and runs `sku start`
+- **THEN** the document references bootstrap modules under `/` (e.g. `/@vite/client`)
+- **AND** those URLs are served as JavaScript by Vite (not HTML / React Router 404 fallthrough)
+- **AND** the document does not require assets under that `publicPath` for hydration
+
+### Requirement: SSR rejects the public assets folder
+
+SSR MUST NOT support config `public` (the folder of files copied/served as-is without content hashing).
+
+Config always includes a `public` path (default `'public'`).
+
+The rejection signal is that `paths.public` exists on disk — not merely that the option is set.
+
+When that directory exists, `sku start` and `sku build` MUST hard-error and guide consumers to import assets from modules instead.
+
+SSR MUST NOT set Vite `publicDir` to that folder and MUST NOT copy public files into the build output.
+
+This edge case MUST NOT require a dedicated browser e2e fixture.
+
+Static Vite and webpack apps MAY keep existing `public` behaviour.
+
+#### Scenario: Existing public directory rejected for SSR
+
+- **WHEN** SSR is enabled and the configured `public` directory exists on disk
+- **THEN** `sku start` / `sku build` fail with a hard error
+- **AND** the error advises importing assets from scripts/modules instead of using the public assets folder
+
+#### Scenario: SSR does not copy or serve publicDir assets
+
+- **WHEN** an SSR app runs without an existing `public` directory
+- **THEN** sku does not enable Vite `publicDir` for that folder
+- **AND** does not copy public assets into the client build output
+
+### Requirement: SSR rejects dangerouslySetViteConfig
+
+SSR MUST NOT support `dangerouslySetViteConfig`.
+
+Sku opens escape hatches only for known best-practice needs.
+
+When that option is set, config validation MUST hard-error and point consumers to sku-support channels with their use-case.
+
+Sku MUST NOT apply the `dangerouslySetViteConfig` decorator plugin on the SSR plugin graph.
+
+Static Vite MAY keep existing `dangerouslySetViteConfig` behaviour.
+
+This edge case MUST NOT require a dedicated browser e2e fixture.
+
+Product / Migrating / `configuration.md` docs MUST state that the option is unsupported for SSR and that exceptional Vite customisation needs should go through support first.
+
+#### Scenario: dangerouslySetViteConfig rejected for SSR
+
+- **WHEN** an SSR app sets `dangerouslySetViteConfig`
+- **THEN** config validation fails
+- **AND** the error points consumers to sku-support channels
+
+#### Scenario: Docs state dangerouslySetViteConfig unsupported for SSR
+
+- **WHEN** a reader opens SSR product, Migrating, or `configuration.md` docs for `dangerouslySetViteConfig`
+- **THEN** docs state that SSR does not support the option
+- **AND** docs direct exceptional Vite customisation use-cases to sku-support
+
+### Requirement: SSR rejects vitePlugins
+
+SSR MUST NOT support `vitePlugins`.
+
+Sku opens escape hatches only for known best-practice needs.
+
+When that option is set, config validation MUST hard-error and point consumers to sku-support channels with their use-case.
+
+Sku MUST NOT mount consumer `vitePlugins` on the SSR plugin graph.
+
+Static Vite MAY keep existing `vitePlugins` behaviour.
+
+This edge case MUST NOT require a dedicated browser e2e fixture.
+
+Product / Migrating / `configuration.md` docs MUST state that the option is unsupported for SSR and that exceptional Vite customisation needs should go through support first.
+
+#### Scenario: vitePlugins rejected for SSR
+
+- **WHEN** an SSR app sets `vitePlugins`
+- **THEN** config validation fails
+- **AND** the error points consumers to sku-support channels
+
+#### Scenario: Docs state vitePlugins unsupported for SSR
+
+- **WHEN** a reader opens SSR product, Migrating, or `configuration.md` docs for `vitePlugins`
+- **THEN** docs state that SSR does not support the option
+- **AND** docs direct exceptional Vite customisation use-cases to sku-support
+
+### Requirement: SSR uses a single port
+
+SSR MUST use config `port` for `sku start` and as the baked production default listen port (`__SKU_DEFAULT_SERVER_PORT__`).
+
+`process.env.PORT` MUST still override the baked default at runtime.
+
+Providing `serverPort` with SSR MUST fail config validation (`serverPort` remains webpack-SSR-only).
+
+SSR config types MUST NOT accept `serverPort`.
+
+#### Scenario: port bakes the production default listen port
+
+- **WHEN** an SSR app sets `port` and runs `sku build`
+- **THEN** the production server’s baked default listen port is that `port` value
+- **AND** `process.env.PORT` still overrides it when set
+
+#### Scenario: serverPort is rejected for SSR
+
+- **WHEN** an SSR app sets `serverPort`
+- **THEN** config validation fails stating that SSR uses `port` only
+
+### Requirement: httpsDevServer works for SSR development
+
+When `httpsDevServer` is enabled, SSR `sku start` MUST serve over HTTPS with working HMR.
+
+Production remains HTTP.
+
+#### Scenario: httpsDevServer start
+
+- **WHEN** `httpsDevServer: true` and the user runs `sku start`
+- **THEN** document responses succeed over HTTPS
+- **AND** local URLs use `https://`
+
+### Requirement: Teams can scaffold an SSR app via create
+
+`@sku-lib/create` MUST offer a `ssr` template that MAY omit config `sites` (sku soft-defaults to `'default'`), with `expressTrustProxy: true` in `sku.config`, `routesEntry` configured, a flat `routes` scaffold with an app-owned pathless root layout at `src/RootLayout.tsx` (optional route-level `sites` only when membership differs), `defineServerEntry` / `defineClientEntry<typeof server>` + `createSkuContexts<typeof server, typeof client>` wiring in `src/ssrContext.ts`, a home page that calls `useSite()`, and realistic default-exported request-entry objects (`middleware`, optional `onListen` / context getters, `onHydrate` — no `routes` re-export, no `Providers`, no `src/App/` shell).
+
+A template with zero or one resolved site MUST omit `getSite` (sku uses the sole resolved site name).
+Multi-site examples MUST declare ≥2 config sites and export `getSite`.
+
+Lazy route page modules in the template MUST use the React Router Data Mode named `Component` export (not `export default`).
+
+The static `vite` template MUST remain unchanged.
+
+#### Scenario: Create ssr template
+
+- **WHEN** a user runs `@sku-lib/create --template ssr`
+- **THEN** the project is SSR with `expressTrustProxy: true` and `routesEntry` exporting flat `routes`
+- **AND** config `sites` may be omitted (soft-default `'default'`) or declare real site names
+- **AND** the server entry exports `middleware` (and may export `onListen` / context getters)
+- **AND** the client entry exports `onHydrate` (and may export context getters)
+- **AND** the template wires `createSkuContexts` in `src/ssrContext.ts` and has no `Providers` export
+- **AND** the template has `src/RootLayout.tsx` and no `src/App/` directory
+- **AND** the home page calls `useSite()` (and does not use `import.meta.env` for site/environment demo)
+- **AND** a 0–1 site template omits `getSite`
+- **AND** request entries do not re-export `routes`
+- **AND** lazy page modules export named `Component`
+- **AND** can `sku start` without further entry setup
+
+#### Scenario: Static vite create template unchanged
+
+- **WHEN** a user creates a project with the existing `vite` template
+- **THEN** it is not configured as `buildType: 'ssr'` by default
+
+### Requirement: CJS default-export interop is documented
+
+SSR product / Migrating docs MUST explain that some CommonJS packages resolve to a module namespace object under `sku start` SSR (React “Element type is invalid … got: object”), that production build may still succeed, and that consumers extend `__UNSAFE_EXPERIMENTAL__cjsInteropDependencies`.
+
+Sku MUST NOT expand baked-in interop defaults beyond existing Apollo behaviour for this change.
+
+Sku MUST NOT rewrite or wrap React render errors at runtime for this case — documentation is sufficient.
+
+#### Scenario: Docs cover CJS interop for SSR start
+
+- **WHEN** a reader opens SSR product or Migrating docs
+- **THEN** docs describe the start-vs-build CJS interop failure mode
+- **AND** document `__UNSAFE_EXPERIMENTAL__cjsInteropDependencies` with common open-source offender examples
+
+### Requirement: Config types describe SSR accurately
+
+`SkuConfig` bundler JSDoc (and generated config docs derived from it) MUST NOT claim that `vite` is only supported for static apps while `buildType: 'ssr'` exists.
+
+#### Scenario: Bundler JSDoc allows SSR
+
+- **WHEN** a reader inspects `bundler` JSDoc on `SkuConfig`
+- **THEN** it reflects that Vite supports static and experimental SSR via `buildType`
+
+### Requirement: SSR uses shared Express 4 with aligned typing
+
+The SSR server runtime MUST use the same Express major as sku’s other Express-based servers (webpack SSR / `sku serve`).
+
+That major MUST remain Express 4 for this change.
+
+Sku MUST NOT upgrade `express` / `@types/express` from 4 → 5 as part of SSR.
+
+Migrating / product docs MUST state that consumers should target Express 4 when typing `middleware` / `SkuMiddleware`.
+
+#### Scenario: Runtime and types use Express 4
+
+- **WHEN** an SSR app runs `sku start` or the production server
+- **THEN** sku’s server depends on Express 4
+- **AND** published Express typings used for SSR middleware align with Express 4
+- **AND** webpack SSR continues to use the same Express 4 major
+
+#### Scenario: Docs state Express 4
+
+- **WHEN** a reader opens SSR middleware or Migrating docs
+- **THEN** docs state that Express 4 is the supported major for middleware typing
+- **AND** docs do not require Express 5 for SSR
+
+### Requirement: SSR ships on React Router 8 (optional peer)
+
+SSR MUST target React Router 8 via an **optional peerDependency** `react-router: ^8` (not a hard sku dependency).
+
+SSR fixtures and the create template MUST install React Router 8.
+
+Webpack / static apps MUST NOT be forced onto React Router 8 by this change.
+
+Sku MUST NOT add Jest transforms for `react-router` / `cookie-es` / `import.meta` in this change. SSR requires Vitest; React Router 8 + Jest is out of scope.
+
+Migrating / product docs MUST state that SSR consumers should install and target React Router 8 for Data Mode / route typing.
+
+#### Scenario: Optional peer is React Router 8
+
+- **WHEN** an SSR app installs `react-router` to satisfy sku’s peer
+- **THEN** the supported major is React Router 8
+- **AND** sku does not hard-depend on `react-router` in a way that hoists RR 8 into non–Vite-SSR apps
+
+#### Scenario: Docs state React Router 8 peer
+
+- **WHEN** a reader opens SSR product or Migrating docs
+- **THEN** docs state that React Router 8 is the supported major for Data Mode / route typing
+- **AND** docs state consumers must install `react-router` (optional peer)
+
+### Requirement: Express and React Router major upgrades may be breaking
+
+Product docs and release notes for SSR MUST state that bumping the Express or React Router major integrated by SSR may be a breaking change.
+
+Consumer `middleware` / `devServerMiddleware` mount into sku’s Express app, and consumer routes/entries use React Router Data Mode APIs.
+
+This change MUST NOT itself bump Express; an Express 4 → 5 upgrade remains a deferred sku-wide breaking change.
+
+#### Scenario: Docs warn major upgrades may break
+
+- **WHEN** a reader opens SSR product docs covering middleware or React Router / routes
+- **THEN** docs state that Express and React Router major upgrades may be breaking for SSR consumers
+
+### Requirement: SSR first release is documented as experimental
+
+The first release MUST be documented as experimental (testing only; not for production) in product docs and the changeset.
+
+Sku MUST NOT add a runtime experimental gate.
+
+#### Scenario: Docs warn experimental
+
+- **WHEN** a reader opens SSR product docs
+- **THEN** an experimental / not-for-production warning is present near the start
+- **AND** the changeset states the same
+
+### Requirement: Product and Migrating docs cover SSR topics
+
+SSR product docs MUST cover `routesEntry` + flat `routes`, optional `sites` membership, `getSite` tree selection (required when config has >1 site; sole resolved site — soft-default `'default'` when config `sites` is empty — when omitted on 0–1 site), default-exported request-entry objects via `defineServerEntry` / `defineClientEntry<typeof server>` with optional getters (`getSite` / `getLanguage` / `getClientContext` / `getReactContext`) and sibling projection, always-on `SkuProvider` + `createSkuContexts<typeof server, typeof client>()`, optional `middleware` / `onListen` / `onHydrate`, config `expressTrustProxy`, the three value channels vs the app-owned root layout route, middleware layers (including production mount order: request-context → optional `express.static(publicPath)` when sibling `client/` exists → server-entry `middleware` → HTML, and the existing `sku start` order), CSP, response headers, data-loading hierarchy, and optional dual-entry `getRouterContext`, and MUST include Migrating docs for Static App and Older / Webpack SSR App.
+
+Docs MUST diagram the three value channels with a Markdown table (and MAY use a nested list). Docs MUST NOT require Mermaid or a VitePress Mermaid plugin for this coverage.
+
+Deploy-to-production docs MUST cover:
+
+- production entry `node dist/server/server.js` and sibling build `client/` + `server/` layout
+- that Document asset URLs come from a baked server-local Vite client manifest (server starts without sibling `client/`)
+- that productionised services SHOULD host hashed `client/` assets via reverse proxy or persistent storage, not from the Node process
+- that shipping sibling `client/` so Node can `express.static` them is standalone / experimentation only
+- that the production Node deploy MUST include runtime `node_modules` (or an equivalent production install) alongside `server/`
+- relative `publicPath` only (no absolute / CDN asset base)
+
+Migrating docs MUST also cover:
+
+- named `Component` (not default export) for lazy routes
+- `routesEntry` + flat `routes` + optional `sites` + `getSite` (required when config has >1 site; fail closed on unknown / non-string site; sole resolved site — soft-default `'default'` when config `sites` is empty — when omitted on 0–1 site)
+- default-exported request-entry objects via `defineServerEntry` / `defineClientEntry<typeof server>` instead of an `onRequest` value return bag; optional `middleware` / `onListen` / `onHydrate`
+- webpack `onStart` → server-entry `onListen({ app, httpServer, port })`; trust proxy via config `expressTrustProxy` (not `onStart`); other trust-proxy values via `onListen`
+- multi-site membership via `sites` on routes (not `routesBySite` maps, dual-entry `routes` re-exports, optional language path params, union tree + allowlist, or sku host matching as the product story)
+- webpack dual-port (`port` + `serverPort`) vs SSR single `port` (`serverPort` rejected; production still honours `PORT`)
+- production entry path `node dist/server/server.js` and sibling `client/` + `server/` layout
+- that Document assets resolve from a baked server-local manifest (no sibling `client/` required to start)
+- that productionised deploys host `client/` via reverse proxy / persistent storage; Node `express.static` of sibling `client/` is standalone / experimentation only
+- that production Node deploys must include runtime `node_modules` (or equivalent) with `server/`
+- that when Node static is mounted, it serves under `publicPath` **before** server-entry `middleware`
+- CJS interop for `sku start`
+- Express 4 typing alignment (shared with webpack SSR; no Express 5 in this change)
+- React Router 8 as optional peerDependency for Data Mode / route typing (template/fixtures install it)
+- that Express / React Router major upgrades may be breaking (middleware + Data Mode integration)
+- that this change does not ship Jest transforms for React Router 8
+- moving off config `public` / the public assets folder (import assets in modules instead; pattern discouraged)
+- that `dangerouslySetViteConfig` and `vitePlugins` are unsupported for SSR (hard-error when set; raise use-cases via sku-support)
+- keeping server-only loader modules out of the client-imported route graph (split trees; set `handle.moduleId` when lazy factories are non-idiomatic)
+- prefer render-time React data loading via Suspense with clients from `useReactContext` / `useClientContext`; use loaders for avoiding heavily-nested waterfalls, document redirects, response headers, or opt-in `getRouterContext` — not as the default for page content
+- Apollo streaming hydration end to end: an app-owned transport over `useInsertHtml`, dual-entry `getReactContext` for `makeClient` / server nonce `extraScriptProps`, isomorphic provider in the root layout via `useReactContext()`, and that Apollo apps must drop two-pass `getDataFromTree`
+- that loader-transported query refs (`@apollo/client-integration-react-router`'s `apolloLoader` / `preloadQuery`) are not supported, because sku's hydration bootstrap is JSON and promise-scrubbed
+- that loader `request` stays Fetch; Express `req` is available where designed on getters / server `getRouterContext`, not as the loader `request` argument
+- that early getters do not receive Fetch `Request` or `res`, and MUST stay synchronous / pure (libs may memoise on `req`); later getters receive sibling values
+- optional dual-entry `getRouterContext` (Data Mode vs Framework Mode; server seeds from middleware bag + Fetch `request` + siblings; client seeds from browser-visible state + siblings; same `createContext` keys; different construction; cadence: once per document `query` vs every client nav/fetcher)
+- how to type Express `req` fields appended by middleware (module augmentation of `express-serve-static-core` `Request`, shared by `middleware` / getters / server `getRouterContext`; same pattern as sku’s `getCspNonce`)
+- relation of Express `middleware` vs RR route `middleware` vs entry `getRouterContext`, and of `getClientContext` / `getReactContext` / `SkuProvider` hooks vs the app’s root layout route vs `getRouterContext` (loader/action context)
+- that wrapping which needs React Router hooks or loader data belongs in the app’s own root layout route in `routesEntry`
+- a **red warning** that apps MUST NOT put Express `req` (or other non-isomorphic platform objects) into `RouterContextProvider` — project values both sides can supply
+- a client-navigation example where context is re-seeded without Express for a location different from the initial SSR location
+- for Braid apps: reset must run before any Braid-touching server module on `sku start` (start evaluation order can differ from production build)
+- libraries that touch `window` must not run in the Document SSR tree (prefer client `getReactContext` + root-layout / `useEffect` consumers)
+- Jest → Vitest as an SSR prerequisite (point at existing Vitest docs / `@sku-lib/codemod jest-to-vitest`)
+- path aliases: bare `src/…` / webpack `baseUrl` → `#src/…` via `pathAliases` (point at existing migrate-root-resolution guidance)
+
+Docs MUST NOT tell consumers to install `@vocab/vite` solely so `@vocab/vite/runtime` resolves (sku owns that pin via Vite alias).
+
+#### Scenario: Primary SSR docs have topic coverage
+
+- **WHEN** a reader opens SSR product docs
+- **THEN** docs cover `routesEntry`, `SkuProvider` / `createSkuContexts`, the three value channels, the app-owned root layout route, flat `routes`, optional `sites`, `getSite`, `defineServerEntry` / `defineClientEntry<typeof server>`, optional `middleware` / `onListen` / `onHydrate`, `expressTrustProxy`, CSP, and response headers
+- **AND** docs steer page content toward render-time data loading with clients from `useReactContext` / `useClientContext` (not loaders as the default)
+- **AND** docs describe loaders as opt-in for deeply-nested waterfalls, document redirects, response headers, or opt-in `getRouterContext`
+- **AND** docs document optional dual-entry `getRouterContext` and Data Mode vs Framework Mode seeding
+- **AND** docs show how to type middleware-appended Express `req` fields via `express-serve-static-core` module augmentation
+- **AND** docs include a red warning against putting Express `req` into `RouterContextProvider`
+- **AND** docs include a client-navigation example where context works for a non-initial location without Express
+- **AND** docs show a complete Apollo streaming setup with `useInsertHtml`, `getReactContext` + root-layout provider, the nonce on injected scripts, and why loader-transported query refs are unsupported
+
+#### Scenario: Migrating docs exist
+
+- **WHEN** a reader opens SSR Migrating docs
+- **THEN** there are self-contained **Migrate from Static App** and **Migrate from Older / Webpack SSR App** docs
+
+#### Scenario: Migrating covers port model and deploy layout
+
+- **WHEN** a reader opens **Migrate from Older / Webpack SSR App** docs
+- **THEN** docs explain webpack dual-port → SSR single `port` (drop `serverPort`; `PORT` still overrides production)
+- **AND** docs state the production server entry is `dist/server/server.js` with sibling `client/` and `server/` build outputs
+- **AND** docs state Document assets resolve from a baked server-local manifest
+- **AND** docs recommend hosting hashed assets outside Node for productionised deploys
+- **AND** docs note optional Node static of sibling `client/` under `publicPath` before server-entry middleware for standalone use
+
+#### Scenario: Deploy docs cover runtime package and asset hosting
+
+- **WHEN** a reader opens SSR deploy-to-production docs
+- **THEN** docs state the production Node deploy needs `server/` plus runtime `node_modules` (or equivalent)
+- **AND** docs recommend reverse proxy / persistent storage for hashed `client/` assets
+- **AND** docs describe sibling `client/` + Node `express.static` as standalone / experimentation only
+- **AND** docs state the server starts without sibling `client/` once the baked manifest is present
+
+#### Scenario: Migrating covers onStart and trust proxy
+
+- **WHEN** a reader opens **Migrate from Older / Webpack SSR App** docs
+- **THEN** docs map webpack `onStart` to server-entry `onListen({ app, httpServer, port })`
+- **AND** docs state trust proxy is opt-in via config `expressTrustProxy` (sets hop count `1`), not via `onStart`
+- **AND** docs note other trust-proxy values are set in `onListen`
+
+#### Scenario: Docs discourage public assets folder for SSR
+
+- **WHEN** a reader opens SSR product or Migrating docs (and `configuration.md` for `public`)
+- **THEN** docs state that SSR does not support the public assets folder
+- **AND** recommend importing assets from modules instead
+- **AND** Migrating notes that existing `public` folder usage must be moved off before adopting SSR
+
+#### Scenario: Docs discourage dangerouslySetViteConfig for SSR
+
+- **WHEN** a reader opens SSR product or Migrating docs (and `configuration.md` for `dangerouslySetViteConfig`)
+- **THEN** docs state that SSR does not support `dangerouslySetViteConfig`
+- **AND** docs direct exceptional Vite customisation use-cases to sku-support
+
+#### Scenario: Docs discourage vitePlugins for SSR
+
+- **WHEN** a reader opens SSR product or Migrating docs (and `configuration.md` for `vitePlugins`)
+- **THEN** docs state that SSR does not support `vitePlugins`
+- **AND** docs direct exceptional Vite customisation use-cases to sku-support
+
+#### Scenario: Migrating covers Older SSR adoption topics
+
+- **WHEN** a reader opens **Migrate from Older / Webpack SSR App** docs
+- **THEN** docs remind readers to keep server-only loader modules off the client route graph
+- **AND** docs steer away from putting raw Express `req` into loaders or `RouterContextProvider` for page content
+- **AND** docs point at dual-entry `getRouterContext` for projecting isomorphic values when loader context is needed
+- **AND** docs note Braid reset-before-Braid on `sku start` for Braid apps
+- **AND** docs note that `window`-touching providers must not run in the SSR tree
+- **AND** docs treat Jest → Vitest as an SSR prerequisite and point at existing Vitest guidance
+- **AND** docs do not require a direct `@vocab/vite` dependency solely for `@vocab/vite/runtime` resolve
+- **AND** docs point bare `src/…` imports at `#` `pathAliases` / migrate-root-resolution

--- a/openspec/changes/vite-ssr/tasks.md
+++ b/openspec/changes/vite-ssr/tasks.md
@@ -1,0 +1,319 @@
+## 1. Config and mode
+
+- [x] 1.1 Add `buildType`; reject webpack + `ssr`, `-ssr` when set, absolute/`CDN` `publicPath`
+- [x] 1.2 Vite SSR single-port: bake `__SKU_DEFAULT_SERVER_PORT__` from `port`; reject / untype `serverPort`; `PORT` still overrides at runtime
+- [x] 1.3 Hard-error on Vite SSR `sku start` / `sku build` when configured `public` directory exists; message advises importing assets instead
+- [x] 1.4 Disable Vite `publicDir` and `copyPublicFiles` for Vite SSR (static Vite / webpack unchanged)
+- [x] 1.5 Add `react-router` as optional peerDependency `^8` for Vite SSR (fixtures/template install RR 8; do not force webpack fixtures onto RR 8); fix `bundler` JSDoc so Vite is not described as static-only
+- [x] 1.6 Hard-error when Vite SSR sets `dangerouslySetViteConfig`; omit decorator plugin on SSR graph; point error at sku-support
+- [x] 1.7 Remove `dangerouslySetViteConfig` from Vite SSR fixtures (e.g. translations `makeStableViteHashes`); use a supported path for stable hashes if still needed
+- [x] 1.8 Hard-error when Vite SSR sets `vitePlugins`; omit consumer `vitePlugins` on SSR plugin graph; point error at sku-support
+- [x] 1.9 Remove `vitePlugins` from Vite SSR fixtures if any set it
+
+## 2. Entries and runtime
+
+- [x] 2.1 Require dual-entry `routes` + `onRequest` / `middleware` / `onHydrate` (hard errors on missing named exports; no noops; no early file-existence gate)
+- [x] 2.2 Wire server-local `language` and `clientContext` → `onHydrate({ clientContext })` (provider wiring lives in §10)
+- [x] 2.3 Mount server-entry `middleware` (start + prod); optional `devServerMiddleware` start-only before it
+- [x] 2.4 `sku start` / `sku build`: middlewareMode, sibling `client/` + `server/`, Document stream, document hydrate
+- [x] 2.5 Abort-before-write; forward loader/action Responses and headers; `statusCode` + ErrorBoundary; `waitForAll`; `httpsDevServer`
+- [x] 2.6 Skip `transformIndexHtml` on SSR; manifest assets; auto `moduleId`
+- [x] 2.10 Mount `vitePluginSsrCss` on the Vite SSR serve graph with SSR module-graph entries; put the virtual stylesheet URL in Document `assets.css` on `sku start`; move HMR cleanup off `transformIndexHtml` (client entry / bootstrap); mark the Document link for cleanup
+- [x] 2.11 Mount `telemetryPlugin` on the Vite SSR serve graph with `type: 'ssr'`; deliver page-load + HMR clients via client entry / bootstrap (not `transformIndexHtml`); mark `initialPageLoad` when the SSR dev server is ready
+- [x] 2.7 Resolve consumer entries via shared `__sku_alias__serverEntry` / `__sku_alias__clientEntry` (same aliases as static Vite)
+- [x] 2.8 Promise-scrub loader/action data; strip production `Error.stack`; harden Express→Fetch adapter (array headers; reconstruct body when stream consumed)
+- [x] 2.9 Import `virtual:sku/polyfills` at the top of the Vite SSR browser client entry (`ssr-client.tsx`; covered by the start-only `.dev` dynamic load of that entry) so config `polyfills` load before hydrate — parity with static `vite-client.tsx` / webpack SSR client; do not load into the Node server entry
+- [x] 2.12 Register the selected site route tree from the client entry; export `usePreloadRoute` from a new `sku/runtime` subpath (both `lazy` shapes; no-op when unregistered + dev warning on client invoke)
+
+## 3. Assets and publicPath
+
+- [x] 3.1 Treat `publicPath` as the static asset prefix only — not React Router basename; bake `__SKU_PUBLIC_PATH__` (not Vite `BASE_URL`)
+- [x] 3.2 `sku start` ignores `publicPath` and serves Vite bootstrap from `/` (webpack SSR start parity); `sku build` / production keep `config.base` + static assets under `publicPath`
+- [x] 3.3 Assert start HTML uses `/@vite/client` and prod HTML uses the configured prefix; fixture for relative `/static/...` assets with app routes outside that prefix
+
+## 4. CSP and vocab
+
+- [x] 4.1 Shell CSP headers (enforcing and/or Report-Only); lazy single nonce only when requested; Async Local Storage holds nonce only
+- [x] 4.2 Align production defines with webpack: `__SKU_CSP__` object (incl. report-only fields); remove `import.meta.env.SKU_*` / `SKU_LANGUAGES`
+- [x] 4.3 Vocab: register language chunk only when `onRequest` returns `language`; no allowlist / sole-language default; no `addLanguageChunk` / client forward
+- [x] 4.4 When vocab / `languages` is active: resolve `@vocab/vite/runtime` from sku via `createRequire(import.meta.url)` and alias the export file in shared Vite `resolve.alias`; do not alias the `@vocab/vite` package root
+- [x] 4.5 Validate Vite SSR with vocab (translations fixture) without a consumer direct `@vocab/vite` dependency
+- [x] 4.6 Reconcile with master's `report-to` feature: consume the `ReportingEndpoint` values resolved by `createSkuContext`, support `cspReportTo` on the enforcing policy, and emit `Reporting-Endpoints` for URL-bearing endpoints
+- [x] 4.7 Cover the reconciled `report-to` behaviour in the Vite SSR fixture, e2e assertions, and `buildCspHeaders` unit tests
+
+## 5. Fixtures and tests
+
+- [x] 5.1 Vite SSR fixture: streaming Suspense, required entries/exports, middleware, CSP (+ report-only), document hydrate, vocab when configured, ≥2 distinct lazy route chunks
+- [x] 5.2 E2E/smoke: shell-first stream, document hydration, HMR preamble
+- [x] 5.12 Assert Vite SSR `sku start` document includes the SSR-CSS virtual stylesheet link (and does not call `transformIndexHtml`)
+- [x] 5.13 Assert Vite SSR `sku start` emits `start.initial` / `start.rebuild` telemetry (or equivalent smoke covering client script + WS wiring)
+- [x] 5.3 Tests: redirects; `waitForAll`; errored-route status; loader `Set-Cookie`; HTTPS start; missing named-export hard errors; nonce request/reuse; abort-before-write
+- [x] 5.4 Tests: `devServerMiddleware` in `sku start`; absent from production server bundle / responses
+- [x] 5.5 Tests: `onHydrate` receives `clientContext` only; no language in bootstrap / request-context; no public `getSkuLanguage`
+- [x] 5.6 Tests: language chunk from `onRequest.language` / omit → no chunk; auto `moduleId` preloads; missing / non-array `routes` hard-error
+- [x] 5.7 Fixture: `PreloadingLink` built on `usePreloadRoute` (drop app-side routes context); production hover test for lazy chunk; assert a foreign-site path does not warm
+- [x] 5.8 Unit tests for simplified language resolution and webpack-aligned production defines
+- [x] 5.9 Config/command validation only for edge cases (webpack + `ssr`, `-ssr` with `buildType`, absolute/`CDN` `publicPath`, Vite SSR + `serverPort`, existing `public` directory, Vite SSR + `dangerouslySetViteConfig`, Vite SSR + `vitePlugins`) — no browser e2e
+- [x] 5.11 Test: Vite SSR + `dangerouslySetViteConfig` hard-errors at config validation
+- [x] 5.14 Test: Vite SSR + `vitePlugins` hard-errors at config validation
+- [x] 5.10 Translations fixture: Vite SSR adapters (shared `App` + vocab; dedicated entries; `sku.config.vite-ssr.ts`) covering `en` / `fr` / `en-PSEUDO` via `?pseudo=true`
+
+## 6. Create template
+
+- [x] 6.1 `@sku-lib/create` `vite-ssr` template (dual `routes` scaffold); leave static `vite` unchanged
+- [x] 6.2 Lazy pages use named `Component` (not default export); Migrating examples match
+
+## 7. Docs and release
+
+- [x] 7.1 Docs: product + Migrating docs, `vite.md`, `csp.md`, `configuration.md`, create READMEs; experimental / not-for-production warning
+- [x] 7.2 Migrating: webpack dual-port → Vite SSR single `port`; `dist/server/server.js` + sibling `client/` / `server/` layout (**superseded in part by §22** — baked manifest, external assets recommended, `node_modules`)
+- [x] 7.3 Document CJS interop for Vite SSR `sku start` + `__UNSAFE_EXPERIMENTAL__cjsInteropDependencies` (docs only; no runtime error rewrite; no new baked-in defaults)
+- [x] 7.4 Discourage `public` for Vite SSR in product + `configuration.md`; Migrating calls out moving off the folder
+- [x] 7.10 Document that Vite SSR does not support `dangerouslySetViteConfig` (hard-error; raise use-cases via sku-support) in `configuration.md` + product / Migrating
+- [x] 7.12 Document that Vite SSR does not support `vitePlugins` (hard-error; raise use-cases via sku-support) in `configuration.md` + product / Migrating
+- [x] 7.5 Prefer render-time data loading via Suspense with clients from Providers (**superseded by §13** — `useReactContext` / `useClientContext`); loaders opt-in for waterfalls / document redirects / headers; no Express `req` → loader bridge
+- [x] 7.6 Migrating: server-only loaders vs client route graph (+ explicit `moduleId` when needed); Braid reset-before-Braid on `sku start`; client-only / window libraries (**superseded by §13** — `getReactContext`); Jest → Vitest prerequisite; `#` pathAliases / migrate-root-resolution
+- [x] 7.7 Drop “install `@vocab/vite` yourself” from product + Migrating once sku-owned alias is in place
+- [x] 7.8 Document Express 4 (shared sku major) and React Router 8 as optional peer; note future major upgrades may be breaking (middleware + Data Mode); do not document Express 5 for this release
+- [x] 7.11 Docs: `routing.md` intent preloading with `usePreloadRoute`; note Data Mode has no `<Link prefetch>`
+- [x] 7.9 Changeset: experimental / not-for-production; React Router 8 optional peer; Express stays on 4; breaking-major policy for later upgrades; no Express 5 bump; no Jest RR8 transforms
+
+## 8. Express↔render context (`onRequest` req + dual `getRouterContext`)
+
+- [x] 8.1 Types: change `SkuSsrOnRequest` to `{ req }` (Express only; drop Fetch `request`); add optional server/client `getRouterContext` export types
+- [x] 8.2 Thread Express `req` into `onRequest` only (`createHtmlRenderMiddleware` / render path); do not pass Fetch `Request` into `onRequest`; `query()` stays Fetch-only
+- [x] 8.3 Wire optional server `getRouterContext({ request, req })` → `query(..., { requestContext })`
+- [x] 8.4 Wire optional client `getRouterContext` → `createBrowserRouter({ getContext })` (wrap if injecting `clientContext`)
+- [x] 8.5 Fixture/template: migrate `onRequest` to `{ req }`; middleware-attached state → `clientContext` / `getRouterContext` (see 10.5); dual `getRouterContext` with client nav to a non-initial location
+- [x] 8.6 Tests: `onRequest` receives `req` only; server/client `getRouterContext` wiring; omit optional → default behaviour
+- [x] 8.7 Docs: `entries.md` / `data-loading.md` / `middleware.md` (+ migrate / routing cross-links) — hierarchy, Data Mode vs Framework Mode, `onRequest({ req })` only, Express `Request` module augmentation for middleware-appended fields (`user` / `log` example), red warning against `req` in context, client-nav ≠ initial SSR example
+- [x] 8.8 Changeset: note `onRequest` args (`{ request }` → `{ req }`) + optional `getRouterContext` if needed
+- [x] 8.9 Rename dual-entry export `getContext` → `getRouterContext` (types `SkuServerGetRouterContext` / `SkuClientGetRouterContext`; RR `createBrowserRouter({ getContext })` unchanged)
+
+## 9. `routesEntry` + site-scoped routes via optional `sites`
+
+- [x] 9.1 Config: add `routesEntry` (default `src/routes.tsx`); resolve path on sku context; alias `__sku_alias__routesEntry` into both Vite SSR graphs; document in `configuration.md`
+- [x] 9.2 Types: export `SkuRouteObject = RouteObject & { sites?: string[] }`; require named `routes` on `routesEntry`; hard-error missing/non-array `routes`; require `onRequest` return field `site`
+- [x] 9.3 Runtime: load `routes` from `routesEntry` only (sku wrappers); drop dual-entry `routes` require from client/server entries
+- [x] 9.4 Pre-build: for each config site name, filter `routes` by `sites` membership (omit ⇒ all sites; no parent→child inheritance); strip `sites` before RR; bake site-name list for production client if needed
+- [x] 9.4a Config: Vite SSR requires non-empty `sites` (≥1 site name); hard-error when empty; drop empty-`sites` soft path in site-name resolution
+- [x] 9.5 Server: take `site` from `onRequest`; select pre-built tree for `createStaticHandler`; fail closed (missing/invalid/unknown site); do not derive site from config hosts
+- [x] 9.6 Client: read hydrated `site` from bootstrap for `createBrowserRouter` (same site as SSR; not `onHydrate` arg)
+- [x] 9.7 Fixture + translations + create template: set `routesEntry`; export `routes` from routes module only; remove `routes` / `routesBySite` re-exports from client/server entries; ≥2 sites; shared routes omit `sites`; site-only routes set `sites`; `onRequest` returns site from request; assert foreign-site path does not match; single-site template returns its sole site
+- [x] 9.7a Template + any single-site fixtures/docs: declare non-empty config `sites`; `onRequest` returns a configured site name (not an invented sole-site placeholder)
+- [x] 9.8 Tests: missing/invalid `routes` on `routesEntry`; missing/invalid/unknown `site` fail closed; omit `sites` ⇒ all sites; explicit `sites` filters; no inheritance; config hosts alone do not select the tree
+- [x] 9.8a Tests: empty config `sites` hard-errors for Vite SSR
+- [x] 9.9 Docs: routing / entries / index / migrate / vite — `routesEntry` + flat `routes` + optional `sites` + `onRequest.site`; multi-site product story (not `routesBySite` / dual-entry re-exports / language param / union+allowlist / sku host matching)
+- [x] 9.9a Docs: Vite SSR requires non-empty config `sites`; template/examples use a real configured site name; drop empty-`sites` soft-path wording
+- [x] 9.10 Changeset: note `routesEntry` + flat `routes` + optional `sites` + required `onRequest.site` (in-progress API; replaces dual-entry `routes` / rejected `routesBySite`)
+
+## 10. `Providers` outside the router + init-time static handler
+
+**Superseded by §13** for how request-scoped values reach React. Historical work kept the handler-at-init / outside-the-router split; §13 replaces app `Providers` with always-on `SkuProvider` + `getReactContext`.
+
+Supersedes the earlier tree-mounted `AppWrapper`: router-aware wrapping becomes an app-owned root layout route, and sku's entry export moves outside the router.
+
+- [x] 10.3 Server: build `createStaticHandler` per site at init; per request select that handler and call only `query()` / `createStaticRouter`
+- [x] 10.1 Types: replace `SkuSsrAppWrapper` with `SkuProviders` / `SkuProvidersProps<Context>` (`children` + `site` + `clientContext`); rename `onHydrate` args to `{ clientContext }`; keep provider components out of the `onRequest` / `onHydrate` return types
+- [x] 10.2 Delete `withAppWrapperLayout.tsx` and `SKU_APP_WRAPPER_ROUTE_ID`; sku no longer wraps the route tree for providers
+- [x] 10.3a Server: render optional `Providers` between `Document` and `StaticRouterProvider` in `render.tsx`, passing `site` + `clientContext`; assert `render.tsx` no longer imports `createStaticHandler`
+- [x] 10.4 Client: render optional `Providers` between `Document` and `RouterProvider` with the same props from the hydrate bootstrap
+- [x] 10.4a Dev-only warning when an entry's `Providers` renders hydration-relevant markup (providers are expected to be context-only)
+- [x] 10.5 Fixtures + translations + create template: export named `Providers`; move `VocabProvider` / `useLocation` language resolution into the app's root layout route; delete the fixture's `requestUserId.ts` ALS helper and the client's module-level `hydratedUserId`
+- [x] 10.5a Create template + fixtures: scaffold the app-owned root layout as a **pathless** route (no `path: '/'`) so it reads as a layout and keeps wrapping any future root-level sibling; child paths stay relative
+- [x] 10.6 Tests: `Providers` render outside the router with `site` + `clientContext` on both sides; omitted ⇒ router rendered directly; route tree unwrapped; handler created once per site; dev DOM warning fires
+- [x] 10.7 Docs: `entries.md` / `index.md` / `routing.md` / migrate — `Providers` vs root layout route vs `getRouterContext` (which channel for which consumer, noting RR 8 has no component-level router-context hook), no-DOM rule, where request-scoped values go
+- [x] 10.8 Changeset: note provider export moves out of `onRequest` / `onHydrate` and out of the route tree; `AppWrapper` → `Providers`; `onHydrate({ context })` → `onHydrate({ clientContext })`
+
+## 11. Streaming data transports (`useInsertHtml`) + Apollo
+
+Opens the one seam apps cannot reach themselves (Decision 21a). Sku stays transport-agnostic; the fixture proves Apollo.
+
+- [x] 11.1 Runtime: render-scoped injection queue + React context in a single module shared by `render` and `sku/runtime`; provide it outermost in `render.tsx` (around `Document`) so route code can reach it
+- [x] 11.2 Runtime: `useInsertHtml()` exported from `sku/runtime`; silent no-op with no injection context (client graph); never throws
+- [x] 11.3 Server: Node transform on the response pipe that renders queued nodes to markup and writes them before the next React chunk, flushing the remainder at stream end; works for `onShellReady` and `waitForAll`
+- [x] 11.4 Fixture `stream-insert-html`: Apollo Client 4 + `@apollo/client-react-streaming` `buildManualDataTransport({ useInsertHtml })`, provider as dual-entry `Providers` (**superseded by §13** — `getReactContext` + root layout), GraphQL endpoint served from server-entry `middleware`, `extraScriptProps={{ nonce: getCspNonce() }}` on the server entry only
+- [x] 11.5 Fixture: a route that queries during SSR and a route that queries only after hydration (client navigation), so cache reuse and fresh fetches are separately observable
+- [x] 11.6 Tests: injected markup lands before hydration; no-op off the SSR path without throwing; nonce present in `script-src`; injection survives `waitForAll`
+- [x] 11.7 E2E: server-run query data unchanged after hydration with no refetch; post-hydration query fetches; passes on both `sku start` and production build (guards the `browser` / `node` condition builds)
+- [x] 11.8 Docs: `data-loading.md` Apollo streaming walkthrough (**superseded by §13** for provider mount); `entries.md` / `csp.md` cross-links; migrate — drop two-pass `getDataFromTree`; state loader-transported query refs are unsupported and why
+- [x] 11.9 Changeset: `useInsertHtml` on `sku/runtime`; sku ships no Apollo dependency or config
+
+## 12. Flatten request-entry getters
+
+Replace `onRequest` with sync getters; make `middleware` / `onHydrate` optional.
+(**Superseded by §13** for the public contract shape — default-exported entry object, not per-getter named exports.)
+
+- [x] 12.1 Types: drop `SkuSsrOnRequest` / `SkuSsrOnRequestResult`; add `SkuGetSite` / `SkuGetLanguage` / `SkuGetClientContext` (sync, `{ req }` only)
+- [x] 12.2 Server entry: optional getter + middleware reads; init-time `getSite` required when `__SKU_SITES__.length > 1`
+- [x] 12.3 Client entry: optional `onHydrate`
+- [x] 12.4 `render.tsx`: call getters before `query()`; sole config site when `getSite` omitted; validate when present
+- [x] 12.5 Production / start servers: tolerate absent `middleware`
+- [x] 12.6 Fixtures + translations: migrate off `onRequest` to getters
+- [x] 12.7 Create template: realistic `middleware` + `Providers` + `onHydrate` (**superseded by §13** — drop `Providers`, default entry objects + `createSkuContexts`); single-site omits `getSite`
+- [x] 12.8 Tests: single-site no `getSite`; multi-site missing `getSite` init error; unknown site per-request; omit `onHydrate`; omit `middleware`
+- [x] 12.9 Docs: entries / providers / multi-language / routing / data-loading + migrate — getters, optional middleware/onHydrate, sync/pure recommendation (**§13 rewrites providers docs + entry shape**)
+- [x] 12.10 Changeset: note getters replace `onRequest`; `middleware` / `onHydrate` optional (experimental API)
+
+## 13. Always-on SkuProvider + default entry objects + three value channels
+
+Replaces app-authored dual-entry `Providers`. Request entries are one default-exported object via `defineServerEntry` / `defineClientEntry` (not per-getter named exports).
+
+- [x] 13.1 Types: drop `SkuProviders` / `SkuProvidersProps`; add `SkuServerEntry` / `SkuClientEntry`; export `defineServerEntry` / `defineClientEntry` (zero-runtime, `NoInfer` sibling typing); extend runtime `getRouterContext` args with `site` / `clientContext` / `reactContext`; export `createSkuContexts<typeof server, typeof client>()` from `sku/runtime`
+- [x] 13.2 Runtime: load `serverEntry` / `clientEntry` via **default export** object; call optional properties; always-on `SkuProvider` in `render.tsx` / client entry (`site` + `clientContext` + `reactContext`); shared context module with `createSkuContexts` (`unbundle: true` — published-install identity completed in §19 / Decision 26)
+- [x] 13.3 Runtime: call order `getSite` → `getLanguage` → `getClientContext` → `getReactContext` → `getRouterContext` → `query()`; pass sibling values; do not serialise `reactContext`
+- [x] 13.4 Runtime: remove optional `Providers` mount, markup-probe warnings, and related tests
+- [x] 13.5 `createSkuContexts<typeof server, typeof client>()`: extract `ClientContext` / `ReactContext` from entry typeofs; typed `useSite` / `useClientContext` / `useReactContext`; no per-property `defineGet*`; no required hand-written context aliases
+- [x] 13.6 Wire client `getReactContext({ site, clientContext })` and client `getRouterContext({ site, clientContext, reactContext })` (wrap RR zero-arg `getContext`)
+- [x] 13.7 Fixtures: `defineServerEntry` / `defineClientEntry` default exports; remove `Providers.tsx`; vite-ssr uses `createSkuContexts<typeof …>` + hooks; stream-insert-html moves Apollo mount to root layout via `useReactContext` + dual-entry `getReactContext` (`makeClient` / server nonce)
+- [x] 13.8 Create template: `define*Entry` + `createSkuContexts<typeof …>` scaffold; no `Providers`; root layout ready for isomorphic provider mounts
+- [x] 13.9 Tests: sibling projection into later getters; hooks read provider values; omit `getClientContext` / `getReactContext` → `undefined`; Apollo fixture still proves cache reuse without `Providers`
+- [x] 13.10 Docs: replace `providers.md` / entries / data-loading / migrate — `define*Entry` inference + `createSkuContexts<typeof …>` example, three-channel Markdown table, root-layout Apollo, no Mermaid required; replace `Providers` API docs in place
+- [x] 13.11 Changeset: experimental API — `defineServerEntry` / `defineClientEntry`; default-exported entry objects; `getReactContext` + `SkuProvider` + `createSkuContexts<typeof …>`; sibling args on later getters (do **not** label as breaking; Vite SSR has not shipped)
+
+## 14. Infer Site / Language in defineServerEntry; type useSite
+
+Fold-in: `getSite` / `getLanguage` returns join the existing `C` / `R` inference scope; `useSite` stops being hardcoded `string`.
+
+- [x] 14.1 `defineServerEntry`: add generics `S` / `L`; infer from `getSite` / `getLanguage` returns; type later sibling `site` as `NoInfer<S>` (keep `defineClientEntry` `site: string`)
+- [x] 14.2 `createSkuContexts`: extract `Site` from server `getSite` (`string` when omitted); type `useSite(): Site`
+- [x] 14.3 Fixture / template: drop widening `SkuGetSite` annotations; narrow inside `getSite`; remove `useSite() as FixtureSite` casts where inference covers them
+- [x] 14.4 Docs (`providers` / `entries`): document Site / Language inference; warn that annotating with `SkuGetSite` / `SkuGetLanguage` widens to `string`
+- [x] 14.5 Type-level / unit coverage: narrowed `getSite` → typed `useSite` + sibling `site`; omit `getSite` → `useSite` is `string`
+
+## 15. Type defineClientEntry from ServerEntry
+
+Fold-in: client callbacks cannot infer `ClientContext` / `Site` (inputs only) — pass `typeof server` like `createSkuContexts`.
+
+- [x] 15.1 `defineClientEntry<ServerEntry>`: extract `Site` / `ClientContext` via the same helpers as `createSkuContexts`; type `onHydrate` / client getter `site` + `clientContext` from those; still infer `ReactContext` from client `getReactContext`; omit type arg ⇒ `ClientContext` is `undefined` and `site` is `string`
+- [x] 15.2 Fixture / template / create snapshot: `defineClientEntry<typeof server>` (type-only server import)
+- [x] 15.3 Docs (`providers` / `entries` / data-loading examples): document `defineClientEntry<typeof server>`; stop claiming client-side `ClientContext` inference alone
+- [x] 15.4 Type-level / unit coverage: narrowed server `getClientContext` / `getSite` → typed client callbacks; omit `ServerEntry` ⇒ `undefined` / `string`
+- [x] 15.5 Changeset: note `defineClientEntry<typeof server>` types `ClientContext` / `Site` from the server entry (experimental API; do **not** label as breaking)
+
+## 16. Production static before middleware
+
+Catch-all / Melways-style server-entry middleware must not eat hashed client assets under `publicPath`.
+
+- [x] 16.1 Production `listen`: mount `express.static(publicPath)` after request-context and **before** server-entry `middleware` when sibling `client/` exists (start order unchanged; **§22** makes the mount conditional)
+- [x] 16.2 Test: catch-all / returning middleware does not prevent serving an existing client asset under `publicPath`
+- [x] 16.3 Docs: `middleware.md` production mount order; migrate-from-webpack note that Vite SSR serves `client/` under `publicPath` before middleware
+
+## 17. Server-entry `onListen` + config `expressTrustProxy`
+
+Post-listen lifecycle (webpack `onStart` window) and opt-in Melways-shaped trust proxy.
+
+- [x] 17.1 Types: add optional `onListen` on `SkuServerEntry` / `defineServerEntry` (`{ app, httpServer, port }` → `void | Promise<void>`)
+- [x] 17.2 Config: add optional boolean `expressTrustProxy` (Vite SSR schema/validation/JSDoc); when `true`, set `app.set('trust proxy', 1)` before listen; omit/false → Express default
+- [x] 17.3 Runtime: call `onListen` once after middleware + HTML mounted and `listen` succeeds (shared production `listen` + `createDevSsrServer`); await promise; failure fails startup; do not re-call on server-entry HMR
+- [x] 17.4 Create template: set `expressTrustProxy: true` in `sku.config`
+- [x] 17.5 Tests: `onListen` receives `{ app, httpServer, port }`; `expressTrustProxy: true` → `trust proxy === 1`; omit → default; failure rejects startup
+- [x] 17.6 Docs: `entries.md` (`onListen`); `configuration.md` (`expressTrustProxy` → hop count `1`); migrate-from-webpack (`onStart` → `onListen` bag; trust proxy via config)
+- [x] 17.7 Changeset: note `onListen` + `expressTrustProxy` (experimental API; do **not** label as breaking)
+
+## 18. Optional empty config `sites` (soft-default `'default'`)
+
+Reverses the §9.4a / 9.7a / 9.8a / 9.9a hard-error for empty Vite SSR `sites`. Empty/omitted soft-defaults to synthetic `'default'` so apps without multi-site needs can omit `sites`; `getSite` stays required only when config has >1 site.
+
+- [x] 18.1 Config: drop Vite SSR empty-`sites` hard-error in `validateConfig`; empty/omitted remains valid (default `[]`)
+- [x] 18.2 Runtime: `resolveConfigSiteNames` soft-defaults empty `sites` to `['default']` (no throw); keep >1 site ⇒ `getSite` required; 0–1 ⇒ optional sole resolved name
+- [x] 18.3 Create template: omit config `sites` (rely on soft-default); keep omitting `getSite`
+- [x] 18.4 Tests: empty config `sites` soft-defaults to `'default'` (no hard-error); sole-name / `getSite` omit still works; multi-site unchanged
+- [x] 18.5 Docs: `configuration.md` / routing / migrate — Vite SSR `sites` optional; empty soft-defaults to `'default'`; `getSite` still required only when >1 site; drop “SSR requires at least one site” wording
+- [x] 18.6 Changeset: note empty config `sites` soft-defaults to `'default'` for Vite SSR (experimental API; do **not** label as breaking)
+
+## 19. Consolidate `sku/runtime` + `optimizeDeps.exclude`
+
+Fixes published-install dual React context / shared-module identity (Decision 26). Fixtures hid the bug via `workspace:*` skipping dep prebundling; `unbundle: true` alone is not enough.
+
+- [x] 19.1 Re-export `@internal` runtime symbols from `sku/runtime` (`SkuProvider`, `InsertHtmlProvider`, `createInsertHtmlQueue`, `registerSiteRouteTree`, `runWithSsrRequestContext`); update identity comments on the four shared modules + `ssr.ts`
+- [x] 19.2 Flip sku runtime call sites to `'sku/runtime'`: `ssr-client.tsx` (`SkuProvider`, `registerSiteRouteTree`), `render.tsx` (`SkuProvider`, insert-html providers/queue, `runWithSsrRequestContext`); leave type-only / Node middleware / unit-test relative imports alone
+- [x] 19.3 Shared Vite config plugin: `optimizeDeps.exclude` includes `'sku'`, `'sku/runtime'`, and `skipPackageCompatibilityCompilation`; extract `SKU_VITE_OPTIMIZE_DEPS_EXCLUDE` for plugin + test
+- [x] 19.4 Node assert: `optimizeDeps.exclude` always includes `'sku'` and `'sku/runtime'`; keep existing `tests/browser/vite-ssr.test.ts` green (self-import / dual-context regression under workspace link); skip new tarball `sku start` e2e this pass
+- [x] 19.5 Validate: `pnpm format` → `pnpm build` → `pnpm lint` → scoped tests (new assert + vite-ssr browser)
+
+## 20. Create template layout cleanup
+
+- [x] 20.1 Flatten vite-ssr template: `src/RootLayout.tsx` + `src/ssrContext.ts`; remove `src/App/`; skip base `NextSteps*` for SSR scaffolds
+- [x] 20.2 Home page inlines welcome content and demos `useSite()` (no `import.meta.env`); link to about route
+- [x] 20.3 Update create generate test + design/spec create-template wording
+
+## 21. Naming: Managed Data Mode + `sku/runtime` + template `ssr` (Decision 27)
+
+End-state naming for the in-progress branch implementation (not yet on master). Update code/docs/fixtures to match design/proposal/specs; no compatibility aliases required for prior in-branch names.
+
+### From → to (public)
+
+| From                                | To                                        |
+| ----------------------------------- | ----------------------------------------- |
+| `sku/runtime`                       | `sku/runtime`                             |
+| create template `vite-ssr`          | `ssr`                                     |
+| `SkuProvider`                       | `SkuProvider`                             |
+| `createSkuContexts`                 | `createSkuContexts`                       |
+| `SkuRouteObject`                    | `SkuRouteObject`                          |
+| `SkuServerEntry` / `SkuClientEntry` | `SkuServerEntry` / `SkuClientEntry`       |
+| other public `SkuSsr*` types        | drop `Ssr` infix                          |
+| product copy “Vite SSR”             | “SSR” (architecture: “Managed Data Mode”) |
+
+OpenSpec change / branch name `vite-ssr` stays as-is.
+
+- [x] 21.1 Package exports: rename `./ssr` → `./runtime`; rename `src/ssr.ts` → `src/runtime.ts` (or equivalent); update `optimizeDeps.exclude` / `SKU_VITE_OPTIMIZE_DEPS_EXCLUDE` to `'sku/runtime'`; flip sku runtime call sites and identity comments from `'sku/ssr'` to `'sku/runtime'`
+- [x] 21.2 Rename public symbols/types (drop `Ssr`): `SkuProvider`, `createSkuContexts`, `SkuRouteObject`, entry/getter types, etc.; update all packages/fixtures/tests/docs imports
+- [x] 21.3 Create template: rename `packages/create/templates/vite-ssr` → `ssr`; update generator (`templates.ts`), Template type, prompts, and create tests from `vite-ssr` → `ssr`
+- [x] 21.4 Optional consistency: rename internal SSR entry modules / `#entries/vite-ssr-client*` → `ssr-client*` (and server counterpart if named similarly); update fixture/test filenames that use `vite-ssr` where practical
+- [x] 21.5 Docs: introduce **Managed Data Mode** as the architecture descriptor; use **SSR** only for render strategy; replace `sku/ssr`, `vite-ssr` template refs, `SkuSsr*` / “Vite SSR” product copy; note future Static is expected to share Managed Data Mode APIs
+- [x] 21.6 Changeset: describe experimental Managed Data Mode SSR end-state naming (`sku/runtime`, template `ssr`, types without `Ssr`) — do **not** call this a breaking change (unreleased)
+- [x] 21.7 Validate: `pnpm format` → `pnpm build` → `pnpm lint` → scoped create + SSR browser/node tests
+
+## 22. Production server self-containment + deploy docs
+
+Bake the Vite client manifest into the server build so production starts without sibling `client/`.
+Document recommended external assets vs standalone Node static, including runtime `node_modules`.
+
+- [x] 22.1 Build: after client Vite build, bake/copy the Vite client manifest into the server output (server-local path the production entry can read)
+- [x] 22.2 Production entry: load the baked server-local manifest; do not require `../client/.vite/manifest.json`
+- [x] 22.3 Production `listen`: mount `express.static(publicPath)` only when a sibling `client/` directory exists; omit the mount (no hard-fail) when absent
+- [x] 22.4 Tests: production server starts and streams HTML without sibling `client/` when baked manifest is present; existing static-before-middleware case still passes when sibling `client/` exists
+- [x] 22.5 Docs: rewrite `deploy-to-production.md` — baked manifest / server without sibling `client/`; recommended reverse proxy or object storage for hashed assets; standalone Node static as experimentation only; production deploy needs `server/` + runtime `node_modules` (or equivalent)
+- [x] 22.6 Docs: Migrating + `middleware.md` — optional Node static when sibling `client/` exists; productionised path hosts assets outside Node
+- [x] 22.7 Validate: `pnpm format` → `pnpm build` → `pnpm lint` → scoped production SSR tests
+
+## Deferred
+
+- Optional compose slot above the router (app `Providers`-like) — deferred until root-layout + `getReactContext` prove insufficient
+- Public `useInitialLanguage` / language-in-React-context hook — deferred (analytics); `getLanguage` stays Document vocab preload only (return type still inferred on the server entry)
+- Generic `SkuRouteObject<Site>` — follow-on; client-entry `Site` / `ClientContext` via `defineClientEntry<typeof server>` is §15; components also use `useSite()`
+- Mermaid / VitePress Mermaid plugin for channel diagrams — optional polish; Markdown table is the required docs shape
+- Provider component returned from request-entry getters — Non-Goals (forced `createStaticHandler` onto the hot path)
+- Sku mounting providers inside the route tree as a pathless layout — Non-Goals (router-aware wrapping is the app's root layout route)
+- Consumer-authored Async Local Storage as the documented route to request state — Non-Goals (`SkuProvider` + hooks instead)
+- Dual-entry `routes` re-exports / env-split route modules as a product feature — Non-Goals (`routesEntry` is one truth)
+- Runtime dual-`routes` / server↔client tree equality validation — Non-Goals (unnecessary with `routesEntry`)
+- Union tree + site allowlist as documented multi-site product story — Non-Goals
+- `routesBySite` map export — Non-Goals (trialled and rejected; replaced by flat `routes` + `sites`)
+- Parent→child inheritance of `sites` — Non-Goals (explicit annotation required)
+- Overloading config `routes` (prerender path lists) as the SSR RouteObject entry — Non-Goals (`routesEntry` instead)
+- Sku-owned site resolution from config `hosts` / `sites[].host` — Non-Goals (apps provide `getSite` on the server entry object)
+- Sku reading site / language / clientContext from a conventional `req` field; sku push API (`setRequestContext`) — Non-Goals (libs contribute getter properties apps spread into the entry object)
+- `onRequest`-style combined value return bag / resolver — Non-Goals (optional getters on the default entry object)
+- Per-getter named exports / per-property `defineGet*` helpers — Non-Goals (`defineServerEntry` / `defineClientEntry` are the inference scopes)
+- Async request-entry getters — Non-Goals (sync/pure; libs may memoise on `req`; optional async `getRouterContext` remains)
+- Tolerating a missing `serverEntry` / `clientEntry` file — Non-Goals (omit unused properties on the default export instead)
+- Sku-owned per-site path expansion / per-site JS bundles / routes returned from getters — Non-Goals
+- SSR support for config `public` / unhashed public assets — Non-Goals until definitive need
+- Sku-owned listen logging by default / `onBeforeListen` — Non-Goals (apps log in `onListen`; top-level for pre-bind setup)
+- Soft-defaulting Express `trust proxy` without config — Non-Goals (opt-in `expressTrustProxy`; other values via `onListen`)
+- Express 5 (sku-wide; webpack SSR + SSR + `sku serve`) — later change
+- React Router majors beyond 8 — later releases
+- Jest support for React Router 8 (webpack) — out of scope for this change
+- Automatic `*.server.ts` client strip — Non-Goals (docs / convention only)
+- Auto-inject Braid reset into sku SSR server entry — Non-Goals (Braid optional; docs only)
+- Raw Express `req` in `RouterContextProvider` — Non-Goals (red-warn in docs; project values via dual `getRouterContext`)
+- Framework Mode server-only `getLoadContext(req, res)` as sole API — Non-Goals (Data Mode dual request entry instead)
+- Passing `res` into getters / `getReactContext` / `getRouterContext` — Non-Goals v1
+- Passing Fetch `Request` into early getters — Non-Goals (`{ req }` only; Fetch on `query` / server `getRouterContext`)
+- `@sku-lib/vite/loadable` Document preloads for SSR — Non-Goals (static / prerender only; optionally gate `preloadPlugin` to static later)
+- Sku-owned Apollo dependency / provider / config — Non-Goals (`useInsertHtml` seam only)
+- `@apollo/client-integration-react-router` loader transport (`apolloLoader` / `preloadQuery` query refs in loader data) — Non-Goals (alpha, RR7 peer, needs streaming loader data)
+- Streaming (turbo-stream) loader-data serialization — Non-Goals (would pull sku toward Framework Mode)
+- Two-pass `getDataFromTree` SSR — Non-Goals (incompatible with streaming)

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -9,6 +9,8 @@ context: |
   - Complements Changesets and Vitepress docs; does not replace them
   - Specs are delta-first by domain; do not backfill the whole codebase
   - Prefer Lite mode (short behavior-first specs); scale rigor only for high-risk work
+  - Break prose into short sentences or paragraphs across all OpenSpec docs
+    (proposal, design, specs, tasks); avoid dense single-line MUST / decision stacks
   - Invoke the CLI via `pnpm openspec` (not bare `openspec`)
   - AI tool adapters are local-only; never commit them
 
@@ -18,14 +20,18 @@ rules:
     - Include Non-goals; omit fluff and background the team already knows
     - State public API / breaking impact; note changeset and/or docs/docs if needed
     - On update: fold new scope into a coherent current proposal; do not simply append new ideas
+    - Short sentences or paragraphs; avoid dense single-line stacks
   specs:
     - Default to Lite: few requirements, only scenarios that catch real risk
     - One SHALL/MUST per requirement; observable behavior only — no code, APIs internals, or libraries
+    - Short sentences or paragraphs in requirement prose; avoid dense single-line MUST stacks
     - Prefer ADDED/MODIFIED/REMOVED deltas; reuse existing domains
     - Happy path plus the failure/edge cases that would hurt if missed — not exhaustive matrices
     - Put how/why in design.md or tasks.md, not in requirements
   design:
     - Skip unless architecture is non-obvious; keep short when present
-    - On update: integrate new decisions into the current design narrative;
+    - On update: integrate new decisions into the current design narrative
+    - Short sentences or paragraphs in decisions; avoid dense single-line stacks
   tasks:
     - Small checklist only; include plop, changeset, and docs when they apply
+    - Keep task items readable; one concern per checklist item where practical


### PR DESCRIPTION
## Summary
- Add the `openspec/changes/vite-ssr` proposal, design, specs, and tasks for Managed Data Mode / experimental Vite SSR.
- Tighten OpenSpec config guidance toward short, readable prose across proposal/design/specs/tasks.

## Why
- Land the design review artifacts before splitting out the implementation, create template, and product docs PRs.