### PR TITLE
Unpin and update `webpack` dep

### DIFF
--- a/.changeset/loud-days-push.md
+++ b/.changeset/loud-days-push.md
@@ -1,0 +1,7 @@
+---
+'sku': patch
+---
+
+Unpin and update `webpack` dependency to `^5.109.0`
+
+`sku`'s `webpack` dependency was pinned to `5.108.1` in the v16 release to prevent a bug in a newer `webpack` version from affecting `sku` consumers. The fix for this bug was released in `5.109.0`, so the `webpack` dependency has now been unpinned.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ catalogs:
       specifier: ^4.1.0
       version: 4.1.9
     webpack:
-      specifier: 5.108.1
-      version: 5.108.1
+      specifier: ^5.109.0
+      version: 5.109.2
     webpack-dev-server:
       specifier: ^5.2.4
       version: 5.2.4
@@ -653,28 +653,28 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
       babel-loader:
         specifier: ^10.0.0
-        version: 10.1.1(@babel/core@7.29.7)(webpack@5.108.1)
+        version: 10.1.1(@babel/core@7.29.7)(webpack@5.109.2)
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.6.7(webpack@5.108.1)
+        version: 5.6.7(webpack@5.109.2)
       http-server:
         specifier: ^14.1.1
         version: 14.1.1(debug@4.4.3)(supports-color@8.1.1)
       mini-css-extract-plugin:
         specifier: ^2.6.1
-        version: 2.10.2(webpack@5.108.1)
+        version: 2.10.2(webpack@5.109.2)
       sku:
         specifier: workspace:*
         version: link:../../packages/sku
       webpack:
         specifier: 'catalog:'
-        version: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+        version: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
       webpack-cli:
         specifier: ^6.0.0
-        version: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.108.1)
+        version: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.109.2)
       webpack-dev-server:
         specifier: 'catalog:'
-        version: 5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.108.1)
+        version: 5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.109.2)
 
   fixtures/sku-with-https:
     dependencies:
@@ -774,13 +774,13 @@ importers:
     devDependencies:
       '@storybook/addon-docs':
         specifier: ^10.5.0
-        version: 10.5.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.108.4)
+        version: 10.5.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.109.2)
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^4.0.1
-        version: 4.0.1(supports-color@8.1.1)(webpack@5.108.4)
+        version: 4.0.1(supports-color@8.1.1)(webpack@5.109.2)
       '@storybook/react-vite':
         specifier: ^10.5.0
-        version: 10.5.4(@types/react-dom@19.2.3)(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7)(react@19.2.7)(rollup@4.62.2)(storybook@10.5.5)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.1.4)(webpack@5.108.4)
+        version: 10.5.4(@types/react-dom@19.2.3)(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7)(react@19.2.7)(rollup@4.62.2)(storybook@10.5.5)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.1.4)(webpack@5.109.2)
       '@storybook/react-webpack5':
         specifier: ^10.5.0
         version: 10.5.0(@swc/core@1.15.41)(@types/react-dom@19.2.3)(@types/react@19.2.17)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.5)(supports-color@8.1.1)(typescript@6.0.3)(uglify-js@3.19.3)(webpack-cli@6.0.1)
@@ -820,7 +820,7 @@ importers:
         version: link:../../private/test-utils
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^4.0.0
-        version: 4.0.1(supports-color@8.1.1)(webpack@5.108.4)
+        version: 4.0.1(supports-color@8.1.1)(webpack@5.109.2)
       '@storybook/react-webpack5':
         specifier: ^10.0.0
         version: 10.5.0(@swc/core@1.15.41)(@types/react-dom@19.2.3)(@types/react@19.2.17)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.5)(supports-color@8.1.1)(typescript@6.0.3)(uglify-js@3.19.3)(webpack-cli@6.0.1)
@@ -887,7 +887,7 @@ importers:
         version: 1.0.4(supports-color@8.1.1)(vite@8.1.4)
       '@vocab/webpack':
         specifier: ^1.2.9
-        version: 1.2.24(supports-color@8.1.1)(webpack@5.108.4)
+        version: 1.2.24(supports-color@8.1.1)(webpack@5.109.2)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -1221,10 +1221,10 @@ importers:
         version: 5.16.7(@loadable/component@5.16.7)(react@19.2.7)
       '@loadable/webpack-plugin':
         specifier: ^5.14.0
-        version: 5.15.2(webpack@5.108.1)
+        version: 5.15.2(webpack@5.109.2)
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: ^0.6.0
-        version: 0.6.2(react-refresh@0.18.0)(type-fest@5.7.0)(webpack-dev-server@5.2.4)(webpack-hot-middleware@2.26.1)(webpack@5.108.1)
+        version: 0.6.2(react-refresh@0.18.0)(type-fest@5.7.0)(webpack-dev-server@5.2.4)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@rolldown/plugin-babel':
         specifier: ^0.2.1
         version: 0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.4)
@@ -1236,7 +1236,7 @@ importers:
         version: link:../vite
       '@storybook/react-vite':
         specifier: ^10.0.0
-        version: 10.5.4(@types/react-dom@19.2.3)(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7)(react@19.2.7)(rollup@4.62.2)(storybook@10.5.5)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.1.4)(webpack@5.108.1)
+        version: 10.5.4(@types/react-dom@19.2.3)(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7)(react@19.2.7)(rollup@4.62.2)(storybook@10.5.5)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.1.4)(webpack@5.109.2)
       '@storybook/react-webpack5':
         specifier: ^10.0.0
         version: 10.5.0(@swc/core@1.15.41)(@types/react-dom@19.2.3)(@types/react@19.2.17)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.5)(supports-color@8.1.1)(typescript@6.0.3)(uglify-js@3.19.3)(webpack-cli@6.0.1)
@@ -1266,7 +1266,7 @@ importers:
         version: 5.2.5(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(jiti@2.7.0)(supports-color@8.1.1)(terser@5.48.0)(tsx@4.22.4)(vite@8.1.4)(yaml@2.9.0)
       '@vanilla-extract/webpack-plugin':
         specifier: 'catalog:'
-        version: 2.3.27(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(webpack@5.108.1)
+        version: 2.3.27(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(webpack@5.109.2)
       '@vitejs/plugin-basic-ssl':
         specifier: ^2.3.0
         version: 2.3.0(vite@8.1.4)
@@ -1287,13 +1287,13 @@ importers:
         version: 1.0.4(supports-color@8.1.1)(vite@8.1.4)
       '@vocab/webpack':
         specifier: ^1.2.9
-        version: 1.2.24(supports-color@8.1.1)(webpack@5.108.1)
+        version: 1.2.24(supports-color@8.1.1)(webpack@5.109.2)
       babel-jest:
         specifier: ^30.0.0
         version: 30.4.1(@babel/core@7.29.7)(supports-color@8.1.1)
       babel-loader:
         specifier: ^10.0.0
-        version: 10.1.1(@babel/core@7.29.7)(webpack@5.108.1)
+        version: 10.1.1(@babel/core@7.29.7)(webpack@5.109.2)
       babel-plugin-macros:
         specifier: ^3.1.0
         version: 3.1.0
@@ -1317,7 +1317,7 @@ importers:
         version: 14.0.3
       css-loader:
         specifier: ^7.1.2
-        version: 7.1.4(webpack@5.108.1)
+        version: 7.1.4(webpack@5.109.2)
       dedent:
         specifier: ^1.5.1
         version: 1.7.2(babel-plugin-macros@3.1.0)
@@ -1377,7 +1377,7 @@ importers:
         version: 11.0.0
       mini-css-extract-plugin:
         specifier: ^2.6.1
-        version: 2.10.2(webpack@5.108.1)
+        version: 2.10.2(webpack@5.109.2)
       node-html-parser:
         specifier: ^7.0.1
         version: 7.1.0
@@ -1398,7 +1398,7 @@ importers:
         version: 1.1.0(postcss@8.5.17)
       postcss-loader:
         specifier: ^8.0.0
-        version: 8.2.1(postcss@8.5.17)(typescript@6.0.3)(webpack@5.108.1)
+        version: 8.2.1(postcss@8.5.17)(typescript@6.0.3)(webpack@5.109.2)
       prettier:
         specifier: ~3.9.0
         version: 3.9.4
@@ -1428,7 +1428,7 @@ importers:
         version: 5.0.0
       terser-webpack-plugin:
         specifier: ^5.1.4
-        version: 5.6.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack@5.108.1)
+        version: 5.6.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack@5.109.2)
       tiny-open:
         specifier: ^1.3.0
         version: 1.3.0
@@ -1446,13 +1446,13 @@ importers:
         version: 4.0.3(vite@8.1.4)
       webpack:
         specifier: 'catalog:'
-        version: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+        version: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
       webpack-bundle-analyzer:
         specifier: ^5.1.1
         version: 5.3.0
       webpack-dev-server:
         specifier: 'catalog:'
-        version: 5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.108.1)
+        version: 5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.109.2)
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -1721,13 +1721,13 @@ importers:
         version: 7.1.0
       webpack:
         specifier: 'catalog:'
-        version: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+        version: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
       webpack-cli:
         specifier: ^6.0.0
-        version: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.108.1)
+        version: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.109.2)
       webpack-dev-server:
         specifier: 'catalog:'
-        version: 5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.108.1)
+        version: 5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.109.2)
 
 packages:
 
@@ -5776,12 +5776,6 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
-  acorn-import-phases@1.0.4:
-    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
-    engines: {node: '>=10.13.0'}
-    peerDependencies:
-      acorn: ^8.14.0
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -6788,6 +6782,10 @@ packages:
 
   enhanced-resolve@5.24.0:
     resolution: {integrity: sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==}
+    engines: {node: '>=10.13.0'}
+
+  enhanced-resolve@5.24.5:
+    resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.4.1:
@@ -8345,10 +8343,6 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-
-  loader-runner@4.3.2:
-    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
-    engines: {node: '>=6.11.5'}
 
   loader-utils@2.0.4:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
@@ -10687,8 +10681,8 @@ packages:
     resolution: {integrity: sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==}
     engines: {node: '>=6'}
 
-  webpack-sources@3.5.0:
-    resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
+  webpack-sources@3.5.1:
+    resolution: {integrity: sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==}
     engines: {node: '>=10.13.0'}
 
   webpack-stats-plugin@1.1.3:
@@ -10697,18 +10691,8 @@ packages:
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
-  webpack@5.108.1:
-    resolution: {integrity: sha512-UUCihHQK3O7483Woa0SulNLDeAiOhHI2PN2PAPU4fVWJqbzhv04EJ8FaWtB9WWh3i8fRt28543U7VfuJTOrpgQ==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-
-  webpack@5.108.4:
-    resolution: {integrity: sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==}
+  webpack@5.109.2:
+    resolution: {integrity: sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -12948,10 +12932,10 @@ snapshots:
       lodash: 4.18.1
       react: 19.2.7
 
-  '@loadable/webpack-plugin@5.15.2(webpack@5.108.1)':
+  '@loadable/webpack-plugin@5.15.2(webpack@5.109.2)':
     dependencies:
       make-dir: 3.1.0
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -13379,7 +13363,7 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.6.2(react-refresh@0.18.0)(type-fest@5.7.0)(webpack-dev-server@5.2.4)(webpack-hot-middleware@2.26.1)(webpack@5.108.1)':
+  '@pmmmwh/react-refresh-webpack-plugin@0.6.2(react-refresh@0.18.0)(type-fest@5.7.0)(webpack-dev-server@5.2.4)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)':
     dependencies:
       anser: 2.3.5
       core-js-pure: 3.49.0
@@ -13388,10 +13372,10 @@ snapshots:
       react-refresh: 0.18.0
       schema-utils: 4.3.3
       source-map: 0.7.6
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
     optionalDependencies:
       type-fest: 5.7.0
-      webpack-dev-server: 5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.108.1)
+      webpack-dev-server: 5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.109.2)
       webpack-hot-middleware: 2.26.1
 
   '@pnpm/catalogs.config@1000.0.6':
@@ -13847,10 +13831,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.5.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.108.4)':
+  '@storybook/addon-docs@10.5.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.109.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@storybook/csf-plugin': 10.5.0(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.108.4)
+      '@storybook/csf-plugin': 10.5.0(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.109.2)
       '@storybook/icons': 2.0.2(react-dom@19.2.7)(react@19.2.7)
       '@storybook/react-dom-shim': 10.5.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.5)
       react: 19.2.7
@@ -13866,29 +13850,18 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-webpack5-compiler-babel@4.0.1(supports-color@8.1.1)(webpack@5.108.4)':
+  '@storybook/addon-webpack5-compiler-babel@4.0.1(supports-color@8.1.1)(webpack@5.109.2)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      babel-loader: 10.1.1(@babel/core@7.29.7)(webpack@5.108.4)
+      babel-loader: 10.1.1(@babel/core@7.29.7)(webpack@5.109.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@storybook/builder-vite@10.5.4(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.108.1)':
+  '@storybook/builder-vite@10.5.4(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.109.2)':
     dependencies:
-      '@storybook/csf-plugin': 10.5.4(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.108.1)
-      storybook: 10.5.5(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
-      ts-dedent: 2.3.0
-      vite: 8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - webpack
-
-  '@storybook/builder-vite@10.5.4(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.108.4)':
-    dependencies:
-      '@storybook/csf-plugin': 10.5.4(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.108.4)
+      '@storybook/csf-plugin': 10.5.4(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.109.2)
       storybook: 10.5.5(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
       ts-dedent: 2.3.0
       vite: 8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -13902,18 +13875,18 @@ snapshots:
       '@storybook/core-webpack': 10.5.0(storybook@10.5.5)
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
-      css-loader: 7.1.4(webpack@5.108.4)
+      css-loader: 7.1.4(webpack@5.109.2)
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@6.0.3)(webpack@5.108.4)
-      html-webpack-plugin: 5.6.7(webpack@5.108.4)
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@6.0.3)(webpack@5.109.2)
+      html-webpack-plugin: 5.6.7(webpack@5.109.2)
       magic-string: 0.30.21
       semver: 7.8.5
       storybook: 10.5.5(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
-      style-loader: 4.0.0(webpack@5.108.4)
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack@5.108.4)
+      style-loader: 4.0.0(webpack@5.109.2)
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack@5.109.2)
       ts-dedent: 2.3.0
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-      webpack-dev-middleware: 6.1.3(webpack@5.108.4)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack-dev-middleware: 6.1.3(webpack@5.109.2)
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -13939,7 +13912,7 @@ snapshots:
       storybook: 10.5.5(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
       ts-dedent: 2.3.0
 
-  '@storybook/csf-plugin@10.5.0(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.108.4)':
+  '@storybook/csf-plugin@10.5.0(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.109.2)':
     dependencies:
       storybook: 10.5.5(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
       unplugin: 2.3.11
@@ -13947,9 +13920,9 @@ snapshots:
       esbuild: 0.28.1
       rollup: 4.62.2
       vite: 8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
 
-  '@storybook/csf-plugin@10.5.4(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.108.1)':
+  '@storybook/csf-plugin@10.5.4(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.109.2)':
     dependencies:
       storybook: 10.5.5(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
       unplugin: 2.3.11
@@ -13957,17 +13930,7 @@ snapshots:
       esbuild: 0.28.1
       rollup: 4.62.2
       vite: 8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-
-  '@storybook/csf-plugin@10.5.4(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.108.4)':
-    dependencies:
-      storybook: 10.5.5(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
-      unplugin: 2.3.11
-    optionalDependencies:
-      esbuild: 0.28.1
-      rollup: 4.62.2
-      vite: 8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
 
   '@storybook/global@5.0.0': {}
 
@@ -13979,7 +13942,7 @@ snapshots:
   '@storybook/preset-react-webpack@10.5.0(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.5)(supports-color@8.1.1)(typescript@6.0.3)(uglify-js@3.19.3)(webpack-cli@6.0.1)':
     dependencies:
       '@storybook/core-webpack': 10.5.0(storybook@10.5.5)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(supports-color@8.1.1)(typescript@6.0.3)(webpack@5.108.4)
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(supports-color@8.1.1)(typescript@6.0.3)(webpack@5.109.2)
       '@types/semver': 7.7.1
       magic-string: 0.30.21
       react: 19.2.7
@@ -13989,7 +13952,7 @@ snapshots:
       semver: 7.8.5
       storybook: 10.5.5(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
       tsconfig-paths: 4.2.0
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -14008,7 +13971,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(supports-color@8.1.1)(typescript@6.0.3)(webpack@5.108.4)':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(supports-color@8.1.1)(typescript@6.0.3)(webpack@5.109.2)':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       endent: 2.1.0
@@ -14018,7 +13981,7 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       tslib: 2.8.1
       typescript: 6.0.3
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14040,36 +14003,11 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@storybook/react-vite@10.5.4(@types/react-dom@19.2.3)(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7)(react@19.2.7)(rollup@4.62.2)(storybook@10.5.5)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.1.4)(webpack@5.108.1)':
+  '@storybook/react-vite@10.5.4(@types/react-dom@19.2.3)(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7)(react@19.2.7)(rollup@4.62.2)(storybook@10.5.5)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.1.4)(webpack@5.109.2)':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.1.4)
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
-      '@storybook/builder-vite': 10.5.4(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.108.1)
-      '@storybook/react': 10.5.4(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.5)(supports-color@8.1.1)(typescript@6.0.3)
-      empathic: 2.0.1
-      magic-string: 0.30.21
-      react: 19.2.7
-      react-docgen: 8.0.3(supports-color@8.1.1)
-      react-dom: 19.2.7(react@19.2.7)
-      resolve: 1.22.12
-      storybook: 10.5.5(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7)(react@19.2.7)
-      tsconfig-paths: 4.2.0
-      vite: 8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - esbuild
-      - rollup
-      - supports-color
-      - webpack
-
-  '@storybook/react-vite@10.5.4(@types/react-dom@19.2.3)(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7)(react@19.2.7)(rollup@4.62.2)(storybook@10.5.5)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.1.4)(webpack@5.108.4)':
-    dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.1.4)
-      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
-      '@storybook/builder-vite': 10.5.4(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.108.4)
+      '@storybook/builder-vite': 10.5.4(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.5)(vite@8.1.4)(webpack@5.109.2)
       '@storybook/react': 10.5.4(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.5)(supports-color@8.1.1)(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -14516,7 +14454,7 @@ snapshots:
     dependencies:
       '@types/node': 26.0.0
       tapable: 2.3.3
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -14535,7 +14473,7 @@ snapshots:
   '@types/webpack-node-externals@3.0.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)':
     dependencies:
       '@types/node': 26.0.0
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -14844,13 +14782,13 @@ snapshots:
       - tsx
       - yaml
 
-  '@vanilla-extract/webpack-plugin@2.3.27(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(webpack@5.108.1)':
+  '@vanilla-extract/webpack-plugin@2.3.27(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(webpack@5.109.2)':
     dependencies:
       '@vanilla-extract/integration': 8.0.10(babel-plugin-macros@3.1.0)(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
       loader-utils: 2.0.4
       picocolors: 1.1.1
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -14991,7 +14929,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vocab/webpack@1.2.24(supports-color@8.1.1)(webpack@5.108.1)':
+  '@vocab/webpack@1.2.24(supports-color@8.1.1)(webpack@5.109.2)':
     dependencies:
       '@vocab/core': 1.8.1(supports-color@8.1.1)
       cjs-module-lexer: 2.2.0
@@ -14999,19 +14937,7 @@ snapshots:
       es-module-lexer: 2.1.0
       picocolors: 1.1.1
       virtual-resource-loader: 2.0.1
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vocab/webpack@1.2.24(supports-color@8.1.1)(webpack@5.108.4)':
-    dependencies:
-      '@vocab/core': 1.8.1(supports-color@8.1.1)
-      cjs-module-lexer: 2.2.0
-      debug: 4.4.3(supports-color@8.1.1)
-      es-module-lexer: 2.1.0
-      picocolors: 1.1.1
-      virtual-resource-loader: 2.0.1
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15194,42 +15120,22 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
-  '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.108.1)':
+  '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.109.2)':
     dependencies:
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.108.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.109.2)
 
-  '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.108.4)':
+  '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.109.2)':
     dependencies:
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.108.4)
-    optional: true
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.109.2)
 
-  '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.108.1)':
+  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.109.2)':
     dependencies:
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.108.1)
-
-  '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.108.4)':
-    dependencies:
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.108.4)
-    optional: true
-
-  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.108.1)':
-    dependencies:
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.108.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.109.2)
     optionalDependencies:
-      webpack-dev-server: 5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.108.1)
-
-  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.108.4)':
-    dependencies:
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.108.4)
-    optionalDependencies:
-      webpack-dev-server: 5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.108.4)
-    optional: true
+      webpack-dev-server: 5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.109.2)
 
   '@wry/caches@1.0.1':
     dependencies:
@@ -15327,10 +15233,6 @@ snapshots:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
-
-  acorn-import-phases@1.0.4(acorn@8.17.0):
-    dependencies:
-      acorn: 8.17.0
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -15547,19 +15449,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.1.1(@babel/core@7.29.7)(webpack@5.108.1):
+  babel-loader@10.1.1(@babel/core@7.29.7)(webpack@5.109.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       find-up: 5.0.0
     optionalDependencies:
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-
-  babel-loader@10.1.1(@babel/core@7.29.7)(webpack@5.108.4):
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      find-up: 5.0.0
-    optionalDependencies:
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
 
   babel-plugin-istanbul@7.0.1(supports-color@8.1.1):
     dependencies:
@@ -16061,7 +15956,7 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
-  css-loader@7.1.4(webpack@5.108.1):
+  css-loader@7.1.4(webpack@5.109.2):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.17)
       postcss: 8.5.17
@@ -16072,20 +15967,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.5
     optionalDependencies:
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-
-  css-loader@7.1.4(webpack@5.108.4):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.5.17)
-      postcss: 8.5.17
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.17)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.17)
-      postcss-modules-scope: 3.2.1(postcss@8.5.17)
-      postcss-modules-values: 4.0.0(postcss@8.5.17)
-      postcss-value-parser: 4.2.0
-      semver: 7.8.5
-    optionalDependencies:
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
 
   css-select@4.3.0:
     dependencies:
@@ -16364,6 +16246,11 @@ snapshots:
       objectorarray: 1.0.5
 
   enhanced-resolve@5.24.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  enhanced-resolve@5.24.5:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -17041,7 +16928,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@6.0.3)(webpack@5.108.4):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@6.0.3)(webpack@5.109.2):
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
@@ -17056,7 +16943,7 @@ snapshots:
       semver: 7.8.5
       tapable: 2.3.3
       typescript: 6.0.3
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
 
   formatly@0.3.0:
     dependencies:
@@ -17372,7 +17259,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.7(webpack@5.108.1):
+  html-webpack-plugin@5.6.7(webpack@5.109.2):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -17380,17 +17267,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-
-  html-webpack-plugin@5.6.7(webpack@5.108.4):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.18.1
-      pretty-error: 4.0.0
-      tapable: 2.3.3
-    optionalDependencies:
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
 
   htmlparser2@5.0.1:
     dependencies:
@@ -18410,8 +18287,6 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  loader-runner@4.3.2: {}
-
   loader-utils@2.0.4:
     dependencies:
       big.js: 5.2.2
@@ -18597,11 +18472,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.10.2(webpack@5.108.1):
+  mini-css-extract-plugin@2.10.2(webpack@5.109.2):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
 
   minimalistic-assert@1.0.1: {}
 
@@ -18619,30 +18494,13 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack@5.108.1):
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack@5.109.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-    optionalDependencies:
-      '@swc/core': 1.15.41
-      clean-css: 5.3.3
-      csso: 5.0.5
-      esbuild: 0.28.1
-      html-minifier-terser: 6.1.0
-      lightningcss: 1.32.0
-      postcss: 8.5.17
-      uglify-js: 3.19.3
-
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack@5.108.4):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.48.0
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
     optionalDependencies:
       '@swc/core': 1.15.41
       clean-css: 5.3.3
@@ -19201,14 +19059,14 @@ snapshots:
       lightningcss: 1.32.0
       postcss: 8.5.17
 
-  postcss-loader@8.2.1(postcss@8.5.17)(typescript@6.0.3)(webpack@5.108.1):
+  postcss-loader@8.2.1(postcss@8.5.17)(typescript@6.0.3)(webpack@5.109.2):
     dependencies:
       cosmiconfig: 9.0.2(typescript@6.0.3)
       jiti: 2.7.0
       postcss: 8.5.17
       semver: 7.8.5
     optionalDependencies:
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - typescript
 
@@ -20211,9 +20069,9 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
-  style-loader@4.0.0(webpack@5.108.4):
+  style-loader@4.0.0(webpack@5.109.2):
     dependencies:
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
 
   superjson@2.2.6:
     dependencies:
@@ -20259,30 +20117,13 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack@5.108.1):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack@5.109.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-    optionalDependencies:
-      '@swc/core': 1.15.41
-      clean-css: 5.3.3
-      csso: 5.0.5
-      esbuild: 0.28.1
-      html-minifier-terser: 6.1.0
-      lightningcss: 1.32.0
-      postcss: 8.5.17
-      uglify-js: 3.19.3
-
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack@5.108.4):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.48.0
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
     optionalDependencies:
       '@swc/core': 1.15.41
       clean-css: 5.3.3
@@ -20872,12 +20713,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-cli@6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.108.1):
+  webpack-cli@6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.109.2):
     dependencies:
       '@discoveryjs/json-ext': 0.6.3
-      '@webpack-cli/configtest': 3.0.1(webpack-cli@6.0.1)(webpack@5.108.1)
-      '@webpack-cli/info': 3.0.1(webpack-cli@6.0.1)(webpack@5.108.1)
-      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.108.1)
+      '@webpack-cli/configtest': 3.0.1(webpack-cli@6.0.1)(webpack@5.109.2)
+      '@webpack-cli/info': 3.0.1(webpack-cli@6.0.1)(webpack@5.109.2)
+      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.109.2)
       colorette: 2.0.20
       commander: 12.1.0
       cross-spawn: 7.0.6
@@ -20886,34 +20727,13 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
     optionalDependencies:
       webpack-bundle-analyzer: 5.3.0
-      webpack-dev-server: 5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.108.1)
+      webpack-dev-server: 5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.109.2)
 
-  webpack-cli@6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.108.4):
-    dependencies:
-      '@discoveryjs/json-ext': 0.6.3
-      '@webpack-cli/configtest': 3.0.1(webpack-cli@6.0.1)(webpack@5.108.4)
-      '@webpack-cli/info': 3.0.1(webpack-cli@6.0.1)(webpack@5.108.4)
-      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.108.4)
-      colorette: 2.0.20
-      commander: 12.1.0
-      cross-spawn: 7.0.6
-      envinfo: 7.21.0
-      fastest-levenshtein: 1.0.16
-      import-local: 3.2.0
-      interpret: 3.1.1
-      rechoir: 0.8.0
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-      webpack-merge: 6.0.1
-    optionalDependencies:
-      webpack-bundle-analyzer: 5.3.0
-      webpack-dev-server: 5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.108.4)
-    optional: true
-
-  webpack-dev-middleware@6.1.3(webpack@5.108.4):
+  webpack-dev-middleware@6.1.3(webpack@5.109.2):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -20921,9 +20741,9 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.108.1):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.109.2):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.8(tslib@2.8.1)
@@ -20932,25 +20752,11 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.108.4):
-    dependencies:
-      colorette: 2.0.20
-      memfs: 4.57.8(tslib@2.8.1)
-      mime-types: 3.0.2
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      schema-utils: 4.3.3
-    optionalDependencies:
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-    transitivePeerDependencies:
-      - tslib
-    optional: true
-
-  webpack-dev-server@5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.108.1):
+  webpack-dev-server@5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.109.2):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -20978,58 +20784,17 @@ snapshots:
       serve-index: 1.9.2(supports-color@8.1.1)
       sockjs: 0.3.24
       spdy: 4.0.2(supports-color@8.1.1)
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.108.1)
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.109.2)
       ws: 8.21.1
     optionalDependencies:
-      webpack: 5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.108.1)
+      webpack: 5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.109.2)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - tslib
       - utf-8-validate
-
-  webpack-dev-server@5.2.4(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.108.4):
-    dependencies:
-      '@types/bonjour': 3.5.13
-      '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.25
-      '@types/express-serve-static-core': 4.19.8
-      '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.10
-      '@types/sockjs': 0.3.36
-      '@types/ws': 8.18.1
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.4.1
-      chokidar: 3.6.0
-      colorette: 2.0.20
-      compression: 1.8.1(supports-color@8.1.1)
-      connect-history-api-fallback: 2.0.0
-      express: 4.22.2(supports-color@8.1.1)
-      graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.10(@types/express@4.17.25)(debug@4.4.3)
-      ipaddr.js: 2.4.0
-      launch-editor: 2.14.1
-      open: 10.2.0
-      p-retry: 6.2.1
-      schema-utils: 4.3.3
-      selfsigned: 5.5.0
-      serve-index: 1.9.2(supports-color@8.1.1)
-      sockjs: 0.3.24
-      spdy: 4.0.2(supports-color@8.1.1)
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.108.4)
-      ws: 8.21.1
-    optionalDependencies:
-      webpack: 5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.108.4)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - tslib
-      - utf-8-validate
-    optional: true
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -21045,13 +20810,13 @@ snapshots:
 
   webpack-node-externals@3.0.0: {}
 
-  webpack-sources@3.5.0: {}
+  webpack-sources@3.5.1: {}
 
   webpack-stats-plugin@1.1.3: {}
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.108.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1):
+  webpack@5.109.2(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -21059,64 +20824,22 @@ snapshots:
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.17.0
-      acorn-import-phases: 1.0.4(acorn@8.17.0)
       browserslist: 4.28.5
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.0
+      enhanced-resolve: 5.24.5
       es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
       graceful-fs: 4.2.11
-      loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack@5.108.1)
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack@5.109.2)
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
       watchpack: 2.5.2
-      webpack-sources: 3.5.0
+      webpack-sources: 3.5.1
     optionalDependencies:
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.108.1)
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-
-  webpack@5.108.4(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack-cli@6.0.1):
-    dependencies:
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.17.0
-      acorn-import-phases: 1.0.4(acorn@8.17.0)
-      browserslist: 4.28.5
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.0
-      es-module-lexer: 2.1.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      graceful-fs: 4.2.11
-      loader-runner: 4.3.2
-      mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.41)(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.17)(uglify-js@3.19.3)(webpack@5.108.4)
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      watchpack: 2.5.2
-      webpack-sources: 3.5.0
-    optionalDependencies:
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.108.4)
+      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.109.2)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,8 +49,7 @@ catalog:
   vite: ^8.0.1
   vitest: ^4.1.0
   webpack-dev-server: ^5.2.4
-  # 14/07/26: pinning until https://github.com/webpack/webpack/pull/21407 is released
-  webpack: 5.108.1
+  webpack: ^5.109.0
 
 configDependencies:
   pnpm-plugin-sku: 0.0.3+sha512-XPcqT+jnn4oGgkUCMLSmlj3R367WTD6O8TlIufxAej7TfE28h4IOVWaJdqVWIq2QRqGoJxjCCXUhlT5Y0vIHaQ==


### PR DESCRIPTION
`webpack` was pinned in #1643 pending the release of https://github.com/webpack/webpack/pull/21407, which happened in `5.109.0`. That release was also significant for [other reasons](https://webpack.js.org/blog/2026-07-24-webpack-5-109/), notably built-in support for various asset types like CSS, TS and HTMl. Our config is opted-out of this new behaviour because we configure custom loaders for these assets, and nothing appears to have broken AFAICT, so I'm happy to unpin.

This also seems to fix errors in #1682 caused by multiple versions of webpack being installed.