### PR TITLE
docs: Update codemod npm badge

### DIFF
--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -1,4 +1,4 @@
-[![npm](https://img.shields.io/npm/v/sku-codemod.svg?style=flat-square)](https://www.npmjs.com/package/sku-codemod)
+[![npm](https://img.shields.io/npm/v/@sku-lib/codemod.svg?style=flat-square)](https://www.npmjs.com/package/@sku-lib/codemod)
 
 # Codemods for `sku`
 


### PR DESCRIPTION
It's currently pointing to an old snapshot of the unscoped `sku-codemod` package that was initially released but then superseded by `@sku-lib/codemod`.

<img width="371" height="70" alt="image" src="https://github.com/user-attachments/assets/f2e2ead2-32f7-4163-acf5-d7345b9b040b" />
