### PR TITLE
Replace owns wording in OpenSpec config and product docs

### DIFF
--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -11,6 +11,7 @@ context: |
   - Prefer Lite mode (short behavior-first specs); scale rigor only for high-risk work
   - Invoke the CLI via `pnpm openspec` (not bare `openspec`)
   - AI tool adapters are local-only; never commit them
+  - Describes what something does, rather than what it "owns"
 
 rules:
   proposal:
@@ -24,6 +25,7 @@ rules:
     - Prefer ADDED/MODIFIED/REMOVED deltas; reuse existing domains
     - Happy path plus the failure/edge cases that would hurt if missed — not exhaustive matrices
     - Put how/why in design.md or tasks.md, not in requirements
+    - Do not restore public APIs or names a change already dropped
   design:
     - Skip unless architecture is non-obvious; keep short when present
     - On update: integrate new decisions into the current design narrative;

--- a/site/docs/extra-features.md
+++ b/site/docs/extra-features.md
@@ -158,7 +158,7 @@ export default {
 
 ## Entry side effects
 
-Sku owns the client and SSR entries.
+Sku provides the client and SSR entries.
 Putting a module first in `App.tsx` or a root layout does not make it first in the graph.
 
 [`entrySideEffects`](./configuration.md#entrysideeffects) lists isomorphic modules that sku imports before any consumer module on Vite static and Vite SSR graphs.

--- a/site/docs/ssr/data-loading.md
+++ b/site/docs/ssr/data-loading.md
@@ -156,7 +156,7 @@ export async function loader({ context }: LoaderFunctionArgs) {
 
 ## Response headers
 
-When sku streams HTML (not a short-circuit redirect), it forwards loader/action headers onto the Express response, then applies sku-owned headers (`Content-Type`, CSP).
+When sku streams HTML (not a short-circuit redirect), it forwards loader/action headers onto the Express response, then applies sku headers (`Content-Type`, CSP).
 
 Set caching and cookies with React Router’s `data()` / header APIs:
 
@@ -179,7 +179,7 @@ export async function loader() {
 ## Apollo streaming hydration
 
 When a client cache must survive the stream (Apollo Client), pair render-time queries with a streaming data transport over [`useInsertHtml`](./runtime-api.md#useinserthtml) from `sku/runtime`.
-sku owns the injection seam; your app owns the client and transport — sku ships no Apollo dependency.
+sku provides the injection seam; your app provides the client and transport — sku ships no Apollo dependency.
 
 ```tsx
 // src/ApolloProvider.tsx — transport only (isomorphic)

--- a/site/docs/ssr/index.md
+++ b/site/docs/ssr/index.md
@@ -9,9 +9,9 @@
 Server-side rendering builds an isomorphic React app that renders on the server for each request, then hydrates in the browser.
 
 This path uses **Managed Data Mode**.
-sku owns the HTTP server, HTML document, streaming, hydration, and CSP headers.
+sku provides the HTTP server, HTML document, streaming, hydration, and CSP headers.
 It wires [React Router Data Mode](https://reactrouter.com/start/modes#data) for routing and data.
-You own pages, data, and providers.
+You provide pages, data, and providers.
 
 > [!CAUTION]
 > Experimental — not for production.
@@ -64,7 +64,7 @@ See [Configuration](../configuration.md) for all options.
 
 ### Unsupported configuration
 
-Because sku owns more of the server and build in Managed Data Mode SSR, these options are not supported and are not planned:
+Because sku handles more of the server and build in Managed Data Mode SSR, these options are not supported and are not planned:
 
 - Absolute `publicPath` (for example `https://seekcdn.com/*`)
 - [`public`](../configuration.md#public) assets folder

--- a/site/docs/ssr/logging.md
+++ b/site/docs/ssr/logging.md
@@ -5,7 +5,7 @@
 > Managed Data Mode SSR is available for evaluation and testing. Do not use it in production yet; the API and behaviour may change.
 > In the meantime, continue using [Webpack SSR](./webpack-ssr.md).
 
-Your app provides logging.
+Your app controls logging.
 Wire it where the event happens:
 
 | Layer                     | Where                     | For                                                |

--- a/site/docs/ssr/logging.md
+++ b/site/docs/ssr/logging.md
@@ -5,7 +5,7 @@
 > Managed Data Mode SSR is available for evaluation and testing. Do not use it in production yet; the API and behaviour may change.
 > In the meantime, continue using [Webpack SSR](./webpack-ssr.md).
 
-Your app owns logging.
+Your app provides logging.
 Wire it where the event happens:
 
 | Layer                     | Where                     | For                                                |


### PR DESCRIPTION
## Summary
- Teach OpenSpec to describe what something does, rather than what it "owns"
- Tell spec updates not to restore public APIs or names a change already dropped
- Replace owns wording in product docs

## Why
- OpenSpec kept copying "Sku owns…" / "Apps own…" back from specs and docs