### PR TITLE
Fail `sku build` when a `sku/@loadable/component` import remains in the module graph, and warn on `sku start`

### DIFF
--- a/.changeset/vite-loadable-throw-or-warn.md
+++ b/.changeset/vite-loadable-throw-or-warn.md
@@ -1,0 +1,7 @@
+---
+'sku': patch
+---
+
+`build|start (vite)`: Fail `sku build` when a `sku/@loadable/component` import remains in the module graph, and warn on `sku start`
+
+Webpack loadable imports now warn on `sku start` and fail `sku build`, whether or not `--convert-loadable` is set. The flag still converts default imports to `@sku-lib/vite/loadable`; any leftover (e.g. `loadableReady`) must be removed manually. Previously these imports were only logged on `sku start` for app source, potentially letting unsupported code ship to production.

--- a/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.test.ts
+++ b/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.test.ts
@@ -46,7 +46,7 @@ describe('convertLoadableDepOptimizePlugin', () => {
 
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0][0]).toContain(
-      `Found 'sku/@loadable/component' import in '${id}'`,
+      `Found sku/@loadable/component import in '${id}'`,
     );
     expect(warn.mock.calls[0][0]).toContain('contact the dependency author');
     expect(code).toBeNull();
@@ -79,7 +79,7 @@ describe('convertLoadableDepOptimizePlugin', () => {
 
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0][0]).toContain(
-      `Found 'sku/@loadable/component' import in '${id}'`,
+      `Found sku/@loadable/component import in '${id}'`,
     );
     expect(warn.mock.calls[0][0]).toContain('contact the dependency author');
     expect(code).toContain('sku/@loadable/component');

--- a/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.test.ts
+++ b/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import { convertLoadableDepOptimizePlugin } from './convertLoadableDepOptimizePlugin.js';
+import dedent from 'dedent';
+
+const runHandler = ({
+  code,
+  id,
+  convertFromWebpack,
+}: {
+  code: string;
+  id: string;
+  convertFromWebpack?: boolean;
+}) => {
+  const plugin = convertLoadableDepOptimizePlugin({
+    convertFromWebpack,
+  }) as unknown as {
+    transform: {
+      handler: (
+        this: { warn: (message: string) => void },
+        code: string,
+        id: string,
+      ) => { code: string } | null;
+    };
+  };
+
+  const warn = vi.fn();
+  const result = plugin.transform.handler.call({ warn }, code, id);
+
+  return { code: result?.code ?? null, warn };
+};
+
+describe('convertLoadableDepOptimizePlugin', () => {
+  const id = '/project/node_modules/some-package/dist/index.js';
+
+  it('warns and does not rewrite when not converting', () => {
+    const source = dedent /* tsx */ `
+      import loadable from 'sku/@loadable/component';
+      const Component = loadable(() => import('./Component'));
+    `;
+
+    const { code, warn } = runHandler({ id, code: source });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain(
+      `Found 'sku/@loadable/component' import in '${id}'`,
+    );
+    expect(code).toBeNull();
+  });
+
+  it('rewrites the default import without warning', () => {
+    const { code, warn } = runHandler({
+      id,
+      convertFromWebpack: true,
+      code: dedent /* tsx */ `
+        import loadable from 'sku/@loadable/component';
+        const Component = loadable(() => import('./Component'));
+      `,
+    });
+
+    expect(code).toContain(`import { loadable } from "@sku-lib/vite/loadable"`);
+    expect(code).not.toContain('sku/@loadable/component');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns and does not rewrite a leftover webpack specifier', () => {
+    const { code, warn } = runHandler({
+      id,
+      convertFromWebpack: true,
+      code: dedent /* tsx */ `
+        import { loadableReady } from 'sku/@loadable/component';
+        loadableReady();
+      `,
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain(
+      `Found 'sku/@loadable/component' import in '${id}'`,
+    );
+    expect(code).toContain('sku/@loadable/component');
+    expect(code).not.toContain('@sku-lib/vite/loadable');
+  });
+});

--- a/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.test.ts
+++ b/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.test.ts
@@ -44,6 +44,7 @@ describe('convertLoadableDepOptimizePlugin', () => {
     expect(warn.mock.calls[0][0]).toContain(
       `Found 'sku/@loadable/component' import in '${id}'`,
     );
+    expect(warn.mock.calls[0][0]).toContain('contact the dependency author');
     expect(code).toBeNull();
   });
 
@@ -76,6 +77,7 @@ describe('convertLoadableDepOptimizePlugin', () => {
     expect(warn.mock.calls[0][0]).toContain(
       `Found 'sku/@loadable/component' import in '${id}'`,
     );
+    expect(warn.mock.calls[0][0]).toContain('contact the dependency author');
     expect(code).toContain('sku/@loadable/component');
     expect(code).not.toContain('@sku-lib/vite/loadable');
   });

--- a/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.test.ts
+++ b/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.test.ts
@@ -1,6 +1,22 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { convertLoadableDepOptimizePlugin } from './convertLoadableDepOptimizePlugin.js';
 import dedent from 'dedent';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const getHandler = (convertFromWebpack?: boolean) => {
+  const plugin = convertLoadableDepOptimizePlugin({
+    convertFromWebpack,
+  }) as unknown as {
+    transform: {
+      handler: (code: string, id: string) => { code: string } | null;
+    };
+  };
+
+  return plugin.transform.handler;
+};
 
 const runHandler = ({
   code,
@@ -11,20 +27,8 @@ const runHandler = ({
   id: string;
   convertFromWebpack?: boolean;
 }) => {
-  const plugin = convertLoadableDepOptimizePlugin({
-    convertFromWebpack,
-  }) as unknown as {
-    transform: {
-      handler: (
-        this: { warn: (message: string) => void },
-        code: string,
-        id: string,
-      ) => { code: string } | null;
-    };
-  };
-
-  const warn = vi.fn();
-  const result = plugin.transform.handler.call({ warn }, code, id);
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const result = getHandler(convertFromWebpack)(code, id);
 
   return { code: result?.code ?? null, warn };
 };
@@ -80,5 +84,19 @@ describe('convertLoadableDepOptimizePlugin', () => {
     expect(warn.mock.calls[0][0]).toContain('contact the dependency author');
     expect(code).toContain('sku/@loadable/component');
     expect(code).not.toContain('@sku-lib/vite/loadable');
+  });
+
+  it('warns once per module across repeated optimization runs', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handler = getHandler();
+    const source = dedent /* tsx */ `
+      import loadable from 'sku/@loadable/component';
+      const Component = loadable(() => import('./Component'));
+    `;
+
+    handler(source, id);
+    handler(source, id);
+
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.ts
+++ b/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.ts
@@ -2,7 +2,7 @@ import type { Plugin } from 'rolldown';
 import { makePluginName } from '../../helpers/makePluginName.js';
 import { WEBPACK_LOADABLE_IMPORT } from '../preloadPlugin/helpers/constants.js';
 import {
-  createWebpackLoadableImportMessage,
+  createWebpackLoadableImportDependencyMessage,
   rewriteWebpackLoadableImports,
 } from '../preloadPlugin/helpers/rewriteWebpackLoadableImports.js';
 
@@ -27,13 +27,13 @@ export const convertLoadableDepOptimizePlugin = ({
     },
     handler(code, id) {
       if (!convertFromWebpack) {
-        this.warn(createWebpackLoadableImportMessage(id));
+        this.warn(createWebpackLoadableImportDependencyMessage(id));
         return null;
       }
 
       const result = rewriteWebpackLoadableImports(code, id);
       if ((result?.code ?? code).includes(WEBPACK_LOADABLE_IMPORT)) {
-        this.warn(createWebpackLoadableImportMessage(id));
+        this.warn(createWebpackLoadableImportDependencyMessage(id));
       }
       return result;
     },

--- a/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.ts
+++ b/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.ts
@@ -18,24 +18,38 @@ interface PluginOptions {
 // Production builds see dependency source through the preload plugin's transform.
 export const convertLoadableDepOptimizePlugin = ({
   convertFromWebpack,
-}: PluginOptions = {}): Plugin => ({
-  name: makePluginName('convert-loadable-dep-optimize'),
-  transform: {
-    filter: {
-      id: /\.[cm]?js$/,
-      code: WEBPACK_LOADABLE_IMPORT,
-    },
-    handler(code, id) {
-      if (!convertFromWebpack) {
-        this.warn(createWebpackLoadableImportDependencyMessage(id));
-        return null;
-      }
+}: PluginOptions = {}): Plugin => {
+  const warnedModules = new Set<string>();
 
-      const result = rewriteWebpackLoadableImports(code, id);
-      if ((result?.code ?? code).includes(WEBPACK_LOADABLE_IMPORT)) {
-        this.warn(createWebpackLoadableImportDependencyMessage(id));
-      }
-      return result;
+  // Vite's dep optimizer runs rolldown with `logLevel: 'silent'`, which
+  // suppresses `this.warn`, so report directly to the console instead.
+  const warn = (id: string) => {
+    if (warnedModules.has(id)) {
+      return;
+    }
+    warnedModules.add(id);
+    console.warn(createWebpackLoadableImportDependencyMessage(id));
+  };
+
+  return {
+    name: makePluginName('convert-loadable-dep-optimize'),
+    transform: {
+      filter: {
+        id: /\.[cm]?js$/,
+        code: WEBPACK_LOADABLE_IMPORT,
+      },
+      handler(code, id) {
+        if (!convertFromWebpack) {
+          warn(id);
+          return null;
+        }
+
+        const result = rewriteWebpackLoadableImports(code, id);
+        if ((result?.code ?? code).includes(WEBPACK_LOADABLE_IMPORT)) {
+          warn(id);
+        }
+        return result;
+      },
     },
-  },
-});
+  };
+};

--- a/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.ts
+++ b/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.ts
@@ -1,9 +1,24 @@
 import type { Plugin } from 'rolldown';
 import { makePluginName } from '../../helpers/makePluginName.js';
 import { WEBPACK_LOADABLE_IMPORT } from '../preloadPlugin/helpers/constants.js';
-import { rewriteWebpackLoadableImports } from '../preloadPlugin/helpers/rewriteWebpackLoadableImports.js';
+import {
+  createWebpackLoadableImportMessage,
+  rewriteWebpackLoadableImports,
+} from '../preloadPlugin/helpers/rewriteWebpackLoadableImports.js';
 
-export const convertLoadableDepOptimizePlugin = (): Plugin => ({
+interface PluginOptions {
+  /**
+   * Convert loadable import from webpack to vite. Any webpack specifier that
+   * remains after the rewrite is still reported.
+   */
+  convertFromWebpack?: boolean;
+}
+
+// Dep optimization only runs on start, so leftovers are always warnings here.
+// Production builds see dependency source through the preload plugin's transform.
+export const convertLoadableDepOptimizePlugin = ({
+  convertFromWebpack,
+}: PluginOptions = {}): Plugin => ({
   name: makePluginName('convert-loadable-dep-optimize'),
   transform: {
     filter: {
@@ -11,7 +26,16 @@ export const convertLoadableDepOptimizePlugin = (): Plugin => ({
       code: WEBPACK_LOADABLE_IMPORT,
     },
     handler(code, id) {
-      return rewriteWebpackLoadableImports(code, id);
+      if (!convertFromWebpack) {
+        this.warn(createWebpackLoadableImportMessage(id));
+        return null;
+      }
+
+      const result = rewriteWebpackLoadableImports(code, id);
+      if ((result?.code ?? code).includes(WEBPACK_LOADABLE_IMPORT)) {
+        this.warn(createWebpackLoadableImportMessage(id));
+      }
+      return result;
     },
   },
 });

--- a/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.ts
+++ b/packages/sku/src/services/vite/plugins/esbuild/convertLoadableDepOptimizePlugin.ts
@@ -5,6 +5,7 @@ import {
   createWebpackLoadableImportDependencyMessage,
   rewriteWebpackLoadableImports,
 } from '../preloadPlugin/helpers/rewriteWebpackLoadableImports.js';
+import { caution } from '@sku-private/utils/console';
 
 interface PluginOptions {
   /**
@@ -28,7 +29,7 @@ export const convertLoadableDepOptimizePlugin = ({
       return;
     }
     warnedModules.add(id);
-    console.warn(createWebpackLoadableImportDependencyMessage(id));
+    console.warn(caution(createWebpackLoadableImportDependencyMessage(id)));
   };
 
   return {

--- a/packages/sku/src/services/vite/plugins/preloadPlugin/helpers/rewriteWebpackLoadableImports.ts
+++ b/packages/sku/src/services/vite/plugins/preloadPlugin/helpers/rewriteWebpackLoadableImports.ts
@@ -19,7 +19,10 @@ export const parseLoadableSource = (code: string) =>
   });
 
 export const createWebpackLoadableImportMessage = (id: string) =>
-  `Found '${WEBPACK_LOADABLE_IMPORT}' import in '${id}'. This import is invalid in a Vite application. Please install '@sku-lib/vite' and run '${getExecuteCommand(['@sku-lib/codemod', 'transform-vite-loadable'])}' to update all imports.`;
+  `Found '${WEBPACK_LOADABLE_IMPORT}' import in '${id}'. This import is invalid with the vite bundler. Please run '${getExecuteCommand(['@sku-lib/codemod', 'transform-vite-loadable'])}' to update all imports.`;
+
+export const createWebpackLoadableImportDependencyMessage = (id: string) =>
+  `Found '${WEBPACK_LOADABLE_IMPORT}' import in '${id}'. This import is invalid with the vite bundler. Please contact the dependency author to migrate to '${VITE_LOADABLE_IMPORT}' and remove any 'loadableReady' calls, which dependencies should not make.`;
 
 export const assertSingleLoadableRuntime = (code: string, id: string) => {
   const hasWebpack = code.includes(WEBPACK_LOADABLE_IMPORT);

--- a/packages/sku/src/services/vite/plugins/preloadPlugin/helpers/rewriteWebpackLoadableImports.ts
+++ b/packages/sku/src/services/vite/plugins/preloadPlugin/helpers/rewriteWebpackLoadableImports.ts
@@ -2,6 +2,7 @@ import { parse } from '@babel/parser';
 import _traverse from '@babel/traverse';
 import _generate from '@babel/generator';
 import * as t from '@babel/types';
+import { getExecuteCommand } from '@sku-private/utils';
 import { VITE_LOADABLE_IMPORT, WEBPACK_LOADABLE_IMPORT } from './constants.js';
 import { getWebpackLoadableSpecifierName } from './getWebpackLoadableSpecifierName.js';
 import { convertWebpackToViteImport } from './convertWebpackToViteImport.js';
@@ -16,6 +17,9 @@ export const parseLoadableSource = (code: string) =>
     sourceType: 'unambiguous',
     plugins: ['jsx', 'typescript'],
   });
+
+export const createWebpackLoadableImportMessage = (id: string) =>
+  `Found '${WEBPACK_LOADABLE_IMPORT}' import in '${id}'. This import is invalid in a Vite application. Please install '@sku-lib/vite' and run '${getExecuteCommand(['@sku-lib/codemod', 'transform-vite-loadable'])}' to update all imports.`;
 
 export const assertSingleLoadableRuntime = (code: string, id: string) => {
   const hasWebpack = code.includes(WEBPACK_LOADABLE_IMPORT);

--- a/packages/sku/src/services/vite/plugins/preloadPlugin/helpers/rewriteWebpackLoadableImports.ts
+++ b/packages/sku/src/services/vite/plugins/preloadPlugin/helpers/rewriteWebpackLoadableImports.ts
@@ -18,11 +18,13 @@ export const parseLoadableSource = (code: string) =>
     plugins: ['jsx', 'typescript'],
   });
 
+// shown when loadable webpack is found within the main bundle and the codemod can be used to fix it
 export const createWebpackLoadableImportMessage = (id: string) =>
-  `Found '${WEBPACK_LOADABLE_IMPORT}' import in '${id}'. This import is invalid with the vite bundler. Please run '${getExecuteCommand(['@sku-lib/codemod', 'transform-vite-loadable'])}' to update all imports.`;
+  `[SKU] Found ${WEBPACK_LOADABLE_IMPORT} import in '${id}'. This import is invalid with the vite bundler. Please run '${getExecuteCommand(['@sku-lib/codemod', 'transform-vite-loadable'])}' to update all imports.`;
 
+// shown when loadable webpack is found within a dependency and the codemod can't be used to fix it (--convert-loadable is required)
 export const createWebpackLoadableImportDependencyMessage = (id: string) =>
-  `Found '${WEBPACK_LOADABLE_IMPORT}' import in '${id}'. This import is invalid with the vite bundler. Please contact the dependency author to migrate to '${VITE_LOADABLE_IMPORT}' and remove any 'loadableReady' calls, which dependencies should not make.`;
+  `[SKU] Found ${WEBPACK_LOADABLE_IMPORT} import in '${id}'. Please run sku with '--convert-loadable' to automatically convert the import to ${VITE_LOADABLE_IMPORT}. If this error persists, please contact the dependency author to remove unsupported loadable imports (e.g., loadableReady).`;
 
 export const assertSingleLoadableRuntime = (code: string, id: string) => {
   const hasWebpack = code.includes(WEBPACK_LOADABLE_IMPORT);

--- a/packages/sku/src/services/vite/plugins/preloadPlugin/preloadPlugin.test.ts
+++ b/packages/sku/src/services/vite/plugins/preloadPlugin/preloadPlugin.test.ts
@@ -110,7 +110,7 @@ describe('preloadPlugin', () => {
       );
       expect(warn).toHaveBeenCalledTimes(1);
       expect(warn.mock.calls[0][0]).toContain(
-        `Found 'sku/@loadable/component' import in '/project/src/App.jsx'`,
+        `Found sku/@loadable/component import in '/project/src/App.jsx'`,
       );
       expect(warn.mock.calls[0][0]).toContain('transform-vite-loadable');
       expect(error).not.toHaveBeenCalled();
@@ -134,7 +134,7 @@ describe('preloadPlugin', () => {
       );
       expect(error).toHaveBeenCalledTimes(1);
       expect(error.mock.calls[0][0]).toContain(
-        `Found 'sku/@loadable/component' import in '/project/src/App.jsx'`,
+        `Found sku/@loadable/component import in '/project/src/App.jsx'`,
       );
       expect(warn).not.toHaveBeenCalled();
     });
@@ -155,7 +155,7 @@ describe('preloadPlugin', () => {
 
       expect(warn).toHaveBeenCalledTimes(1);
       expect(warn.mock.calls[0][0]).toContain(
-        `Found 'sku/@loadable/component' import in '${id}'`,
+        `Found sku/@loadable/component import in '${id}'`,
       );
       expect(warn.mock.calls[0][0]).toContain('contact the dependency author');
       expect(error).not.toHaveBeenCalled();
@@ -176,7 +176,7 @@ describe('preloadPlugin', () => {
 
       expect(error).toHaveBeenCalledTimes(1);
       expect(error.mock.calls[0][0]).toContain(
-        `Found 'sku/@loadable/component' import in '${id}'`,
+        `Found sku/@loadable/component import in '${id}'`,
       );
       expect(error.mock.calls[0][0]).toContain('contact the dependency author');
       expect(warn).not.toHaveBeenCalled();

--- a/packages/sku/src/services/vite/plugins/preloadPlugin/preloadPlugin.test.ts
+++ b/packages/sku/src/services/vite/plugins/preloadPlugin/preloadPlugin.test.ts
@@ -112,6 +112,7 @@ describe('preloadPlugin', () => {
       expect(warn.mock.calls[0][0]).toContain(
         `Found 'sku/@loadable/component' import in '/project/src/App.jsx'`,
       );
+      expect(warn.mock.calls[0][0]).toContain('transform-vite-loadable');
       expect(error).not.toHaveBeenCalled();
     });
 
@@ -156,6 +157,7 @@ describe('preloadPlugin', () => {
       expect(warn.mock.calls[0][0]).toContain(
         `Found 'sku/@loadable/component' import in '${id}'`,
       );
+      expect(warn.mock.calls[0][0]).toContain('contact the dependency author');
       expect(error).not.toHaveBeenCalled();
       expect(code).toBeNull();
     });
@@ -176,6 +178,7 @@ describe('preloadPlugin', () => {
       expect(error.mock.calls[0][0]).toContain(
         `Found 'sku/@loadable/component' import in '${id}'`,
       );
+      expect(error.mock.calls[0][0]).toContain('contact the dependency author');
       expect(warn).not.toHaveBeenCalled();
       expect(code).toBeNull();
     });

--- a/packages/sku/src/services/vite/plugins/preloadPlugin/preloadPlugin.test.ts
+++ b/packages/sku/src/services/vite/plugins/preloadPlugin/preloadPlugin.test.ts
@@ -8,33 +8,49 @@ const transformCode = async ({
   id,
   convertFromWebpack = true,
   environment = 'client',
+  commandName = 'start',
 }: {
   code: string;
   id: string;
   convertFromWebpack?: boolean;
   environment?: 'client' | 'ssr';
+  commandName?: 'start' | 'build';
 }) => {
-  const { transform } = preloadPlugin({ convertFromWebpack }) as Plugin & {
+  const { transform } = preloadPlugin({
+    convertFromWebpack,
+    commandName,
+  }) as Plugin & {
     transform: (
-      this: { environment: { name: string } },
+      this: {
+        environment: { name: string };
+        warn: (message: string) => void;
+        error: (message: string) => void;
+      },
       code: string,
       id: string,
     ) => Promise<TransformResult>;
   };
 
+  const warn = vi.fn();
+  const error = vi.fn();
+
   const result = await transform.call(
-    { environment: { name: environment } },
+    { environment: { name: environment }, warn, error },
     code,
     id,
   );
 
-  return typeof result === 'string' ? result : (result?.code ?? null);
+  return {
+    code: typeof result === 'string' ? result : (result?.code ?? null),
+    warn,
+    error,
+  };
 };
 
 describe('preloadPlugin', () => {
   describe('convert from webpack', () => {
     it('converts the webpack loadable import', async () => {
-      const code = await transformCode({
+      const { code, warn, error } = await transformCode({
         id: '/project/src/App.jsx',
         code: dedent /* tsx */ `
         import loadable from 'sku/@loadable/component';
@@ -46,12 +62,14 @@ describe('preloadPlugin', () => {
         `import { loadable } from "@sku-lib/vite/loadable"`,
       );
       expect(code).not.toContain('sku/@loadable/component');
+      expect(warn).not.toHaveBeenCalled();
+      expect(error).not.toHaveBeenCalled();
     });
 
     it.for(['.mjs', '.cjs', '.mts', '.cts', '.js', '.jsx', '.ts', '.tsx'])(
       'converts the webpack loadable import in %s files',
       async (extension) => {
-        const code = await transformCode({
+        const { code } = await transformCode({
           id: `/project/node_modules/some-package/dist/index${extension}`,
           code: dedent /* tsx */ `
           import loadable from 'sku/@loadable/component';
@@ -66,22 +84,67 @@ describe('preloadPlugin', () => {
     );
 
     it('ignores files that are not scanned', async () => {
-      const code = await transformCode({
+      const { code } = await transformCode({
         id: '/project/src/App.vue',
         code: `import loadable from 'sku/@loadable/component';`,
       });
 
       expect(code).toBeNull();
     });
+
+    it('rewrites the default import and warns about a leftover webpack specifier on start', async () => {
+      const { code, warn, error } = await transformCode({
+        commandName: 'start',
+        id: '/project/src/App.jsx',
+        code: dedent /* tsx */ `
+        import loadable, { loadableReady } from 'sku/@loadable/component';
+        const Home = loadable(() => import('./Home'));
+        `,
+      });
+
+      expect(code).toContain(
+        `import { loadable } from "@sku-lib/vite/loadable"`,
+      );
+      expect(code).toContain(
+        `import { loadableReady } from "sku/@loadable/component"`,
+      );
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain(
+        `Found 'sku/@loadable/component' import in '/project/src/App.jsx'`,
+      );
+      expect(error).not.toHaveBeenCalled();
+    });
+
+    it('rewrites the default import and errors on a leftover webpack specifier on build', async () => {
+      const { code, warn, error } = await transformCode({
+        commandName: 'build',
+        id: '/project/src/App.jsx',
+        code: dedent /* tsx */ `
+        import loadable, { loadableReady } from 'sku/@loadable/component';
+        const Home = loadable(() => import('./Home'));
+        `,
+      });
+
+      expect(code).toContain(
+        `import { loadable } from "@sku-lib/vite/loadable"`,
+      );
+      expect(code).toContain(
+        `import { loadableReady } from "sku/@loadable/component"`,
+      );
+      expect(error).toHaveBeenCalledTimes(1);
+      expect(error.mock.calls[0][0]).toContain(
+        `Found 'sku/@loadable/component' import in '/project/src/App.jsx'`,
+      );
+      expect(warn).not.toHaveBeenCalled();
+    });
   });
 
   describe('without conversion', () => {
-    it('warns about webpack loadable imports in dependencies', async () => {
-      const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
-
+    it('warns about webpack loadable imports in dependencies on start', async () => {
       const id = '/project/node_modules/some-package/dist/index.mjs';
-      const code = await transformCode({
+      const { code, warn, error } = await transformCode({
         convertFromWebpack: false,
+        commandName: 'start',
         id,
         code: dedent /* tsx */ `
         import loadable from 'sku/@loadable/component';
@@ -89,19 +152,36 @@ describe('preloadPlugin', () => {
         `,
       });
 
-      expect(consoleLog).toHaveBeenCalledTimes(1);
-      expect(consoleLog.mock.calls[0][0]).toContain(
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain(
         `Found 'sku/@loadable/component' import in '${id}'`,
       );
+      expect(error).not.toHaveBeenCalled();
       expect(code).toBeNull();
+    });
 
-      consoleLog.mockRestore();
+    it('errors on webpack loadable imports in dependencies on build', async () => {
+      const id = '/project/node_modules/some-package/dist/index.mjs';
+      const { code, warn, error } = await transformCode({
+        convertFromWebpack: false,
+        commandName: 'build',
+        id,
+        code: dedent /* tsx */ `
+        import loadable from 'sku/@loadable/component';
+        const Component = loadable(() => import('./Component.mjs'));
+        `,
+      });
+
+      expect(error).toHaveBeenCalledTimes(1);
+      expect(error.mock.calls[0][0]).toContain(
+        `Found 'sku/@loadable/component' import in '${id}'`,
+      );
+      expect(warn).not.toHaveBeenCalled();
+      expect(code).toBeNull();
     });
 
     it('warns once per file', async () => {
-      const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
-
-      await transformCode({
+      const { warn, error } = await transformCode({
         convertFromWebpack: false,
         id: '/project/src/App.jsx',
         code: dedent /* tsx */ `
@@ -113,9 +193,8 @@ describe('preloadPlugin', () => {
         `,
       });
 
-      expect(consoleLog).toHaveBeenCalledTimes(1);
-
-      consoleLog.mockRestore();
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(error).not.toHaveBeenCalled();
     });
   });
 
@@ -124,7 +203,7 @@ describe('preloadPlugin', () => {
     const id = `${import.meta.dirname}/preloadPlugin.ts`;
 
     it('injects the module ID without renaming an aliased vite import', async () => {
-      const code = await transformCode({
+      const { code } = await transformCode({
         environment: 'ssr',
         id,
         code: dedent /* tsx */ `
@@ -142,7 +221,7 @@ describe('preloadPlugin', () => {
     });
 
     it('injects the module ID for a converted aliased webpack import', async () => {
-      const code = await transformCode({
+      const { code } = await transformCode({
         environment: 'ssr',
         id,
         code: dedent /* tsx */ `

--- a/packages/sku/src/services/vite/plugins/preloadPlugin/preloadPlugin.ts
+++ b/packages/sku/src/services/vite/plugins/preloadPlugin/preloadPlugin.ts
@@ -10,6 +10,7 @@ import { getViteLoadableSpecifierName } from './helpers/getViteLoadableSpecifier
 import { injectModuleID } from './helpers/injectModuleID.js';
 import {
   assertSingleLoadableRuntime,
+  createWebpackLoadableImportDependencyMessage,
   createWebpackLoadableImportMessage,
   parseLoadableSource,
   rewriteWebpackLoadableImportsInAst,
@@ -151,7 +152,9 @@ export function preloadPlugin({
           return;
         }
 
-        const message = createWebpackLoadableImportMessage(id);
+        const message = id.includes('node_modules')
+          ? createWebpackLoadableImportDependencyMessage(id)
+          : createWebpackLoadableImportMessage(id);
         if (isBuild) {
           this.error(message);
         } else {

--- a/packages/sku/src/services/vite/plugins/preloadPlugin/preloadPlugin.ts
+++ b/packages/sku/src/services/vite/plugins/preloadPlugin/preloadPlugin.ts
@@ -10,10 +10,10 @@ import { getViteLoadableSpecifierName } from './helpers/getViteLoadableSpecifier
 import { injectModuleID } from './helpers/injectModuleID.js';
 import {
   assertSingleLoadableRuntime,
+  createWebpackLoadableImportMessage,
   parseLoadableSource,
   rewriteWebpackLoadableImportsInAst,
 } from './helpers/rewriteWebpackLoadableImports.js';
-import { getExecuteCommand } from '@sku-private/utils';
 import { makePluginName } from '../../helpers/makePluginName.js';
 import { convertLoadableDepOptimizePlugin } from '../esbuild/convertLoadableDepOptimizePlugin.js';
 
@@ -31,6 +31,11 @@ interface PluginOptions {
    * Convert loadable import from webpack to vite
    */
   convertFromWebpack?: boolean;
+  /**
+   * The sku command being run. Remaining webpack loadable imports fail the
+   * build on `build` and warn on any other command.
+   */
+  commandName?: string;
 }
 
 // Modules to scan for dynamic imports.
@@ -41,27 +46,18 @@ const cleanId = (id: string) => id.split('?')[0];
 
 /**
  * If conversion is enabled, rewrites the webpack loadable import to its Vite equivalent.
- * Otherwise, warns that the import is invalid and needs to be converted via codemod.
+ * Returns whether a rewrite was attempted.
  */
-const convertOrWarnAboutWebpackLoadable = ({
+const convertWebpackLoadable = ({
   hasWebpack,
   ast,
-  id,
   convertFromWebpack,
 }: {
   hasWebpack: boolean;
   ast: t.File;
-  id: string;
   convertFromWebpack: boolean | undefined;
 }) => {
-  if (!hasWebpack) {
-    return false;
-  }
-
-  if (!convertFromWebpack) {
-    console.log(
-      `Found '${WEBPACK_LOADABLE_IMPORT}' import in '${id}'. This import is invalid in a Vite application. Please install '@sku-lib/vite' and run '${getExecuteCommand(['@sku-lib/codemod', 'transform-vite-loadable'])}' to update all imports.`,
-    );
+  if (!hasWebpack || !convertFromWebpack) {
     return false;
   }
 
@@ -112,25 +108,27 @@ const injectLoadableModuleId = ({
 export function preloadPlugin({
   debug,
   convertFromWebpack,
+  commandName,
 }: PluginOptions = {}): Plugin {
   const lazyImportedModules = new Set();
   const injectedModules = new Set();
   let count = 0;
+
+  // Vite's own `command` can't be trusted here: the VE compiler's `createServer`
+  // reports `serve` during `sku build`, so switch on the sku command instead.
+  const isBuild = Boolean(commandName?.startsWith('build'));
+
   return {
     name: makePluginName('preload'),
 
     // handle pre-bundled or optimized code that contains webpack loadable imports
-    ...(convertFromWebpack
-      ? {
-          config: () => ({
-            optimizeDeps: {
-              rolldownOptions: {
-                plugins: [convertLoadableDepOptimizePlugin()],
-              },
-            },
-          }),
-        }
-      : {}),
+    config: () => ({
+      optimizeDeps: {
+        rolldownOptions: {
+          plugins: [convertLoadableDepOptimizePlugin({ convertFromWebpack })],
+        },
+      },
+    }),
 
     // handles bundled code only.
     transform(code, rawId) {
@@ -146,16 +144,31 @@ export function preloadPlugin({
         return null;
       }
 
+      // The webpack specifier must never survive to the bundle. Conversion is
+      // best-effort, so whatever remains after any rewrite is reported.
+      const reportRemainingWebpackImport = (outputCode: string) => {
+        if (!outputCode.includes(WEBPACK_LOADABLE_IMPORT)) {
+          return;
+        }
+
+        const message = createWebpackLoadableImportMessage(id);
+        if (isBuild) {
+          this.error(message);
+        } else {
+          this.warn(message);
+        }
+      };
+
       const ast = parseLoadableSource(code);
-      const converted = convertOrWarnAboutWebpackLoadable({
+      const converted = convertWebpackLoadable({
         ast,
-        id,
         hasWebpack,
         convertFromWebpack,
       });
       const injected = isSsr && injectLoadableModuleId({ ast, id });
 
       if (!converted && !injected) {
+        reportRemainingWebpackImport(code);
         return null;
       }
 
@@ -167,6 +180,7 @@ export function preloadPlugin({
         injectedModules.add(id);
       }
       const output = generate(ast, {}, code);
+      reportRemainingWebpackImport(output.code);
       return {
         code: output.code,
         map: output.map,

--- a/packages/sku/src/services/vite/plugins/preloadPlugin/preloadPlugin.ts
+++ b/packages/sku/src/services/vite/plugins/preloadPlugin/preloadPlugin.ts
@@ -155,6 +155,7 @@ export function preloadPlugin({
         const message = id.includes('node_modules')
           ? createWebpackLoadableImportDependencyMessage(id)
           : createWebpackLoadableImportMessage(id);
+
         if (isBuild) {
           this.error(message);
         } else {

--- a/packages/sku/src/services/vite/skuPlugin.ts
+++ b/packages/sku/src/services/vite/skuPlugin.ts
@@ -32,6 +32,7 @@ export const skuPlugin = ({
   preloadPlugin({
     // Convert loadable import from webpack to vite. Can be put behind a flag.
     convertFromWebpack: skuContext.convertLoadable,
+    commandName: skuContext.commandName,
   }),
   polyfillsPlugin(skuContext),
   vitePluginSsrCss({


### PR DESCRIPTION
The current checks we run for loadable imports only warns on bundled code. _Dependancies_ with loadable imports are not caught, so unsupported code can leak into production. This change makes sku warn when it catches source _or_ dependancies that need `--convert-loadable` enabled, and will throw an error on build if you try to bundle code with the webpack loadable import somewhere in the sourcemap when using the vite bundler and not using `--convert-loadable` (or if the lib uses unsupported loadable APIs, like loadableReady)

This would technically be a breaking change since it can fail build, but it is an edge case and prevents apps from shipping code that could silently break production, so I've labeled it as a bug fix instead. 

**Warn when source has loadable entry that needs the codemod to be run**
<img width="1433" height="386" alt="CleanShot 2026-08-25 at 14 43 20" src="https://github.com/user-attachments/assets/250da594-840b-478a-82c5-5985218e5e8e" />

**Warn when deps have loadable entries that need to be fixed (enable --convert-loadable or fix the lib)**
<img width="1423" height="259" alt="CleanShot 2026-08-25 at 14 43 42" src="https://github.com/user-attachments/assets/fc66396c-4a0e-4d59-8084-2d8dc6d68138" />

**Builds fail for either reason**
<img width="2150" height="563" alt="CleanShot 2026-08-25 at 15 37 24" src="https://github.com/user-attachments/assets/f74d7a4a-094a-4bf5-b711-6c933ba91a94" />
