### PR TITLE
Stop writing removed pnpm 11 settings into pnpm-workspace.yaml

### DIFF
--- a/.changeset/pnpm11-workspace-settings.md
+++ b/.changeset/pnpm11-workspace-settings.md
@@ -1,0 +1,8 @@
+---
+'pnpm-plugin-sku': patch
+'@sku-lib/create': patch
+---
+
+Stop writing pnpm 10-only settings into `pnpm-workspace.yaml`
+
+`ignorePatchFailures` and `packageManagerStrictVersion` were removed in pnpm 11, which is what `@sku-lib/create` pins for new apps. Leaving them in the default config made pnpm warn that the settings were unrecognized.

--- a/packages/pnpm-plugin/src/config.ts
+++ b/packages/pnpm-plugin/src/config.ts
@@ -9,7 +9,6 @@ export const defaultConfig = {
     'unrs-resolver': true,
   },
   blockExoticSubdeps: true,
-  ignorePatchFailures: false,
   minimumReleaseAge: 4320,
   minimumReleaseAgeExclude: [
     '@braid-design-system/*',
@@ -23,7 +22,6 @@ export const defaultConfig = {
     'eslint-config-seek',
     'sku',
   ],
-  packageManagerStrictVersion: true,
   publicHoistPattern: ['eslint', 'prettier'],
   strictDepBuilds: false,
   trustPolicy: 'off',

--- a/tests/node/__snapshots__/sku-create.test.ts.snap
+++ b/tests/node/__snapshots__/sku-create.test.ts.snap
@@ -125,7 +125,6 @@ exports[`sku-create vite > should create pnpm-workspace.yaml 1`] = `
 blockExoticSubdeps: true
 configDependencies:
   pnpm-plugin-sku: VERSION_IGNORED
-ignorePatchFailures: false
 minimumReleaseAge: 4320 # 3 days
 minimumReleaseAgeExclude:
   - '@braid-design-system/*'
@@ -138,7 +137,6 @@ minimumReleaseAgeExclude:
   - browserslist-config-seek
   - eslint-config-seek
   - sku
-packageManagerStrictVersion: true
 publicHoistPattern:
   - eslint
   - prettier
@@ -514,7 +512,6 @@ exports[`sku-create webpack > should create pnpm-workspace.yaml 1`] = `
 blockExoticSubdeps: true
 configDependencies:
   pnpm-plugin-sku: VERSION_IGNORED
-ignorePatchFailures: false
 minimumReleaseAge: 4320 # 3 days
 minimumReleaseAgeExclude:
   - '@braid-design-system/*'
@@ -527,7 +524,6 @@ minimumReleaseAgeExclude:
   - browserslist-config-seek
   - eslint-config-seek
   - sku
-packageManagerStrictVersion: true
 publicHoistPattern:
   - eslint
   - prettier


### PR DESCRIPTION
## Fixes
<img width="942" height="47" alt="image" src="https://github.com/user-attachments/assets/fc8fc893-8c28-4ac0-b359-2c5fc6918b21" />


## Summary
- Stop emitting `ignorePatchFailures` and `packageManagerStrictVersion` from `pnpm-plugin-sku`'s default workspace config.
- Update `sku-create` snapshots so new apps no longer get those keys.

## Why
- `@sku-lib/create` pins pnpm 11, which dropped both settings. Writing them made pnpm warn that they were unrecognized.
- Behaviour is unchanged for new apps:
  - `ignorePatchFailures: false` is now the only behaviour in pnpm 11: failed patches always throw. Omitting the key is the same as setting it to `false`.
  - `packageManagerStrictVersion: true` meant "do not run if this is not the `package.json#packageManager` version". pnpm 11 still honours that field. The replacement `pmOnFail` defaults to `download`, which installs the declared pnpm version instead of erroring, so apps still run the pinned version.
  
Usually the [migration codemod](https://pnpm.io/migration#run-the-codemod) would update these for you, but as sku create config is programatically generated it wouldn't apply.