### PR TITLE
Update pnpm and make `verifyDepsBeforeRun` warn

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "engines": {
     "node": ">=22.19.0"
   },
-  "packageManager": "pnpm@11.18.0",
+  "packageManager": "pnpm@11.24.0",
   "skuSkipPostInstall": true,
   "skuSkipConfigure": true,
   "skuSkipValidatePeerDeps": true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,3 +69,5 @@ preferWorkspacePackages: true
 
 publicHoistPattern:
   - '@babel/*'
+
+verifyDepsBeforeRun: warn


### PR DESCRIPTION
Pnpm constantly runs an install when running tasks. Bumping the pnpm version _seems_ to help but I couldn't test it enough to really confirm. I'm changing `verifyDepsBeforeRun` to `warn` so we can notice if/when it has issues without it being a nuisance (particularly in agents)