### PR TITLE
Use `link:` protocol instead of packing a tarball for `sku-create` tests

### DIFF
--- a/openspec/changes/create-sku-link-override/.openspec.yaml
+++ b/openspec/changes/create-sku-link-override/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/create-sku-link-override/design.md
+++ b/openspec/changes/create-sku-link-override/design.md
@@ -1,0 +1,67 @@
+## Context
+
+See proposal.md for why. Create already installs sku from `SKU_CREATE_SKU_SPECIFIER` when set, otherwise unversioned `sku`. The sku-create suite currently packs `packages/sku` and passes `sku@file:<tarball>`. Nested `pnpm-workspace.yaml` in the created project still forbids resolving sku via parent workspace config (`linkWorkspacePackages` / `workspace:*`). The override must stay a **dependency specifier**.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Pin this commit’s sku in create tests without resolving sku’s workspace deps from the registry
+- Keep the override as a specifier so nested project workspaces still work
+
+**Non-Goals:**
+
+- Changing create’s production install path or documenting `SKU_CREATE_SKU_SPECIFIER` for consumers
+- Recursively packing / rewriting tarballs to point workspace deps at local `.tgz` files
+- A pack/`files` assertion (that only retests that pnpm pack honours `files`)
+- A local registry, `pnpm.overrides`, or generate-only / skip-install mode
+- start/build smoke tests
+
+## Decisions
+
+### 1. Create tests use `link:`, not `file:` tarball
+
+Harness sets `SKU_CREATE_SKU_SPECIFIER` to `sku@link:<absolute-path-to-packages/sku>`. Create already treats the env as a raw specifier, so product code does not change.
+
+`link:` is still a specifier, so it survives the nested `pnpm-workspace.yaml` that broke workspace-layout linking. pnpm does not rewrite sku’s `workspace:` ranges against the registry, so unpublished sibling versions on a release branch do not fail install.
+
+**Alternatives considered:**
+
+| Approach                                                   | Why not                                                                                                              |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Keep packing sku only                                      | Same failure: packed `package.json` asks for unpublished `@sku-lib/vite` (and any future bumped workspace dep)       |
+| Pack sku **and** rewrite workspace deps to nested tarballs | Works, but stacks more pack/unpack/rewrite on an already test-only override; slower; more code                       |
+| `file:` to the package directory                           | Directory `file:` is a looser install than `link:`; `link:` is the usual pnpm way to consume a local package by path |
+| Parent `workspace:*` / `linkWorkspacePackages`             | Nested project yaml becomes its own workspace root; already rejected in `create-sku-tarball-override`                |
+| Skip create tests on `changeset-release/*`                 | Hides the skew instead of removing it                                                                                |
+
+### 2. Do not pack at all in this change
+
+Packing in create was the closest authentic publish install. It also caused the registry skew, leaked `sku@file:…` into generated `pnpm-workspace.yaml`, and was slower.
+
+A follow-on test that packs sku and asserts the tarball matches `package.json` `files` is tautological: it checks that pnpm pack honours `files`, not that sku’s published contract is correct. Catching a missing runtime path would require installing or running the packed package (the original create-pack problem) or hard-coding required paths (a different, publish-oriented test). Out of scope.
+
+Create snapshots MUST NOT encode pack-only artifacts (e.g. `onlyBuiltDependencies` keys for `sku@file:…`). Generated `pnpm-workspace.yaml` SHOULD match an end-user create (`sku: true` among only-built deps, not a tarball path).
+
+### 3. Publish fidelity vs create authenticity
+
+Create tests still run a real `pnpm add` of sku (linked) plus other `@latest` deps, then post-create lint. Isolated `node_modules` still constrains sku to declared deps. Residual difference: `node_modules/sku` is a symlink into the monorepo, so ancestor-directory config resolution can differ from a published install. A missing `files` entry is a publish concern, not a create-test concern.
+
+## Risks / Trade-offs
+
+| Risk                                            | Mitigation                                                                        |
+| ----------------------------------------------- | --------------------------------------------------------------------------------- |
+| Missing `files` entry ships                     | Accepted; publish is the gate. A pack-vs-`files` test would only retest pnpm      |
+| `link:` sees the monorepo as an ancestor        | Post-create lint still must pass; do not treat pack-in-create as the quality gate |
+| Absolute `link:` left in created `package.json` | Test-only; existing version-ignoring snapshots                                    |
+| Other `@latest` deps still network-bound        | Unchanged; not this bug                                                           |
+
+## Migration Plan
+
+1. Point sku-create `SKU_CREATE_SKU_SPECIFIER` at `sku@link:<packages/sku>`
+2. Remove pack helper, temp-dir cleanup, and `sku@file:` YAML scrubbing; update snapshots
+3. No consumer migration; rollback is reverting the test changes
+
+## Open Questions
+
+(none)

--- a/openspec/changes/create-sku-link-override/proposal.md
+++ b/openspec/changes/create-sku-link-override/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Create integration tests pack local `sku` into a tarball and install it via `SKU_CREATE_SKU_SPECIFIER`. `pnpm pack` rewrites `workspace:` dependencies to local semver, so on a changesets release branch those versions are not on the registry yet and the suite fails with `ERR_PNPM_NO_MATCHING_VERSION`. Tests still need this commit’s sku without that registry coupling.
+
+## What Changes
+
+- sku-create tests pin local sku with `sku@link:<absolute-path-to-packages/sku>` instead of packing a tarball
+- Drop pack-only snapshot scrubbing (`sku@file:` in generated `pnpm-workspace.yaml`)
+- No separate pack/`files` test: asserting a tarball contains `package.json` `files` only retests pnpm pack
+- No change to create’s production install path or to `SKU_CREATE_SKU_SPECIFIER` itself (still a full specifier, used as-is)
+
+## Capabilities
+
+### New Capabilities
+
+- (none)
+
+### Modified Capabilities
+
+- `create-project`: How create tests pin local sku (link specifier instead of packed tarball), and that packing is not used for create
+
+## Impact
+
+- **Code**: `tests/node/sku-create.test.ts` and its snapshots. `packages/create` install path unchanged.
+- **Public API**: None. `SKU_CREATE_SKU_SPECIFIER` remains internal/test-only.
+- **Breaking**: None for consumers.
+- **Release**: No changeset (test-only).
+- **Docs**: None for users; comments in the test harness are enough.

--- a/openspec/changes/create-sku-link-override/specs/create-project/spec.md
+++ b/openspec/changes/create-sku-link-override/specs/create-project/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Default sku install from registry
+
+When creating a project without a test override, create SHALL install the `sku` dependency using an unversioned specifier so the package manager resolves it from the registry as it does for end users.
+
+#### Scenario: No override set
+
+- **WHEN** a user runs create and `SKU_CREATE_SKU_SPECIFIER` is unset
+- **THEN** create installs `sku` without a `link:` or `file:` specifier
+
+### Requirement: Test-only sku specifier override
+
+Create SHALL support an internal environment variable `SKU_CREATE_SKU_SPECIFIER` whose value is a full dependency specifier for `sku`. When set, create MUST install sku using that specifier as-is (no copy or path normalisation in create). When unset, create MUST install unversioned `sku`.
+
+Create integration tests MUST pin this commit’s sku with `sku@link:<absolute-path-to-packages/sku>`. They MUST NOT pack sku and MUST NOT install a `file:` tarball for that purpose. Packing rewrites `workspace:` ranges to local semver that may not exist on the registry yet (for example on a changesets release branch), and it is slower and heavier than `link:`.
+
+#### Scenario: Override installs linked local sku
+
+- **WHEN** `SKU_CREATE_SKU_SPECIFIER` is set to a valid `sku@link:<absolute-path-to-packages/sku>`
+- **THEN** the new project’s installed `sku` dependency resolves from that specifier
+- **AND** installation MUST NOT rely on parent workspace `linkWorkspacePackages` or `workspace:*` to resolve sku
+- **AND** installation MUST NOT require packing sku or fetching sku’s workspace dependencies from the registry
+
+#### Scenario: Nested project workspace does not block override
+
+- **WHEN** create writes a `pnpm-workspace.yaml` inside the new project
+- **AND** `SKU_CREATE_SKU_SPECIFIER` is set to an absolute `sku@link:…` specifier
+- **THEN** sku still installs from that link specifier
+
+### Requirement: Create integration tests validate via lint
+
+After a successful create in integration tests that use the sku specifier override, the harness MUST run the new project’s lint step. It MUST pass.
+
+#### Scenario: Post-create lint passes
+
+- **WHEN** create finishes successfully for a project under the sku-create integration suite
+- **AND** the suite uses `SKU_CREATE_SKU_SPECIFIER` to install linked local sku
+- **THEN** running the new project’s lint step succeeds

--- a/openspec/changes/create-sku-link-override/tasks.md
+++ b/openspec/changes/create-sku-link-override/tasks.md
@@ -1,0 +1,9 @@
+## 1. Create tests use linked local sku
+
+- [x] 1.1 In `tests/node/sku-create.test.ts`, set `SKU_CREATE_SKU_SPECIFIER` to `sku@link:<absolute-path-to-packages/sku>`
+- [x] 1.2 Remove packing (`pnpm pack`, temp dest, tarball path, `afterAll` cleanup of the pack dir)
+- [x] 1.3 Remove `sku@file:` YAML scrubbing; update `pnpm-workspace.yaml` snapshots so they do not contain a tarball `onlyBuiltDependencies` key
+
+## 2. Verify
+
+- [x] 2.1 Run the sku-create suite; it MUST pass without resolving unpublished workspace versions from the registry

--- a/tests/node/__snapshots__/sku-create.test.ts.snap
+++ b/tests/node/__snapshots__/sku-create.test.ts.snap
@@ -122,7 +122,6 @@ exports[`sku-create ssr > should create pnpm-workspace.yaml 1`] = `
   core-js-pure: false
   esbuild: true
   sku: true
-  sku@file: VERSION_IGNORED
   unrs-resolver: true
 blockExoticSubdeps: true
 configDependencies:
@@ -657,7 +656,6 @@ exports[`sku-create vite > should create pnpm-workspace.yaml 1`] = `
   core-js-pure: false
   esbuild: true
   sku: true
-  sku@file: VERSION_IGNORED
   unrs-resolver: true
 blockExoticSubdeps: true
 configDependencies:
@@ -1045,7 +1043,6 @@ exports[`sku-create webpack > should create pnpm-workspace.yaml 1`] = `
   core-js-pure: false
   esbuild: true
   sku: true
-  sku@file: VERSION_IGNORED
   unrs-resolver: true
 blockExoticSubdeps: true
 configDependencies:

--- a/tests/node/sku-create.test.ts
+++ b/tests/node/sku-create.test.ts
@@ -1,10 +1,7 @@
 import { describe, beforeAll, afterAll, it, expect, vi } from 'vitest';
 
 import fs from 'node:fs/promises';
-import os from 'node:os';
 import path from 'node:path';
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
 
 import {
   configure,
@@ -12,8 +9,6 @@ import {
 } from '@sku-private/testing-library';
 import { scopeToFixture } from '@sku-private/testing-library/create';
 import { normalizePackageManagerVersion } from '@sku-private/test-utils';
-
-const execFileAsync = promisify(execFile);
 
 const { create, fixturePath } = scopeToFixture('sku-create');
 
@@ -31,47 +26,20 @@ vi.setConfig({
 const projectName = 'new-project';
 const projectDirectory = fixturePath(projectName);
 
-let pack: Awaited<ReturnType<typeof packSku>>;
 let createEnv: NodeJS.ProcessEnv;
 
 /**
- * Packs the local `packages/sku` workspace into a temporary `.tgz` so create
- * tests can install sku via `SKU_CREATE_SKU_SPECIFIER` (`sku@file:…`) instead
- * of the published registry package.
+ * Links the local `packages/sku` workspace so create tests exercise this
+ * commit's sku via `SKU_CREATE_SKU_SPECIFIER` instead of the published
+ * registry package. A specifier (rather than workspace config) is required
+ * because create writes a nested `pnpm-workspace.yaml` into the new project.
  */
-const packSku = async () => {
-  const packDestination = await fs.mkdtemp(
-    path.join(os.tmpdir(), 'sku-create-pack-'),
-  );
-  const skuPackageDir = path.resolve(__dirname, '../../packages/sku');
-
-  await execFileAsync('pnpm', ['pack', '--pack-destination', packDestination], {
-    cwd: skuPackageDir,
-  });
-
-  const packedFiles = await fs.readdir(packDestination);
-  const tarball = packedFiles.find((file) => file.endsWith('.tgz'));
-
-  if (!tarball) {
-    throw new Error('Expected sku pack to produce a .tgz file');
-  }
-
-  return {
-    tarballPath: path.join(packDestination, tarball),
-    remove: () => fs.rm(packDestination, { recursive: true, force: true }),
-  };
-};
+const skuPackageDir = path.resolve(__dirname, '../../packages/sku');
 
 beforeAll(async () => {
-  pack = await packSku();
-
   createEnv = {
-    SKU_CREATE_SKU_SPECIFIER: `sku@file:${pack.tarballPath}`,
+    SKU_CREATE_SKU_SPECIFIER: `sku@link:${skuPackageDir}`,
   };
-});
-
-afterAll(async () => {
-  await pack.remove();
 });
 
 describe('template flag', () => {
@@ -302,10 +270,8 @@ function replaceDependencyVersions(packageJson: Record<string, any>) {
  * This function strips version numbers from YAML content.
  */
 function stripYamlVersions(yamlContent: string): string {
-  return yamlContent
-    .replace(
-      /(?<!minimumReleaseAge):\s*[\d.]+(?:\+sha\d+-[a-f0-9]+)?.*/g,
-      ': VERSION_IGNORED',
-    )
-    .replace(/sku@file:\s*.+/g, 'sku@file: VERSION_IGNORED');
+  return yamlContent.replace(
+    /(?<!minimumReleaseAge):\s*[\d.]+(?:\+sha\d+-[a-f0-9]+)?.*/g,
+    ': VERSION_IGNORED',
+  );
 }


### PR DESCRIPTION
Draft for now while we iterate on the right fixes/solutions to the `sku-create` test issues.

Digging into the problem, it seems to occur because we pack sku into a tarball, which forces pnpm to re-resolve sku's dependencies from the registry. If we link the workspace directory instead, nothing about sku is resolved from npm and the version skew can't happen.

The original design doc rejected workspace linking, but its objection was specifically that create writes a nested `pnpm-workspace.yaml`, which breaks workspace-config-based linking. Its stated requirement was that the override "must live in the dependency specifier, not workspace layout" - and `link:` is a dependency specifier, so it satisfies that constraint.

This seems to speed up `sku-create` tests a bit as well as the `link:` protocol is faster than using a tarball.