### PR TITLE
`create`: Include Vite client types in the `vite` template

### DIFF
--- a/.changeset/vite-env-types.md
+++ b/.changeset/vite-env-types.md
@@ -1,0 +1,7 @@
+---
+'@sku-lib/create': patch
+---
+
+Include Vite client types in the vite template
+
+New vite projects now have Vite client APIs typed out of the box.

--- a/packages/create/templates/vite/src/vite.env.d.ts
+++ b/packages/create/templates/vite/src/vite.env.d.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line spaced-comment
+/// <reference types="sku/vite/client" />

--- a/tests/node/__snapshots__/sku-create.test.ts.snap
+++ b/tests/node/__snapshots__/sku-create.test.ts.snap
@@ -387,7 +387,7 @@ export function NextSteps({ environment }: NextStepsProps) {
 
 exports[`sku-create vite > should create src/vite.env.d.ts 1`] = `
 "// eslint-disable-next-line spaced-comment
-/// <reference types=\\"sku/vite/client\\" />
+/// <reference types="sku/vite/client" />
 "
 `;
 

--- a/tests/node/__snapshots__/sku-create.test.ts.snap
+++ b/tests/node/__snapshots__/sku-create.test.ts.snap
@@ -385,6 +385,12 @@ export function NextSteps({ environment }: NextStepsProps) {
 "
 `;
 
+exports[`sku-create vite > should create src/vite.env.d.ts 1`] = `
+"// eslint-disable-next-line spaced-comment
+/// <reference types=\\"sku/vite/client\\" />
+"
+`;
+
 exports[`sku-create webpack > should create .gitignore 1`] = `
 "node_modules
 npm-debug.log

--- a/tests/node/sku-create.test.ts
+++ b/tests/node/sku-create.test.ts
@@ -189,6 +189,15 @@ describe.each(['webpack', 'vite'])('sku-create %s', (template) => {
     expect(stripYamlVersions(contents)).toMatchSnapshot();
   });
 
+  it.runIf(template === 'vite')('should create src/vite.env.d.ts', async () => {
+    const contents = await fs.readFile(
+      fixturePath(projectName, 'src/vite.env.d.ts'),
+      'utf-8',
+    );
+
+    expect(contents).toMatchSnapshot();
+  });
+
   it('should pass lint', async () => {
     const { sku } = scopeToSkuFixture('sku-create/new-project');
     const result = await sku('lint');

--- a/tests/node/sku-create.test.ts
+++ b/tests/node/sku-create.test.ts
@@ -182,20 +182,12 @@ describe.each(['webpack', 'vite'])('sku-create %s', (template) => {
     'README.md',
     '.prettierignore',
     'src/App/NextSteps.tsx',
+    ...(template !== 'webpack' ? ['src/vite.env.d.ts'] : []),
     'pnpm-workspace.yaml',
   ])('should create %s', async (file) => {
     const contents = await fs.readFile(fixturePath(projectName, file), 'utf-8');
 
     expect(stripYamlVersions(contents)).toMatchSnapshot();
-  });
-
-  it.runIf(template === 'vite')('should create src/vite.env.d.ts', async () => {
-    const contents = await fs.readFile(
-      fixturePath(projectName, 'src/vite.env.d.ts'),
-      'utf-8',
-    );
-
-    expect(contents).toMatchSnapshot();
   });
 
   it('should pass lint', async () => {


### PR DESCRIPTION
Seeing the `ssr` template in #1687 made me realize we currently don't initialize Vite client types in the `vite` SSG template. This PR adds that file to the template.