### PR TITLE
Harden Vite SSR stream failure handling

### DIFF
--- a/openspec/changes/vite-ssr/design.md
+++ b/openspec/changes/vite-ssr/design.md
@@ -580,10 +580,32 @@ Docs (`configuration.md` + SSR product / Migrating) MUST state that both options
 ### 9. Full-document streaming
 
 React owns `<html>`, `<head>`, and `<body>`.
-Pipe on `onShellReady`.
-Optional `handle.waitForAll` waits for `onAllReady`.
-Abort on client disconnect.
 Client hydrates via `hydrateRoot(document, …)`.
+
+Default pipe is `onShellReady` (shell first, then deferred).
+Optional `handle.waitForAll` waits for `onAllReady` before the HTML body starts.
+
+**Commit is the point of no return.**
+Before sku pipes the document, the request must end as HTML (success or ErrorBoundary) or as a cancelled request.
+After pipe starts, sku MUST NOT start a second document.
+
+Loader / action errors already on the static context from `query()` render ErrorBoundary on the first pass (Decision 3).
+A throw from the React tree during `renderToPipeableStream` does not.
+React will not produce ErrorBoundary HTML on that first pass, and under `waitForAll` a rejected Suspense tree means `onAllReady` never settles.
+
+**Before commit**, sku recovers at most once: abort the failed attempt, put the error on a static context at the deepest rendered boundary, and render again so the nearest ErrorBoundary is the body (status 500, or the status of a route error response).
+That second pass is a normal errored-route render.
+If it cannot produce a document, fail the request (Express). Do not loop. Do not hang waiting for `onAllReady`.
+
+Client abort is not a render error and MUST NOT start recovery.
+The HTML middleware owns request liveness as one `AbortSignal`.
+The stream attempt honours it in every phase (Decision 18).
+
+**After commit**, disconnect aborts React.
+Insert / pipeline failures abort React and MUST be surfaced on `onError` — React’s `abort()` after the shell does not reliably call `onError` (Decision 21a owns the insert transform).
+Partial HTML on a live connection is inherent to streaming.
+
+Rejected: a sku-owned error-page API; treating `onError` after the shell as a new document; retrying on abort.
 
 ### 10. No `transformIndexHtml` on the SSR path
 
@@ -1088,7 +1110,14 @@ Loader-data prefetch stays out of scope.
 
 ### 18. Shared HTML middleware + loader/action headers
 
-Dev/prod share abort-before-write.
+The HTML middleware owns request liveness as one `AbortSignal` from disconnect (`req` aborted / `res` close).
+The stream attempt honours that signal in every phase (Decision 9).
+
+Before commit: abort, do not write the document body, do not start ErrorBoundary recovery, do not `next(error)` for the abort.
+After pipe starts: abort React. Do not start a second document.
+
+Dev/prod share this behaviour.
+
 On streamed HTML, forward `loaderHeaders` / `actionHeaders` (append; preserve `Set-Cookie`), then sku `Content-Type` / CSP.
 
 ### 19. Hydration payload safety
@@ -1648,6 +1677,12 @@ Client instrumentations MAY include `router` and `route` levels.
 | Duplicate queries after hydration                 | Fixture asserts server-run queries are served from the transported cache and that a post-hydration query still fetches.                                                                                         |
 | Wrong transport build resolved                    | Apollo ships separate `browser` / `node` condition builds and asserts on mismatch. Fixture exercises both `sku start` and production.                                                                           |
 | Injection lost under `waitForAll`                 | Buffer to `onAllReady` and write injected nodes in stream order. Covered by tests.                                                                                                                              |
+| `waitForAll` hangs on rejected Suspense           | Treat a render error while still buffering as pre-commit failure. Recover once via ErrorBoundary. Must not wait forever for `onAllReady`.                                                                       |
+| Render-error retry loops                          | Recover at most once. Abort / disconnect is not a render error and must not start recovery.                                                                                                                     |
+| Recovery pass hangs when it also errors           | Fail closed to Express if the ErrorBoundary pass cannot produce a document (including `waitForAll` errors that arrive via `onError`, not `onShellError`).                                                       |
+| Abort reported as Express 500                     | Middleware swallows rejection when the signal is aborted / the client is gone. Do not `next(error)` for disconnect.                                                                                             |
+| Silent post-shell abort                           | React `abort()` after the shell does not reliably call `onError`. Sku surfaces insert / pipeline failures on `onError` itself.                                                                                  |
+| RR private deepest-boundary id                    | Used only to place the recovered error on the static context. Fall back to the root route id; re-throw if none.                                                                                                 |
 | Transport module duplicated in graph              | Decision 26 (same as `getCspNonce` / preload / `SkuProvider`). Exclude stops `.vite/deps` clone. Public + private `#` paths share physical modules via `unbundle`.                                              |
 | Dual path under published install                 | `optimizeDeps.exclude` for `sku` + `sku/runtime` keeps app imports and sku `#` mounts on the same unbundled modules. Skip dedicated tarball e2e this pass.                                                      |
 | Trust proxy off unless configured                 | Opt-in `expressTrustProxy`. Template sets `true`. Other values via `onListen`.                                                                                                                                  |

--- a/openspec/changes/vite-ssr/specs/ssr/spec.md
+++ b/openspec/changes/vite-ssr/specs/ssr/spec.md
@@ -161,16 +161,89 @@ When a matched route sets `handle.waitForAll: true`, sku MUST wait for `onAllRea
 - **WHEN** a matched route has `handle.waitForAll: true`
 - **THEN** sku pipes the HTML body only after `onAllReady`
 
-### Requirement: Client disconnect aborts render before write
+### Requirement: Pre-commit render errors produce an ErrorBoundary document
 
-When the client disconnects before HTML headers are committed, sku MUST abort the stream and MUST NOT write the document body.
+A render error is a throw from the React tree during document SSR (a sync component throw, or a rejected Suspense tree).
 
-Dev and production MUST share this abort-before-write behaviour.
+This is distinct from a route error already recorded on the static handler context by `query()` (loaders / actions). Those remain the errored-route requirement below.
+
+Commit is the point of no return: sku starts the HTML body (pipes the document).
+
+When a render error occurs before commit, sku MUST still produce a streamed HTML document whose body is the nearest `ErrorBoundary` (or React Router’s default) and whose status is `500`, or the status of a route error response if the thrown value is one.
+
+Sku MUST NOT hang waiting for `onAllReady` when a render error occurs while buffering for `waitForAll`.
+
+Sku MUST attempt this recovery at most once per request. If recovery cannot produce a document, the render MUST fail and Express error handling MUST run.
+
+Client abort / disconnect MUST NOT be treated as a render error and MUST NOT start recovery.
+
+Sku MAY report the original render error to `onError` / `onShellError` even when recovery succeeds.
+
+#### Scenario: Sync throw before the shell is piped
+
+- **WHEN** a matched route component throws during SSR before the HTML body is committed
+- **THEN** the response is HTML with status 500
+- **AND** the body is the nearest `ErrorBoundary`
+
+#### Scenario: waitForAll Suspense rejection does not hang
+
+- **WHEN** a matched route has `handle.waitForAll: true`
+- **AND** a deferred tree rejects before `onAllReady`
+- **THEN** sku does not wait forever for `onAllReady`
+- **AND** the response is HTML with status 500
+- **AND** the body is the nearest `ErrorBoundary`
+
+#### Scenario: Recovery is once
+
+- **WHEN** the ErrorBoundary pass also fails to produce a document
+- **THEN** sku does not retry again
+- **AND** the render fails to Express error handling
+
+#### Scenario: Abort is not recovery
+
+- **WHEN** the request is aborted while a `waitForAll` render is still buffering
+- **THEN** sku does not render an ErrorBoundary document
+- **AND** sku does not treat that abort as a render error for Express
+
+### Requirement: Client disconnect aborts the render
+
+When the client disconnects before the HTML body is committed, sku MUST abort the stream and MUST NOT write the document body.
+
+When the client disconnects after piping has started, sku MUST abort the React stream.
+
+Disconnect MUST NOT be forwarded as an Express render error.
+
+Dev and production MUST share this behaviour.
 
 #### Scenario: Disconnect before headers
 
 - **WHEN** the client disconnects before HTML headers are committed
 - **THEN** sku aborts the stream and does not write the document body
+
+#### Scenario: Disconnect after piping starts
+
+- **WHEN** the client disconnects after sku has started piping the HTML body
+- **THEN** sku aborts the React stream
+
+#### Scenario: Disconnect during render is not an Express error
+
+- **WHEN** the client disconnects while render is still in progress
+- **THEN** sku does not call Express `next(error)` for that abort
+
+### Requirement: Post-commit pipe failures abort React
+
+After the HTML body is committed, sku MUST NOT start a second document.
+
+When the insert-html transform or the response pipe fails after commit, sku MUST abort the React stream and MUST surface that error through the render `onError` path.
+
+Partial HTML on a live connection is inherent to streaming.
+
+#### Scenario: Insert callback throw after shell
+
+- **WHEN** an `insertHtml` callback throws after the shell is ready
+- **THEN** sku aborts the React stream
+- **AND** the error is reported through `onError`
+- **AND** sku does not start a second HTML document
 
 ### Requirement: Loader and action Responses are forwarded
 
@@ -192,7 +265,9 @@ On streamed HTML (not a short-circuit `Response`), sku MUST forward `loaderHeade
 
 ### Requirement: Errored routes use the static handler status code
 
-Errored routes MUST use `context.statusCode` and the nearest `ErrorBoundary` (or React Router’s default).
+When React Router records a route error on the static handler context during `query()` (loader / action), sku MUST use `context.statusCode` and the nearest `ErrorBoundary` (or React Router’s default) on the first render pass.
+
+Throws during `renderToPipeableStream` are the pre-commit render-error requirement above, not this one.
 
 Sku MUST NOT provide a separate error-page API.
 

--- a/openspec/changes/vite-ssr/tasks.md
+++ b/openspec/changes/vite-ssr/tasks.md
@@ -54,7 +54,7 @@ It is not a history of intermediate APIs.
 - [x] 5.8 Promise-scrub loader/action data. Strip production `Error.stack`. Harden Express→Fetch adapter.
 - [x] 5.9 Hydrate client from bootstrap `site` (same as SSR). Call optional `onHydrate({ clientContext })` only.
 - [x] 5.10 Stream commit point: one ErrorBoundary recovery before the HTML body starts; abort is not recovery; post-commit insert/pipeline abort surfaces `onError`; disconnect after pipe aborts React.
-- [ ] 5.11 Fail closed when that recovery pass cannot produce a document (must not hang on `waitForAll`).
+- [x] 5.11 Fail closed when that recovery pass cannot produce a document (must not hang on `waitForAll`).
 
 ## 6. Assets, `publicPath`, and production layout
 

--- a/openspec/changes/vite-ssr/tasks.md
+++ b/openspec/changes/vite-ssr/tasks.md
@@ -53,6 +53,8 @@ It is not a history of intermediate APIs.
 - [x] 5.7 Mount `telemetryPlugin` with `type: 'ssr'`. Deliver page-load + HMR clients via client entry / bootstrap.
 - [x] 5.8 Promise-scrub loader/action data. Strip production `Error.stack`. Harden Express→Fetch adapter.
 - [x] 5.9 Hydrate client from bootstrap `site` (same as SSR). Call optional `onHydrate({ clientContext })` only.
+- [x] 5.10 Stream commit point: one ErrorBoundary recovery before the HTML body starts; abort is not recovery; post-commit insert/pipeline abort surfaces `onError`; disconnect after pipe aborts React.
+- [ ] 5.11 Fail closed when that recovery pass cannot produce a document (must not hang on `waitForAll`).
 
 ## 6. Assets, `publicPath`, and production layout
 
@@ -99,6 +101,7 @@ It is not a history of intermediate APIs.
 - [x] 11.7 Tests: site filtering, soft-default `'default'`, fail-closed unknown site, foreign-site path does not match, catch-all middleware does not block assets under `publicPath`.
 - [x] 11.8 Tests: production server starts and streams without sibling `client/` when baked manifest is present. Dual-context / `sku/runtime` identity stays green under workspace link.
 - [x] 11.9 Fixture `PreloadingLink` on `usePreloadRoute`. Production hover warms lazy chunk. Foreign-site path does not warm.
+- [x] 11.10 Tests: sync throw → ErrorBoundary; `waitForAll` sync / Suspense → ErrorBoundary; abort-before-render; abort during `waitForAll` does not retry; `insertHtml` throw aborts and `onError`; disconnect after pipe; disconnect does not `next(error)`.
 
 ## 12. Create template
 

--- a/packages/sku/src/services/vite/ssr/insertHtml.stream.test.tsx
+++ b/packages/sku/src/services/vite/ssr/insertHtml.stream.test.tsx
@@ -1,7 +1,7 @@
 import { Writable } from 'node:stream';
 import { Suspense, use, cache } from 'react';
 import type { Request as ExpressRequest } from 'express';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { buildSiteStaticHandlers } from './buildSiteStaticHandlers.js';
 import { render } from './render.js';
@@ -18,8 +18,10 @@ const getSite = () => 'au';
 
 const renderToHtml = async ({
   routes,
+  onError,
 }: {
   routes: Parameters<typeof buildSiteStaticHandlers>[0]['au'];
+  onError?: (error: unknown) => void;
 }) => {
   const result = await render({
     siteStaticHandlers: buildSiteStaticHandlers({ au: routes }),
@@ -27,6 +29,7 @@ const renderToHtml = async ({
     req: { path: '/' } as ExpressRequest,
     assets,
     getSite,
+    options: onError ? { onError } : undefined,
   });
 
   if ('response' in result) {
@@ -120,6 +123,7 @@ describe('insertHtml stream injection', () => {
 
   it('aborts the React stream when an insertion callback throws', async () => {
     const insertionError = new Error('Unable to serialize inserted state');
+    const onError = vi.fn();
     const ThrowingInjectingPage = () => {
       const insertHtml = useInsertHtml();
       insertHtml(() => {
@@ -131,8 +135,10 @@ describe('insertHtml stream injection', () => {
     await expect(
       renderToHtml({
         routes: [{ path: '/', Component: ThrowingInjectingPage }],
+        onError,
       }),
     ).rejects.toBe(insertionError);
+    expect(onError).toHaveBeenCalledWith(insertionError);
 
     const { html } = await renderToHtml({
       routes: [

--- a/packages/sku/src/services/vite/ssr/insertHtml.stream.test.tsx
+++ b/packages/sku/src/services/vite/ssr/insertHtml.stream.test.tsx
@@ -118,6 +118,30 @@ describe('insertHtml stream injection', () => {
     expect(html).toContain('>deferred<');
   });
 
+  it('aborts the React stream when an insertion callback throws', async () => {
+    const insertionError = new Error('Unable to serialize inserted state');
+    const ThrowingInjectingPage = () => {
+      const insertHtml = useInsertHtml();
+      insertHtml(() => {
+        throw insertionError;
+      });
+      return <main>page</main>;
+    };
+
+    await expect(
+      renderToHtml({
+        routes: [{ path: '/', Component: ThrowingInjectingPage }],
+      }),
+    ).rejects.toBe(insertionError);
+
+    const { html } = await renderToHtml({
+      routes: [
+        { path: '/', Component: () => <InjectingPage marker="recovered" /> },
+      ],
+    });
+    expect(html).toContain('data-marker="recovered"');
+  });
+
   it('allows injected scripts to carry a CSP nonce from getCspNonce', async () => {
     const { createSsrRequestContextStore } =
       await import('./createSsrRequestContextStore.js');

--- a/packages/sku/src/services/vite/ssr/render.test.tsx
+++ b/packages/sku/src/services/vite/ssr/render.test.tsx
@@ -393,6 +393,101 @@ describe('render', () => {
     expect(html).toContain('Suspense recovered');
   });
 
+  it('fails closed when waitForAll ErrorBoundary recovery throws', async () => {
+    const Boom = () => {
+      throw new Error('Boom from render');
+    };
+    const ErrorBoundary = () => {
+      throw new Error('Boom from ErrorBoundary');
+    };
+    const Layout = () => <Outlet />;
+    const handlers = buildSiteStaticHandlers({
+      au: [
+        {
+          Component: Layout,
+          ErrorBoundary,
+          children: [
+            {
+              index: true,
+              Component: Boom,
+              handle: { waitForAll: true },
+            },
+          ],
+        },
+      ],
+    });
+    const onError = vi.fn();
+    const onShellError = vi.fn();
+
+    await expect(
+      render({
+        siteStaticHandlers: handlers,
+        request: new Request('http://localhost/'),
+        req: { path: '/' } as ExpressRequest,
+        assets,
+        getSite,
+        options: { onError, onShellError },
+      }),
+    ).rejects.toThrow('Boom from ErrorBoundary');
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('fails closed when waitForAll ErrorBoundary recovery rejects under Suspense', async () => {
+    const getRejected = (message: string) =>
+      new Promise<string>((_resolve, reject) => {
+        setTimeout(() => {
+          reject(new Error(message));
+        }, 20);
+      });
+
+    let pagePending: Promise<string> | undefined;
+    const DeferredBoom = () => {
+      pagePending ??= getRejected('Boom from suspense');
+      return <p>{use(pagePending)}</p>;
+    };
+
+    let boundaryPending: Promise<string> | undefined;
+    const ErrorBoundary = () => {
+      boundaryPending ??= getRejected('Boom from ErrorBoundary');
+      return <p>{use(boundaryPending)}</p>;
+    };
+    const Layout = () => <Outlet />;
+    const handlers = buildSiteStaticHandlers({
+      au: [
+        {
+          Component: Layout,
+          ErrorBoundary,
+          children: [
+            {
+              index: true,
+              Component: () => (
+                <Suspense fallback={<p>Loading</p>}>
+                  <DeferredBoom />
+                </Suspense>
+              ),
+              handle: { waitForAll: true },
+            },
+          ],
+        },
+      ],
+    });
+    const onError = vi.fn();
+    const onShellError = vi.fn();
+
+    await expect(
+      render({
+        siteStaticHandlers: handlers,
+        request: new Request('http://localhost/'),
+        req: { path: '/' } as ExpressRequest,
+        assets,
+        getSite,
+        options: { onError, onShellError },
+      }),
+    ).rejects.toThrow('Boom from ErrorBoundary');
+    expect(onError).toHaveBeenCalled();
+    expect(onShellError).not.toHaveBeenCalled();
+  });
+
   it('rejects promptly when the render signal is already aborted', async () => {
     const controller = new AbortController();
     const reason = new Error('Already disconnected');
@@ -419,7 +514,7 @@ describe('render', () => {
   });
 
   it('does not retry a pending waitForAll render after signal abort', async () => {
-    const never = new Promise<string>(() => {});
+    const never = new Promise<string>(() => { });
     const Suspended = () => <p>{use(never)}</p>;
     const renderErrorBoundary = vi.fn();
     const ErrorBoundary = () => {

--- a/packages/sku/src/services/vite/ssr/render.test.tsx
+++ b/packages/sku/src/services/vite/ssr/render.test.tsx
@@ -3,7 +3,7 @@ import { Writable } from 'node:stream';
 import type { Request as ExpressRequest } from 'express';
 import { Suspense, use } from 'react';
 import { Outlet, RouterContextProvider } from 'react-router';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { buildSiteStaticHandlers } from './buildSiteStaticHandlers.js';
 import { createSkuContexts } from './skuContext.js';
@@ -199,7 +199,7 @@ describe('render', () => {
     );
   });
 
-  it('recovers sync render throws via a second ErrorBoundary pass', async () => {
+  it('recovers waitForAll sync render throws via a second ErrorBoundary pass', async () => {
     const Boom = () => {
       throw new Error('Boom from render');
     };
@@ -212,10 +212,18 @@ describe('render', () => {
         {
           Component: Layout,
           ErrorBoundary,
-          children: [{ index: true, Component: Boom }],
+          children: [
+            {
+              index: true,
+              Component: Boom,
+              handle: { waitForAll: true },
+            },
+          ],
         },
       ],
     });
+    const onError = vi.fn();
+    const onShellError = vi.fn();
 
     const result = await render({
       siteStaticHandlers: handlers,
@@ -223,6 +231,7 @@ describe('render', () => {
       req: { path: '/' } as ExpressRequest,
       assets,
       getSite,
+      options: { onError, onShellError },
     });
 
     if ('response' in result) {
@@ -250,6 +259,8 @@ describe('render', () => {
     const html = Buffer.concat(chunks).toString('utf-8');
     expect(html).toContain('data-testid="error-boundary"');
     expect(html).toContain('Boom recovered');
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onShellError).not.toHaveBeenCalled();
   });
 
   it('recovers waitForAll Suspense rejections via a second ErrorBoundary pass', async () => {
@@ -322,5 +333,83 @@ describe('render', () => {
     const html = Buffer.concat(chunks).toString('utf-8');
     expect(html).toContain('data-testid="error-boundary"');
     expect(html).toContain('Suspense recovered');
+  });
+
+  it('rejects promptly when the render signal is already aborted', async () => {
+    const controller = new AbortController();
+    const reason = new Error('Already disconnected');
+    controller.abort(reason);
+    const onError = vi.fn();
+    const onShellError = vi.fn();
+
+    await expect(
+      render({
+        siteStaticHandlers,
+        request: new Request('http://localhost/'),
+        req: { path: '/' } as ExpressRequest,
+        assets,
+        getSite,
+        options: {
+          signal: controller.signal,
+          onError,
+          onShellError,
+        },
+      }),
+    ).rejects.toBe(reason);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onShellError).not.toHaveBeenCalled();
+  });
+
+  it('does not retry a pending waitForAll render after signal abort', async () => {
+    const never = new Promise<string>(() => {});
+    const Suspended = () => <p>{use(never)}</p>;
+    const renderErrorBoundary = vi.fn();
+    const ErrorBoundary = () => {
+      renderErrorBoundary();
+      return <main>Should not render</main>;
+    };
+    const handlers = buildSiteStaticHandlers({
+      au: [
+        {
+          ErrorBoundary,
+          Component: () => <Outlet />,
+          children: [
+            {
+              index: true,
+              Component: () => (
+                <Suspense fallback={<p>Loading</p>}>
+                  <Suspended />
+                </Suspense>
+              ),
+              handle: { waitForAll: true },
+            },
+          ],
+        },
+      ],
+    });
+    const controller = new AbortController();
+    const reason = new Error('Client disconnected');
+    const onError = vi.fn();
+    const onShellError = vi.fn();
+
+    const result = render({
+      siteStaticHandlers: handlers,
+      request: new Request('http://localhost/'),
+      req: { path: '/' } as ExpressRequest,
+      assets,
+      getSite,
+      options: {
+        signal: controller.signal,
+        onError,
+        onShellError,
+      },
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    controller.abort(reason);
+
+    await expect(result).rejects.toBe(reason);
+    expect(renderErrorBoundary).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(onShellError).not.toHaveBeenCalled();
   });
 });

--- a/packages/sku/src/services/vite/ssr/render.test.tsx
+++ b/packages/sku/src/services/vite/ssr/render.test.tsx
@@ -199,6 +199,64 @@ describe('render', () => {
     );
   });
 
+  it('recovers sync render throws via a second ErrorBoundary pass', async () => {
+    const Boom = () => {
+      throw new Error('Boom from render');
+    };
+    const ErrorBoundary = () => (
+      <main data-testid="error-boundary">Boom recovered</main>
+    );
+    const Layout = () => <Outlet />;
+    const handlers = buildSiteStaticHandlers({
+      au: [
+        {
+          Component: Layout,
+          ErrorBoundary,
+          children: [{ index: true, Component: Boom }],
+        },
+      ],
+    });
+    const onError = vi.fn();
+    const onShellError = vi.fn();
+
+    const result = await render({
+      siteStaticHandlers: handlers,
+      request: new Request('http://localhost/'),
+      req: { path: '/' } as ExpressRequest,
+      assets,
+      getSite,
+      options: { onError, onShellError },
+    });
+
+    if ('response' in result) {
+      throw new Error('Expected a streamed document, not a Response');
+    }
+
+    expect(result.statusCode).toBe(500);
+
+    const chunks: Buffer[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const writable = new Writable({
+        write(chunk, _encoding, callback) {
+          chunks.push(Buffer.from(chunk));
+          callback();
+        },
+        final(callback) {
+          callback();
+          resolve();
+        },
+      });
+      writable.on('error', reject);
+      result.pipe(writable);
+    });
+
+    const html = Buffer.concat(chunks).toString('utf-8');
+    expect(html).toContain('data-testid="error-boundary"');
+    expect(html).toContain('Boom recovered');
+    expect(onShellError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
   it('recovers waitForAll sync render throws via a second ErrorBoundary pass', async () => {
     const Boom = () => {
       throw new Error('Boom from render');

--- a/packages/sku/src/services/vite/ssr/ssrServerShared.test.ts
+++ b/packages/sku/src/services/vite/ssr/ssrServerShared.test.ts
@@ -13,10 +13,25 @@ import {
 } from './ssrServerShared.js';
 import type { RenderResult } from './types.js';
 
+const createMockReq = (overrides: Record<string, unknown> = {}): Request =>
+  Object.assign(
+    new EventEmitter(),
+    {
+      protocol: 'http',
+      originalUrl: '/',
+      method: 'GET',
+      get: () => 'localhost',
+      headers: {},
+      aborted: false,
+    },
+    overrides,
+  ) as unknown as Request;
+
 const createMockRes = (): Response => {
   const headers: Record<string, string | string[]> = {};
   const res = new EventEmitter() as any;
   res.writableEnded = false;
+  res.destroyed = false;
   res.setHeader = vi.fn((name: string, value: unknown) => {
     headers[String(name).toLowerCase()] = value as string | string[];
     return res;
@@ -173,13 +188,7 @@ describe('createHtmlRenderMiddleware abort-before-write', () => {
       development: true,
     });
 
-    const req = {
-      protocol: 'http',
-      originalUrl: '/',
-      method: 'GET',
-      get: () => 'localhost',
-      headers: {},
-    } as unknown as Request;
+    const req = createMockReq();
     const res = createMockRes();
     const next = vi.fn();
 
@@ -206,6 +215,146 @@ describe('createHtmlRenderMiddleware abort-before-write', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it('does not render when middleware starts after the request disconnected', async () => {
+    const render = vi.fn<RenderFunction>();
+    const middleware = createHtmlRenderMiddleware({
+      render,
+      assets: { bootstrapModules: [], css: [], modulePreloads: [] },
+      cspEnabled: false,
+      cspExtraScriptSrcHosts: [],
+      cspReportOnlyEnabled: false,
+      cspReportOnlyExtraScriptSrcHosts: [],
+      development: true,
+    });
+    const req = createMockReq({ aborted: true });
+    const res = createMockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(render).not.toHaveBeenCalled();
+    expect(res.set).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('does not forward a Response resolved after disconnect', async () => {
+    let resolveRender!: (result: RenderResult) => void;
+    const renderPromise = new Promise<RenderResult>((resolve) => {
+      resolveRender = resolve;
+    });
+    const middleware = createHtmlRenderMiddleware({
+      render: async () => renderPromise,
+      assets: { bootstrapModules: [], css: [], modulePreloads: [] },
+      cspEnabled: false,
+      cspExtraScriptSrcHosts: [],
+      cspReportOnlyEnabled: false,
+      cspReportOnlyExtraScriptSrcHosts: [],
+      development: true,
+    });
+    const req = createMockReq();
+    const res = createMockRes();
+    const next = vi.fn();
+
+    const done = middleware(req, res, next);
+    res.emit('close');
+    resolveRender({
+      response: new globalThis.Response('Too late', {
+        status: 302,
+        headers: { Location: '/elsewhere' },
+      }),
+    });
+
+    await done;
+
+    expect(res.append).not.toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.end).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('aborts React when the request disconnects after piping starts', async () => {
+    const abort = vi.fn();
+    const pipe = vi.fn();
+    const middleware = createHtmlRenderMiddleware({
+      render: async () => ({
+        pipe,
+        abort,
+        statusCode: 200,
+        headers: new Headers(),
+        inlineScripts: [],
+      }),
+      assets: { bootstrapModules: [], css: [], modulePreloads: [] },
+      cspEnabled: false,
+      cspExtraScriptSrcHosts: [],
+      cspReportOnlyEnabled: false,
+      cspReportOnlyExtraScriptSrcHosts: [],
+      development: true,
+    });
+    const req = createMockReq();
+    const res = createMockRes();
+
+    await middleware(req, res, vi.fn());
+    req.emit('aborted');
+    res.emit('close');
+
+    expect(pipe).toHaveBeenCalledWith(res);
+    expect(abort).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards a connected render rejection to Express unchanged', async () => {
+    const error = new Error('Render failed');
+    const onRenderError = vi.fn();
+    const next = vi.fn();
+    const middleware = createHtmlRenderMiddleware({
+      render: async () => {
+        throw error;
+      },
+      assets: { bootstrapModules: [], css: [], modulePreloads: [] },
+      cspEnabled: false,
+      cspExtraScriptSrcHosts: [],
+      cspReportOnlyEnabled: false,
+      cspReportOnlyExtraScriptSrcHosts: [],
+      development: true,
+      onRenderError,
+    });
+
+    await middleware(createMockReq(), createMockRes(), next);
+
+    expect(onRenderError).toHaveBeenCalledTimes(1);
+    expect(onRenderError).toHaveBeenCalledWith(error);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(error);
+  });
+
+  it('suppresses a render rejection after disconnect', async () => {
+    let rejectRender!: (error: Error) => void;
+    const renderPromise = new Promise<RenderResult>((_resolve, reject) => {
+      rejectRender = reject;
+    });
+    const onRenderError = vi.fn();
+    const next = vi.fn();
+    const middleware = createHtmlRenderMiddleware({
+      render: async () => renderPromise,
+      assets: { bootstrapModules: [], css: [], modulePreloads: [] },
+      cspEnabled: false,
+      cspExtraScriptSrcHosts: [],
+      cspReportOnlyEnabled: false,
+      cspReportOnlyExtraScriptSrcHosts: [],
+      development: true,
+      onRenderError,
+    });
+    const req = createMockReq();
+    const res = createMockRes();
+
+    const done = middleware(req, res, next);
+    res.emit('close');
+    rejectRender(new Error('Aborted render'));
+    await done;
+
+    expect(onRenderError).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it('omits nonce from CSP headers when none was requested', async () => {
     const middleware = createHtmlRenderMiddleware({
       render: async () => ({
@@ -223,13 +372,7 @@ describe('createHtmlRenderMiddleware abort-before-write', () => {
       development: false,
     });
 
-    const req = {
-      protocol: 'http',
-      originalUrl: '/',
-      method: 'GET',
-      get: () => 'localhost',
-      headers: {},
-    } as unknown as Request;
+    const req = createMockReq();
     const res = createMockRes();
 
     await middleware(req, res, vi.fn());
@@ -258,13 +401,7 @@ describe('createHtmlRenderMiddleware abort-before-write', () => {
       development: false,
     });
 
-    const req = {
-      protocol: 'http',
-      originalUrl: '/set-cookie',
-      method: 'GET',
-      get: () => 'localhost',
-      headers: {},
-    } as unknown as Request;
+    const req = createMockReq({ originalUrl: '/set-cookie' });
     const res = createMockRes();
 
     await middleware(req, res, vi.fn());
@@ -295,15 +432,11 @@ describe('createHtmlRenderMiddleware abort-before-write', () => {
       development: true,
     });
 
-    const req = {
-      protocol: 'http',
+    const req = createMockReq({
       originalUrl: '/about?x=1',
-      method: 'GET',
       path: '/about',
-      get: () => 'localhost',
-      headers: {},
       skuUserId: 'from-middleware',
-    } as unknown as Request;
+    });
     const res = createMockRes();
 
     await middleware(req, res, vi.fn());

--- a/packages/sku/src/services/vite/ssr/ssrServerShared.ts
+++ b/packages/sku/src/services/vite/ssr/ssrServerShared.ts
@@ -303,7 +303,7 @@ export const createHtmlRenderMiddleware =
         }),
       });
       res.status(result.statusCode);
-      controller.signal.addEventListener('abort', result.abort, {
+      controller.signal.addEventListener('abort', () => result.abort(), {
         once: true,
       });
       result.pipe(res);

--- a/packages/sku/src/services/vite/ssr/ssrServerShared.ts
+++ b/packages/sku/src/services/vite/ssr/ssrServerShared.ts
@@ -206,6 +206,9 @@ export const sendResponse = async (
   }
 };
 
+const isDisconnected = (req: Request, res: Response): boolean =>
+  req.aborted || res.destroyed;
+
 export const createHtmlRenderMiddleware =
   ({
     render,
@@ -234,13 +237,23 @@ export const createHtmlRenderMiddleware =
     | 'onRenderError'
   >): RequestHandler =>
   async (req, res, next) => {
+    if (isDisconnected(req, res)) {
+      return;
+    }
+
     const controller = new AbortController();
-    const onClose = () => {
+    const onDisconnect = () => {
       if (!res.writableEnded) {
         controller.abort();
       }
     };
-    res.once('close', onClose);
+    req.once('aborted', onDisconnect);
+    res.once('close', onDisconnect);
+
+    if (isDisconnected(req, res)) {
+      onDisconnect();
+      return;
+    }
 
     try {
       const requestContextStore =
@@ -258,12 +271,16 @@ export const createHtmlRenderMiddleware =
         manifest,
       );
 
-      if ('response' in result) {
-        await sendResponse(result.response, res);
+      if (controller.signal.aborted || isDisconnected(req, res)) {
+        controller.abort();
+        if (!('response' in result)) {
+          result.abort();
+        }
         return;
       }
-      if (controller.signal.aborted) {
-        result.abort();
+
+      if ('response' in result) {
+        await sendResponse(result.response, res);
         return;
       }
 
@@ -291,7 +308,7 @@ export const createHtmlRenderMiddleware =
       });
       result.pipe(res);
     } catch (error) {
-      if (controller.signal.aborted) {
+      if (controller.signal.aborted || isDisconnected(req, res)) {
         return;
       }
       onRenderError?.(error as Error);

--- a/packages/sku/src/services/vite/ssr/streamDocument.tsx
+++ b/packages/sku/src/services/vite/ssr/streamDocument.tsx
@@ -201,10 +201,12 @@ export const streamDocument = ({
             return;
           }
           options.onError?.(error);
-          // Suspense rejections never settle for onAllReady; retry once we
-          // see the error while still buffering for waitForAll.
-          if (waitForAll && state === 'rendering') {
-            retryFromError(error);
+          // Suspense rejections never settle for onAllReady. Recover once
+          // while still buffering; fail closed if this pass cannot produce
+          // a document (recovery has allowErrorRetry: false).
+          if (waitForAll && state === 'rendering' && !retryFromError(error)) {
+            rejectAttempt(error);
+            abortStream();
           }
         },
       },

--- a/packages/sku/src/services/vite/ssr/streamDocument.tsx
+++ b/packages/sku/src/services/vite/ssr/streamDocument.tsx
@@ -35,8 +35,16 @@ export type StreamDocumentArgs = {
   allowErrorRetry: boolean;
 };
 
+const RENDER_ATTEMPT_STATE = {
+  RENDERING: 'rendering',
+  RETRYING: 'retrying',
+  READY: 'ready',
+  ABORTED: 'aborted',
+  FAILED: 'failed',
+} as const;
+
 type RenderAttemptState =
-  'rendering' | 'retrying' | 'ready' | 'aborted' | 'failed';
+  (typeof RENDER_ATTEMPT_STATE)[keyof typeof RENDER_ATTEMPT_STATE];
 
 export const streamDocument = ({
   renderContext,
@@ -68,7 +76,7 @@ export const streamDocument = ({
   const insertHtmlQueue = createInsertHtmlQueue();
 
   return new Promise((resolve, reject) => {
-    let state: RenderAttemptState = 'rendering';
+    let state: RenderAttemptState = RENDER_ATTEMPT_STATE.RENDERING;
     let streamAborted = false;
     let removeAbortListener = () => {};
 
@@ -81,19 +89,19 @@ export const streamDocument = ({
     };
 
     const rejectAttempt = (error: unknown) => {
-      if (state !== 'rendering') {
+      if (state !== RENDER_ATTEMPT_STATE.RENDERING) {
         return;
       }
-      state = 'failed';
+      state = RENDER_ATTEMPT_STATE.FAILED;
       removeAbortListener();
       reject(error);
     };
 
     const retryFromError = (error: unknown) => {
-      if (!allowErrorRetry || state !== 'rendering') {
+      if (!allowErrorRetry || state !== RENDER_ATTEMPT_STATE.RENDERING) {
         return false;
       }
-      state = 'retrying';
+      state = RENDER_ATTEMPT_STATE.RETRYING;
       removeAbortListener();
       abortStream();
 
@@ -148,10 +156,10 @@ export const streamDocument = ({
         bootstrapScriptContent,
         nonce,
         onShellReady() {
-          if (waitForAll || state !== 'rendering') {
+          if (waitForAll || state !== RENDER_ATTEMPT_STATE.RENDERING) {
             return;
           }
-          state = 'ready';
+          state = RENDER_ATTEMPT_STATE.READY;
           resolve({
             pipe: wrapPipeWithInsertHtml(
               stream.pipe.bind(stream),
@@ -165,10 +173,10 @@ export const streamDocument = ({
           });
         },
         onAllReady() {
-          if (!waitForAll || state !== 'rendering') {
+          if (!waitForAll || state !== RENDER_ATTEMPT_STATE.RENDERING) {
             return;
           }
-          state = 'ready';
+          state = RENDER_ATTEMPT_STATE.READY;
           resolve({
             pipe: wrapPipeWithInsertHtml(
               stream.pipe.bind(stream),
@@ -182,7 +190,7 @@ export const streamDocument = ({
           });
         },
         onShellError(error) {
-          if (state !== 'rendering') {
+          if (state !== RENDER_ATTEMPT_STATE.RENDERING) {
             return;
           }
           options.onShellError?.(error);
@@ -192,13 +200,16 @@ export const streamDocument = ({
           rejectAttempt(error);
         },
         onError(error) {
-          if (state !== 'rendering' && state !== 'ready') {
+          if (
+            state !== RENDER_ATTEMPT_STATE.RENDERING &&
+            state !== RENDER_ATTEMPT_STATE.READY
+          ) {
             return;
           }
           options.onError?.(error);
           // Suspense rejections never settle for onAllReady; retry once we
           // see the error while still buffering for waitForAll.
-          if (waitForAll && state === 'rendering') {
+          if (waitForAll && state === RENDER_ATTEMPT_STATE.RENDERING) {
             retryFromError(error);
           }
         },
@@ -207,10 +218,14 @@ export const streamDocument = ({
 
     const signal = options.signal;
     const abortFromSignal = () => {
-      if (state === 'retrying' || state === 'aborted' || state === 'failed') {
+      if (
+        state === RENDER_ATTEMPT_STATE.RETRYING ||
+        state === RENDER_ATTEMPT_STATE.ABORTED ||
+        state === RENDER_ATTEMPT_STATE.FAILED
+      ) {
         return;
       }
-      state = 'aborted';
+      state = RENDER_ATTEMPT_STATE.ABORTED;
       abortStream();
       reject(
         signal?.reason ??

--- a/packages/sku/src/services/vite/ssr/streamDocument.tsx
+++ b/packages/sku/src/services/vite/ssr/streamDocument.tsx
@@ -35,16 +35,8 @@ export type StreamDocumentArgs = {
   allowErrorRetry: boolean;
 };
 
-const RENDER_ATTEMPT_STATE = {
-  RENDERING: 'rendering',
-  RETRYING: 'retrying',
-  READY: 'ready',
-  ABORTED: 'aborted',
-  FAILED: 'failed',
-} as const;
-
 type RenderAttemptState =
-  (typeof RENDER_ATTEMPT_STATE)[keyof typeof RENDER_ATTEMPT_STATE];
+  'rendering' | 'retrying' | 'ready' | 'aborted' | 'failed';
 
 export const streamDocument = ({
   renderContext,
@@ -76,32 +68,37 @@ export const streamDocument = ({
   const insertHtmlQueue = createInsertHtmlQueue();
 
   return new Promise((resolve, reject) => {
-    let state: RenderAttemptState = RENDER_ATTEMPT_STATE.RENDERING;
+    let state: RenderAttemptState = 'rendering';
     let streamAborted = false;
-    let removeAbortListener = () => {};
+    let removeAbortListener = () => { };
 
-    const abortStream = () => {
+    const abortStream = (reason?: unknown) => {
       if (streamAborted) {
         return;
       }
       streamAborted = true;
-      stream.abort();
+      stream.abort(reason);
+      // After the shell, React abort() does not call onError unless abortable
+      // work remains. Surface insert/pipeline failures ourselves.
+      if (state === 'ready' && reason !== undefined) {
+        options.onError?.(reason);
+      }
     };
 
     const rejectAttempt = (error: unknown) => {
-      if (state !== RENDER_ATTEMPT_STATE.RENDERING) {
+      if (state !== 'rendering') {
         return;
       }
-      state = RENDER_ATTEMPT_STATE.FAILED;
+      state = 'failed';
       removeAbortListener();
       reject(error);
     };
 
     const retryFromError = (error: unknown) => {
-      if (!allowErrorRetry || state !== RENDER_ATTEMPT_STATE.RENDERING) {
+      if (!allowErrorRetry || state !== 'rendering') {
         return false;
       }
-      state = RENDER_ATTEMPT_STATE.RETRYING;
+      state = 'retrying';
       removeAbortListener();
       abortStream();
 
@@ -156,10 +153,10 @@ export const streamDocument = ({
         bootstrapScriptContent,
         nonce,
         onShellReady() {
-          if (waitForAll || state !== RENDER_ATTEMPT_STATE.RENDERING) {
+          if (waitForAll || state !== 'rendering') {
             return;
           }
-          state = RENDER_ATTEMPT_STATE.READY;
+          state = 'ready';
           resolve({
             pipe: wrapPipeWithInsertHtml(
               stream.pipe.bind(stream),
@@ -173,10 +170,10 @@ export const streamDocument = ({
           });
         },
         onAllReady() {
-          if (!waitForAll || state !== RENDER_ATTEMPT_STATE.RENDERING) {
+          if (!waitForAll || state !== 'rendering') {
             return;
           }
-          state = RENDER_ATTEMPT_STATE.READY;
+          state = 'ready';
           resolve({
             pipe: wrapPipeWithInsertHtml(
               stream.pipe.bind(stream),
@@ -190,7 +187,7 @@ export const streamDocument = ({
           });
         },
         onShellError(error) {
-          if (state !== RENDER_ATTEMPT_STATE.RENDERING) {
+          if (state !== 'rendering') {
             return;
           }
           options.onShellError?.(error);
@@ -200,16 +197,13 @@ export const streamDocument = ({
           rejectAttempt(error);
         },
         onError(error) {
-          if (
-            state !== RENDER_ATTEMPT_STATE.RENDERING &&
-            state !== RENDER_ATTEMPT_STATE.READY
-          ) {
+          if (state !== 'rendering' && state !== 'ready') {
             return;
           }
           options.onError?.(error);
           // Suspense rejections never settle for onAllReady; retry once we
           // see the error while still buffering for waitForAll.
-          if (waitForAll && state === RENDER_ATTEMPT_STATE.RENDERING) {
+          if (waitForAll && state === 'rendering') {
             retryFromError(error);
           }
         },
@@ -218,19 +212,15 @@ export const streamDocument = ({
 
     const signal = options.signal;
     const abortFromSignal = () => {
-      if (
-        state === RENDER_ATTEMPT_STATE.RETRYING ||
-        state === RENDER_ATTEMPT_STATE.ABORTED ||
-        state === RENDER_ATTEMPT_STATE.FAILED
-      ) {
+      if (state === 'retrying' || state === 'aborted' || state === 'failed') {
         return;
       }
-      state = RENDER_ATTEMPT_STATE.ABORTED;
-      abortStream();
-      reject(
+      state = 'aborted';
+      const reason =
         signal?.reason ??
-          new DOMException('The render was aborted', 'AbortError'),
-      );
+        new DOMException('The render was aborted', 'AbortError');
+      abortStream(reason);
+      reject(reason);
     };
 
     if (signal?.aborted) {
@@ -240,7 +230,7 @@ export const streamDocument = ({
       removeAbortListener = () =>
         signal.removeEventListener('abort', abortFromSignal);
     } else {
-      removeAbortListener = () => {};
+      removeAbortListener = () => { };
     }
   });
 };

--- a/packages/sku/src/services/vite/ssr/streamDocument.tsx
+++ b/packages/sku/src/services/vite/ssr/streamDocument.tsx
@@ -35,6 +35,9 @@ export type StreamDocumentArgs = {
   allowErrorRetry: boolean;
 };
 
+type RenderAttemptState =
+  'rendering' | 'retrying' | 'ready' | 'aborted' | 'failed';
+
 export const streamDocument = ({
   renderContext,
   dataRoutes,
@@ -65,34 +68,62 @@ export const streamDocument = ({
   const insertHtmlQueue = createInsertHtmlQueue();
 
   return new Promise((resolve, reject) => {
-    let ready = false;
-    let abortedForRetry = false;
+    let state: RenderAttemptState = 'rendering';
+    let streamAborted = false;
+    let removeAbortListener = () => {};
+
+    const abortStream = () => {
+      if (streamAborted) {
+        return;
+      }
+      streamAborted = true;
+      stream.abort();
+    };
+
+    const rejectAttempt = (error: unknown) => {
+      if (state !== 'rendering') {
+        return;
+      }
+      state = 'failed';
+      removeAbortListener();
+      reject(error);
+    };
 
     const retryFromError = (error: unknown) => {
-      if (!allowErrorRetry || abortedForRetry) {
+      if (!allowErrorRetry || state !== 'rendering') {
         return false;
       }
-      abortedForRetry = true;
-      stream.abort();
-      const errorContext = getStaticContextFromError(
-        dataRoutes,
-        renderContext,
-        error,
-      );
-      streamDocument({
-        renderContext: errorContext,
-        dataRoutes,
-        documentAssets,
-        assets,
-        site,
-        clientContext,
-        reactContext,
-        routeHeaders,
-        waitForAll,
-        nonce,
-        options,
-        allowErrorRetry: false,
-      }).then(resolve, reject);
+      state = 'retrying';
+      removeAbortListener();
+      abortStream();
+
+      const retry = async () => {
+        try {
+          const errorContext = getStaticContextFromError(
+            dataRoutes,
+            renderContext,
+            error,
+          );
+          const result = await streamDocument({
+            renderContext: errorContext,
+            dataRoutes,
+            documentAssets,
+            assets,
+            site,
+            clientContext,
+            reactContext,
+            routeHeaders,
+            waitForAll,
+            nonce,
+            options,
+            allowErrorRetry: false,
+          });
+          resolve(result);
+        } catch (retryError) {
+          reject(retryError);
+        }
+      };
+      retry();
       return true;
     };
 
@@ -117,60 +148,84 @@ export const streamDocument = ({
         bootstrapScriptContent,
         nonce,
         onShellReady() {
-          if (waitForAll || ready || abortedForRetry) {
+          if (waitForAll || state !== 'rendering') {
             return;
           }
-          ready = true;
+          state = 'ready';
           resolve({
             pipe: wrapPipeWithInsertHtml(
               stream.pipe.bind(stream),
               insertHtmlQueue,
+              abortStream,
             ),
-            abort: stream.abort.bind(stream),
+            abort: abortStream,
             statusCode: renderContext.statusCode,
             headers: routeHeaders,
             inlineScripts: [bootstrapScriptContent],
           });
         },
         onAllReady() {
-          if (!waitForAll || ready || abortedForRetry) {
+          if (!waitForAll || state !== 'rendering') {
             return;
           }
-          ready = true;
+          state = 'ready';
           resolve({
             pipe: wrapPipeWithInsertHtml(
               stream.pipe.bind(stream),
               insertHtmlQueue,
+              abortStream,
             ),
-            abort: stream.abort.bind(stream),
+            abort: abortStream,
             statusCode: renderContext.statusCode,
             headers: routeHeaders,
             inlineScripts: [bootstrapScriptContent],
           });
         },
         onShellError(error) {
+          if (state !== 'rendering') {
+            return;
+          }
           options.onShellError?.(error);
           if (retryFromError(error)) {
             return;
           }
-          reject(error);
+          rejectAttempt(error);
         },
         onError(error) {
+          if (state !== 'rendering' && state !== 'ready') {
+            return;
+          }
           options.onError?.(error);
           // Suspense rejections never settle for onAllReady; retry once we
           // see the error while still buffering for waitForAll.
-          if (waitForAll && !ready) {
+          if (waitForAll && state === 'rendering') {
             retryFromError(error);
           }
         },
       },
     );
 
-    const abort = () => stream.abort();
-    if (options.signal?.aborted) {
-      abort();
+    const signal = options.signal;
+    const abortFromSignal = () => {
+      if (state === 'retrying' || state === 'aborted' || state === 'failed') {
+        return;
+      }
+      state = 'aborted';
+      abortStream();
+      reject(
+        signal?.reason ??
+          new DOMException('The render was aborted', 'AbortError'),
+      );
+    };
+
+    if (signal?.aborted) {
+      abortFromSignal();
+    } else if (signal) {
+      signal.addEventListener('abort', abortFromSignal, { once: true });
+      removeAbortListener = () =>
+        signal.removeEventListener('abort', abortFromSignal);
     } else {
-      options.signal?.addEventListener('abort', abort, { once: true });
+      removeAbortListener = () => {};
     }
   });
 };

--- a/packages/sku/src/services/vite/ssr/wrapPipeWithInsertHtml.ts
+++ b/packages/sku/src/services/vite/ssr/wrapPipeWithInsertHtml.ts
@@ -1,5 +1,5 @@
 import type { PipeableStream } from 'react-dom/server';
-import { pipeline } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 
 import { createInsertHtmlTransform } from './createInsertHtmlTransform.js';
 import type { InsertHtmlQueue } from './insertHtml.js';
@@ -11,11 +11,14 @@ export const wrapPipeWithInsertHtml = (
 ): PipeableStream['pipe'] => {
   const wrappedPipe: PipeableStream['pipe'] = (destination) => {
     const transform = createInsertHtmlTransform(queue);
-    pipeline(transform, destination, (error) => {
-      if (error) {
+    const pipeToDestination = async () => {
+      try {
+        await pipeline(transform, destination);
+      } catch {
         abort();
       }
-    });
+    };
+    pipeToDestination();
     try {
       pipe(transform);
     } catch (error) {

--- a/packages/sku/src/services/vite/ssr/wrapPipeWithInsertHtml.ts
+++ b/packages/sku/src/services/vite/ssr/wrapPipeWithInsertHtml.ts
@@ -1,4 +1,5 @@
 import type { PipeableStream } from 'react-dom/server';
+import { pipeline } from 'node:stream';
 
 import { createInsertHtmlTransform } from './createInsertHtmlTransform.js';
 import type { InsertHtmlQueue } from './insertHtml.js';
@@ -6,11 +7,23 @@ import type { InsertHtmlQueue } from './insertHtml.js';
 export const wrapPipeWithInsertHtml = (
   pipe: PipeableStream['pipe'],
   queue: InsertHtmlQueue,
+  abort: PipeableStream['abort'],
 ): PipeableStream['pipe'] => {
   const wrappedPipe: PipeableStream['pipe'] = (destination) => {
     const transform = createInsertHtmlTransform(queue);
-    pipe(transform);
-    return transform.pipe(destination);
+    pipeline(transform, destination, (error) => {
+      if (error) {
+        abort();
+      }
+    });
+    try {
+      pipe(transform);
+    } catch (error) {
+      transform.destroy(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
+    return destination;
   };
   return wrappedPipe;
 };

--- a/packages/sku/src/services/vite/ssr/wrapPipeWithInsertHtml.ts
+++ b/packages/sku/src/services/vite/ssr/wrapPipeWithInsertHtml.ts
@@ -14,8 +14,8 @@ export const wrapPipeWithInsertHtml = (
     const pipeToDestination = async () => {
       try {
         await pipeline(transform, destination);
-      } catch {
-        abort();
+      } catch (error) {
+        abort(error);
       }
     };
     pipeToDestination();


### PR DESCRIPTION
## Summary
- Make React SSR render attempts single-owner so retries, aborts, and callbacks cannot settle the same attempt more than once.
- Stop rendering or forwarding responses after request disconnects, including disconnects during streaming.
- Propagate insert-HTML transform failures through the stream pipeline and abort React.
- Add focused coverage for aborted signals, disconnect windows, render rejections, and insertion failures.

## Why
- Prevent hung render promises, retries after cancellation, and rendering work continuing after the client disconnects.
- Preserve genuine render failures for Express while suppressing expected cancellation errors.