### PR TITLE
`pnpm-plugin`: Allow `@parcel/watcher` builds

### DIFF
--- a/.changeset/tame-birds-laugh.md
+++ b/.changeset/tame-birds-laugh.md
@@ -1,0 +1,5 @@
+---
+'pnpm-plugin-sku': patch
+---
+
+Add `'@parcel/watcher': true` to `allowBuilds`

--- a/packages/pnpm-plugin/src/config.ts
+++ b/packages/pnpm-plugin/src/config.ts
@@ -2,6 +2,7 @@ import type { Config } from '@pnpm/config';
 
 export const defaultConfig = {
   allowBuilds: {
+    '@parcel/watcher': true,
     '@swc/core': true,
     'core-js-pure': false,
     esbuild: true,

--- a/tests/node/__snapshots__/sku-create.test.ts.snap
+++ b/tests/node/__snapshots__/sku-create.test.ts.snap
@@ -117,7 +117,7 @@ exports[`sku-create ssr > should create package.json 1`] = `
 
 exports[`sku-create ssr > should create pnpm-workspace.yaml 1`] = `
 "allowBuilds:
-  '@parcel/watcher': set this to true or false
+  '@parcel/watcher': true
   '@swc/core': true
   core-js-pure: false
   esbuild: true
@@ -652,7 +652,7 @@ exports[`sku-create vite > should create package.json 1`] = `
 
 exports[`sku-create vite > should create pnpm-workspace.yaml 1`] = `
 "allowBuilds:
-  '@parcel/watcher': set this to true or false
+  '@parcel/watcher': true
   '@swc/core': true
   core-js-pure: false
   esbuild: true
@@ -1040,7 +1040,7 @@ exports[`sku-create webpack > should create package.json 1`] = `
 
 exports[`sku-create webpack > should create pnpm-workspace.yaml 1`] = `
 "allowBuilds:
-  '@parcel/watcher': set this to true or false
+  '@parcel/watcher': true
   '@swc/core': true
   core-js-pure: false
   esbuild: true

--- a/tests/node/__snapshots__/sku-create.test.ts.snap
+++ b/tests/node/__snapshots__/sku-create.test.ts.snap
@@ -117,6 +117,7 @@ exports[`sku-create ssr > should create package.json 1`] = `
 
 exports[`sku-create ssr > should create pnpm-workspace.yaml 1`] = `
 "allowBuilds:
+  '@parcel/watcher': set this to true or false
   '@swc/core': true
   core-js-pure: false
   esbuild: true
@@ -651,6 +652,7 @@ exports[`sku-create vite > should create package.json 1`] = `
 
 exports[`sku-create vite > should create pnpm-workspace.yaml 1`] = `
 "allowBuilds:
+  '@parcel/watcher': set this to true or false
   '@swc/core': true
   core-js-pure: false
   esbuild: true
@@ -1038,6 +1040,7 @@ exports[`sku-create webpack > should create package.json 1`] = `
 
 exports[`sku-create webpack > should create pnpm-workspace.yaml 1`] = `
 "allowBuilds:
+  '@parcel/watcher': set this to true or false
   '@swc/core': true
   core-js-pure: false
   esbuild: true


### PR DESCRIPTION
https://github.com/seek-oss/sku/pull/1709 is blocked by [a test failure](https://github.com/seek-oss/sku/actions/runs/33452799979/job/99686240683#step:12:542) caused by [the latest jest release](https://github.com/jestjs/jest/releases/tag/v30.5.0) which added a [`@parcel/watcher`](https://npmx.dev/package/@parcel/watcher) dep.

It seems like when a new dep with an install script is added in the dep tree, we have to make a PR to allow/disable it in the plugin (this PR) and then ~_another_ PR (once the previous change is released) to a update the snapshot~ (**EDIT**: it seems like we don't need a second PR to update the snapshot, but I can't get it to update during a test run so I updated it manually). This is probably because the `sku-create` test uses the latest released version of the config, not the version in the monorepo.