### PR TITLE
Update `cli-testing-library` dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@sku-private/testing-library": "workspace:*",
     "@tsconfig/node24": "^24.0.4",
     "@types/node": "catalog:",
-    "cli-testing-library": "^3.0.1",
+    "cli-testing-library": "catalog:",
     "eslint": "^9.10.0",
     "eslint-config-seek": "^15.0.4",
     "eslint-import-resolver-typescript": "^4.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ catalogs:
     braid-design-system:
       specifier: ^34.0.0
       version: 34.6.1
+    cli-testing-library:
+      specifier: ^4.0.0
+      version: 4.0.0
     commander:
       specifier: ^14.0.1
       version: 14.0.3
@@ -129,8 +132,8 @@ importers:
         specifier: 'catalog:'
         version: 24.13.3
       cli-testing-library:
-        specifier: ^3.0.1
-        version: 3.0.1(vitest@4.1.10)
+        specifier: 'catalog:'
+        version: 4.0.0(@jest/globals@30.4.1)(vitest@4.1.10)
       eslint:
         specifier: ^9.10.0
         version: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
@@ -1691,8 +1694,8 @@ importers:
         specifier: workspace:*
         version: link:../test-utils
       cli-testing-library:
-        specifier: ^3.0.1
-        version: 3.0.1(vitest@4.1.10)
+        specifier: 'catalog:'
+        version: 4.0.0(@jest/globals@30.4.1)(vitest@4.1.10)
       fs-fixture:
         specifier: ^2.6.0
         version: 2.14.0
@@ -1944,6 +1947,10 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@8.0.0':
+    resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/compat-data@7.29.7':
     resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
@@ -2030,6 +2037,10 @@ packages:
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@8.0.4':
+    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-option@7.29.7':
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
@@ -6151,16 +6162,13 @@ packages:
     resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
     engines: {node: '>=18.20'}
 
-  cli-testing-library@3.0.1:
-    resolution: {integrity: sha512-fkQ8D2hQS53RP3s0yuCMHmTfPUMEqtVtJG0rs13MNE2khnkSaY8MsNxN7rSJZAzOOVsSg2I2F2XjEITJwf5dFg==}
-    engines: {node: '>=16'}
+  cli-testing-library@4.0.0:
+    resolution: {integrity: sha512-QfC3cJyIA8z9YltHTtHG+zWgxxPIaMctikPZBR5f3ZG9Ku+DvzLseH3aybijuyd1PQOD/RmIfI9A/O5TFhSR+w==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
-      '@jest/expect': ^29.0.0
-      '@jest/globals': ^29.0.0
-      vitest: ^3.0.0
+      '@jest/globals': ^29.0.0 || ^30.0.0
+      vitest: ^3.2.0 || ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
-      '@jest/expect':
-        optional: true
       '@jest/globals':
         optional: true
       vitest:
@@ -8044,6 +8052,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -9585,9 +9596,9 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
 
-  slice-ansi@7.1.2:
-    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
-    engines: {node: '>=18'}
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
 
   smol-toml@1.7.1:
     resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
@@ -10955,6 +10966,11 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@8.0.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 8.0.4
+      js-tokens: 10.0.0
+
   '@babel/compat-data@7.29.7': {}
 
   '@babel/core@7.29.7(supports-color@8.1.1)':
@@ -11087,6 +11103,8 @@ snapshots:
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-identifier@8.0.4': {}
 
   '@babel/helper-validator-option@7.29.7': {}
 
@@ -15547,17 +15565,17 @@ snapshots:
 
   cli-spinners@3.4.0: {}
 
-  cli-testing-library@3.0.1(vitest@4.1.10):
+  cli-testing-library@4.0.0(@jest/globals@30.4.1)(vitest@4.1.10):
     dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/runtime': 7.29.7
+      '@babel/code-frame': 8.0.0
       picocolors: 1.1.1
       redent: 4.0.0
-      slice-ansi: 7.1.2
+      slice-ansi: 9.0.0
       strip-ansi: 7.2.0
       strip-final-newline: 4.0.0
       tree-kill: 1.2.2
     optionalDependencies:
+      '@jest/globals': 30.4.1(supports-color@8.1.1)
       vitest: 4.1.10(@types/node@24.13.3)(jsdom@26.1.0)(vite@8.2.0)
 
   cli-width@4.1.0: {}
@@ -17863,6 +17881,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.15.1:
@@ -19531,7 +19551,7 @@ snapshots:
 
   slash@5.1.0: {}
 
-  slice-ansi@7.1.2:
+  slice-ansi@9.0.0:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,7 @@ catalog:
   '@vanilla-extract/webpack-plugin': '^2.3.26'
   '@vocab/vite': ^1.0.4
   braid-design-system: ^34.0.0
+  cli-testing-library: ^4.0.0
   commander: ^14.0.1
   # 05/08/25: there is currently a bug in later versions of jiti that break eslint ts support. Pinning to 2.4.2 fixes the issue. (last checked with v2.6.1)
   # 12/11/25: Unpinning for now and using JS eslint config because jiti peer deps from other packages are causing issues. We can re-evaluate later.

--- a/private/testing-library/package.json
+++ b/private/testing-library/package.json
@@ -10,7 +10,7 @@
     "./matchers": "./matchers.ts"
   },
   "devDependencies": {
-    "cli-testing-library": "^3.0.1",
+    "cli-testing-library": "catalog:",
     "fs-fixture": "^2.6.0",
     "@sku-private/test-utils": "workspace:*"
   }


### PR DESCRIPTION
The new major version of [`cli-testing-library`](https://npmx.dev/package/cli-testing-library) now officially supports `vitest>=4` and fixes the annoying `[DEP0190] DeprecationWarning` that has been polluting test runs for a while.