### PR TITLE
`csp`: Update `sku serve` command to include CSP headers in response

### DIFF
--- a/.changeset/loose-cities-create.md
+++ b/.changeset/loose-cities-create.md
@@ -1,0 +1,5 @@
+---
+'sku': patch
+---
+
+`csp`: Update `sku serve` command to include CSP headers in response.

--- a/packages/sku/src/program/commands/serve/serve.action.ts
+++ b/packages/sku/src/program/commands/serve/serve.action.ts
@@ -1,3 +1,4 @@
+import { glob, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import exists from '../../../utils/exists.js';
 import express from 'express';
@@ -25,6 +26,13 @@ import {
 import type { SkuContext } from '../../../context/createSkuContext.js';
 import { serverUrls } from '@sku-private/utils';
 import { accent, critical, strong } from '@sku-private/utils/console';
+import type { Metadata } from '../../../types/types.js';
+
+const metadataHeaderMap: Record<keyof Metadata, string> = {
+  csp: 'content-security-policy',
+  cspReportOnly: 'content-security-policy-report-only',
+  reportingEndpoints: 'reporting-endpoints',
+};
 
 export const serveAction = async ({
   site: preferredSite,
@@ -102,6 +110,34 @@ export const serveAction = async ({
     skuContext,
   });
 
+  const headers = [
+    {
+      source: '**/*.*',
+      headers: [
+        {
+          key: 'Access-Control-Allow-Origin',
+          value: '*',
+        },
+      ],
+    },
+  ];
+
+  const metadataFilesPattern = join(environment, '**/index.html.json');
+  const metadataFiles = glob(metadataFilesPattern, { cwd: paths.target });
+
+  for await (const metadataFile of metadataFiles) {
+    const { metadata } = JSON.parse(
+      await readFile(join(paths.target, metadataFile), 'utf-8'),
+    ) as { metadata: Metadata };
+
+    headers.push({
+      source: metadataFile.slice(0, -5), // Remove '.json' extension.
+      headers: (Object.entries(metadata) as Array<[keyof Metadata, string]>)
+        .filter(([key]) => key in metadataHeaderMap)
+        .map(([key, value]) => ({ key: metadataHeaderMap[key], value })),
+    });
+  }
+
   const app = express();
 
   if (paths.devServerMiddleware) {
@@ -163,17 +199,7 @@ export const serveAction = async ({
       rewrites,
       public: paths.relativeTarget,
       directoryListing: false,
-      headers: [
-        {
-          source: '**/*.*',
-          headers: [
-            {
-              key: 'Access-Control-Allow-Origin',
-              value: '*',
-            },
-          ],
-        },
-      ],
+      headers,
     });
   });
 

--- a/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
+++ b/packages/sku/src/services/vite/helpers/prerender/prerenderWorker.ts
@@ -16,13 +16,7 @@ import {
 } from '../../../../utils/csp.js';
 
 import type { WorkerData } from './prerenderConcurrently.js';
-import type { Render } from '../../../../types/types.js';
-
-type Metadata = {
-  csp?: string;
-  cspReportOnly?: string;
-  reportingEndpoints?: string;
-};
+import type { Metadata, Render } from '../../../../types/types.js';
 
 // Vite handles generating Vanilla Extract CSS during its build, so we set a mock adapter
 // to prevent Vanilla Extract errors during pre-rendering.

--- a/packages/sku/src/types/types.ts
+++ b/packages/sku/src/types/types.ts
@@ -610,3 +610,9 @@ export type SkuConfig = SkuConfigBase &
       } & WebpackSkuConfig)
     | ({ bundler: 'vite' } & ViteSkuConfig)
   );
+
+export type Metadata = {
+  csp?: string;
+  cspReportOnly?: string;
+  reportingEndpoints?: string;
+};

--- a/tests/browser/__snapshots__/security-controls.test.ts.snap
+++ b/tests/browser/__snapshots__/security-controls.test.ts.snap
@@ -91,6 +91,61 @@ exports[`security-controls > build-ssr > should start a server with content-secu
 </html>
 `;
 
+exports[`security-controls > bundler vite > csp-delivery > serve > should serve an app with security controls 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -1,43 +1,46 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       rel="stylesheet"
+       href="/vite-client.css"
+       crossorigin
+     >
+     <link
+       rel="modulepreload"
+       href="/vite-client.js"
+       crossorigin
+     >
+   </head>
+   <body>
+     <div id="app">
+       <div class="_14y9ssh0">
+         <div class="_14y9ssh1">
+-          Initial
++          Client
+         </div>
+       </div>
+     </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"environment":"","dynamicScriptNonce":"RANDOM_NONCE"}
+     </script>
+     <script
+       type="module"
+       src="/vite-client.js"
+     >
+     </script>
++    <script nonce="RANDOM_NONCE">
++      console.log("Hello from dynamically created script")
++    </script>
+   </body>
+ </html>
+\\ No newline at end of file
+`;
+
 exports[`security-controls > bundler vite > csp-delivery > start > should start an app with security controls 1`] = `
 content-security-policy: script-src 'self' https://some-cdn.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' 'sha256-UBWhRaCtYn0qJIs3GeFksNFLt/GkChOdRUDOMGEwb4A=' 'nonce-RANDOM_NONCE';
 ===================================================================
@@ -178,6 +233,65 @@ content-security-policy: script-src 'self' https://some-cdn.com 'sha256-Z2/iFzh9
        {"environment":"","dynamicScriptNonce":"RANDOM_NONCE"}
      </script>
 +    <script nonce>
++      console.log("Hello from dynamically created script")
++    </script>
+   </body>
+ </html>
+\\ No newline at end of file
+`;
+
+exports[`security-controls > bundler vite > csp-report-only > serve > should serve an app with security controls 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -1,47 +1,50 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta
+       http-equiv="Content-Security-Policy"
+       content="script-src 'self' https://some-cdn.com 'nonce-RANDOM_NONCE';"
+     >
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       rel="stylesheet"
+       href="/vite-client.css"
+       crossorigin
+     >
+     <link
+       rel="modulepreload"
+       href="/vite-client.js"
+       crossorigin
+     >
+   </head>
+   <body>
+     <div id="app">
+       <div class="_14y9ssh0">
+         <div class="_14y9ssh1">
+-          Initial
++          Client
+         </div>
+       </div>
+     </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"environment":"","dynamicScriptNonce":"RANDOM_NONCE"}
+     </script>
+     <script
+       type="module"
+       src="/vite-client.js"
+     >
+     </script>
++    <script nonce="RANDOM_NONCE">
 +      console.log("Hello from dynamically created script")
 +    </script>
    </body>
@@ -283,6 +397,61 @@ content-security-policy-report-only: script-src 'self' https://some-report-only-
 \\ No newline at end of file
 `;
 
+exports[`security-controls > bundler vite > csp-report-to > endpoint > serve > should serve an app with security controls 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -1,43 +1,46 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       rel="stylesheet"
+       href="/vite-client.css"
+       crossorigin
+     >
+     <link
+       rel="modulepreload"
+       href="/vite-client.js"
+       crossorigin
+     >
+   </head>
+   <body>
+     <div id="app">
+       <div class="_14y9ssh0">
+         <div class="_14y9ssh1">
+-          Initial
++          Client
+         </div>
+       </div>
+     </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"environment":"","dynamicScriptNonce":"RANDOM_NONCE"}
+     </script>
+     <script
+       type="module"
+       src="/vite-client.js"
+     >
+     </script>
++    <script nonce="RANDOM_NONCE">
++      console.log("Hello from dynamically created script")
++    </script>
+   </body>
+ </html>
+\\ No newline at end of file
+`;
+
 exports[`security-controls > bundler vite > csp-report-to > endpoint > start > should start an app with security controls 1`] = `
 content-security-policy: script-src 'self' https://some-cdn.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' 'sha256-UBWhRaCtYn0qJIs3GeFksNFLt/GkChOdRUDOMGEwb4A=' 'nonce-RANDOM_NONCE'; report-to some-reporting-endpoint;
 content-security-policy-report-only: script-src 'self' https://some-cdn.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' 'sha256-UBWhRaCtYn0qJIs3GeFksNFLt/GkChOdRUDOMGEwb4A=' 'nonce-RANDOM_NONCE'; report-to some-report-only-reporting-endpoint;
@@ -371,6 +540,61 @@ content-security-policy-report-only: script-src 'self' https://some-cdn.com 'sha
        {"environment":"","dynamicScriptNonce":"RANDOM_NONCE"}
      </script>
 +    <script nonce>
++      console.log("Hello from dynamically created script")
++    </script>
+   </body>
+ </html>
+\\ No newline at end of file
+`;
+
+exports[`security-controls > bundler vite > csp-report-to > tuple > serve > should serve an app with security controls 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -1,43 +1,46 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       rel="stylesheet"
+       href="/vite-client.css"
+       crossorigin
+     >
+     <link
+       rel="modulepreload"
+       href="/vite-client.js"
+       crossorigin
+     >
+   </head>
+   <body>
+     <div id="app">
+       <div class="_14y9ssh0">
+         <div class="_14y9ssh1">
+-          Initial
++          Client
+         </div>
+       </div>
+     </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"environment":"","dynamicScriptNonce":"RANDOM_NONCE"}
+     </script>
+     <script
+       type="module"
+       src="/vite-client.js"
+     >
+     </script>
++    <script nonce="RANDOM_NONCE">
 +      console.log("Hello from dynamically created script")
 +    </script>
    </body>
@@ -474,6 +698,61 @@ reporting-endpoints: some-reporting-endpoint="https://some-reporting-url.com", s
 \\ No newline at end of file
 `;
 
+exports[`security-controls > bundler vite > csp-report-to > url > serve > should serve an app with security controls 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -1,43 +1,46 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       rel="stylesheet"
+       href="/vite-client.css"
+       crossorigin
+     >
+     <link
+       rel="modulepreload"
+       href="/vite-client.js"
+       crossorigin
+     >
+   </head>
+   <body>
+     <div id="app">
+       <div class="_14y9ssh0">
+         <div class="_14y9ssh1">
+-          Initial
++          Client
+         </div>
+       </div>
+     </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"environment":"","dynamicScriptNonce":"RANDOM_NONCE"}
+     </script>
+     <script
+       type="module"
+       src="/vite-client.js"
+     >
+     </script>
++    <script nonce="RANDOM_NONCE">
++      console.log("Hello from dynamically created script")
++    </script>
+   </body>
+ </html>
+\\ No newline at end of file
+`;
+
 exports[`security-controls > bundler vite > csp-report-to > url > start > should start an app with security controls 1`] = `
 content-security-policy: script-src 'self' https://some-cdn.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' 'sha256-UBWhRaCtYn0qJIs3GeFksNFLt/GkChOdRUDOMGEwb4A=' 'nonce-RANDOM_NONCE'; report-to endpoint-c3d91ec9;
 content-security-policy-report-only: script-src 'self' https://some-cdn.com 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' 'sha256-UBWhRaCtYn0qJIs3GeFksNFLt/GkChOdRUDOMGEwb4A=' 'nonce-RANDOM_NONCE'; report-to endpoint-abc46dc8;
@@ -570,6 +849,65 @@ reporting-endpoints: endpoint-c3d91ec9="https://some-reporting-url.com", endpoin
 \\ No newline at end of file
 `;
 
+exports[`security-controls > bundler vite > serve > should serve an app with security controls 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -1,47 +1,50 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta
+       http-equiv="Content-Security-Policy"
+       content="script-src 'self' https://some-cdn.com 'nonce-RANDOM_NONCE';"
+     >
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       rel="stylesheet"
+       href="/vite-client.css"
+       crossorigin
+     >
+     <link
+       rel="modulepreload"
+       href="/vite-client.js"
+       crossorigin
+     >
+   </head>
+   <body>
+     <div id="app">
+       <div class="_14y9ssh0">
+         <div class="_14y9ssh1">
+-          Initial
++          Client
+         </div>
+       </div>
+     </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"environment":"","dynamicScriptNonce":"RANDOM_NONCE"}
+     </script>
+     <script
+       type="module"
+       src="/vite-client.js"
+     >
+     </script>
++    <script nonce="RANDOM_NONCE">
++      console.log("Hello from dynamically created script")
++    </script>
+   </body>
+ </html>
+\\ No newline at end of file
+`;
+
 exports[`security-controls > bundler vite > start > should start an app with security controls 1`] = `
 ===================================================================
 --- sourceHtml
@@ -658,6 +996,103 @@ exports[`security-controls > bundler vite > start > should start an app with sec
        type="application/json"
      >
        {"environment":"","dynamicScriptNonce":"RANDOM_NONCE"}
+     </script>
++    <script nonce="RANDOM_NONCE">
++      console.log("Hello from dynamically created script")
++    </script>
+   </body>
+ </html>
+\\ No newline at end of file
+`;
+
+exports[`security-controls > bundler webpack > serve > should serve an app with security controls 1`] = `
+===================================================================
+--- sourceHtml
++++ clientHtml
+@@ -1,85 +1,88 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta
+       http-equiv="Content-Security-Policy"
+       content="script-src 'self' https://some-cdn.com 'nonce-RANDOM_NONCE';"
+     >
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <link
+       data-chunk="main"
+       rel="stylesheet"
+       href="/main-3c56f665610e32e791fe.css"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/runtime.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/2.js"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="/main.js"
+     >
+   </head>
+   <body>
+     <div id="app">
+       <div class="_14y9ssh0">
+         <div class="_14y9ssh1">
+-          Initial
++          Client
+         </div>
+       </div>
+     </div>
+     <script
+       id="__SKU_CLIENT_CONTEXT__"
+       type="application/json"
+     >
+       {"environment":"","dynamicScriptNonce":"RANDOM_NONCE"}
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/runtime.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/2.js"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="/main.js"
+     >
      </script>
 +    <script nonce="RANDOM_NONCE">
 +      console.log("Hello from dynamically created script")

--- a/tests/browser/__snapshots__/security-controls.test.ts.snap
+++ b/tests/browser/__snapshots__/security-controls.test.ts.snap
@@ -92,6 +92,7 @@ exports[`security-controls > build-ssr > should start a server with content-secu
 `;
 
 exports[`security-controls > bundler vite > csp-delivery > serve > should serve an app with security controls 1`] = `
+content-security-policy: script-src 'self' https://some-cdn.com 'nonce-RANDOM_NONCE';
 ===================================================================
 --- sourceHtml
 +++ clientHtml
@@ -138,7 +139,7 @@ exports[`security-controls > bundler vite > csp-delivery > serve > should serve 
        src="/vite-client.js"
      >
      </script>
-+    <script nonce="RANDOM_NONCE">
++    <script nonce>
 +      console.log("Hello from dynamically created script")
 +    </script>
    </body>
@@ -241,6 +242,7 @@ content-security-policy: script-src 'self' https://some-cdn.com 'sha256-Z2/iFzh9
 `;
 
 exports[`security-controls > bundler vite > csp-report-only > serve > should serve an app with security controls 1`] = `
+content-security-policy-report-only: script-src 'self' https://some-report-only-cdn.com 'nonce-RANDOM_NONCE';
 ===================================================================
 --- sourceHtml
 +++ clientHtml
@@ -291,7 +293,7 @@ exports[`security-controls > bundler vite > csp-report-only > serve > should ser
        src="/vite-client.js"
      >
      </script>
-+    <script nonce="RANDOM_NONCE">
++    <script nonce>
 +      console.log("Hello from dynamically created script")
 +    </script>
    </body>
@@ -398,6 +400,8 @@ content-security-policy-report-only: script-src 'self' https://some-report-only-
 `;
 
 exports[`security-controls > bundler vite > csp-report-to > endpoint > serve > should serve an app with security controls 1`] = `
+content-security-policy: script-src 'self' https://some-cdn.com 'nonce-RANDOM_NONCE'; report-to some-reporting-endpoint;
+content-security-policy-report-only: script-src 'self' https://some-cdn.com 'nonce-RANDOM_NONCE'; report-to some-report-only-reporting-endpoint;
 ===================================================================
 --- sourceHtml
 +++ clientHtml
@@ -444,7 +448,7 @@ exports[`security-controls > bundler vite > csp-report-to > endpoint > serve > s
        src="/vite-client.js"
      >
      </script>
-+    <script nonce="RANDOM_NONCE">
++    <script nonce>
 +      console.log("Hello from dynamically created script")
 +    </script>
    </body>
@@ -548,6 +552,9 @@ content-security-policy-report-only: script-src 'self' https://some-cdn.com 'sha
 `;
 
 exports[`security-controls > bundler vite > csp-report-to > tuple > serve > should serve an app with security controls 1`] = `
+content-security-policy: script-src 'self' https://some-cdn.com 'nonce-RANDOM_NONCE'; report-to some-reporting-endpoint;
+content-security-policy-report-only: script-src 'self' https://some-cdn.com 'nonce-RANDOM_NONCE'; report-to some-report-only-reporting-endpoint;
+reporting-endpoints: some-reporting-endpoint="https://some-reporting-url.com", some-report-only-reporting-endpoint="https://some-report-only-reporting-url.com"
 ===================================================================
 --- sourceHtml
 +++ clientHtml
@@ -594,7 +601,7 @@ exports[`security-controls > bundler vite > csp-report-to > tuple > serve > shou
        src="/vite-client.js"
      >
      </script>
-+    <script nonce="RANDOM_NONCE">
++    <script nonce>
 +      console.log("Hello from dynamically created script")
 +    </script>
    </body>
@@ -699,6 +706,9 @@ reporting-endpoints: some-reporting-endpoint="https://some-reporting-url.com", s
 `;
 
 exports[`security-controls > bundler vite > csp-report-to > url > serve > should serve an app with security controls 1`] = `
+content-security-policy: script-src 'self' https://some-cdn.com 'nonce-RANDOM_NONCE'; report-to endpoint-c3d91ec9;
+content-security-policy-report-only: script-src 'self' https://some-cdn.com 'nonce-RANDOM_NONCE'; report-to endpoint-abc46dc8;
+reporting-endpoints: endpoint-c3d91ec9="https://some-reporting-url.com", endpoint-abc46dc8="https://some-report-only-reporting-url.com"
 ===================================================================
 --- sourceHtml
 +++ clientHtml
@@ -745,7 +755,7 @@ exports[`security-controls > bundler vite > csp-report-to > url > serve > should
        src="/vite-client.js"
      >
      </script>
-+    <script nonce="RANDOM_NONCE">
++    <script nonce>
 +      console.log("Hello from dynamically created script")
 +    </script>
    </body>

--- a/tests/browser/security-controls.test.ts
+++ b/tests/browser/security-controls.test.ts
@@ -76,6 +76,26 @@ describe('security-controls', () => {
       });
     });
 
+    describe('serve', async () => {
+      const port = await getPort();
+      const url = `http://localhost:${port}`;
+
+      beforeAll(async () => {
+        const build = await sku('build', [...args[bundler]]);
+        await build.findByText('Sku build complete');
+
+        const serve = await sku('serve', [`--port=${port}`]);
+        await serve.findByText('Server started');
+      });
+
+      it('should serve an app with security controls', async () => {
+        const app = await getAppSnapshot({
+          url,
+        });
+        expect(app).toMatchSnapshot();
+      });
+    });
+
     describe.runIf(bundler === 'vite')('csp-delivery', () => {
       describe('start', async () => {
         const port = await getPort();
@@ -129,6 +149,28 @@ describe('security-controls', () => {
 
         it('should generate a CSP with nonce value', async () => {
           expect(cspHeader).match(/nonce-RANDOM_NONCE/);
+        });
+      });
+
+      describe('serve', async () => {
+        const port = await getPort();
+        const url = `http://localhost:${port}`;
+
+        beforeAll(async () => {
+          const build = await sku('build', [
+            '--config=sku.config.vite.csp-delivery.ts',
+          ]);
+          await build.findByText('Sku build complete');
+
+          const serve = await sku('serve', [`--port=${port}`]);
+          await serve.findByText('Server started');
+        });
+
+        it('should serve an app with security controls', async () => {
+          const app = await getAppSnapshot({
+            url,
+          });
+          expect(app).toMatchSnapshot();
         });
       });
     });
@@ -190,6 +232,28 @@ describe('security-controls', () => {
           expect(cspReportOnlyHeader).match(/nonce-RANDOM_NONCE/);
         });
       });
+
+      describe('serve', async () => {
+        const port = await getPort();
+        const url = `http://localhost:${port}`;
+
+        beforeAll(async () => {
+          const build = await sku('build', [
+            '--config=sku.config.vite.csp-report-only.ts',
+          ]);
+          await build.findByText('Sku build complete');
+
+          const serve = await sku('serve', [`--port=${port}`]);
+          await serve.findByText('Server started');
+        });
+
+        it('should serve an app with security controls', async () => {
+          const app = await getAppSnapshot({
+            url,
+          });
+          expect(app).toMatchSnapshot();
+        });
+      });
     });
 
     describe.runIf(bundler === 'vite')('csp-report-to', () => {
@@ -247,6 +311,28 @@ describe('security-controls', () => {
 
           it('should not generate a reporting-endpoints header', () => {
             expect(reportingEndpointsHeader).toBeNull();
+          });
+        });
+
+        describe('serve', async () => {
+          const port = await getPort();
+          const url = `http://localhost:${port}`;
+
+          beforeAll(async () => {
+            const build = await sku('build', [
+              '--config=sku.config.vite.csp-report-to.endpoint.ts',
+            ]);
+            await build.findByText('Sku build complete');
+
+            const serve = await sku('serve', [`--port=${port}`]);
+            await serve.findByText('Server started');
+          });
+
+          it('should serve an app with security controls', async () => {
+            const app = await getAppSnapshot({
+              url,
+            });
+            expect(app).toMatchSnapshot();
           });
         });
       });
@@ -324,6 +410,28 @@ describe('security-controls', () => {
             );
           });
         });
+
+        describe('serve', async () => {
+          const port = await getPort();
+          const url = `http://localhost:${port}`;
+
+          beforeAll(async () => {
+            const build = await sku('build', [
+              '--config=sku.config.vite.csp-report-to.url.ts',
+            ]);
+            await build.findByText('Sku build complete');
+
+            const serve = await sku('serve', [`--port=${port}`]);
+            await serve.findByText('Server started');
+          });
+
+          it('should serve an app with security controls', async () => {
+            const app = await getAppSnapshot({
+              url,
+            });
+            expect(app).toMatchSnapshot();
+          });
+        });
       });
 
       describe('tuple', () => {
@@ -392,6 +500,28 @@ describe('security-controls', () => {
             expect(reportingEndpointsHeader).toContain(
               'some-report-only-reporting-endpoint="https://some-report-only-reporting-url.com"',
             );
+          });
+        });
+
+        describe('serve', async () => {
+          const port = await getPort();
+          const url = `http://localhost:${port}`;
+
+          beforeAll(async () => {
+            const build = await sku('build', [
+              '--config=sku.config.vite.csp-report-to.tuple.ts',
+            ]);
+            await build.findByText('Sku build complete');
+
+            const serve = await sku('serve', [`--port=${port}`]);
+            await serve.findByText('Server started');
+          });
+
+          it('should serve an app with security controls', async () => {
+            const app = await getAppSnapshot({
+              url,
+            });
+            expect(app).toMatchSnapshot();
           });
         });
       });


### PR DESCRIPTION
This change follows on from #1630 and #1631 and updates the `sku serve` command to include any CSP headers as written to the JSON metadata file alongside the rendered HTML content in the response for that content. With this change the `sku serve` command matches the expected behaviour of a compliant static serving solution in a deployed production-like environment.