### PR TITLE
Fix security-controls SSR fixture so client assets load from http-server

### DIFF
--- a/fixtures/security-controls/package.json
+++ b/fixtures/security-controls/package.json
@@ -6,7 +6,7 @@
     "build": "sku build",
     "build:ssr": "sku build-ssr --config sku-server.config.ts",
     "build:vite": "sku build --config sku.config.vite.ts",
-    "serve:assets": "http-server dist --cors",
+    "serve:assets": "http-server dist -p 9848 --cors",
     "start": "sku start",
     "start:vite": "sku start --config sku.config.vite.ts",
     "start-ssr:vite": "sku start-ssr --config sku-server.config.ts"

--- a/fixtures/security-controls/sku-server.config.ts
+++ b/fixtures/security-controls/sku-server.config.ts
@@ -5,6 +5,8 @@ import {
 
 export default {
   port: 9847,
+  // Required for the test to serve client assets from http-server.
+  publicPath: 'http://localhost:9848',
   clientEntry: './src/serverClient.jsx',
   renderEntry: './src/render.jsx',
   serverEntry: './src/server.jsx',

--- a/fixtures/security-controls/src/serverClient.jsx
+++ b/fixtures/security-controls/src/serverClient.jsx
@@ -1,7 +1,10 @@
-import { hydrateRoot } from 'react-dom';
+import { hydrateRoot } from 'react-dom/client';
 import { loadableReady } from 'sku/@loadable/component';
 
 import App from './App';
+
+// Set to true to demonstrate attempting load unsafe script execution
+const ATTEMPT_LOAD_UNSAFE_SCRIPT = false;
 
 loadableReady(() => {
   const contextElement = document.getElementById('render-context');
@@ -17,10 +20,12 @@ loadableReady(() => {
     'console.log("Hello from dynamically created script")';
   document.body.appendChild(safeScript);
 
-  const evilScript = document.createElement('script');
-  evilScript.textContent =
-    'throw new Error("Evil Code Executed! Muahahaha! 🧛‍♂️")';
-  document.body.appendChild(evilScript);
+  if (ATTEMPT_LOAD_UNSAFE_SCRIPT) {
+    const evilScript = document.createElement('script');
+    evilScript.textContent =
+      'throw new Error("Evil Code Executed! Muahahaha! 🧛‍♂️")';
+    document.body.appendChild(evilScript);
+  }
 
   hydrateRoot(document.getElementById('app'), <App />);
 });

--- a/tests/browser/__snapshots__/security-controls.test.ts.snap
+++ b/tests/browser/__snapshots__/security-controls.test.ts.snap
@@ -4,91 +4,105 @@ exports[`security-controls > build-ssr > should start a server with content-secu
 ===================================================================
 --- sourceHtml
 +++ clientHtml
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>
-      hello-world
-    </title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    >
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="script-src 'self' https://some-cdn.com 'nonce-RANDOM_NONCE';"
-    >
-    <link
-      data-chunk="main"
-      rel="stylesheet"
-      href="/main-3c56f665610e32e791fe.css"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/runtime.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/2.js"
-    >
-    <link
-      data-chunk="main"
-      rel="preload"
-      as="script"
-      href="/main.js"
-    >
-  </head>
-  <body>
-    <div id="app">
-      <div class="_14y9ssh0">
-        <div class="_14y9ssh1">
-          Initial
-        </div>
-      </div>
-    </div>
-    <script
-      id="render-context"
-      type="application/json"
-    >
-      {"dynamicScriptNonce":"RANDOM_NONCE"}
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS__"
-      type="application/json"
-    >
-      []
-    </script>
-    <script
-      id="__LOADABLE_REQUIRED_CHUNKS___ext"
-      type="application/json"
-    >
-      {"namedChunks":[]}
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/runtime.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/2.js"
-    >
-    </script>
-    <script
-      async
-      data-chunk="main"
-      src="/main.js"
-    >
-    </script>
-  </body>
-</html>
+@@ -1,93 +1,96 @@
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="UTF-8">
+     <title>
+       hello-world
+     </title>
+     <meta
+       name="viewport"
+       content="width=device-width, initial-scale=1"
+     >
+     <meta
+       http-equiv="Content-Security-Policy"
+       content="script-src 'self' http://localhost:9848 https://some-cdn.com 'nonce-RANDOM_NONCE';"
+     >
+     <link
+       data-chunk="main"
+       rel="stylesheet"
+       href="http://localhost:9848/main-3c56f665610e32e791fe.css"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="http://localhost:9848/runtime.js"
+       crossorigin="anonymous"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="http://localhost:9848/2.js"
+       crossorigin="anonymous"
+     >
+     <link
+       data-chunk="main"
+       rel="preload"
+       as="script"
+       href="http://localhost:9848/main.js"
+       crossorigin="anonymous"
+     >
+   </head>
+   <body>
+     <div id="app">
+       <div class="_14y9ssh0">
+         <div class="_14y9ssh1">
+-          Initial
++          Client
+         </div>
+       </div>
+     </div>
+     <script
+       id="render-context"
+       type="application/json"
+     >
+       {"dynamicScriptNonce":"RANDOM_NONCE"}
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS__"
+       type="application/json"
+       crossorigin="anonymous"
+     >
+       []
+     </script>
+     <script
+       id="__LOADABLE_REQUIRED_CHUNKS___ext"
+       type="application/json"
+       crossorigin="anonymous"
+     >
+       {"namedChunks":[]}
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="http://localhost:9848/runtime.js"
+       crossorigin="anonymous"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="http://localhost:9848/2.js"
+       crossorigin="anonymous"
+     >
+     </script>
+     <script
+       async
+       data-chunk="main"
+       src="http://localhost:9848/main.js"
+       crossorigin="anonymous"
+     >
+     </script>
++    <script nonce="RANDOM_NONCE">
++      console.log("Hello from dynamically created script")
++    </script>
+   </body>
+ </html>
+\\ No newline at end of file
 `;
 
 exports[`security-controls > bundler vite > csp-delivery > serve > should serve an app with security controls 1`] = `

--- a/tests/browser/security-controls.test.ts
+++ b/tests/browser/security-controls.test.ts
@@ -530,7 +530,6 @@ describe('security-controls', () => {
 
   describe('build-ssr', async () => {
     const port = await getPort();
-    const assetPort = await getPort();
     const url = `http://localhost:${port}`;
 
     beforeAll(async () => {
@@ -540,11 +539,7 @@ describe('security-controls', () => {
 
     it('should start a server with content-security-policies', async () => {
       await node(['dist/server.cjs', `--port=${port}`]);
-      const assetServer = await exec('pnpm', [
-        'run',
-        'serve:assets',
-        `--port=${assetPort}`,
-      ]);
+      const assetServer = await exec('pnpm', ['run', 'serve:assets']);
       expect(await assetServer.findByText('serving dist')).toBeInTheConsole();
 
       const app = await getAppSnapshot({ url });


### PR DESCRIPTION
The adjacent Vite loadable work surfaced that the `security-controls` fixture was producing some page errors we weren't seeing. This explains why the app snapshot shows no post-hydration diff: the client was never loading.

This can be fixed by serving static assets the same way other SSR fixtures do: point publicPath at a hardcoded asset-server port.